### PR TITLE
crush: don't divide by a zero total weight when normalizing weight maps

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -2533,11 +2533,14 @@ void CrushWrapper::_normalize_weight_map(float sum,
 					 map<int,float> *pmap) const
 {
   for (auto& p : m) {
+    // When the total weight is zero all the weights in m are zero as well, so
+    // don't divide by it - that would yield inf / nan weights.
+    float w = (sum > 0) ? p.second / sum : 0.0f;
     map<int,float>::iterator q = pmap->find(p.first);
     if (q == pmap->end()) {
-      (*pmap)[p.first] = p.second / sum;
+      (*pmap)[p.first] = w;
     } else {
-      q->second += p.second / sum;
+      q->second += w;
     }
   }
 }

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -21,6 +21,7 @@
  *
  */
 
+#include <cmath>
 #include <iostream>
 #include <gtest/gtest.h>
 
@@ -939,6 +940,48 @@ TEST_F(CrushWrapperTest, dump_rules) {
   c->get_rule_weight_osd_map(0, &wm);
   ASSERT_TRUE(wm.size() == 1);
   ASSERT_TRUE(wm[0] == 1.0);
+}
+
+TEST_F(CrushWrapperTest, weight_osd_map_zero_weights) {
+  std::unique_ptr<CrushWrapper> c(new CrushWrapper);
+
+  const int ROOT_TYPE = 1;
+  c->set_type_name(ROOT_TYPE, "root");
+  const int OSD_TYPE = 0;
+  c->set_type_name(OSD_TYPE, "osd");
+
+  int rootno;
+  c->add_bucket(0, CRUSH_BUCKET_STRAW2, CRUSH_HASH_RJENKINS1,
+		ROOT_TYPE, 0, NULL, NULL, &rootno);
+  c->set_item_name(rootno, "default");
+
+  // all the OSDs under the root have a zero crush weight
+  for (int osd = 0; osd < 3; ++osd) {
+    map<string,string> loc;
+    loc["root"] = "default";
+    ASSERT_EQ(0, c->insert_item(cct, osd, 0.0, "osd." + stringify(osd), loc));
+  }
+
+  string name("NAME");
+  ASSERT_EQ(0, c->add_simple_rule(name, "default", "osd", "",
+				  "firstn", pg_pool_t::TYPE_REPLICATED));
+
+  // the normalized weights must stay at zero rather than become nan
+  map<int,float> wm;
+  ASSERT_EQ(0, c->get_take_weight_osd_map(rootno, &wm));
+  ASSERT_EQ(3u, wm.size());
+  for (auto& [osd, w] : wm) {
+    EXPECT_FALSE(std::isnan(w)) << "osd." << osd << " weight is nan";
+    EXPECT_EQ(0.0f, w);
+  }
+
+  wm.clear();
+  ASSERT_EQ(0, c->get_rule_weight_osd_map(0, &wm));
+  ASSERT_EQ(3u, wm.size());
+  for (auto& [osd, w] : wm) {
+    EXPECT_FALSE(std::isnan(w)) << "osd." << osd << " weight is nan";
+    EXPECT_EQ(0.0f, w);
+  }
 }
 
 TEST_F(CrushWrapperTest, distance) {


### PR DESCRIPTION
_normalize_weight_map() divides every OSD weight by the sum of the weights of the take(s) it was collected from. When that sum is zero (all the OSDs under the root have crush weight 0) every weight becomes 0/0 = nan, and those weights leak into the callers - among them the read balance score calculation, the mgr balancer (via get_take_weight_osd_map) and PGMap.

All the weights are zero in that case anyway, so just keep them at zero.



## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
