### PR TITLE
rgw/posix: use mtime for version-ids

### DIFF
--- a/src/rgw/driver/posix/fsent.cc
+++ b/src/rgw/driver/posix/fsent.cc
@@ -1253,11 +1253,11 @@ std::unique_ptr<File> MPDirectory::get_part_file(int partnum)
 int MPDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield y,
                             fill_cache_cb_t &cb, uint32_t flags)
 {
-  int ret = FSEnt::fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
+  int ret = FSEnt::fill_cache(dpp, y, cb, flags);
   if (ret < 0)
     return ret;
 
-  return Directory::fill_cache(dpp, y, cb, FSEnt::FLAG_NONE);
+  return Directory::fill_cache(dpp, y, cb, flags);
 }
 
 int VersionedDirectory::open(const DoutPrefixProvider* dpp)
@@ -1393,6 +1393,10 @@ int VersionedDirectory::stat(const DoutPrefixProvider* dpp, bool force)
   if (ret < 0)
     return ret;
 
+  if (force) {
+    cur_version.reset();
+  }
+
   if (cur_version) {
     /* Already have a File for the current version, use it */
     ret = cur_version->stat(dpp);
@@ -1439,10 +1443,12 @@ int VersionedDirectory::stat(const DoutPrefixProvider* dpp, bool force)
       uint16_t flags = 0;
       ceph::decode(flags, bl);
       if (flags & rgw_bucket_dir_entry::FLAG_DELETE_MARKER) {
-        ldpp_dout(dpp, 0) << "ERROR: a delete marker, returning ENOENT "
+        ldpp_dout(dpp, 0) << "INFO: found a delete marker, "
                           << get_name() << dendl;
-        cur_version.reset();
-        return -ENOENT;
+       // cur_version.reset();
+       // return -ENOENT;
+        curr_is_dm = true;
+        return 0;
       }
     }
   }
@@ -1717,6 +1723,7 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
       return ret;
     }
     cur_version = std::move(f);
+    curr_is_dm = true;
     return 0;
   } else {
     /* Delete specific version */
@@ -1783,6 +1790,11 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
     if (ret < 0) {
       return ret;
     }
+    ret = f->stat(dpp);
+    if (ret < 0) {
+      return ret;
+    }
+
     ret = set_cur_version_ent(dpp, f.get());
     if (ret < 0) {
       return ret;

--- a/src/rgw/driver/posix/fsent.cc
+++ b/src/rgw/driver/posix/fsent.cc
@@ -59,6 +59,58 @@ struct OFDLockGuard {
   }
 };
 
+
+/*  Versions */
+
+static std::string to_base36(uint64_t v)
+{
+  if (v == 0) return "0";
+  const char digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+  std::string result;
+  while (v > 0) {
+    result.insert(result.begin(), digits[v % 36]);
+    v /= 36;
+  }
+  return result;
+}
+
+#if 0
+static bool from_base36(const std::string& s, uint64_t& out)
+{
+  out = 0;
+  for (char c : s) {
+    uint64_t d;
+    if (c >= '0' && c <= '9') {
+      d = c - '0';
+    } else if (c >= 'a' && c <= 'z') {
+      d = 10 + (c - 'a');
+    } else {
+      return false;
+    }
+    out = out * 36 + d;
+  }
+  return true;
+}
+#endif
+
+
+static uint64_t statx_mtime_ns(const struct statx& stx)
+{
+  return (uint64_t)stx.stx_mtime.tv_sec * 1000000000ULL
+       + stx.stx_mtime.tv_nsec;
+}
+
+std::string posix_version_id_from_statx(const struct statx& stx)
+{
+  return "mtime-" + to_base36(statx_mtime_ns(stx))
+       + "-ino-" + to_base36(stx.stx_ino);
+}
+
+
+/* Versions ends */
+
+
+
 static int get_x_attrs(optional_yield y, const DoutPrefixProvider* dpp, int fd,
 		       Attrs& attrs, const std::string& display)
 {
@@ -659,7 +711,7 @@ int File::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y, std::s
     return ret;
   }
 
-  ret = stat(dpp);
+  ret = stat(dpp, true);
   if (ret < 0) {
     ldpp_dout(dpp, 20) << "ERROR: POSIXAtomicWriter failed closing file" << dendl;
     return ret;
@@ -1449,7 +1501,25 @@ int VersionedDirectory::link_temp_file(const DoutPrefixProvider *dpp, optional_y
 {
   if (!cur_version)
     return -EINVAL;
-  int ret = cur_version->link_temp_file(dpp, y, temp_fname);
+  // Get the mtime+inode info for the temp file via its fd
+
+  struct statx stx;
+  int ret = statx(cur_version->get_fd(), "", AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH,
+		  STATX_ALL, &stx);
+  if (ret == 0) {
+    std::string ver_id = posix_version_id_from_statx (stx);
+    rgw_obj_key key = decode_obj_key(get_name());
+    key.instance = ver_id;
+    std::string versioned_fname = get_key_fname(key, true);
+    cur_version->set_name(versioned_fname);
+  } else {
+    ret = errno;
+    ldpp_dout(dpp, 0) << "ERROR: could not stat temp file for" << get_name() << ": "
+                      << cpp_strerror(ret) << dendl;
+    return ret;
+  }
+
+  ret = cur_version->link_temp_file(dpp, y, temp_fname);
   if (ret < 0)
     return ret;
 
@@ -1587,6 +1657,17 @@ int VersionedDirectory::add_delete_marker(const DoutPrefixProvider* dpp,
     marker->remove(dpp, y, /*delete_children=*/false, nullptr);
     return ret;
   }
+  struct statx stx;
+  ret = statx(marker->get_fd(), "", AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH,
+		  STATX_ALL, &stx);
+  if (ret < 0) {
+    return ret;
+  }
+  std::string ver_id = posix_version_id_from_statx (stx);
+  rgw_obj_key key = decode_obj_key(get_name());
+  key.instance = ver_id;
+  std::string versioned_fname = get_key_fname(key, true);
+  marker->set_name(versioned_fname);
 
   // Link temp file to final name atomically
   ret = marker->link_temp_file(dpp, y, name);
@@ -1594,6 +1675,9 @@ int VersionedDirectory::add_delete_marker(const DoutPrefixProvider* dpp,
     // removing the temporary files before returning failure
     marker->remove(dpp, y, /*delete_children=*/false, nullptr);
     return ret;
+  }
+  if (instance_id.empty()){
+    instance_id = ver_id;
   }
 
   return 0;
@@ -1626,13 +1710,14 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
     key.instance = gen_rand_instance_name();
     tgtname = get_key_fname(key, /*use_version=*/true);
 
-    result->delete_marker = true;
-    result->version_id = key.instance;
-
     f = std::make_unique<File>(tgtname, this, ctx);
     ret = add_delete_marker(dpp, y, f, tgtname);
     if (ret < 0) {
       return ret;
+    }
+    if (result) {
+      result->delete_marker = true;
+      result->version_id = instance_id;
     }
 
     newlink = true;
@@ -1661,12 +1746,16 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
       }
       bufferlist bl;
       if (get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
-       result->delete_marker = true;
+        if (result) {
+          result->delete_marker = true;
+        }
       }
       ret = f->remove(dpp, y, /*delete_children=*/true, result);
       if (ret < 0)
        return ret;
-      result->version_id = instance_id;
+      if (result) {
+        result->version_id = instance_id;
+      }
     } else {
       return ret;
     }

--- a/src/rgw/driver/posix/fsent.cc
+++ b/src/rgw/driver/posix/fsent.cc
@@ -1863,6 +1863,29 @@ int VersionedDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield
   return 0;
 }
 
+int VersionedDirectory::get_latest_version_ent(const DoutPrefixProvider* dpp, std::unique_ptr<FSEnt> &latest)
+{
+  std::unique_ptr<Symlink> sl = std::make_unique<Symlink>(get_name(), this, ctx);
+  int ret = sl->stat(dpp);
+  if (ret < 0) {
+    if (ret == -ENOENT)
+      return 0;
+    return ret;
+  }
+
+  if (!sl->exists()) {
+    return 0;
+  }
+
+  auto nent = sl->get_target()->clone_base();
+  ret = nent->open(dpp);
+  if (ret < 0) {
+    return 0;
+  }
+  latest.swap(nent);
+  return 0;
+}
+
 std::string VersionedDirectory::get_cur_version()
 {
   if (!cur_version)

--- a/src/rgw/driver/posix/fsent.cc
+++ b/src/rgw/driver/posix/fsent.cc
@@ -1298,6 +1298,7 @@ int VersionedDirectory::create(const DoutPrefixProvider* dpp, bool* existed, boo
     }
   } else if (ret == 0) {
     created = true;
+    cur_version.reset();
   }
   ret = open(dpp);
   if (ret < 0) {

--- a/src/rgw/driver/posix/fsent.cc
+++ b/src/rgw/driver/posix/fsent.cc
@@ -1694,15 +1694,6 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
     return ret;
 
   if (instance_id.empty()) {
-    /* Check if directory is empty */
-    ret = for_each(dpp, [](const char *n) {
-      return -ENOENT;
-    });
-
-    if (ret == 0) {
-      /* We're empty, nuke us */
-      return Directory::remove(dpp, y, /*delete_children=*/true, result);
-    }
 
     /* Add a delete marker */
     std::unique_ptr<File> f;

--- a/src/rgw/driver/posix/fsent.cc
+++ b/src/rgw/driver/posix/fsent.cc
@@ -25,6 +25,7 @@ const std::string MP_OBJ_PART_PFX = "part-";
 const std::string MP_OBJ_HEAD_NAME = MP_OBJ_PART_PFX + "00000";
 const int64_t READ_SIZE = 128 * 1024;
 
+
 namespace posix {
 
 /*
@@ -1299,6 +1300,7 @@ int VersionedDirectory::create(const DoutPrefixProvider* dpp, bool* existed, boo
   } else if (ret == 0) {
     created = true;
     cur_version.reset();
+    cur_is_dm = false;
   }
   ret = open(dpp);
   if (ret < 0) {
@@ -1400,6 +1402,7 @@ int VersionedDirectory::stat(const DoutPrefixProvider* dpp, bool force)
 
   if (force) {
     cur_version.reset();
+    cur_is_dm = false;
   }
 
   if (cur_version) {
@@ -1444,15 +1447,15 @@ int VersionedDirectory::stat(const DoutPrefixProvider* dpp, bool force)
       return ret;
     }
     bufferlist bl;
-    if (get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
-      uint16_t flags = 0;
-      ceph::decode(flags, bl);
-      if (flags & rgw_bucket_dir_entry::FLAG_DELETE_MARKER) {
+    if (get_attr(attrs, RGW_POSIX_ATTR_DELETE_MARKER, bl)) {
+      bool val{false};
+      ceph::decode(val, bl);
+      if (val) {
         ldpp_dout(dpp, 0) << "INFO: found a delete marker, "
                           << get_name() << dendl;
        // cur_version.reset();
        // return -ENOENT;
-        curr_is_dm = true;
+        cur_is_dm = true;
         return 0;
       }
     }
@@ -1656,10 +1659,10 @@ int VersionedDirectory::add_delete_marker(const DoutPrefixProvider* dpp,
   }
 
   buffer::list bl;
-  uint16_t flags = 0;
-  flags |= rgw_bucket_dir_entry::FLAG_DELETE_MARKER;
-  ceph::encode(flags, bl);
-  attrs[RGW_POSIX_ATTR_VERSION] = std::move(bl);
+  bool dm = 0;
+  dm = true;
+  ceph::encode(dm, bl);
+  attrs[RGW_POSIX_ATTR_DELETE_MARKER] = std::move(bl);
 
   // Write attributes before linking
   ret = marker->write_attrs(dpp, y, attrs, nullptr);
@@ -1728,7 +1731,7 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
       return ret;
     }
     cur_version = std::move(f);
-    curr_is_dm = true;
+    cur_is_dm = true;
     return 0;
   } else {
     /* Delete specific version */
@@ -1748,7 +1751,7 @@ int VersionedDirectory::remove(const DoutPrefixProvider* dpp, optional_yield y,
         return ret;
       }
       bufferlist bl;
-      if (get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+      if (get_attr(attrs, RGW_POSIX_ATTR_DELETE_MARKER, bl)) {
         if (result) {
           result->delete_marker = true;
         }
@@ -1859,7 +1862,7 @@ int VersionedDirectory::fill_cache(const DoutPrefixProvider *dpp, optional_yield
         if (ret < 0) {
           return ret;
         }
-        if (get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+        if (get_attr(attrs, RGW_POSIX_ATTR_DELETE_MARKER, bl)) {
           fill_flags |= FSEnt::FLAG_DELETE_MARKER;
         }
       }

--- a/src/rgw/driver/posix/fsent.cc
+++ b/src/rgw/driver/posix/fsent.cc
@@ -1286,6 +1286,7 @@ int VersionedDirectory::open(const DoutPrefixProvider* dpp)
 
 int VersionedDirectory::create(const DoutPrefixProvider* dpp, bool* existed, bool temp_file)
 {
+  bool created{false};
   int ret = mkdirat(parent->get_fd(), fname.c_str(), S_IRWXU);
   if (ret < 0) {
     ret = errno;
@@ -1295,8 +1296,9 @@ int VersionedDirectory::create(const DoutPrefixProvider* dpp, bool* existed, boo
 	  << cpp_strerror(ret) << dendl;
       return -ret;
     }
+  } else if (ret == 0) {
+    created = true;
   }
-
   ret = open(dpp);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: could not open versioned directory " << get_name()
@@ -1304,13 +1306,15 @@ int VersionedDirectory::create(const DoutPrefixProvider* dpp, bool* existed, boo
     return ret;
   }
 
-  /* Need type attribute written */
-  Attrs attrs;
-  ret = write_attrs(dpp, null_yield, attrs, nullptr);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: could not write attrs for versioned directory " << get_name()
-                      << dendl;
-    return ret;
+  if (created) {
+    /* Need type attribute written */
+    Attrs attrs;
+    ret = write_attrs(dpp, null_yield, attrs, nullptr);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: could not write attrs for versioned directory " << get_name()
+                        << dendl;
+      return ret;
+    }
   }
 
   if (temp_file) {

--- a/src/rgw/driver/posix/fsent.h
+++ b/src/rgw/driver/posix/fsent.h
@@ -277,6 +277,7 @@ public:
   virtual std::unique_ptr<FSEnt> clone_base() = 0;
   virtual int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb, uint32_t flags);
   virtual std::string get_cur_version() { return ""; };
+  virtual std::string get_instance() { return ""; };
 };
 
 class File : public FSEnt {
@@ -477,6 +478,7 @@ class VersionedDirectory : public Directory {
 protected:
   std::string instance_id;
   std::unique_ptr<FSEnt> cur_version;
+  bool curr_is_dm{false};
 
 public:
   VersionedDirectory(std::string _name, Directory* _parent, CephContext* _ctx) : Directory(_name, _parent, _ctx)
@@ -516,6 +518,7 @@ public:
   virtual int link_temp_file(const DoutPrefixProvider* dpp, optional_yield y, std::string target_fname) override;
   virtual int remove(const DoutPrefixProvider* dpp, optional_yield y, bool delete_children, DeleteResult* result) override;
   virtual std::string get_cur_version() override;
+  virtual std::string get_instance() override { return instance_id; };
   std::string get_new_instance();
   int remove_symlink(const DoutPrefixProvider *dpp, optional_yield y, std::string match = "");
   int add_file(const DoutPrefixProvider *dpp, std::unique_ptr<FSEnt>&& file, bool* existed = nullptr, bool temp_file = false);
@@ -523,6 +526,7 @@ public:
   FSEnt* get_cur_version_ent() { return cur_version.get(); };
   int set_cur_version_ent(const DoutPrefixProvider *dpp, FSEnt* file);
   int get_latest_version_ent(const DoutPrefixProvider* dpp, std::unique_ptr<FSEnt>& latest);
+  bool curr_is_delete_marker() { return curr_is_dm; };
   virtual std::unique_ptr<FSEnt> clone_base() override {
     return std::make_unique<VersionedDirectory>(*this);
   }

--- a/src/rgw/driver/posix/fsent.h
+++ b/src/rgw/driver/posix/fsent.h
@@ -522,6 +522,7 @@ public:
   int add_delete_marker(const DoutPrefixProvider* dpp, optional_yield y, std::unique_ptr<File>& marker, const std::string &name);
   FSEnt* get_cur_version_ent() { return cur_version.get(); };
   int set_cur_version_ent(const DoutPrefixProvider *dpp, FSEnt* file);
+  int get_latest_version_ent(const DoutPrefixProvider* dpp, std::unique_ptr<FSEnt>& latest);
   virtual std::unique_ptr<FSEnt> clone_base() override {
     return std::make_unique<VersionedDirectory>(*this);
   }

--- a/src/rgw/driver/posix/fsent.h
+++ b/src/rgw/driver/posix/fsent.h
@@ -257,6 +257,7 @@ public:
 
   int get_fd() { return fd; };
   std::string& get_name() { return fname; }
+  void set_name(const std::string& name) { fname = name; }
   Directory* get_parent() { return parent; }
   bool exists() { return exist; }
   struct statx& get_stx() { return stx; }
@@ -535,6 +536,7 @@ public:
 };
 
 std::string get_key_fname(rgw_obj_key& key, bool use_version);
+std::string posix_version_id_from_statx(const struct statx& stx);
 
 } // namespace posix
 } } // namespace rgw::sal

--- a/src/rgw/driver/posix/fsent.h
+++ b/src/rgw/driver/posix/fsent.h
@@ -32,12 +32,12 @@ class POSIXObject;
 using DeleteResult = rgw::sal::Object::DeleteOp::Result;
 
 extern const std::string ATTR_PREFIX;
-#define RGW_POSIX_ATTR_BUCKET_INFO "POSIX-Bucket-Info"
-#define RGW_POSIX_ATTR_MPUPLOAD "POSIX-Multipart-Upload"
-#define RGW_POSIX_ATTR_OBJECT_TYPE "POSIX-Object-Type"
-#define RGW_POSIX_ATTR_VERSION "POSIX-version"
-#define RGW_POSIX_ATTR_MULTIPART_PART_COUNT "POSIX-Multipart-Part-Count"
-#define RGW_POSIX_ATTR_MULTIPART_TOTAL_SIZE "POSIX-Multipart-Total-Size"
+#define RGW_POSIX_ATTR_BUCKET_INFO "bucket-info"
+#define RGW_POSIX_ATTR_MPUPLOAD "multipart-upload"
+#define RGW_POSIX_ATTR_OBJECT_TYPE "object-type"
+#define RGW_POSIX_ATTR_DELETE_MARKER "delete-marker"
+#define RGW_POSIX_ATTR_MULTIPART_PART_COUNT "multipart-part-count"
+#define RGW_POSIX_ATTR_MULTIPART_TOTAL_SIZE "multipart-total-size"
 extern const std::string mp_ns;
 extern const std::string MP_OBJ_PART_PFX;
 extern const std::string MP_OBJ_HEAD_NAME;
@@ -478,7 +478,7 @@ class VersionedDirectory : public Directory {
 protected:
   std::string instance_id;
   std::unique_ptr<FSEnt> cur_version;
-  bool curr_is_dm{false};
+  bool cur_is_dm{false};
 
 public:
   VersionedDirectory(std::string _name, Directory* _parent, CephContext* _ctx) : Directory(_name, _parent, _ctx)
@@ -526,7 +526,7 @@ public:
   FSEnt* get_cur_version_ent() { return cur_version.get(); };
   int set_cur_version_ent(const DoutPrefixProvider *dpp, FSEnt* file);
   int get_latest_version_ent(const DoutPrefixProvider* dpp, std::unique_ptr<FSEnt>& latest);
-  bool curr_is_delete_marker() { return curr_is_dm; };
+  bool cur_is_delete_marker() { return cur_is_dm; };
   virtual std::unique_ptr<FSEnt> clone_base() override {
     return std::make_unique<VersionedDirectory>(*this);
   }

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2070,17 +2070,28 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
   }
 
   int ret = stat(dpp);
-  if (ret < 0) {
-      if (ret == -ENOENT) {
-	// Nothing to do
-	return 0;
-      }
-      return ret;
-  }
-  ret = ent->remove(dpp, y, /*delete_children=*/false, &del_result);
 
   cls_rgw_obj_key key;
   get_key().get_index_key(&key);
+
+  if (ret == -ENOENT) {
+    if (!versioned() || !key.instance.empty() ) {
+      // Nothing to do
+      return 0;
+    }
+    // A delete marker must be created even if the key does not exist
+    // Create the versioned directory and create a delete marker
+    ret = make_ent(posix::ObjectType::VERSIONED);
+    if (ret < 0) {
+      return ret;
+    }
+    ret = ent->create(dpp, nullptr, false);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: could not create " << ent->get_name() << dendl;
+      return ret;
+    }
+  }
+  ret = ent->remove(dpp, y, /*delete_children=*/false, &del_result);
 
   driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
 

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2074,6 +2074,32 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
   cls_rgw_obj_key key;
   get_key().get_index_key(&key);
 
+
+  if (!versioned()) {
+    if (ret == -ENOENT) {
+      return 0;
+    }
+    ret = ent->remove(dpp, y, /*delete_children=*/false, &del_result);
+
+    if (ret < 0) {
+      return ret;
+    }
+    driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
+    driver->get_quota_handler()->update_stats(b->get_owner(), b->get_key(),
+                                              -1, 0, state.accounted_size);
+    return 0;
+  }
+
+  bool created = false;
+  auto* vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
+  // Versioned bucket
+  if (vd_ent && !vd_ent->get_cur_version_ent()) {
+    if (!key.instance.empty()) {
+      // Nothing to do
+      return 0;
+    }
+  }
+
   if (ret == -ENOENT) {
     if (!versioned() || !key.instance.empty() ) {
       // Nothing to do

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2094,7 +2094,7 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
   bool created = false;
   auto* vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
 
-  if (!vd_ent){
+  if (key.instance.empty() && !vd_ent){
     // A delete marker must be created even if the key does not exist
     // Create the versioned directory in order to be able to create a delete marker
     ret = make_ent(posix::ObjectType::VERSIONED);
@@ -2109,6 +2109,10 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
     }
     created = true;
     vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
+  }
+
+  if (!vd_ent) {
+    return 0;
   }
 
   bool update_cur_version = false;
@@ -2719,6 +2723,7 @@ int POSIXObject::stat(const DoutPrefixProvider* dpp)
     auto* vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
     if (vd_ent && vd_ent->curr_is_delete_marker()) {
       state.exists = false;
+      state.is_dm = true;
       return -ENOENT;
     }
   }
@@ -2835,6 +2840,7 @@ int POSIXObject::link_temp_file(const DoutPrefixProvider *dpp, optional_yield y)
   if (ret < 0)
     return ret;
 
+  state.obj.key.set_instance(ent->get_cur_version());
   POSIXBucket *b = static_cast<POSIXBucket *>(get_bucket());
   if (!b) {
     ldpp_dout(dpp, 0) << "ERROR: could not get bucket for " << get_name()
@@ -3866,6 +3872,7 @@ int POSIXAtomicWriter::complete(size_t accounted_size, const std::string& etag,
 {
   int ret;
   uint64_t orig_size = 0;
+
   auto exists = obj->check_exists(dpp);
   if (exists) {
     orig_size = obj->get_size();

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2169,7 +2169,7 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
         Attrs attrs;
         bufferlist bl;
         if (old_cur_ent->read_attrs(dpp, y, attrs) >= 0 &&
-            ::rgw::sal::posix::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+            ::rgw::sal::posix::get_attr(attrs, RGW_POSIX_ATTR_DELETE_MARKER, bl)) {
           fill_flags |= posix::FSEnt::FLAG_DELETE_MARKER;
         }
         old_cur_ent->fill_cache( dpp, null_yield,
@@ -2195,7 +2195,7 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
         Attrs attrs;
         bufferlist bl;
         if (cur_ent->read_attrs(dpp, y, attrs) >= 0 &&
-            ::rgw::sal::posix::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+            ::rgw::sal::posix::get_attr(attrs, RGW_POSIX_ATTR_DELETE_MARKER, bl)) {
           fill_flags |= posix::FSEnt::FLAG_DELETE_MARKER;
         }
         cur_ent->fill_cache( dpp, null_yield,
@@ -2721,7 +2721,7 @@ int POSIXObject::stat(const DoutPrefixProvider* dpp)
 
   if (ent->get_type() == posix::ObjectType::VERSIONED) {
     auto* vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
-    if (vd_ent && vd_ent->curr_is_delete_marker()) {
+    if (vd_ent && vd_ent->cur_is_delete_marker()) {
       state.exists = false;
       state.is_dm = true;
       return -ENOENT;

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -1540,16 +1540,16 @@ int POSIXBucket::list(const DoutPrefixProvider* dpp, ListParams& params,
     return 0;
   }
 
-int count{0};
-bool in_prefix{false};
-// Names in the cache are in OID format
-rgw_obj_key marker_key(params.marker);
-params.marker = marker_key.get_oid();
-{
-  rgw_obj_key key(params.prefix);
-  params.prefix = key.name;
-}
-if (max <= 0) {
+  int count{0};
+  bool in_prefix{false};
+  // Names in the cache are in OID format
+  rgw_obj_key marker_key(params.marker);
+  params.marker = marker_key.get_oid();
+  {
+    rgw_obj_key key(params.prefix);
+    params.prefix = key.name;
+  }
+  if (max <= 0) {
     return 0;
   }
 
@@ -1560,6 +1560,7 @@ if (max <= 0) {
 	std::string ns;
 	// bde.key can be encoded with the namespace.  Decode it here
 	rgw_obj_key bde_key{bde.key};
+
 	if (!params.list_versions && !bde.is_visible()) {
 	  return true;
 	}
@@ -2092,79 +2093,113 @@ int POSIXObject::delete_object(const DoutPrefixProvider* dpp,
 
   bool created = false;
   auto* vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
-  // Versioned bucket
-  if (vd_ent && !vd_ent->get_cur_version_ent()) {
-    if (!key.instance.empty()) {
-      // Nothing to do
-      return 0;
-    }
-  }
 
-  if (ret == -ENOENT) {
-    if (!versioned() || !key.instance.empty() ) {
-      // Nothing to do
-      return 0;
-    }
+  if (!vd_ent){
     // A delete marker must be created even if the key does not exist
-    // Create the versioned directory and create a delete marker
+    // Create the versioned directory in order to be able to create a delete marker
     ret = make_ent(posix::ObjectType::VERSIONED);
     if (ret < 0) {
       return ret;
     }
+
     ret = ent->create(dpp, nullptr, false);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << "ERROR: could not create " << ent->get_name() << dendl;
       return ret;
     }
+    created = true;
+    vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
   }
+
+  bool update_cur_version = false;
+  std::string remove_ver_id = ent->get_instance();
+
+  std::unique_ptr<posix::FSEnt> old_cur_ent;
+  // The cur version exists
+  if (!created && !key.instance.empty()) {
+    ret = vd_ent->get_latest_version_ent(dpp, old_cur_ent);
+    if (ret < 0) {
+      return ret;
+    }
+    if (old_cur_ent){
+      old_cur_ent->stat(dpp, true);
+    }
+  }
+
+  // A new delete maker will be created
+  if (old_cur_ent && remove_ver_id.empty()) {
+    update_cur_version = true;
+  }
+
   ret = ent->remove(dpp, y, /*delete_children=*/false, &del_result);
+  if (ret < 0) {
+    return ret;
+  }
 
-  driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
+  if ((ent->get_type() == posix::ObjectType::VERSIONED) && !remove_ver_id.empty())  {
+    // key.instance will be the same as ent->instance_id
+    driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
+  }
 
+
+  // Last version was removed
   if (!key.instance.empty() && !ent->exists()) {
     /* Remove the non-versioned key as well */
     key.instance.clear();
     driver->get_bucket_cache()->remove_entry(dpp, b->get_name(), key);
+    driver->get_quota_handler()->update_stats(b->get_owner(), b->get_key(),
+                                            -1, 0, state.accounted_size);
+    return 0;
   }
 
   /* after removing a versioned entry, the current version may have
    * changed — if the symlink now points to a delete marker, update
    * its cache entry to add FLAG_CURRENT so the LC can expire it */
-  if (!get_key().instance.empty() && ent->get_parent()) {
-    auto* vdir = dynamic_cast<posix::VersionedDirectory*>(ent->get_parent());
-    if (vdir) {
-      std::unique_ptr<posix::Symlink> sl =
-	std::make_unique<posix::Symlink>(vdir->get_name(), vdir, driver->ctx());
-      if (sl->stat(dpp) >= 0 && sl->exists()) {
-	auto* target = sl->get_target();
-	std::string cur_name = target->get_name();
-	if (!cur_name.empty()) {
-	  std::unique_ptr<posix::FSEnt> cur_ent;
-	  ret = vdir->get_ent(dpp, y, cur_name, std::string(), cur_ent);
-	  if (ret == 0) {
-	    cur_ent->stat(dpp);
-	    rgw_bucket_dir_entry bde{};
-	    rgw_obj_key cur_key = posix::decode_obj_key(cur_name);
-	    cur_key.get_index_key(&bde.key);
-	    bde.flags = rgw_bucket_dir_entry::FLAG_VER
-	      | rgw_bucket_dir_entry::FLAG_CURRENT;
-	    bde.ver.pool = 1;
-	    bde.ver.epoch = 1;
-	    bde.exists = true;
-	    bde.meta.mtime = from_statx_timestamp(cur_ent->get_stx().stx_mtime);
-	    bde.meta.size = cur_ent->get_stx().stx_size;
-	    bde.meta.accounted_size = bde.meta.size;
-	    if (bde.meta.size == 0) {
-	      Attrs attrs;
-	      bufferlist bl;
-	      if (cur_ent->read_attrs(dpp, y, attrs) >= 0 &&
-		  posix::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
-		bde.flags |= rgw_bucket_dir_entry::FLAG_DELETE_MARKER;
-	      }
-	    }
-	    driver->get_bucket_cache()->add_entry(dpp, b->get_name(), bde);
-	  }
-	}
+
+  if (update_cur_version) {
+    if (old_cur_ent) {
+      std::string old_cur_name = old_cur_ent->get_name();
+      if (!old_cur_name.empty()) {
+        old_cur_ent->stat(dpp);
+        uint32_t fill_flags = posix::FSEnt::FLAG_NONE;
+        Attrs attrs;
+        bufferlist bl;
+        if (old_cur_ent->read_attrs(dpp, y, attrs) >= 0 &&
+            ::rgw::sal::posix::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+          fill_flags |= posix::FSEnt::FLAG_DELETE_MARKER;
+        }
+        old_cur_ent->fill_cache( dpp, null_yield,
+          [&](const DoutPrefixProvider *dpp, rgw_bucket_dir_entry &bde) -> int {
+          driver->get_bucket_cache()->add_entry(dpp, b->get_name(), bde);
+          return 0;
+        }, fill_flags);
+      }
+    }
+  }
+  if (vd_ent) {
+    std::unique_ptr<posix::FSEnt> new_cur_ent;
+    ret = vd_ent->get_latest_version_ent(dpp, new_cur_ent);
+    if (ret < 0) {
+      return ret;
+    }
+    auto *cur_ent = new_cur_ent.get();
+    if (cur_ent) {
+      std::string cur_name = cur_ent->get_name();
+      if (!cur_name.empty()) {
+        cur_ent->stat(dpp);
+        uint32_t fill_flags = posix::FSEnt::FLAG_CURRENT;
+        Attrs attrs;
+        bufferlist bl;
+        if (cur_ent->read_attrs(dpp, y, attrs) >= 0 &&
+            ::rgw::sal::posix::get_attr(attrs, RGW_POSIX_ATTR_VERSION, bl)) {
+          fill_flags |= posix::FSEnt::FLAG_DELETE_MARKER;
+        }
+        cur_ent->fill_cache( dpp, null_yield,
+          [&](const DoutPrefixProvider *dpp, rgw_bucket_dir_entry &bde) -> int {
+          driver->get_bucket_cache()->add_entry(dpp, b->get_name(), bde);
+        return 0;
+      }, fill_flags);
+
       }
     }
   }
@@ -2649,6 +2684,11 @@ int POSIXObject::set_cur_version(const DoutPrefixProvider *dpp)
   }
 
   ret = vdir->set_cur_version_ent(dpp, child.get());
+  if (ret < 0) {
+    return ret;
+  }
+
+  ret = vdir->stat(dpp, true);
   return ret;
 }
 
@@ -2673,6 +2713,14 @@ int POSIXObject::stat(const DoutPrefixProvider* dpp)
 
   if (state.obj.key.instance.empty()) {
     state.obj.key.instance = ent->get_cur_version();
+  }
+
+  if (ent->get_type() == posix::ObjectType::VERSIONED) {
+    auto* vd_ent = static_cast<posix::VersionedDirectory*>(ent.get());
+    if (vd_ent && vd_ent->curr_is_delete_marker()) {
+      state.exists = false;
+      return -ENOENT;
+    }
   }
 
   state.exists = ent->exists();
@@ -3602,6 +3650,12 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
 
   // remove staging directory listing cache entry (frees LMDB DBI slot)
   driver->get_bucket_cache()->invalidate_bucket(dpp, shadow_cache_name, true);
+  to->stat(dpp);
+  to->fill_cache( nullptr, null_yield,
+      [&](const DoutPrefixProvider *dpp, rgw_bucket_dir_entry &bde) -> int {
+	driver->get_bucket_cache()->add_entry(dpp, sb->get_name(), bde);
+	return 0;
+      });
 
   return 0;
 }

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -1425,6 +1425,77 @@ void POSIXDriver::meta_list_keys_complete(void* handle)
   return;
 }
 
+/* LMDB comparator for versioned bucket listing.
+ * Key format: name \0 instance.
+ * Sort: name ascending, then instance descending (newest version first).
+ * Instance is "mtime-{base36}-ino-{base36}" — we extract and compare
+ * the mtime numerically for correct ordering regardless of base36 width. */
+static int posix_lmdb_cmp(const MDB_val *a, const MDB_val *b)
+{
+  std::string_view sa(static_cast<const char*>(a->mv_data), a->mv_size);
+  std::string_view sb(static_cast<const char*>(b->mv_data), b->mv_size);
+
+  auto sep_a = sa.find('\0');
+  auto sep_b = sb.find('\0');
+  std::string_view name_a = sa.substr(0, sep_a);
+  std::string_view name_b = sb.substr(0, sep_b);
+
+  int cmp = name_a.compare(name_b);
+  if (cmp != 0) {
+    return cmp;
+  }
+
+  /* same name — compare instances in reverse (newest first) */
+  std::string_view inst_a = (sep_a != std::string_view::npos)
+    ? sa.substr(sep_a + 1) : std::string_view{};
+  std::string_view inst_b = (sep_b != std::string_view::npos)
+    ? sb.substr(sep_b + 1) : std::string_view{};
+
+  /* empty instance (non-versioned) sorts before any version */
+  if (inst_a.empty() && inst_b.empty()) { return 0; }
+  if (inst_a.empty()) { return -1; }
+  if (inst_b.empty()) { return 1; }
+
+  /* extract mtime from "mtime-{base36}-ino-{base36}" */
+  auto extract_mtime = [](std::string_view inst) -> uint64_t {
+    static constexpr std::string_view pfx = "mtime-";
+    static constexpr std::string_view sep = "-ino-";
+    if (inst.substr(0, pfx.size()) != pfx) {
+      return 0;
+    }
+    auto ino_pos = inst.find(sep, pfx.size());
+    if (ino_pos == std::string_view::npos) {
+      return 0;
+    }
+    uint64_t val = 0;
+    for (size_t i = pfx.size(); i < ino_pos; ++i) {
+      char c = inst[i];
+      uint64_t d;
+      if (c >= '0' && c <= '9') { d = c - '0'; }
+      else if (c >= 'a' && c <= 'z') { d = 10 + (c - 'a'); }
+      else { return 0; }
+      val = val * 36 + d;
+    }
+    return val;
+  };
+
+  uint64_t mt_a = extract_mtime(inst_a);
+  uint64_t mt_b = extract_mtime(inst_b);
+
+  /* descending: larger mtime sorts first */
+  if (mt_a > mt_b) { return -1; }
+  if (mt_a < mt_b) { return 1; }
+
+  /* same mtime — compare full instance for determinism */
+  return inst_b.compare(inst_a);
+}
+
+
+MDB_cmp_func* POSIXBucket::lmdb_cmp()
+{
+  return posix_lmdb_cmp;
+}
+
 int POSIXBucket::fill_cache(const DoutPrefixProvider* dpp, optional_yield y,
                             fill_cache_cb_t& cb)
 {
@@ -3462,6 +3533,21 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
   // save shadow name before rename changes info.bucket.name
   std::string shadow_cache_name = shadow->get_name();
 
+  // If versioned, update the version id in the POSIXObject to the mtime+inode
+  // so the directory will be renamed to the correct name.
+
+  POSIXObject *to = static_cast<POSIXObject*>(target_obj);
+  POSIXBucket *sb = static_cast<POSIXBucket*>(target_obj->get_bucket());
+
+  if (sb->versioned()) {
+    auto *shadow_dir = shadow->get_dir();
+    ret = shadow_dir->stat(dpp, true);
+    struct statx f_stx = shadow_dir->get_stx();
+    std::string ver_id = posix::posix_version_id_from_statx (f_stx);
+    to->set_instance_id(ver_id);
+  }
+
+
   // Rename to target_obj
   ret = shadow->rename(dpp, y, target_obj);
   if (ret < 0) {
@@ -3470,8 +3556,6 @@ int POSIXMultipartUpload::complete(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  POSIXObject *to = static_cast<POSIXObject*>(target_obj);
-  POSIXBucket *sb = static_cast<POSIXBucket*>(target_obj->get_bucket());
   if (sb->versioned()) {
     ret = to->set_cur_version(dpp);
     if (ret < 0) {

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -708,7 +708,7 @@ public:
   /* enumerate all entries by callback, in any order */
   int fill_cache(const DoutPrefixProvider* dpp, optional_yield y, fill_cache_cb_t& cb);
 
-  static MDB_cmp_func* lmdb_cmp() { return nullptr; }
+  static MDB_cmp_func* lmdb_cmp();
 
 private:
   int write_attrs(const DoutPrefixProvider *dpp, optional_yield y);
@@ -882,6 +882,7 @@ public:
   int make_ent(posix::ObjectType type);
   bool versioned() { return bucket->versioned(); }
   DeleteResult get_result() {return del_result;}
+  void set_instance_id(const std::string& instance) { state.obj.key.set_instance(instance); };
 
 protected:
   int read(int64_t ofs, int64_t end, bufferlist& bl, const DoutPrefixProvider* dpp, optional_yield y);

--- a/src/test/rgw/test_rgw_posix_driver.cc
+++ b/src/test/rgw/test_rgw_posix_driver.cc
@@ -25,7 +25,7 @@ using namespace rgw::sal;
 const std::string ATTR1{"attr1"};
 const std::string ATTR2{"attr2"};
 const std::string ATTR3{"attr3"};
-const std::string ATTR_OBJECT_TYPE{"POSIX-Object-Type"};
+const std::string ATTR_OBJECT_TYPE{"object-type"};
 
 namespace sf = std::filesystem;
 class Environment* env;
@@ -68,7 +68,29 @@ public:
   }
 };
 
+static std::string to_base36(uint64_t v)
+{
+  if (v == 0) return "0";
+  const char digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+  std::string result;
+  while (v > 0) {
+    result.insert(result.begin(), digits[v % 36]);
+    v /= 36;
+  }
+  return result;
+}
 
+static uint64_t statx_mtime_ns(const struct statx& stx)
+{
+  return (uint64_t)stx.stx_mtime.tv_sec * 1000000000ULL
+       + stx.stx_mtime.tv_nsec;
+}
+
+static std::string posix_version_id_from_statx(const struct statx& stx)
+{
+  return "mtime-" + to_base36(statx_mtime_ns(stx))
+       + "-ino-" + to_base36(stx.stx_ino);
+}
 static inline void add_attr(Attrs& attrs, const std::string& name, const std::string& value)
 {
   bufferlist bl;
@@ -831,8 +853,22 @@ TEST(FSEnt, VerDirBase)
   EXPECT_EQ(ret, 0);
   EXPECT_EQ(ent->get_type(), posix::ObjectType::VERSIONED);
 
-  ret = testdir->remove(env->dpp, null_yield, false, nullptr);
+  // This will create a delete marker
+  struct rgw::sal::Object::DeleteOp::Result result;
+  ret = testdir->remove(env->dpp, null_yield, false, &result);
   EXPECT_EQ(ret, 0);
+
+  std::unique_ptr<posix::VersionedDirectory> testdir2 = std::make_unique<posix::VersionedDirectory>(dirname, root.get(),
+                                                 result.version_id, env->cct.get());
+
+  ret = testdir2->open(env->dpp);
+  EXPECT_EQ(ret, 0);
+  EXPECT_GT(testdir2->get_fd(), 0);
+
+  // remove the delete marker
+  ret = testdir2->remove(env->dpp, null_yield, false, nullptr);
+  EXPECT_EQ(ret, 0);
+
   EXPECT_FALSE(sf::exists(tp));
 }
 
@@ -844,7 +880,6 @@ TEST(FSEnt, VerDirReadWrite)
   std::string instance_id{verdir->get_new_instance()};
   std::string vfname{"_%3A" + instance_id + "_" + fname};
   sf::path tp{base_path / fname};
-  sf::path fp{tp / vfname};
   sf::path lp{tp / fname};
 
   int ret = verdir->create(env->dpp, /*existed=*/nullptr, /*temp_file=*/false);
@@ -856,13 +891,20 @@ TEST(FSEnt, VerDirReadWrite)
 
   std::string temp_fname{fname + "-blargh"};
   ret = verdir->link_temp_file(env->dpp, null_yield, temp_fname);
+
+  posix::FSEnt* cur = verdir->get_cur_version_ent();
+  ret = cur->stat(env->dpp, true);
+  std::string ver_id = posix_version_id_from_statx(cur->get_stx());
+  std::string vfname2{"_%3A" + ver_id + "_" + fname};
+  sf::path fp{tp / vfname2};
+
   EXPECT_TRUE(sf::exists(tp));
   EXPECT_TRUE(sf::is_directory(tp));
   EXPECT_TRUE(sf::exists(fp));
   EXPECT_TRUE(sf::is_regular_file(fp));
   EXPECT_TRUE(sf::exists(lp));
   EXPECT_TRUE(sf::is_symlink(lp));
-  EXPECT_EQ(sf::read_symlink(lp), vfname);
+  EXPECT_EQ(sf::read_symlink(lp), vfname2);
 
   bufferlist bl;
   encode(fname, bl);
@@ -950,6 +992,7 @@ TEST(FSEnt, MPVerDirReadWrite)
 
   std::string temp_fname{testname + "-blargh"};
   ret = verdir->link_temp_file(env->dpp, null_yield, temp_fname);
+
   EXPECT_TRUE(sf::exists(vp));
   EXPECT_TRUE(sf::is_directory(vp));
   EXPECT_TRUE(sf::exists(mp));
@@ -1904,7 +1947,12 @@ TEST_F(POSIXBucketTest, VersionedObjectWrite)
   EXPECT_TRUE(sf::exists(tp));
   EXPECT_TRUE(sf::is_directory(tp));
 
-  std::string vfname{"_%3A" + inst_id + "_" + testname};
+  POSIXObject* px_obj = static_cast<POSIXObject *>(object.get());
+  ret = px_obj->stat(env->dpp);
+  posix::VersionedDirectory *vdir = static_cast<posix::VersionedDirectory*>(px_obj->get_fsent());
+
+  std::string ver_id = vdir->get_cur_version();
+  std::string vfname{"_%3A" + ver_id + "_" + testname};
   sf::path op{tp / vfname};
   EXPECT_TRUE(sf::exists(op));
   EXPECT_TRUE(sf::is_regular_file(op));
@@ -1960,7 +2008,12 @@ TEST_F(POSIXBucketTest, VersionedObjectWrite)
   EXPECT_TRUE(sf::exists(tp));
   EXPECT_TRUE(sf::is_directory(tp));
 
-  vfname = "_%3A" + inst_id + "_" + testname;
+  px_obj = static_cast<POSIXObject *>(obj2.get());
+  ret = px_obj->stat(env->dpp);
+  posix::VersionedDirectory *vdir2 = static_cast<posix::VersionedDirectory*>(px_obj->get_fsent());
+  ver_id = vdir2->get_cur_version();
+
+  vfname = "_%3A" + ver_id + "_" + testname;
   sf::path o2p{tp / vfname};
   EXPECT_TRUE(sf::exists(o2p));
   EXPECT_TRUE(sf::is_regular_file(o2p));
@@ -1975,7 +2028,7 @@ TEST_F(POSIXBucketTest, VersionedObjectWrite)
   std::unique_ptr<rgw::sal::Object::ReadOp> read_op(robj->get_read_op());
   ret = read_op->prepare(null_yield, env->dpp);
   EXPECT_EQ(ret, 0);
-  EXPECT_EQ(robj->get_key().instance, inst_id);
+  EXPECT_EQ(robj->get_key().instance, ver_id);
 }
 
 class POSIXVerObjectTest : public POSIXBucketTest {
@@ -2441,8 +2494,6 @@ public:
     owner.id = bucket->get_owner();
     mp_obj->gen_rand_obj_instance_name();
     std::string inst_id = mp_obj->get_instance();
-    std::string vfname{"_%3A" + inst_id + "_" + objname};
-    sf::path op{bp / "root" / testname / objname / vfname };
 
     int ret = upload->complete(env->dpp, null_yield, get_pointer(env->cct), parts,
                                remove_objs, accounted_size, compressed, cs_info,
@@ -2450,6 +2501,12 @@ public:
     EXPECT_EQ(ret, 0);
     EXPECT_EQ(write_size, ofs);
     EXPECT_EQ(write_size, accounted_size);
+
+    rgw_obj_key key;
+    auto posix_mp_obj = static_cast<POSIXObject*>(mp_obj.get());
+    posix::FSEnt *fs = posix_mp_obj->get_fsent();
+    std::string vfname{"_%3A" + fs->get_cur_version() + "_" + objname};
+    sf::path op{bp / "root" / testname / objname / vfname };
     EXPECT_TRUE(sf::exists(op));
     EXPECT_TRUE(sf::is_directory(op));
 


### PR DESCRIPTION
Replace the counter based versioning scheme with one that uses the mtime and inode of the object file.
Copied from the nsfs code.

Credit: Matt Benjamin <mbenjamin@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
