### PR TITLE
tentacle: doc/rados: cephx upgrade OSD key rotation step to update osd_key bluestore label

### DIFF
--- a/doc/rados/configuration/auth-config-ref.rst
+++ b/doc/rados/configuration/auth-config-ref.rst
@@ -370,6 +370,27 @@ this upgrade, it's necessary to do the upgrade in several steps.
 
    Adjust the above script based on where the data directory for your daemons are located.
 
+   If the daemon is an OSD created using ceph-volume the ``osd_key`` bluestore label may also
+   need to be updated. To find the device that must be passed to the bluestore tool:
+
+   .. code:: bash
+
+       ceph-volume lvm list $OSD_ID --format json
+
+   and find the ``lv_path`` field. Or, for a raw OSD:
+
+   .. code:: bash
+
+       ceph-volume raw list --format json
+
+   and find the ``device`` field for the OSD who's key you wish to rotate.
+
+   Once the device path is acquired the bluestore label can be rotated by executing:
+
+   .. code:: bash
+
+       ceph-bluestore-tool --dev $DEV_PATH set-label-key --key osd_key -v $COPIED_KEYRING
+
    Finally, restart the daemon:
 
    .. code:: bash


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79715

---

backport of https://github.com/ceph/ceph/pull/71224
parent tracker: https://tracker.ceph.com/issues/79709

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh