### PR TITLE
mgr/DaemonServer: fix race conditions and resource leaks in shutdown()

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -139,24 +139,6 @@ DaemonServer::DaemonServer(MonClient *monc_,
                                                     cct->_conf->mgr_op_history_slow_op_threshold);
 }
 
-void DaemonServer::shutdown()
-{
-  bool expected = false;
-  if (!shutting_down.compare_exchange_strong(expected, true)) {
-    return;
-  }
-
-  op_tracker.on_shutdown();
-
-  delete msgr;
-  msgr = nullptr;
-  g_conf().remove_observer(this);
-}
-
-DaemonServer::~DaemonServer() {
-  shutdown();
-}
-
 class DaemonServerHook : public AdminSocketHook {
   DaemonServer *daemon_server;
 public:
@@ -179,6 +161,43 @@ public:
     return r;
   }
 };
+
+void DaemonServer::shutdown()
+{
+  bool expected = false;
+  if (!shutting_down.compare_exchange_strong(expected, true)) {
+    return;
+  }
+
+  op_tracker.on_shutdown();
+
+  {
+    std::lock_guard l(lock);
+    timer.shutdown();
+  }
+
+  if (asok_hook) {
+    AdminSocket *admin_socket = g_ceph_context->get_admin_socket();
+    admin_socket->unregister_commands(asok_hook);
+    delete asok_hook;
+    asok_hook = nullptr;
+  }
+
+  if (msgr) {
+    msgr->shutdown();
+    msgr->wait();
+    delete msgr;
+    msgr = nullptr;
+  }
+
+  monc->set_handle_authentication_dispatcher(nullptr);
+
+  g_conf().remove_observer(this);
+}
+
+DaemonServer::~DaemonServer() {
+  shutdown();
+}
 
 int DaemonServer::init(uint64_t gid, entity_addrvec_t client_addrs)
 {

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1809,7 +1809,8 @@ int MonClient::handle_auth_request(
     // for some channels prior to nautilus (osd heartbeat), we
     // tolerate the lack of an authorizer.
     if (!con->get_messenger()->require_authorizer) {
-      if (handle_authentication_dispatcher->ms_handle_fast_authentication(con)) {
+      if (handle_authentication_dispatcher != nullptr &&
+          handle_authentication_dispatcher->ms_handle_fast_authentication(con)) {
         return 1;
       }
     }
@@ -1848,7 +1849,8 @@ int MonClient::handle_auth_request(
     &auth_meta->connection_secret,
     ac);
   if (isvalid) {
-    if (handle_authentication_dispatcher->ms_handle_fast_authentication(con)) {
+    if (handle_authentication_dispatcher != nullptr &&
+        handle_authentication_dispatcher->ms_handle_fast_authentication(con)) {
       return 1;
     }
     return handle_auth_failure(cct);


### PR DESCRIPTION
Unit testing revealed that DaemonServer::shutdown() had bugs that could cause crashes during MGR daemon shutdown and failover:

1. The SafeTimer thread was never joined before destruction. With safe_callbacks=true (the default), timer.shutdown() must be called under the DaemonServer lock so that it can join the timer thread cleanly. Inflight timer callbacks could also invoke virtual methods on a partially destroyed object, causing "pure virtual method called" errors.

2. The admin socket hook registered in init() was never unregistered or freed, leaving the admin socket with a dangling pointer to the destroyed DaemonServer.

3. msgr was deleted directly without calling shutdown()+wait() first, racing the messenger dispatch thread against object destruction.

Fix shutdown() to: join the timer under the lock; unregister and delete asok_hook; call msgr->shutdown()+wait() before deleting msgr; and clear the handle_authentication_dispatcher pointer in monc after msgr is fully stopped (msgr is monc's auth server, so no new auth requests can arrive on monc once msgr is joined).

Guard both dereferences of handle_authentication_dispatcher in MonClient::handle_auth_request() against nullptr, so that connections arriving in the brief window between MGR deactivation and the next activation are rejected cleanly via handle_auth_failure() rather than crashing.

Fixes: https://tracker.ceph.com/issues/76335





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
