### PR TITLE
tentacle: doc: correct inverted logic for health warning check

### DIFF
--- a/doc/rados/configuration/auth-config-ref.rst
+++ b/doc/rados/configuration/auth-config-ref.rst
@@ -380,7 +380,7 @@ this upgrade, it's necessary to do the upgrade in several steps.
 
    .. code:: bash
 
-       ceph --format=json health detail | jq '.checks | has("AUTH_INSECURE_SERVICE_KEY_TYPE") | not'
+       ceph --format=json health detail | jq '.checks | has("AUTH_INSECURE_SERVICE_KEY_TYPE")'
 
    output gives ``false``.
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79712

---

backport of https://github.com/ceph/ceph/pull/71225
parent tracker: https://tracker.ceph.com/issues/79710

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh