### PR TITLE
mgr/dashboard: fix flaky RGW accounts, users e2e  and language tests 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cd.js
+++ b/src/pybind/mgr/dashboard/frontend/cd.js
@@ -46,11 +46,11 @@ function prepareLocales() {
   }
 
   let langs = process.env.DASHBOARD_FRONTEND_LANGS || '';
-  langs = langs.replace(/\"\'/g, '')
-  if (langs == 'ALL') {
+  langs = langs.replace(/["']/g, '')
+  if (langs === 'ALL') {
     logger(`Preparing build of all languages.`);
     return;
-  } else if (langs.length == 0) {
+  } else if (langs.length === 0) {
     langs = [];
     logger(`Preparing build of EN.`);
   } else {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/accounts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/accounts.po.ts
@@ -130,11 +130,13 @@ export class AccountsPageHelper extends PageHelper {
     cy.get('input#max_access_keys').click().clear().type(account.max_access_keys);
 
     cy.get('input#bucket_checkbox_input').should('be.checked');
+    cy.get('input#bucketunlimitedSize_checkbox_input').uncheck({ force: true });
     cy.get('input#bucket_quota_max_size').clear().type('1234');
     cy.get('input#bucketunlimitedObjects_checkbox_input').uncheck({ force: true });
     cy.get('input#bucket_quota_max_objects').clear().type('200');
 
     cy.get('input#account_checkbox_input').should('be.checked');
+    cy.get('input#accountunlimitedSize_checkbox_input').uncheck({ force: true });
     cy.get('input#account_quota_max_size').clear().type('1234');
     cy.get('input#accountunlimitedObjects_checkbox_input').uncheck({ force: true });
     cy.get('input#account_quota_max_objects').clear().type('200');
@@ -289,6 +291,7 @@ export class AccountsPageHelper extends PageHelper {
       .should('have.text', 'Enter number greater than 0');
 
     cy.get('input#bucket_checkbox_input').should('be.checked');
+    cy.get('input#bucketunlimitedSize_checkbox_input').uncheck({ force: true });
     cy.get('input#bucket_quota_max_size').clear().type('0').blur();
     cy.get('label[for=bucket_quota_max_size]')
       .parent()

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/users.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/users.e2e-spec.ts
@@ -50,7 +50,6 @@ describe('RGW users page', () => {
   });
 
   describe('link user with account test', () => {
-    let account_id: string;
     const user_id = 'account_user';
     const account = {
       name: 'test_account',
@@ -58,22 +57,24 @@ describe('RGW users page', () => {
       tenant: 'tenanted_acc'
     };
 
-    it('should create an account and store account_id', () => {
-      accounts.navigateTo('create');
-      accounts.create(account);
-      accounts.navigateTo();
-      accounts
-        .getTableRow(account.name)
-        .find('td')
-        .eq(2)
-        .invoke('text')
-        .then((acc_id: string) => {
-          cy.log(acc_id);
-          account_id = acc_id;
-        });
+    before(() => {
+      cy.login();
+      cy.request({
+        method: 'POST',
+        url: 'api/rgw/accounts',
+        headers: { Accept: 'application/vnd.ceph.api.v1.0+json' },
+        body: {
+          account_name: account.name,
+          email: account.email,
+          tenant: account.tenant
+        }
+      }).then((resp) => {
+        Cypress.env('account_id', resp.body.id);
+      });
     });
 
     it('should link user with account', () => {
+      const account_id = Cypress.env('account_id');
       users.navigateTo();
       users.navigateTo('create');
       users.linkAccount(account_id, account.name, user_id, account.tenant);


### PR DESCRIPTION
**accounts.po.ts:** uncheck unlimited size before accessing bucket_quota_max_size in edit() and invalidEdit(). The field is hidden by *ngIf when unlimited=true, which is the default when an account is created without an explicit size.

**users.e2e-spec.ts:** replace UI-based account creation in the 'link user with account' suite with a cy.request() API call in a before() hook. The old approach called accounts.create() which made 5+ sequential RGW API calls and exceeded Cypress's 120s timeout after 22 min of prior tests. account_id is now stored via Cypress.env() instead of a JS variable, surviving test retries.

**language.e2e-spec.ts** :  intermittently fails with "Found 1, expected 13" — the language dropdown shows only English:  `cd.js's` quote-stripping `regex /\"\'/g` only removed the pair `"'`, so when CMake passed "ALL" (with quotes), it stayed, langs == 'ALL' failed, and the build made English only -> e2e language test saw 1 language instead of 13. Changed the regex to` /["']/g` so it strips any `"` or` '`, turning "ALL" into 'ALL'.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
