### PR TITLE
mgr/dashboard: Storage class details view missing location_constraint field

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-storage-class.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-storage-class.model.ts
@@ -50,6 +50,7 @@ export interface StorageClassDetails {
   glacier_restore_tier_type?: string;
   read_through_restore_days?: number;
   restore_storage_class?: string;
+  location_constraint?: string;
   retain_head_object?: boolean;
   acls?: ACL[];
   acl_mappings?: ACL[];
@@ -116,6 +117,7 @@ export interface S3Details {
   storage_class: string;
   target_path: string;
   target_storage_class: string;
+  location_constraint?: string;
   region: string;
   secret: string;
   multipart_min_part_size: number;
@@ -155,6 +157,7 @@ export interface PlacementTarget {
     restore_storage_class?: string;
     read_through_restore_days?: number;
     target_storage_class?: string;
+    location_constraint?: string;
     acls?: ACL[];
   };
   storage_class?: string;
@@ -190,6 +193,7 @@ export interface TextLabels {
   restoreDaysText: string;
   readthroughrestoreDaysText: string;
   restoreStorageClassText: string;
+  locationConstraintText: string;
 }
 
 export const CLOUD_TIER_REQUIRED_FIELDS = [
@@ -277,6 +281,8 @@ export const RESTORE_DAYS_TEXT = $localize`Refers to number of days to the objec
 export const READTHROUGH_RESTORE_DAYS_TEXT = $localize`The days for which objects restored via read-through are retained.`;
 
 export const RESTORE_STORAGE_CLASS_TEXT = $localize`The storage class to which object data is to be restored.`;
+
+export const LOCATION_CONSTRAINT_TEXT = $localize`The region constraint for the target bucket on the remote S3 endpoint. For AWS, set this only if the region is other than US East (us-east-1).`;
 
 export const ZONEGROUP_TEXT = $localize`A Zonegroup is a logical grouping of one or more zones that share the same data
                   and metadata, allowing for multi-site replication and geographic distribution of

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.html
@@ -253,6 +253,23 @@
               </ng-template>
             </div>
           </div>
+          <div class="form-item">
+            <cds-text-label
+              labelInputID="location_constraint"
+              i18n
+              [helperText]="helpTextLabels.locationConstraintText"
+              cdOptionalField="Location constraint"
+              >Location constraint
+              <input
+                cdsText
+                type="text"
+                id="location_constraint"
+                formControlName="location_constraint"
+                placeholder="e.g, eu-north-1"
+                i18n-placeholder
+              />
+            </cds-text-label>
+          </div>
           <!-- Access Key  -->
           <div class="form-item">
             <div

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.ts
@@ -30,6 +30,7 @@ import {
   TARGET_PATH_TEXT,
   TARGET_REGION_TEXT,
   TARGET_SECRET_KEY_TEXT,
+  LOCATION_CONSTRAINT_TEXT,
   TierTarget,
   TIER_TYPE,
   ZoneGroup,
@@ -160,7 +161,8 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
       glacierRestoreTiertypeText: GLACIER_RESTORE_TIER_TYPE_TEXT,
       restoreDaysText: RESTORE_DAYS_TEXT,
       readthroughrestoreDaysText: READTHROUGH_RESTORE_DAYS_TEXT,
-      restoreStorageClassText: RESTORE_STORAGE_CLASS_TEXT
+      restoreStorageClassText: RESTORE_STORAGE_CLASS_TEXT,
+      locationConstraintText: LOCATION_CONSTRAINT_TEXT
     };
     this.storageClassOptions = [
       { value: TIER_TYPE.LOCAL, label: TIER_TYPE_DISPLAY.LOCAL },
@@ -220,6 +222,7 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
             this.storageClassForm.patchValue({
               zonegroup: this.storageClassInfo?.zonegroup_name,
               region: response?.region,
+              location_constraint: response?.location_constraint ?? '',
               placement_target: this.storageClassInfo?.placement_target,
               storageClassType: this.tierTargetInfo?.val?.tier_type ?? TIER_TYPE.LOCAL,
               target_endpoint: response?.endpoint,
@@ -456,6 +459,7 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
       region: new FormControl('', [
         CdValidators.composeIf({ storageClassType: TIER_TYPE.CLOUD_TIER }, [Validators.required])
       ]),
+      location_constraint: new FormControl(''),
       placement_target: new FormControl('', {
         validators: [Validators.required]
       }),
@@ -755,6 +759,7 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
       retain_head_object,
       allow_read_through: rawFormValue.allow_read_through,
       region: rawFormValue.region,
+      location_constraint: rawFormValue.location_constraint || '',
       multipart_sync_threshold,
       multipart_min_part_size,
       restore_storage_class: rawFormValue.restore_storage_class,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-resource-page/rgw-storage-class-resource-page.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-resource-page/rgw-storage-class-resource-page.component.spec.ts
@@ -94,6 +94,37 @@ describe('RgwStorageClassResourcePageComponent', () => {
     expect(component.details?.data_pool).toBe('my-local-pool');
   });
 
+  it('should include location_constraint in cloud-s3 overview fields', () => {
+    jest.spyOn(BucketTieringUtils, 'filterAndMapTierTargets').mockReturnValue([
+      {
+        zonegroup_name: 'zg-1',
+        placement_target: 'pt-1',
+        storage_class: 'sc-cloud',
+        tier_type: TIER_TYPE_DISPLAY.CLOUD_TIER,
+        region: 'default',
+        endpoint: 'http://s3.example.com',
+        location_constraint: 'eu-north-1'
+      }
+    ]);
+
+    component.ngOnInit();
+
+    pushRouteParams({
+      zonegroup_name: 'zg-1',
+      placement_target: 'pt-1',
+      storage_class: 'sc-cloud'
+    });
+
+    const locationConstraintField = component.overviewFields.find(
+      (field) => field.label === 'Location constraint'
+    );
+    expect(locationConstraintField).toEqual(
+      expect.objectContaining({
+        value: 'eu-north-1'
+      })
+    );
+  });
+
   it('should handle API errors gracefully', () => {
     zonegroupService.getAllZonegroupsInfo.mockReturnValue(throwError(() => new Error('API Error')));
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-resource-page/rgw-storage-class-resource-page.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-resource-page/rgw-storage-class-resource-page.component.ts
@@ -17,6 +17,7 @@ import {
   StorageClassDetails,
   TARGET_ACCESS_KEY_TEXT,
   TARGET_PATH_TEXT,
+  LOCATION_CONSTRAINT_TEXT,
   TIER_TYPE,
   TIER_TYPE_DISPLAY,
   ZoneGroupDetails
@@ -261,6 +262,11 @@ export class RgwStorageClassResourcePageComponent implements OnInit, OnDestroy {
         {
           label: $localize`Target Region`,
           value: details?.region
+        },
+        {
+          label: $localize`Location constraint`,
+          value: details?.location_constraint,
+          helperText: LOCATION_CONSTRAINT_TEXT
         },
         {
           label: $localize`Target Endpoint`,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/utils/rgw-bucket-tiering.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/utils/rgw-bucket-tiering.ts
@@ -6,8 +6,18 @@ import {
   ZoneGroup,
   ZoneGroupDetails,
   StorageClassDetails,
+  S3Details,
   Zone
 } from '../models/rgw-storage-class.model';
+
+type MappedTierTarget = Omit<Partial<StorageClassDetails>, 'host_style'> &
+  Partial<Pick<S3Details, 'region' | 'endpoint' | 'location_constraint'>> & {
+    zonegroup_name: string;
+    placement_target: string;
+    storage_class: string;
+    tier_type: string;
+    host_style?: string | boolean;
+  };
 
 export class BucketTieringUtils {
   static mapTierTypeDisplay(tierType: string): string {
@@ -23,7 +33,7 @@ export class BucketTieringUtils {
     }
   }
 
-  static filterAndMapTierTargets(zonegroupData: ZoneGroupDetails) {
+  static filterAndMapTierTargets(zonegroupData: ZoneGroupDetails): MappedTierTarget[] {
     return zonegroupData.zonegroups.flatMap((zoneGroup: ZoneGroup) =>
       zoneGroup.placement_targets.flatMap((target: Target) => {
         const storage_class = new Set<string>(
@@ -32,7 +42,7 @@ export class BucketTieringUtils {
         const tierTargetDetails = (target.tier_targets || []).map((tierTarget: TierTarget) =>
           this.getTierTargets(tierTarget, zoneGroup.name, target.name)
         );
-        const localStorageClasses = (target.storage_classes || [])
+        const localStorageClasses: MappedTierTarget[] = (target.storage_classes || [])
           .filter((storageClass) => storageClass !== 'STANDARD' && !storage_class.has(storageClass))
           .map((storageClass) => ({
             zonegroup_name: zoneGroup.name,
@@ -46,7 +56,11 @@ export class BucketTieringUtils {
     );
   }
 
-  private static getTierTargets(tierTarget: TierTarget, zoneGroup: string, targetName: string) {
+  private static getTierTargets(
+    tierTarget: TierTarget,
+    zoneGroup: string,
+    targetName: string
+  ): MappedTierTarget {
     const val = tierTarget.val;
     const tierType = val.tier_type;
     const commonProps = {
@@ -62,7 +76,8 @@ export class BucketTieringUtils {
       restore_storage_class: val.restore_storage_class,
       read_through_restore_days: val.read_through_restore_days,
       acls: val.s3.acl_mappings,
-      ...val.s3
+      ...val.s3,
+      location_constraint: val.s3?.location_constraint ?? ''
     };
 
     if (!tierType || tierType === TIER_TYPE.LOCAL) {


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/79663


<img width="1680" height="945" alt="image" src="https://github.com/user-attachments/assets/e7029187-714f-43e7-99de-4ea639d3026c" />
<img width="1680" height="945" alt="image" src="https://github.com/user-attachments/assets/c65cb4ec-f806-4b25-acee-665ce2bbe09d" />



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
