### PR TITLE
rgw/multisite: fall back to plain endpoint when all resolved IPs are down

### DIFF
--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -130,6 +130,7 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct,
 RGWRESTConn::RGWRESTConn(RGWRESTConn&& other)
   : cct(other.cct),
     endpoint_rr_index(other.endpoint_rr_index.load()),
+    in_endpoint_fallback(other.in_endpoint_fallback.load()),
     resolved_endpoints(std::move(other.resolved_endpoints)),
     key(std::move(other.key)),
     self_zone_group(std::move(other.self_zone_group)),
@@ -143,6 +144,7 @@ RGWRESTConn& RGWRESTConn::operator=(RGWRESTConn&& other)
 {
   cct = other.cct;
   endpoint_rr_index = other.endpoint_rr_index.load();
+  in_endpoint_fallback = other.in_endpoint_fallback.load();
   resolved_endpoints = std::move(other.resolved_endpoints);
   key = std::move(other.key);
   self_zone_group = std::move(other.self_zone_group);
@@ -259,8 +261,21 @@ int RGWRESTConn::get_endpoint(RGWEndpoint& endpoint)
   }
 
   if (num == resolved_endpoints.size()) {
-    ldout(cct, 1) << "ERROR: no valid endpoint (all IPs down for all endpoints)" << dendl;
-    return -EINVAL;
+    // Every tracked IP is down. Return an endpoint without a connect_to hint rather than failing
+    ResolvedEndpoint& res_ep = resolved_endpoints[selected_idx];
+    endpoint.set_url(res_ep.url);
+    if (!in_endpoint_fallback.exchange(true)) {
+      ldout(cct, 1) << "no endpoint has a reachable IP for remote_id=" << remote_id
+        << " (" << resolved_endpoints.size() << " endpoint(s)); returning endpoint "
+        << "URLs without a connect_to hint so libcurl can resolve and connect "
+        << "on its own" << dendl;
+    }
+    return 0;
+  }
+
+  if (in_endpoint_fallback.load() && in_endpoint_fallback.exchange(false)) {
+    ldout(cct, 1) << "remote_id=" << remote_id << " has a reachable endpoint "
+      << "again (" << endpoint.get_url() << "), no longer falling back" << dendl;
   }
 
   populate_connect_to(endpoint, resolved_endpoints[selected_idx]);

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -156,6 +156,7 @@ class RGWRESTConn
 {
   CephContext *cct;
   std::atomic<int64_t> endpoint_rr_index = { 0 }; // Round-robin counter for resolved_endpoints
+  std::atomic<bool> in_endpoint_fallback = { false }; // Set while no endpoint has a usable IP
   std::vector<ResolvedEndpoint> resolved_endpoints;
   RGWAccessKey key;
   std::string self_zone_group;

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -500,6 +500,12 @@ add_ceph_unittest(unittest_rgw_http_client)
 target_link_libraries(unittest_rgw_http_client
   rgw_common ${rgw_libs} ${UNITTEST_LIBS})
 
+# unittest_rgw_rest_conn
+add_executable(unittest_rgw_rest_conn test_rgw_rest_conn.cc)
+add_ceph_unittest(unittest_rgw_rest_conn)
+target_link_libraries(unittest_rgw_rest_conn
+  rgw_common ${rgw_libs} ${UNITTEST_LIBS})
+
 if(WITH_RADOSGW_FDB)
  list(APPEND rgw_incs "${CMAKE_BINARY_DIR}/_deps/zpp_bits-src/")
  add_catch2_test_rgw(rgw_hex)

--- a/src/test/rgw/test_rgw_rest_conn.cc
+++ b/src/test/rgw/test_rgw_rest_conn.cc
@@ -1,0 +1,74 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include "rgw_rest_conn.h"
+
+#include "common/ceph_argparse.h"
+#include "global/global_init.h"
+
+#include <gtest/gtest.h>
+
+using namespace std;
+
+static constexpr const char* EP1 = "http://127.0.0.1:8000";
+static constexpr const char* EP2 = "http://127.0.0.2:8000";
+
+static RGWRESTConn make_conn(const list<string>& endpoints)
+{
+  return RGWRESTConn(g_ceph_context, "remote-zone", endpoints,
+                     RGWAccessKey("access", "secret"), "zonegroup", nullopt);
+}
+
+TEST(RGWRESTConn, get_endpoint_uses_resolved_ip)
+{
+  auto conn = make_conn({EP1});
+  ASSERT_EQ(1u, conn.get_endpoint_count());
+
+  RGWEndpoint ep;
+  ASSERT_EQ(0, conn.get_endpoint(ep));
+  EXPECT_EQ(EP1, ep.get_url());
+  EXPECT_EQ("127.0.0.1:8000:127.0.0.1:8000", ep.get_connect_to());
+}
+
+TEST(RGWRESTConn, get_endpoint_without_endpoints)
+{
+  auto conn = make_conn({});
+
+  RGWEndpoint ep;
+  EXPECT_EQ(-EINVAL, conn.get_endpoint(ep));
+}
+
+TEST(RGWRESTConn, get_endpoint_when_all_ips_are_down)
+{
+  auto conn = make_conn({EP1, EP2});
+
+  for (size_t i = 0; i < conn.get_endpoint_count(); ++i) {
+    RGWEndpoint ep;
+    ASSERT_EQ(0, conn.get_endpoint(ep));
+    ASSERT_FALSE(ep.get_connect_to().empty());
+    conn.set_endpoint_unconnectable(ep);
+  }
+
+  RGWEndpoint ep;
+  ASSERT_EQ(0, conn.get_endpoint(ep));
+  EXPECT_FALSE(ep.get_url().empty());
+  // no connect_to hint:
+  EXPECT_TRUE(ep.get_connect_to().empty());
+}
+
+int main(int argc, char** argv)
+{
+  auto args = argv_to_vec(argc, argv);
+  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+                         CODE_ENVIRONMENT_UTILITY,
+                         CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+
+  cct->_conf.set_val_or_die("rgw_rest_conn_connect_to_resolved_ips", "true");
+  // never let a marked-down IP recover while a test is running
+  cct->_conf.set_val_or_die("rgw_rest_conn_ip_fail_timeout_secs", "60");
+  cct->_conf.apply_changes(nullptr);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/79722


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
