### PR TITLE
doc: cross-link the parallel deployment procedures

### DIFF
--- a/doc/cephadm/services/mon.rst
+++ b/doc/cephadm/services/mon.rst
@@ -234,4 +234,5 @@ Further Reading
 * :ref:`rados-operations`
 * :ref:`rados-troubleshooting-mon`
 * :ref:`cephadm-restore-quorum`
+* :ref:`adding-and-removing-monitors` (clusters not managed by cephadm)
 

--- a/doc/cephadm/services/osd.rst
+++ b/doc/cephadm/services/osd.rst
@@ -1317,3 +1317,4 @@ Further Reading
 
 * :ref:`ceph-volume`
 * :ref:`rados-index`
+* :ref:`adding-and-removing-osds` (clusters not managed by cephadm)

--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -4,6 +4,13 @@
  Manual Deployment
 ===================
 
+.. note:: This page describes deploying a cluster entirely by hand,
+   without cephadm. Manual deployment is intended mainly for
+   developers of deployment tools and for environments where cephadm
+   cannot be used. For production clusters, the recommended method is
+   :ref:`cephadm <cephadm_deploying_new_cluster>`; see
+   :ref:`install-overview` for all installation methods.
+
 All Ceph clusters require at least one monitor, and at least as many OSDs as
 copies of an object stored on the cluster.  Bootstrapping the initial monitor(s)
 is the first step in deploying a Ceph Storage Cluster. Monitor deployment also
@@ -355,6 +362,8 @@ Manager daemon configuration
 On each node where you run a ceph-mon daemon, you should also set up a ceph-mgr daemon.
 
 See :ref:`mgr-administrator-guide`
+
+.. _manual-deployment-adding-osds:
 
 Adding OSDs
 ===========

--- a/doc/install/manual-freebsd-deployment.rst
+++ b/doc/install/manual-freebsd-deployment.rst
@@ -1,6 +1,14 @@
+.. _manual-freebsd-deployment:
+
 ==============================
  Manual Deployment on FreeBSD
 ==============================
+
+.. note:: cephadm is not available on FreeBSD, so manual deployment
+   is the supported method on that platform. On Linux, the
+   recommended method is :ref:`cephadm
+   <cephadm_deploying_new_cluster>` instead of the procedures
+   described here.
 
 This a largely a copy of the regular Manual Deployment with FreeBSD specifics.
 The difference lies in two parts: the underlying disk format, and the way to use

--- a/doc/install/manual-freebsd-deployment.rst
+++ b/doc/install/manual-freebsd-deployment.rst
@@ -5,10 +5,10 @@
 ==============================
 
 .. note:: cephadm is not available on FreeBSD, so manual deployment
-   is the supported method on that platform. On Linux, the
-   recommended method is :ref:`cephadm
-   <cephadm_deploying_new_cluster>` instead of the procedures
-   described here.
+   is necessary on that platform. Note that FreeBSD is not supported
+   by the core Ceph effort. On Linux, the recommended method is
+   :ref:`cephadm <cephadm_deploying_new_cluster>` instead of the
+   procedures described here.
 
 This a largely a copy of the regular Manual Deployment with FreeBSD specifics.
 The difference lies in two parts: the underlying disk format, and the way to use

--- a/doc/rados/operations/add-or-rm-mons.rst
+++ b/doc/rados/operations/add-or-rm-mons.rst
@@ -4,6 +4,13 @@
  Adding/Removing Monitors
 ==========================
 
+.. note:: The procedures on this page are for clusters that are not
+   managed by cephadm. In a cephadm-managed cluster, Monitors are
+   added and removed through the orchestrator: see
+   :ref:`deploy_additional_monitors`. Using the procedures below on a
+   cephadm-managed cluster will conflict with the orchestrator's own
+   management of the daemons.
+
 It is possible to add Monitors to a running cluster as long as redundancy is
 maintained. To bootstrap a Monitor, see `Manual Deployment`_ or `Monitor
 Bootstrap`_.
@@ -168,7 +175,7 @@ lost.
 
    .. prompt:: bash $
 
-      service ceph -a stop mon.{mon-id}
+      systemctl stop ceph-mon@{mon-id}
 
 #. Remove the Monitor from the cluster:
 

--- a/doc/rados/operations/add-or-rm-osds.rst
+++ b/doc/rados/operations/add-or-rm-osds.rst
@@ -1,8 +1,17 @@
+.. _adding-and-removing-osds:
+
 ======================
  Adding/Removing OSDs
 ======================
 
-When a cluster is up and running, it is possible to add or remove OSDs. 
+.. note:: The procedures on this page are for clusters that are not
+   managed by cephadm. In a cephadm-managed cluster, OSDs are added
+   and removed through the orchestrator: see
+   :ref:`cephadm-deploy-osds` and :ref:`cephadm-osd-removal`. Using
+   the procedures below on a cephadm-managed cluster will conflict
+   with the orchestrator's own management of the daemons.
+
+When a cluster is up and running, it is possible to add or remove OSDs.
 
 Adding OSDs
 ===========
@@ -52,6 +61,13 @@ and root permissions.
 
 Adding an OSD (Manual)
 ----------------------
+
+.. seealso:: The :ref:`manual-deployment-adding-osds` section of the
+   Manual Deployment guide documents the same task using
+   ``ceph-volume``, which automates most of the steps below, and a
+   long form based on the newer ``ceph osd new`` command. Prefer
+   those procedures where possible; the steps below remain valid for
+   environments where ``ceph-volume`` cannot be used.
 
 The following procedure sets up a ``ceph-osd`` daemon, configures this OSD to
 use one drive, and configures the cluster to distribute data to the OSD. If
@@ -124,7 +140,7 @@ cluster have and therefore might have greater weight as well.
 
    .. prompt:: bash $
 
-      ceph auth add osd.{osd-num} osd 'allow *' mon 'allow rwx' -i /var/lib/ceph/osd/ceph-{osd-num}/keyring
+      ceph auth add osd.{osd-num} osd 'allow *' mon 'allow profile osd' -i /var/lib/ceph/osd/ceph-{osd-num}/keyring
 
    This presentation of the command has ``ceph-{osd-num}`` in the listed path
    because many clusters have the name ``ceph``. However, if your cluster name


### PR DESCRIPTION
Adding and removing Monitors and OSDs is documented independently in the cephadm pages, the rados operations pages, and the manual deployment guides, with almost no cross-referencing, and the copies have drifted. This PR establishes cephadm as the canonical path and stitches the parallel pages together:

- The rados operations pages (add-or-rm-mons, add-or-rm-osds) open with a note that their procedures are for non-cephadm clusters, pointing at the orchestrator equivalents.
- manual-deployment.rst points at cephadm as the recommended method; the FreeBSD guide instead notes that cephadm is unavailable on FreeBSD, so manual deployment is the supported path there.
- The cephadm mon and OSD service pages link back to the manual pages for non-cephadm clusters, making the cross-links symmetric.
- Drift fixes found while comparing the copies: a leftover SysV 'service ceph -a stop' in the monitor removal procedure (now systemctl), and stale mon auth caps in the manual OSD add procedure ('allow rwx', now 'allow profile osd', matching the FreeBSD copy).
- The three diverged long-form add-an-OSD procedures now cross-reference each other. Harmonizing them onto one command set (ceph osd new vs ceph osd create) is left for a follow-up since it changes procedure semantics.

Fixes: https://tracker.ceph.com/issues/77203

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
