### PR TITLE
tentacle: os/bluestore: Skip unconfigured allocators in free-score

### DIFF
--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -233,9 +233,11 @@ void super_dump(
   delete fs;
 }
 
-void inferring_bluefs_devices(vector<string>& devs, std::string& path)
+void inferring_bluefs_devices(vector<string>& devs, std::string& path, bool verbose = true)
 {
-  cout << "inferring bluefs devices from bluestore path" << std::endl;
+  if (verbose) {
+    cout << "inferring bluefs devices from bluestore path" << std::endl;
+  }
   for (auto fn : {"block", "block.wal", "block.db"}) {
     string p = path + "/" + fn;
     struct stat st;
@@ -1221,8 +1223,24 @@ int main(int argc, char **argv)
       cerr << "error from cold_open: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
     }
+    
+    // Device inference is sufficient here, as
+    // cold_open() has already initialized the allocators.
+    vector<string> present_devs;
+    inferring_bluefs_devices(present_devs, path, false);
+    auto device_present = [&](const string& alloc_name) {
+      string suffix = (alloc_name == "bluefs-wal") ? "block.wal" :
+                      (alloc_name == "bluefs-db")  ? "block.db"  : "block";
+      return std::any_of(present_devs.begin(), present_devs.end(),
+                         [&](const string& dev) {
+                           return dev.ends_with(suffix);
+                         });
+    };
 
     for (auto alloc_name : allocs_name) {
+      if (!device_present(alloc_name)) {
+        continue;
+      }	    
       ceph::bufferlist in, out;
       ostringstream err;
       int r = admin_socket->execute_command(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79703

---

backport of https://github.com/ceph/ceph/pull/69635
parent tracker: https://tracker.ceph.com/issues/77462

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh