### PR TITLE
smb: extend teuthology suite to verify users groups updates

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
@@ -97,10 +97,19 @@ tasks:
 # verify CTDB is healthy, cluster well formed
 - smb.workunit:
     admin_node: host.a
+    smb_nodes: [host.a, host.b, host.c]
+    smb_shares:
+      - share1
+      - share2
+    smb_users:
+      - username: user1
+        password: t3stP4ss1
+      - username: user2
+        password: t3stP4ss2
     timeout: 15m
     clients:
       client.0:
-        - [ctdb_healthy]
+        - [ctdb_healthy, default, hosts_access, users_groups_access]
 
 # Test a different host in the cluster
 - template.exec:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_basic.yaml
@@ -93,7 +93,7 @@ tasks:
     timeout: 1h
     clients:
       client.0:
-        - [default, hosts_access, rate_limiting]
+        - [default, hosts_access, rate_limiting, users_groups_access]
 
 - cephadm.shell:
     host.a:

--- a/qa/tasks/smb.py
+++ b/qa/tasks/smb.py
@@ -8,6 +8,7 @@ import json
 import logging
 import shlex
 import time
+import threading
 
 from teuthology.exceptions import ConfigError, CommandFailedError
 from teuthology.task import ssh_keys
@@ -555,10 +556,40 @@ def workunit(ctx, config):
     _config['params'] = config.get('params', {})  # freeform test parameters
     log.info('Passing workunit config: %r', _config)
     with contextlib.ExitStack() as estack:
+        estack.enter_context(_workunit_background_keepalive(ctx))
         if _config['enable_ssh_keys']:
             estack.enter_context(ssh_keys.task(ctx, _ssh_keys_config))
         estack.enter_context(write_metadata_file(ctx, _config))
         return workunit.task(ctx, _config)
+
+
+@contextlib.contextmanager
+def _workunit_background_keepalive(ctx):
+    ctx._smb_workunit_done = False
+    try:
+        t = threading.Thread(target=_workunit_keepalive, args=(ctx,))
+        t.start()
+        try:
+            yield
+        finally:
+            ctx._smb_workunit_done = True
+            t.join()
+    finally:
+        delattr(ctx, '_smb_workunit_done')
+
+
+def _workunit_keepalive(ctx, echo_sec=5 * 60):
+    t = 0
+    while not ctx._smb_workunit_done:
+        time.sleep(1)
+        t += 1
+        if t < echo_sec:
+            continue
+        t = 0
+        for remote in ctx.cluster.remotes:
+            remote.run(
+                args=['echo', '(ping) waiting for workunit to complete'],
+            )
 
 
 def _node_info(ctx, role_name, **kwargs):

--- a/qa/workunits/smb/smb_tests.sh
+++ b/qa/workunits/smb/smb_tests.sh
@@ -24,4 +24,4 @@ trap cleanup EXIT
 
 cd "${HERE}"
 "${VENV}/bin/${PY}" -m pip install pytest 'smbprotocol<1.17.0' grpcio grpcio-reflection
-"${VENV}/bin/${PY}" -m pytest -v "$@"
+"${VENV}/bin/${PY}" -m pytest --durations=0 -v "$@"

--- a/qa/workunits/smb/tests/pytest.ini
+++ b/qa/workunits/smb/tests/pytest.ini
@@ -10,3 +10,4 @@ markers =
     hosts_access: Host access tests
     kb_fscrypt: Keybridge and FSCrypt tests
     rate_limiting: Rate limit tests
+    users_groups_access: Users & Groups Access

--- a/qa/workunits/smb/tests/smbutil.py
+++ b/qa/workunits/smb/tests/smbutil.py
@@ -100,12 +100,12 @@ class SMBTestConf:
 
 
 @contextlib.contextmanager
-def connection(conf, share):
+def connection(conf, share, username=None, password=None):
     """Return a PathWrapper connecting to the given share."""
     server = conf.server.ip_address
     port = conf.server.port
-    username = conf.username
-    password = conf.password
+    username = conf.username if username is None else username
+    password = conf.password if password is None else password
 
     smbclient.register_session(
         server=server,
@@ -176,59 +176,91 @@ class PathWrapper:
         smbclient.remove(str(self.share_path))
 
 
-def get_shares(smb_cfg):
-    """Get all SMB shares.
-
-    ``ceph smb show`` defaults to --results=collapsed: with exactly one
-    matching share it returns the share object itself; otherwise it returns
-    {"resources": [...]}. Normalize both shapes to a list.
-    """
+def _get_resources(smb_cfg, rtype):
     jres = cephutil.cephadm_shell_cmd(
         smb_cfg,
-        ["ceph", "smb", "show", "ceph.smb.share"],
+        ["ceph", "smb", "show", "--results=full", rtype],
         load_json=True,
     )
     assert jres.obj
     obj = jres.obj
-    if 'resources' in obj:
-        resources = obj['resources']
-    elif obj.get('resource_type') == 'ceph.smb.share':
-        resources = [obj]
-    else:
-        raise AssertionError(f'unexpected smb show output: {obj!r}')
+    assert 'resources' in obj
+    resources = obj['resources']
     assert len(resources) > 0
+    return resources
+
+
+def get_shares(smb_cfg):
+    """Get all SMB shares."""
+    resources = _get_resources(smb_cfg, "ceph.smb.share")
     assert all(r['resource_type'] == 'ceph.smb.share' for r in resources)
+    return resources
+
+
+def get_ug(smb_cfg):
+    """Get all users and groups resources."""
+    resources = _get_resources(smb_cfg, "ceph.smb.usersgroups")
+    assert all(r['resource_type'] == 'ceph.smb.usersgroups' for r in resources)
     return resources
 
 
 def get_share_by_id(smb_cfg, cluster_id, share_id):
     """Get a specific share by cluster_id and share_id."""
-    shares = get_shares(smb_cfg)
-    for share in shares:
-        if share['cluster_id'] == cluster_id and share['share_id'] == share_id:
-            return share
-    return None
+    shares = _get_resources(smb_cfg, f"ceph.smb.share.{cluster_id}.{share_id}")
+    assert len(shares) == 1
+    share = shares[0]
+    assert share['cluster_id'] == cluster_id and share['share_id'] == share_id
+    return share
 
 
-def apply_share_config(smb_cfg, share, immediate=False):
-    """Apply share configuration via the apply command."""
+def _apply(smb_cfg, resources, immediate=False, check=None):
     jres = cephutil.cephadm_shell_cmd(
         smb_cfg,
         ['ceph', 'smb', 'apply', '-i-'],
-        input_json={'resources': [share]},
+        input_json={'resources': resources},
         load_json=True,
     )
     assert jres.returncode == 0
     assert jres.obj and jres.obj.get('success')
+    if check:
+        ret = check(jres)
+    else:
+        ret = jres
+    # sleep to ensure the settings got applied in smbd
+    # TODO: make this more dynamic somehow
+    if not immediate:
+        time.sleep(60)
+    return ret
+
+
+def _res_check(jres):
     assert 'results' in jres.obj
     _results = jres.obj['results']
     assert len(_results) == 1, "more than one result found"
     _result = _results[0]
     assert 'resource' in _result
     resources_ret = _result['resource']
-    assert resources_ret['resource_type'] == 'ceph.smb.share'
-    # sleep to ensure the settings got applied in smbd
-    # TODO: make this more dynamic somehow
-    if not immediate:
-        time.sleep(60)
     return resources_ret
+
+
+def apply_share_config(smb_cfg, share, immediate=False):
+    """Apply share configuration via the apply command."""
+
+    def _check(jres):
+        resources_ret = _res_check(jres)
+        assert resources_ret['resource_type'] == 'ceph.smb.share'
+        return resources_ret
+
+    rr = _apply(smb_cfg, [share], immediate=immediate, check=_check)
+    return rr
+
+
+def apply_resource(
+    smb_cfg,
+    resource,
+    immediate=False,
+):
+    """Apply a single generic resource via the apply command."""
+
+    rr = _apply(smb_cfg, [resource], immediate=immediate, check=_res_check)
+    return rr

--- a/qa/workunits/smb/tests/test_user_access.py
+++ b/qa/workunits/smb/tests/test_user_access.py
@@ -1,0 +1,62 @@
+import copy
+import uuid
+
+import pytest
+import smbprotocol
+
+import smbutil
+
+
+@pytest.mark.users_groups_access
+def test_update_users_groups(smb_cfg):
+    filename = 'TestUserAccess1.txt'
+    tv = str(uuid.uuid4())
+    share_name1 = smbutil.get_shares(smb_cfg)[0]['name']
+
+    # test with existing user, update test file
+    with smbutil.connection(smb_cfg, share_name1) as sharep:
+        fname = sharep / filename
+        fname.write_text(f'value: {tv}\n')
+
+    new_u = [
+        {"name": "tc_duke", "password": "bcb7690188317ef17f54"},  # notsecret
+        {"name": "tc_shelley", "password": "0177941ab5e569681b02"},  # notsecret
+        {"name": "tc_gordon", "password": "ef97aec3a09c6de8cce8"},  # notsecret
+        {"name": "tc_alex", "password": "085872411a373142a55c"},  # notsecret
+    ]
+
+    # these users should not be defined
+    for uinfo in new_u:
+        username = uinfo['name']
+        password = uinfo['password']
+        with pytest.raises(smbprotocol.exceptions.LogonFailure):
+            with smbutil.connection(
+                smb_cfg, share_name1, username=username, password=password
+            ) as sharep:
+                fname = sharep / filename
+                fname.read_text()
+
+    # fetch current u/g
+    ug = smbutil.get_ug(smb_cfg)[0]
+    assert 'values' in ug
+    assert 'users' in ug['values']
+    ug2 = copy.deepcopy(ug)
+
+    # update u/g
+    ug2['values']['users'].extend(new_u)
+    smbutil.apply_resource(smb_cfg, ug2)
+
+    try:
+        # check updated users for access
+        for uinfo in new_u:
+            username = uinfo['name']
+            password = uinfo['password']
+            with smbutil.connection(
+                smb_cfg, share_name1, username=username, password=password
+            ) as sharep:
+
+                fname = sharep / filename
+                assert fname.read_text() == f'value: {tv}\n'
+    finally:
+        # restore orig config
+        smbutil.apply_resource(smb_cfg, ug)


### PR DESCRIPTION
Fixes:  https://tracker.ceph.com/issues/78925


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
