### PR TITLE
test/mgr: Add scaffolding and surface level tests to various objects within the Mgr

### DIFF
--- a/src/test/mgr/CMakeLists.txt
+++ b/src/test/mgr/CMakeLists.txt
@@ -1,7 +1,68 @@
+set(unittest_mgr_base_srcs
+  ${CMAKE_SOURCE_DIR}/src/mgr/ClusterState.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonKey.cc
+)
+
+set(unittest_mgr_daemonstate_srcs
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonState.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonPerfCounters.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PerfCounterInstance.cc
+)
+
+set(unittest_mgr_python_helpers_srcs
+  ${CMAKE_SOURCE_DIR}/src/mgr/PyFormatter.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PyUtil.cc
+)
+
+set(unittest_mgr_servicemap_srcs
+  ${CMAKE_SOURCE_DIR}/src/mgr/ServiceMap.cc
+)
+
+set(unittest_mgr_map_cache_srcs
+  ${CMAKE_SOURCE_DIR}/src/mgr/MgrMapCache.cc
+)
+
+set(unittest_mgr_perfcounterinstance_srcs
+  ${CMAKE_SOURCE_DIR}/src/mgr/PerfCounterInstance.cc
+)
+
+set(unittest_mgr_metriccollector_srcs
+  ${CMAKE_SOURCE_DIR}/src/mgr/MetricCollector.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/OSDPerfMetricCollector.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/OSDPerfMetricTypes.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/MDSPerfMetricCollector.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/MDSPerfMetricTypes.cc
+)
+
+add_library(unittest_mgr_base_obj OBJECT ${unittest_mgr_base_srcs})
+target_link_libraries(unittest_mgr_base_obj legacy-option-headers)
+
+add_library(unittest_mgr_daemonstate_obj OBJECT ${unittest_mgr_daemonstate_srcs})
+target_link_libraries(unittest_mgr_daemonstate_obj legacy-option-headers)
+
+add_library(unittest_mgr_python_helpers_obj OBJECT ${unittest_mgr_python_helpers_srcs})
+target_include_directories(unittest_mgr_python_helpers_obj PRIVATE
+  $<TARGET_PROPERTY:Python3::Python,INTERFACE_INCLUDE_DIRECTORIES>)
+target_link_libraries(unittest_mgr_python_helpers_obj legacy-option-headers)
+
+add_library(unittest_mgr_servicemap_obj OBJECT ${unittest_mgr_servicemap_srcs})
+target_link_libraries(unittest_mgr_servicemap_obj legacy-option-headers)
+
+add_library(unittest_mgr_map_cache_obj OBJECT ${unittest_mgr_map_cache_srcs})
+target_include_directories(unittest_mgr_map_cache_obj PRIVATE
+  $<TARGET_PROPERTY:Python3::Python,INTERFACE_INCLUDE_DIRECTORIES>)
+target_link_libraries(unittest_mgr_map_cache_obj legacy-option-headers)
+
+add_library(unittest_mgr_perfcounterinstance_obj OBJECT ${unittest_mgr_perfcounterinstance_srcs})
+target_link_libraries(unittest_mgr_perfcounterinstance_obj legacy-option-headers)
+
+add_library(unittest_mgr_metriccollector_obj OBJECT ${unittest_mgr_metriccollector_srcs})
+target_link_libraries(unittest_mgr_metriccollector_obj legacy-option-headers)
+
 # unittest_mgr_clusterstate
 add_executable(unittest_mgr_clusterstate
   test_clusterstate.cc
-  ${CMAKE_SOURCE_DIR}/src/mgr/ClusterState.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
 )
 add_ceph_unittest(unittest_mgr_clusterstate)
 target_link_libraries(unittest_mgr_clusterstate
@@ -13,7 +74,7 @@ target_link_libraries(unittest_mgr_clusterstate
 # unittest_mgr_daemonkey
 add_executable(unittest_mgr_daemonkey
   test_daemonkey.cc
-  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonKey.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
 )
 add_ceph_unittest(unittest_mgr_daemonkey)
 target_link_libraries(unittest_mgr_daemonkey
@@ -23,10 +84,8 @@ target_link_libraries(unittest_mgr_daemonkey
 # unittest_mgr_daemonstate
 add_executable(unittest_mgr_daemonstate
   test_daemonstate.cc
-  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonState.cc
-  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonKey.cc
-  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonPerfCounters.cc
-  ${CMAKE_SOURCE_DIR}/src/mgr/PerfCounterInstance.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+  $<TARGET_OBJECTS:unittest_mgr_daemonstate_obj>
 )
 add_ceph_unittest(unittest_mgr_daemonstate)
 target_link_libraries(unittest_mgr_daemonstate
@@ -44,7 +103,8 @@ target_link_libraries(unittest_mgr_mgrcap global)
 # unittest_mgr_pyformatter
 add_executable(unittest_mgr_pyformatter
   test_pyformatter.cc
-  ${CMAKE_SOURCE_DIR}/src/mgr/PyFormatter.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+  $<TARGET_OBJECTS:unittest_mgr_python_helpers_obj>
 )
 add_ceph_unittest(unittest_mgr_pyformatter)
 target_link_libraries(unittest_mgr_pyformatter
@@ -55,7 +115,8 @@ target_link_libraries(unittest_mgr_pyformatter
 # unittest_mgr_pyutil
 add_executable(unittest_mgr_pyutil
   test_pyutil.cc
-  ${CMAKE_SOURCE_DIR}/src/mgr/PyUtil.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+  $<TARGET_OBJECTS:unittest_mgr_python_helpers_obj>
 )
 add_ceph_unittest(unittest_mgr_pyutil)
 target_link_libraries(unittest_mgr_pyutil
@@ -66,7 +127,7 @@ target_link_libraries(unittest_mgr_pyutil
 # unittest_mgr_servicemap
 add_executable(unittest_mgr_servicemap
   test_servicemap.cc
-  ${CMAKE_SOURCE_DIR}/src/mgr/ServiceMap.cc
+  $<TARGET_OBJECTS:unittest_mgr_servicemap_obj>
 )
 add_ceph_unittest(unittest_mgr_servicemap)
 target_link_libraries(unittest_mgr_servicemap
@@ -76,10 +137,351 @@ target_link_libraries(unittest_mgr_servicemap
 # unittest_mgr_map_cache
 add_executable(unittest_mgr_map_cache
   test_mgrmapcache.cc
-  ${CMAKE_SOURCE_DIR}/src/mgr/MgrMapCache.cc)
+  $<TARGET_OBJECTS:unittest_mgr_map_cache_obj>)
 add_ceph_unittest(unittest_mgr_map_cache)
 target_link_libraries(unittest_mgr_map_cache ceph-common
   Python3::Python ${CMAKE_DL_LIBS} ${GSSAPI_LIBRARIES})
+
+# unittest_mgr_daemonperfcounters
+add_executable(unittest_mgr_daemonperfcounters
+  test_daemonperfcounters.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+  $<TARGET_OBJECTS:unittest_mgr_daemonstate_obj>
+)
+add_ceph_unittest(unittest_mgr_daemonperfcounters)
+target_link_libraries(unittest_mgr_daemonperfcounters
+  ceph-common
+  Python3::Python
+)
+
+# unittest_mgr_perfcounterinstance
+add_executable(unittest_mgr_perfcounterinstance
+  test_perfcounterinstance.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+  $<TARGET_OBJECTS:unittest_mgr_perfcounterinstance_obj>
+)
+add_ceph_unittest(unittest_mgr_perfcounterinstance)
+target_link_libraries(unittest_mgr_perfcounterinstance
+  ceph-common
+  Python3::Python
+)
+
+# unittest_mgr_metriccollector
+add_executable(unittest_mgr_metriccollector
+  test_metriccollector.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+  $<TARGET_OBJECTS:unittest_mgr_metriccollector_obj>
+)
+add_ceph_unittest(unittest_mgr_metriccollector)
+target_link_libraries(unittest_mgr_metriccollector
+  ceph-common
+  global
+  Python3::Python
+)
+
+# unittest_mgr_osdperfmetriccollector
+add_executable(unittest_mgr_osdperfmetriccollector
+  test_osdperfmetriccollector.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+  $<TARGET_OBJECTS:unittest_mgr_metriccollector_obj>
+)
+add_ceph_unittest(unittest_mgr_osdperfmetriccollector)
+target_link_libraries(unittest_mgr_osdperfmetriccollector
+  ceph-common
+  global
+  Python3::Python
+)
+
+# unittest_mgr_mdsperfmetriccollector
+add_executable(unittest_mgr_mdsperfmetriccollector
+  test_mdsperfmetriccollector.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+  $<TARGET_OBJECTS:unittest_mgr_metriccollector_obj>
+)
+add_ceph_unittest(unittest_mgr_mdsperfmetriccollector)
+target_link_libraries(unittest_mgr_mdsperfmetriccollector
+  ceph-common
+  global
+  Python3::Python
+)
+
+# unittest_mgr_daemonhealthmetriccollector
+add_executable(unittest_mgr_daemonhealthmetriccollector
+  test_daemonhealthmetriccollector.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+  $<TARGET_OBJECTS:unittest_mgr_metriccollector_obj>
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonHealthMetricCollector.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonHealthMetric.cc
+)
+add_ceph_unittest(unittest_mgr_daemonhealthmetriccollector)
+target_link_libraries(unittest_mgr_daemonhealthmetriccollector
+  ceph-common
+  global
+  Python3::Python
+)
+
+set(unittest_mgr_common_srcs
+  ${CMAKE_SOURCE_DIR}/src/mgr/ActivePyModule.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/ActivePyModules.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/BaseMgrModule.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/BaseMgrStandbyModule.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/ClusterState.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonHealthMetricCollector.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonHealthMetric.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonKey.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonPerfCounters.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonServer.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/DaemonState.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/Gil.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/MDSPerfMetricCollector.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/MDSPerfMetricTypes.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/MetricCollector.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/MgrMapCache.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/MgrOpRequest.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/OSDPerfMetricCollector.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/OSDPerfMetricTypes.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PerfCounterInstance.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PyFormatter.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PyModule.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PyModuleRegistry.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PyModuleRunner.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PyOSDMap.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/PyUtil.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/ServiceMap.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/StandbyPyModules.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/ThreadMonitor.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/mgr_commands.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/mgr_perf_counters.cc
+)
+
+add_library(unittest_mgr_common_obj OBJECT ${unittest_mgr_common_srcs})
+target_include_directories(unittest_mgr_common_obj PRIVATE
+  $<TARGET_PROPERTY:RocksDB::RocksDB,INTERFACE_INCLUDE_DIRECTORIES>
+  $<TARGET_PROPERTY:Python3::Python,INTERFACE_INCLUDE_DIRECTORIES>)
+target_compile_definitions(unittest_mgr_common_obj PRIVATE UNIT_TESTS_BUILT)
+target_link_libraries(unittest_mgr_common_obj legacy-option-headers)
+if(WITH_LTTNG)
+  add_dependencies(unittest_mgr_common_obj mgr_op_tp)
+endif()
+
+set(unittest_mgr_common_objs
+  $<TARGET_OBJECTS:unittest_mgr_common_obj>
+  $<TARGET_OBJECTS:mgr_cap_obj>)
+
+set(unittest_mgr_common_with_mgr_objs
+  ${unittest_mgr_common_objs}
+  ${CMAKE_SOURCE_DIR}/src/mgr/Mgr.cc)
+
+# unittest_mgr_pyosdmap
+add_executable(unittest_mgr_pyosdmap
+  test_pyosdmap.cc
+  ${unittest_mgr_common_with_mgr_objs}
+)
+add_ceph_unittest(unittest_mgr_pyosdmap)
+target_compile_definitions(unittest_mgr_pyosdmap PRIVATE UNIT_TESTS_BUILT)
+target_include_directories(unittest_mgr_pyosdmap PRIVATE
+  $<TARGET_PROPERTY:RocksDB::RocksDB,INTERFACE_INCLUDE_DIRECTORIES>)
+if(WITH_LTTNG)
+  add_dependencies(unittest_mgr_pyosdmap mgr_op_tp)
+endif()
+target_link_libraries(unittest_mgr_pyosdmap
+  ceph-common
+  osdc
+  mon
+  global
+  Boost::python${MGR_PYTHON_VERSION_MAJOR}${MGR_PYTHON_VERSION_MINOR}
+  Python3::Python
+  ${CMAKE_DL_LIBS}
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:cephsqlite>
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:SQLite3::SQLite3>
+)
+
+# unittest_mgr_mgrclient
+add_executable(unittest_mgr_mgrclient
+  test_mgrclient.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/MgrClient.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+)
+add_ceph_unittest(unittest_mgr_mgrclient)
+target_link_libraries(unittest_mgr_mgrclient
+  ceph-common
+  global
+  Python3::Python
+)
+
+# unittest_mgr_threadmonitor
+add_executable(unittest_mgr_threadmonitor
+  test_threadmonitor.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/ThreadMonitor.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+)
+add_ceph_unittest(unittest_mgr_threadmonitor)
+target_link_libraries(unittest_mgr_threadmonitor
+  ceph-common
+  global
+  Python3::Python
+)
+
+# unittest_mgr_mgroprequest
+add_executable(unittest_mgr_mgroprequest
+  test_mgroprequest.cc
+  ${CMAKE_SOURCE_DIR}/src/mgr/MgrOpRequest.cc
+  $<TARGET_OBJECTS:unittest_mgr_base_obj>
+)
+add_ceph_unittest(unittest_mgr_mgroprequest)
+if(WITH_LTTNG)
+  add_dependencies(unittest_mgr_mgroprequest mgr_op_tp)
+endif()
+target_link_libraries(unittest_mgr_mgroprequest
+  ceph-common
+  global
+  Python3::Python
+)
+
+# unittest_mgr_pymodulerunner
+add_executable(unittest_mgr_pymodulerunner
+  test_pymodulerunner.cc
+  ${unittest_mgr_common_with_mgr_objs}
+)
+add_ceph_unittest(unittest_mgr_pymodulerunner)
+target_compile_definitions(unittest_mgr_pymodulerunner PRIVATE UNIT_TESTS_BUILT)
+target_include_directories(unittest_mgr_pymodulerunner PRIVATE
+  $<TARGET_PROPERTY:RocksDB::RocksDB,INTERFACE_INCLUDE_DIRECTORIES>)
+if(WITH_LTTNG)
+  add_dependencies(unittest_mgr_pymodulerunner mgr_op_tp)
+endif()
+target_link_libraries(unittest_mgr_pymodulerunner
+  ceph-common
+  osdc
+  mon
+  global
+  Boost::python${MGR_PYTHON_VERSION_MAJOR}${MGR_PYTHON_VERSION_MINOR}
+  Python3::Python
+  ${CMAKE_DL_LIBS}
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:cephsqlite>
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:SQLite3::SQLite3>
+)
+
+# unittest_mgr_pymoduleregistry
+add_executable(unittest_mgr_pymoduleregistry
+  test_pymoduleregistry.cc
+  ${unittest_mgr_common_with_mgr_objs}
+)
+add_ceph_unittest(unittest_mgr_pymoduleregistry)
+target_compile_definitions(unittest_mgr_pymoduleregistry PRIVATE UNIT_TESTS_BUILT)
+target_include_directories(unittest_mgr_pymoduleregistry PRIVATE
+  $<TARGET_PROPERTY:RocksDB::RocksDB,INTERFACE_INCLUDE_DIRECTORIES>)
+if(WITH_LTTNG)
+  add_dependencies(unittest_mgr_pymoduleregistry mgr_op_tp)
+endif()
+target_link_libraries(unittest_mgr_pymoduleregistry
+  ceph-common
+  osdc
+  mon
+  global
+  Boost::python${MGR_PYTHON_VERSION_MAJOR}${MGR_PYTHON_VERSION_MINOR}
+  Python3::Python
+  ${CMAKE_DL_LIBS}
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:cephsqlite>
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:SQLite3::SQLite3>
+)
+
+# unittest_mgr_standbypymodules
+add_executable(unittest_mgr_standbypymodules
+  test_standbypymodules.cc
+  ${unittest_mgr_common_with_mgr_objs}
+)
+add_ceph_unittest(unittest_mgr_standbypymodules)
+target_compile_definitions(unittest_mgr_standbypymodules PRIVATE UNIT_TESTS_BUILT)
+target_include_directories(unittest_mgr_standbypymodules PRIVATE
+  $<TARGET_PROPERTY:RocksDB::RocksDB,INTERFACE_INCLUDE_DIRECTORIES>)
+if(WITH_LTTNG)
+  add_dependencies(unittest_mgr_standbypymodules mgr_op_tp)
+endif()
+target_link_libraries(unittest_mgr_standbypymodules
+  ceph-common
+  osdc
+  mon
+  global
+  Boost::python${MGR_PYTHON_VERSION_MAJOR}${MGR_PYTHON_VERSION_MINOR}
+  Python3::Python
+  ${CMAKE_DL_LIBS}
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:cephsqlite>
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:SQLite3::SQLite3>
+)
+
+# unittest_mgr_daemonserver
+add_executable(unittest_mgr_daemonserver
+  test_daemonserver.cc
+  ${unittest_mgr_common_with_mgr_objs}
+)
+add_ceph_unittest(unittest_mgr_daemonserver)
+target_compile_definitions(unittest_mgr_daemonserver PRIVATE UNIT_TESTS_BUILT)
+target_include_directories(unittest_mgr_daemonserver PRIVATE
+  $<TARGET_PROPERTY:RocksDB::RocksDB,INTERFACE_INCLUDE_DIRECTORIES>)
+if(WITH_LTTNG)
+  add_dependencies(unittest_mgr_daemonserver mgr_op_tp)
+endif()
+target_link_libraries(unittest_mgr_daemonserver
+  ceph-common
+  osdc
+  mon
+  global
+  Boost::python${MGR_PYTHON_VERSION_MAJOR}${MGR_PYTHON_VERSION_MINOR}
+  Python3::Python
+  ${CMAKE_DL_LIBS}
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:cephsqlite>
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:SQLite3::SQLite3>
+)
+
+# unittest_mgr_mgrstandby
+add_executable(unittest_mgr_mgrstandby
+  test_mgrstandby.cc
+  ${unittest_mgr_common_with_mgr_objs}
+  ${CMAKE_SOURCE_DIR}/src/mgr/MgrStandby.cc
+)
+add_ceph_unittest(unittest_mgr_mgrstandby)
+target_compile_definitions(unittest_mgr_mgrstandby PRIVATE UNIT_TESTS_BUILT)
+target_include_directories(unittest_mgr_mgrstandby PRIVATE
+  $<TARGET_PROPERTY:RocksDB::RocksDB,INTERFACE_INCLUDE_DIRECTORIES>)
+if(WITH_LTTNG)
+  add_dependencies(unittest_mgr_mgrstandby mgr_op_tp)
+endif()
+target_link_libraries(unittest_mgr_mgrstandby
+  ceph-common
+  osdc
+  mon
+  global
+  Boost::python${MGR_PYTHON_VERSION_MAJOR}${MGR_PYTHON_VERSION_MINOR}
+  Python3::Python
+  ${CMAKE_DL_LIBS}
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:cephsqlite>
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:SQLite3::SQLite3>
+)
+
+# unittest_mgr_mgr
+add_executable(unittest_mgr_mgr
+  test_mgr.cc
+  ${unittest_mgr_common_with_mgr_objs}
+)
+add_ceph_unittest(unittest_mgr_mgr)
+target_compile_definitions(unittest_mgr_mgr PRIVATE UNIT_TESTS_BUILT)
+target_include_directories(unittest_mgr_mgr PRIVATE
+  $<TARGET_PROPERTY:RocksDB::RocksDB,INTERFACE_INCLUDE_DIRECTORIES>)
+if(WITH_LTTNG)
+  add_dependencies(unittest_mgr_mgr mgr_op_tp)
+endif()
+target_link_libraries(unittest_mgr_mgr
+  ceph-common
+  osdc
+  mon
+  global
+  Boost::python${MGR_PYTHON_VERSION_MAJOR}${MGR_PYTHON_VERSION_MINOR}
+  Python3::Python
+  ${CMAKE_DL_LIBS}
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:cephsqlite>
+  $<$<BOOL:${WITH_LIBCEPHSQLITE}>:SQLite3::SQLite3>
+)
 
 #scripts
 if(WITH_MGR_DASHBOARD_FRONTEND)

--- a/src/test/mgr/TestMgr.h
+++ b/src/test/mgr/TestMgr.h
@@ -6,11 +6,18 @@
 #include <cassert>
 
 #include "common/async/context_pool.h"
+#include "common/Finisher.h"
+#include "common/LogClient.h"
 #include "global/global_context.h"
+#include "global/global_init.h"
 #include "gtest/gtest.h"
 #include "messages/MPGStats.h"
+#include "messages/MMgrReport.h"
 #include "mgr/ClusterState.h"
+#include "mgr/DaemonServer.h"
 #include "mgr/DaemonState.h"
+#include "mgr/PyModuleRegistry.h"
+#include "mgr/ThreadMonitor.h"
 #include "mon/MgrMap.h"
 #include "mon/MonClient.h"
 #include "msg/Messenger.h"
@@ -188,3 +195,213 @@ struct PythonEnv : public ::testing::Environment {
     Py_Finalize();
   }
 };
+
+// Mgr itself requires full daemon init (monc, objecter, etc.) before it is
+// usable; this helper only scaffolds construction/teardown.
+class MgrTestHelper : public TestMgr {
+public:
+  LogChannelRef clog;
+  LogChannelRef audit_clog;
+  std::unique_ptr<PyModuleRegistry> py_registry;
+
+  void SetUp() override {
+    TestMgr::SetUp();
+    clog = std::make_shared<LogChannel>(cct.get(), nullptr, "cluster");
+    audit_clog = std::make_shared<LogChannel>(cct.get(), nullptr, "audit");
+    py_registry = std::make_unique<PyModuleRegistry>(clog);
+  }
+
+  void TearDown() override {
+    py_registry.reset();
+    audit_clog.reset();
+    clog.reset();
+    TestMgr::TearDown();
+  }
+};
+
+class DaemonServerTestHelper : public TestMgr {
+public:
+  LogChannelRef clog;
+  LogChannelRef audit_clog;
+  std::unique_ptr<PyModuleRegistry> py_registry;
+  std::unique_ptr<DaemonStateIndex> daemon_state_index;
+  std::unique_ptr<Finisher> finisher;
+  std::unique_ptr<DaemonServer> daemon_server;
+
+  void SetUp() override {
+    TestMgr::SetUp();
+    clog = std::make_shared<LogChannel>(cct.get(), nullptr, "cluster");
+    audit_clog = std::make_shared<LogChannel>(cct.get(), nullptr, "audit");
+    daemon_state_index = std::make_unique<DaemonStateIndex>();
+    py_registry = std::make_unique<PyModuleRegistry>(clog);
+    finisher = std::make_unique<Finisher>(cct.get(), "test_finisher", "test_fin");
+    finisher->start();
+    daemon_server = std::make_unique<DaemonServer>(
+        mc.get(),
+        *finisher,
+        *daemon_state_index,
+        *cs,
+        *py_registry,
+        clog,
+        audit_clog);
+  }
+
+  void TearDown() override {
+    daemon_server.reset();
+    py_registry.reset();
+    if (finisher) {
+      finisher->stop();
+      finisher.reset();
+    }
+    daemon_state_index.reset();
+    audit_clog.reset();
+    clog.reset();
+    TestMgr::TearDown();
+  }
+};
+
+class DaemonPerfCountersTestHelper : public ::testing::Test {
+public:
+  PerfCounterTypes types;
+  std::unique_ptr<DaemonPerfCounters> perf_counters;
+  
+  void SetUp() override {
+    perf_counters = std::make_unique<DaemonPerfCounters>(types);
+  }
+
+  void TearDown() override {
+    perf_counters.reset();
+    types.clear();
+  }
+};
+
+class MockMetricListener : public MetricListener {
+public:
+  int update_count = 0;
+  
+  void handle_query_updated() override {
+    update_count++;
+  }
+};
+
+class MetricCollectorTestHelper : public ::testing::Test {
+public:
+  static inline boost::intrusive_ptr<CephContext> cct;
+  
+  static void SetUpTestSuite() {
+    if (!cct) {
+      std::vector<const char*> args = {"unittest_metriccollector"};
+      cct = global_init(
+          nullptr, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+          CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+      common_init_finish(cct.get());
+    }
+  }
+};
+
+class ThreadMonitorTestHelper : public ::testing::Test {
+public:
+  static inline boost::intrusive_ptr<CephContext> cct;
+  std::unique_ptr<ThreadMonitor> thread_monitor;
+  
+  static void SetUpTestSuite() {
+    if (!cct) {
+      std::vector<const char*> args = {"unittest_threadmonitor"};
+      cct = global_init(
+          nullptr, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+          CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+      common_init_finish(cct.get());
+    }
+  }
+  
+  void SetUp() override {
+    thread_monitor = std::make_unique<ThreadMonitor>(cct.get());
+  }
+  
+  void TearDown() override {
+    thread_monitor.reset();
+  }
+};
+
+class PyModuleRegistryTestHelper : public ::testing::Test {
+public:
+  static inline boost::intrusive_ptr<CephContext> cct;
+  LogChannelRef clog;
+  std::unique_ptr<PyModuleRegistry> registry;
+  
+  static void SetUpTestSuite() {
+    if (!cct) {
+      std::vector<const char*> args = {"unittest_pymoduleregistry"};
+      cct = global_init(
+          nullptr, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+          CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+      common_init_finish(cct.get());
+    }
+  }
+  
+  void SetUp() override {
+    clog = std::make_shared<LogChannel>(cct.get(), nullptr, "cluster");
+    registry = std::make_unique<PyModuleRegistry>(clog);
+  }
+  
+  void TearDown() override {
+    registry.reset();
+    clog.reset();
+  }
+};
+
+class PyOSDMapTest : public ::testing::Test {
+public:
+  OSDMap osd_map;
+  
+  void SetUp() override {
+    osd_map.set_epoch(1);
+  }
+};
+
+class MgrStandbyTestHelper : public TestMgr {
+public:
+  LogChannelRef clog;
+  std::unique_ptr<PyModuleRegistry> py_registry;
+  
+  void SetUp() override {
+    TestMgr::SetUp();
+    clog = std::make_shared<LogChannel>(cct.get(), nullptr, "cluster");
+    py_registry = std::make_unique<PyModuleRegistry>(clog);
+  }
+  
+  void TearDown() override {
+    py_registry.reset();
+    clog.reset();
+    TestMgr::TearDown();
+  }
+};
+
+// StandbyPyModules tests share the same fixture as MgrStandby.
+using StandbyPyModulesTestHelper = MgrStandbyTestHelper;
+
+class MgrOpRequestTestHelper : public ::testing::Test {
+public:
+  static inline boost::intrusive_ptr<CephContext> cct;
+  std::unique_ptr<OpTracker> tracker;
+  
+  static void SetUpTestSuite() {
+    if (!cct) {
+      std::vector<const char*> args = {"unittest_mgr_mgroprequest"};
+      cct = global_init(
+          nullptr, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+          CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+      common_init_finish(cct.get());
+    }
+  }
+  
+  void SetUp() override {
+    tracker = std::make_unique<OpTracker>(cct.get(), true, 1);
+  }
+  
+  void TearDown() override {
+    tracker.reset();
+  }
+};
+
+

--- a/src/test/mgr/test_daemonhealthmetriccollector.cc
+++ b/src/test/mgr/test_daemonhealthmetriccollector.cc
@@ -1,0 +1,22 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/DaemonHealthMetricCollector.h"
+#include "mgr/DaemonHealthMetric.h"
+#include "mgr/DaemonKey.h"
+#include "mon/health_check.h"
+#include <memory>
+
+TEST_F(MetricCollectorTestHelper, DaemonHealthMetricCollectorBasicSetup) {
+  ASSERT_NE(cct, nullptr);
+
+  auto slow_ops_collector = DaemonHealthMetricCollector::create(daemon_metric::SLOW_OPS);
+  ASSERT_NE(slow_ops_collector, nullptr);
+
+  auto pending_pgs_collector = DaemonHealthMetricCollector::create(daemon_metric::PENDING_CREATING_PGS);
+  ASSERT_NE(pending_pgs_collector, nullptr);
+
+  auto none_collector = DaemonHealthMetricCollector::create(daemon_metric::NONE);
+  ASSERT_EQ(none_collector, nullptr);
+}

--- a/src/test/mgr/test_daemonperfcounters.cc
+++ b/src/test/mgr/test_daemonperfcounters.cc
@@ -1,0 +1,14 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/DaemonPerfCounters.h"
+#include "mgr/PerfCounterInstance.h"
+#include "common/perf_counters.h"
+#include "messages/MMgrReport.h"
+
+TEST_F(DaemonPerfCountersTestHelper, BasicSetup) {
+  ASSERT_NE(perf_counters, nullptr);
+  ASSERT_TRUE(types.empty());
+  ASSERT_TRUE(perf_counters->instances.empty());
+}

--- a/src/test/mgr/test_daemonserver.cc
+++ b/src/test/mgr/test_daemonserver.cc
@@ -1,0 +1,14 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/DaemonServer.h"
+
+TEST_F(DaemonServerTestHelper, BasicSetup) {
+  ASSERT_NE(mc, nullptr);
+  ASSERT_NE(cs, nullptr);
+  ASSERT_NE(py_registry, nullptr);
+  ASSERT_NE(daemon_state_index, nullptr);
+  ASSERT_NE(finisher, nullptr);
+  ASSERT_NE(daemon_server, nullptr);
+}

--- a/src/test/mgr/test_mdsperfmetriccollector.cc
+++ b/src/test/mgr/test_mdsperfmetriccollector.cc
@@ -1,0 +1,9 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/MDSPerfMetricCollector.h"
+
+TEST_F(MetricCollectorTestHelper, MDSPerfMetricCollectorBasicSetup) {
+  ASSERT_NE(cct, nullptr);
+}

--- a/src/test/mgr/test_metriccollector.cc
+++ b/src/test/mgr/test_metriccollector.cc
@@ -1,0 +1,19 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/MetricCollector.h"
+#include "mgr/OSDPerfMetricCollector.h"
+#include "mgr/MDSPerfMetricCollector.h"
+
+TEST_F(MetricCollectorTestHelper, BasicSetup) {
+  ASSERT_NE(cct, nullptr);
+
+  MockMetricListener osd_listener;
+  OSDPerfMetricCollector osd_collector(osd_listener);
+  ASSERT_EQ(osd_listener.update_count, 0);
+
+  MockMetricListener mds_listener;
+  MDSPerfMetricCollector mds_collector(mds_listener);
+  ASSERT_EQ(mds_listener.update_count, 0);
+}

--- a/src/test/mgr/test_mgr.cc
+++ b/src/test/mgr/test_mgr.cc
@@ -1,0 +1,16 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/Mgr.h"
+
+TEST_F(MgrTestHelper, BasicSetup) {
+  ASSERT_NE(cct, nullptr);
+  ASSERT_NE(clog, nullptr);
+  ASSERT_NE(audit_clog, nullptr);
+  ASSERT_NE(py_registry, nullptr);
+  ASSERT_NE(cs, nullptr);
+  ASSERT_NE(messenger, nullptr);
+  ASSERT_NE(mc, nullptr);
+  ASSERT_NE(objecter, nullptr);
+}

--- a/src/test/mgr/test_mgrclient.cc
+++ b/src/test/mgr/test_mgrclient.cc
@@ -1,0 +1,21 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/MgrClient.h"
+#include "mon/MonMap.h"
+
+TEST_F(TestMgr, MgrClientBasicSetup) {
+  ASSERT_NE(mc, nullptr);
+  ASSERT_NE(objecter, nullptr);
+  ASSERT_NE(messenger, nullptr);
+
+  MonMap monmap;
+  MgrClient client(cct.get(), messenger.get(), &monmap);
+  ASSERT_FALSE(client.is_initialized());
+
+  client.init();
+  ASSERT_TRUE(client.is_initialized());
+
+  client.shutdown();
+}

--- a/src/test/mgr/test_mgroprequest.cc
+++ b/src/test/mgr/test_mgroprequest.cc
@@ -1,0 +1,16 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/MgrOpRequest.h"
+#include "common/TrackedOp.h"
+#include "messages/MCommand.h"
+
+TEST_F(MgrOpRequestTestHelper, BasicSetup) {
+  auto msg = ceph::make_message<MCommand>();
+  msg->set_tid(123);
+
+  auto req = tracker->create_request<MgrOpRequest>(msg);
+  ASSERT_TRUE(req);
+  ASSERT_EQ(req->get_req(), msg);
+}

--- a/src/test/mgr/test_mgrstandby.cc
+++ b/src/test/mgr/test_mgrstandby.cc
@@ -1,0 +1,18 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/MgrStandby.h"
+
+TEST_F(MgrStandbyTestHelper, BasicSetup) {
+  ASSERT_NE(cct, nullptr);
+  ASSERT_NE(py_registry, nullptr);
+  ASSERT_NE(clog, nullptr);
+  ASSERT_NE(mc, nullptr);
+  ASSERT_NE(objecter, nullptr);
+  ASSERT_NE(messenger, nullptr);
+  ASSERT_NE(cs, nullptr);
+  ASSERT_NE(cs->test_get_objecter(), nullptr);
+  ASSERT_EQ(mgr_map.epoch, 0);
+  ASSERT_GE(osd_map.get_epoch(), 0);
+}

--- a/src/test/mgr/test_osdperfmetriccollector.cc
+++ b/src/test/mgr/test_osdperfmetriccollector.cc
@@ -1,0 +1,16 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/OSDPerfMetricCollector.h"
+#include "mgr/MetricTypes.h"
+
+TEST_F(MetricCollectorTestHelper, OSDPerfMetricCollectorBasicSetup) {
+  ASSERT_NE(cct, nullptr);
+
+  MockMetricListener listener;
+  OSDPerfMetricCollector collector(listener);
+
+  auto queries = collector.get_queries();
+  ASSERT_TRUE(queries.empty());
+}

--- a/src/test/mgr/test_perfcounterinstance.cc
+++ b/src/test/mgr/test_perfcounterinstance.cc
@@ -1,0 +1,215 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "gtest/gtest.h"
+#include "mgr/PerfCounterInstance.h"
+#include "common/perf_counters.h"
+
+TEST(PerfCounterInstance, ConstructorNormalCounter) {
+  PerfCounterInstance counter(PERFCOUNTER_U64);
+  ASSERT_EQ(counter.get_data().size(), 0);
+}
+
+TEST(PerfCounterInstance, ConstructorAvgCounter) {
+  PerfCounterInstance counter(PERFCOUNTER_LONGRUNAVG);
+  ASSERT_EQ(counter.get_data_avg().size(), 0);
+}
+
+TEST(PerfCounterInstance, PushSingleValue) {
+  PerfCounterInstance counter(PERFCOUNTER_U64);
+  utime_t t1(100, 0);
+  uint64_t v1 = 42;
+
+  counter.push(t1, v1);
+
+  ASSERT_EQ(counter.get_data().size(), 1);
+  ASSERT_EQ(counter.get_latest_data().v, v1);
+  ASSERT_EQ(counter.get_latest_data().t, t1);
+}
+
+TEST(PerfCounterInstance, PushMultipleValues) {
+  PerfCounterInstance counter(PERFCOUNTER_U64);
+
+  for (int i = 0; i < 10; i++) {
+    utime_t t(100 + i, 0);
+    uint64_t v = i * 10;
+    counter.push(t, v);
+  }
+
+  ASSERT_EQ(counter.get_data().size(), 10);
+  ASSERT_EQ(counter.get_latest_data().v, 90);
+  ASSERT_EQ(counter.get_latest_data().t.sec(), 109);
+}
+
+// The circular buffer capacity is 20; values beyond that evict the oldest.
+TEST(PerfCounterInstance, CircularBufferOverflow) {
+  PerfCounterInstance counter(PERFCOUNTER_U64);
+
+  for (int i = 0; i < 25; i++) {
+    utime_t t(100 + i, 0);
+    uint64_t v = i;
+    counter.push(t, v);
+  }
+
+  ASSERT_EQ(counter.get_data().size(), 20);
+  ASSERT_EQ(counter.get_latest_data().v, 24);
+  ASSERT_EQ(counter.get_latest_data().t.sec(), 124);
+  ASSERT_EQ(counter.get_data().front().v, 5);
+  ASSERT_EQ(counter.get_data().front().t.sec(), 105);
+}
+
+TEST(PerfCounterInstance, PushAvgSingleValue) {
+  PerfCounterInstance counter(PERFCOUNTER_LONGRUNAVG);
+  utime_t t1(100, 0);
+  uint64_t sum = 1000;
+  uint64_t count = 10;
+
+  counter.push_avg(t1, sum, count);
+
+  ASSERT_EQ(counter.get_data_avg().size(), 1);
+  ASSERT_EQ(counter.get_latest_data_avg().s, sum);
+  ASSERT_EQ(counter.get_latest_data_avg().c, count);
+  ASSERT_EQ(counter.get_latest_data_avg().t, t1);
+}
+
+TEST(PerfCounterInstance, PushAvgMultipleValues) {
+  PerfCounterInstance counter(PERFCOUNTER_LONGRUNAVG);
+
+  for (int i = 0; i < 10; i++) {
+    utime_t t(100 + i, 0);
+    uint64_t sum = i * 100;
+    uint64_t count = i + 1;
+    counter.push_avg(t, sum, count);
+  }
+
+  ASSERT_EQ(counter.get_data_avg().size(), 10);
+  ASSERT_EQ(counter.get_latest_data_avg().s, 900);
+  ASSERT_EQ(counter.get_latest_data_avg().c, 10);
+  ASSERT_EQ(counter.get_latest_data_avg().t.sec(), 109);
+}
+
+// The circular buffer capacity is 20; values beyond that evict the oldest.
+TEST(PerfCounterInstance, AvgCircularBufferOverflow) {
+  PerfCounterInstance counter(PERFCOUNTER_LONGRUNAVG);
+
+  for (int i = 0; i < 25; i++) {
+    utime_t t(100 + i, 0);
+    uint64_t sum = i * 10;
+    uint64_t count = i + 1;
+    counter.push_avg(t, sum, count);
+  }
+
+  ASSERT_EQ(counter.get_data_avg().size(), 20);
+  ASSERT_EQ(counter.get_latest_data_avg().s, 240);
+  ASSERT_EQ(counter.get_latest_data_avg().c, 25);
+  ASSERT_EQ(counter.get_latest_data_avg().t.sec(), 124);
+  ASSERT_EQ(counter.get_data_avg().front().s, 50);
+  ASSERT_EQ(counter.get_data_avg().front().c, 6);
+  ASSERT_EQ(counter.get_data_avg().front().t.sec(), 105);
+}
+
+TEST(PerfCounterInstance, GetDataReturnsCorrectBuffer) {
+  PerfCounterInstance counter(PERFCOUNTER_U64);
+
+  for (int i = 0; i < 5; i++) {
+    utime_t t(100 + i, 0);
+    counter.push(t, i * 10);
+  }
+
+  const auto& data = counter.get_data();
+  ASSERT_EQ(data.size(), 5);
+
+  int idx = 0;
+  for (const auto& point : data) {
+    ASSERT_EQ(point.v, idx * 10);
+    ASSERT_EQ(point.t.sec(), 100 + idx);
+    idx++;
+  }
+}
+
+TEST(PerfCounterInstance, GetDataAvgReturnsCorrectBuffer) {
+  PerfCounterInstance counter(PERFCOUNTER_LONGRUNAVG);
+
+  for (int i = 0; i < 5; i++) {
+    utime_t t(100 + i, 0);
+    counter.push_avg(t, i * 100, i + 1);
+  }
+
+  const auto& data = counter.get_data_avg();
+  ASSERT_EQ(data.size(), 5);
+
+  int idx = 0;
+  for (const auto& point : data) {
+    ASSERT_EQ(point.s, idx * 100);
+    ASSERT_EQ(point.c, idx + 1);
+    ASSERT_EQ(point.t.sec(), 100 + idx);
+    idx++;
+  }
+}
+
+TEST(PerfCounterInstance, DifferentCounterTypes) {
+  PerfCounterInstance time_counter(PERFCOUNTER_TIME);
+  utime_t t1(100, 0);
+  time_counter.push(t1, 12345);
+  ASSERT_EQ(time_counter.get_data().size(), 1);
+  ASSERT_EQ(time_counter.get_latest_data().v, 12345);
+
+  // LONGRUNAVG|TIME is a distinct type combination; test that it routes to the avg buffer
+  PerfCounterInstance avg_time_counter(
+      static_cast<perfcounter_type_d>(PERFCOUNTER_LONGRUNAVG | PERFCOUNTER_TIME));
+  avg_time_counter.push_avg(t1, 5000, 10);
+  ASSERT_EQ(avg_time_counter.get_data_avg().size(), 1);
+  ASSERT_EQ(avg_time_counter.get_latest_data_avg().s, 5000);
+  ASSERT_EQ(avg_time_counter.get_latest_data_avg().c, 10);
+}
+
+TEST(PerfCounterInstance, ZeroValues) {
+  PerfCounterInstance counter(PERFCOUNTER_U64);
+  utime_t t(0, 0);
+
+  counter.push(t, 0);
+
+  ASSERT_EQ(counter.get_data().size(), 1);
+  ASSERT_EQ(counter.get_latest_data().v, 0);
+  ASSERT_EQ(counter.get_latest_data().t.sec(), 0);
+}
+
+TEST(PerfCounterInstance, LargeValues) {
+  PerfCounterInstance counter(PERFCOUNTER_U64);
+  utime_t t(1000000, 999999);
+  uint64_t large_val = UINT64_MAX;
+
+  counter.push(t, large_val);
+
+  ASSERT_EQ(counter.get_data().size(), 1);
+  ASSERT_EQ(counter.get_latest_data().v, large_val);
+}
+
+TEST(PerfCounterInstance, AvgZeroCount) {
+  PerfCounterInstance counter(PERFCOUNTER_LONGRUNAVG);
+  utime_t t(100, 0);
+
+  counter.push_avg(t, 1000, 0);
+
+  ASSERT_EQ(counter.get_data_avg().size(), 1);
+  ASSERT_EQ(counter.get_latest_data_avg().s, 1000);
+  ASSERT_EQ(counter.get_latest_data_avg().c, 0);
+}
+
+TEST(PerfCounterInstance, TimeOrdering) {
+  PerfCounterInstance counter(PERFCOUNTER_U64);
+
+  for (int i = 0; i < 5; i++) {
+    utime_t t(100 + i * 10, i * 1000);
+    counter.push(t, i);
+  }
+
+  const auto& data = counter.get_data();
+  ASSERT_EQ(data.size(), 5);
+
+  utime_t prev_t(0, 0);
+  for (const auto& point : data) {
+    ASSERT_TRUE(point.t > prev_t);
+    prev_t = point.t;
+  }
+}

--- a/src/test/mgr/test_pymoduleregistry.cc
+++ b/src/test/mgr/test_pymoduleregistry.cc
@@ -1,0 +1,123 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/PyModuleRegistry.h"
+#include "mon/MgrMap.h"
+
+TEST_F(PyModuleRegistryTestHelper, BasicCreation) {
+  ASSERT_NE(registry, nullptr);
+  ASSERT_NE(cct, nullptr);
+  ASSERT_NE(clog, nullptr);
+}
+
+TEST_F(PyModuleRegistryTestHelper, GetModulesEmpty) {
+  auto modules = registry->get_modules();
+  ASSERT_TRUE(modules.empty());
+}
+
+TEST_F(PyModuleRegistryTestHelper, GetNonExistentModule) {
+  auto module = registry->get_module("nonexistent_module");
+  ASSERT_FALSE(module);
+}
+
+TEST_F(PyModuleRegistryTestHelper, RegisterClient) {
+  entity_addrvec_t addrs;
+  entity_addr_t addr;
+  addr.parse("127.0.0.1:6789", nullptr);
+  addrs.v.push_back(addr);
+
+  registry->register_client("test_client", addrs, false);
+
+  auto clients = registry->get_clients();
+  ASSERT_EQ(clients.size(), 1);
+  ASSERT_EQ(clients.count("test_client"), 1);
+}
+
+TEST_F(PyModuleRegistryTestHelper, RegisterClientReplace) {
+  entity_addrvec_t addrs1, addrs2;
+  entity_addr_t addr1, addr2;
+
+  addr1.parse("127.0.0.1:6789", nullptr);
+  addrs1.v.push_back(addr1);
+
+  addr2.parse("127.0.0.1:6790", nullptr);
+  addrs2.v.push_back(addr2);
+
+  registry->register_client("test_client", addrs1, false);
+  auto clients = registry->get_clients();
+  ASSERT_EQ(clients.size(), 1);
+
+  // clients is a multimap: a second insert with replace=false adds a second entry
+  registry->register_client("test_client", addrs2, false);
+  clients = registry->get_clients();
+  ASSERT_EQ(clients.size(), 2); // Both should exist
+
+  // replace=true erases all entries for the name, then inserts one
+  registry->register_client("test_client", addrs2, true);
+  clients = registry->get_clients();
+  ASSERT_EQ(clients.size(), 1); // Only one should remain
+}
+
+TEST_F(PyModuleRegistryTestHelper, UnregisterClient) {
+  entity_addrvec_t addrs;
+  entity_addr_t addr;
+  addr.parse("127.0.0.1:6789", nullptr);
+  addrs.v.push_back(addr);
+
+  registry->register_client("test_client", addrs, false);
+  auto clients = registry->get_clients();
+  ASSERT_EQ(clients.size(), 1);
+
+  registry->unregister_client("test_client", addrs);
+  clients = registry->get_clients();
+  ASSERT_TRUE(clients.empty());
+}
+
+TEST_F(PyModuleRegistryTestHelper, MultipleClients) {
+  entity_addrvec_t addrs1, addrs2;
+  entity_addr_t addr1, addr2;
+
+  addr1.parse("127.0.0.1:6789", nullptr);
+  addrs1.v.push_back(addr1);
+
+  addr2.parse("127.0.0.1:6790", nullptr);
+  addrs2.v.push_back(addr2);
+
+  registry->register_client("client1", addrs1, false);
+  registry->register_client("client2", addrs2, false);
+
+  auto clients = registry->get_clients();
+  ASSERT_EQ(clients.size(), 2);
+  ASSERT_EQ(clients.count("client1"), 1);
+  ASSERT_EQ(clients.count("client2"), 1);
+}
+
+TEST_F(PyModuleRegistryTestHelper, HandleMgrMapFirstSeen) {
+  // Internal epoch starts at 0; the first call takes the epoch==0 branch,
+  // which sets enabled flags on modules and always returns false.
+  MgrMap mgr_map;
+  mgr_map.epoch = 1;
+
+  bool needs_restart = registry->handle_mgr_map(mgr_map);
+  ASSERT_FALSE(needs_restart);
+}
+
+TEST_F(PyModuleRegistryTestHelper, HandleMgrMapUpdate) {
+  // Prime the registry with epoch 1 (epoch==0 branch).
+  MgrMap mgr_map;
+  mgr_map.epoch = 1;
+  registry->handle_mgr_map(mgr_map);
+
+  // A second call with the same module sets takes the else branch.
+  // No module sets changed, so needs_restart must be false.
+  MgrMap mgr_map2;
+  mgr_map2.epoch = 2;
+  bool needs_restart = registry->handle_mgr_map(mgr_map2);
+  ASSERT_FALSE(needs_restart);
+}
+
+TEST_F(PyModuleRegistryTestHelper, StandbyModulesState) {
+  ASSERT_FALSE(registry->have_standby_modules());
+  ASSERT_FALSE(registry->is_standby_running());
+}

--- a/src/test/mgr/test_pymodulerunner.cc
+++ b/src/test/mgr/test_pymodulerunner.cc
@@ -1,0 +1,80 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/PyModuleRunner.h"
+#include "mgr/PyModule.h"
+#include "common/LogClient.h"
+
+// AddGlobalTestEnvironment must be called before RUN_ALL_TESTS(); a file-scope
+// pointer is the standard way to ensure this runs during static initialisation.
+::testing::Environment* const python_env =
+    ::testing::AddGlobalTestEnvironment(new PythonEnv);
+
+TEST_F(TestMgr, PyModuleRunnerCephContextInitialized) {
+  ASSERT_NE(cct, nullptr);
+  EXPECT_NE(cct.get(), nullptr);
+}
+
+TEST_F(TestMgr, PyModuleRunner_PyModuleCreation) {
+  auto py_module = std::make_shared<PyModule>("test_module");
+  ASSERT_NE(py_module, nullptr);
+  EXPECT_EQ(py_module->get_name(), "test_module");
+}
+
+TEST_F(TestMgr, PyModuleRunner_PyModuleNames) {
+  auto py_module1 = std::make_shared<PyModule>("module1");
+  auto py_module2 = std::make_shared<PyModule>("module2");
+  auto py_module3 = std::make_shared<PyModule>("very_long_module_name");
+
+  EXPECT_EQ(py_module1->get_name(), "module1");
+  EXPECT_EQ(py_module2->get_name(), "module2");
+  EXPECT_EQ(py_module3->get_name(), "very_long_module_name");
+}
+
+TEST_F(TestMgr, PyModuleRunner_PyModuleEmptyName) {
+  auto py_module = std::make_shared<PyModule>("");
+  ASSERT_NE(py_module, nullptr);
+  EXPECT_EQ(py_module->get_name(), "");
+}
+
+TEST_F(TestMgr, PyModuleRunner_PyModuleSpecialChars) {
+  auto py_module = std::make_shared<PyModule>("test-module_123");
+  ASSERT_NE(py_module, nullptr);
+  EXPECT_EQ(py_module->get_name(), "test-module_123");
+}
+
+TEST_F(TestMgr, PyModuleRunner_LogChannelCreation) {
+  auto clog = std::make_shared<LogChannel>(cct.get(), nullptr, "cluster");
+  ASSERT_NE(clog, nullptr);
+  EXPECT_NE(clog.get(), nullptr);
+}
+
+TEST_F(TestMgr, PyModuleRunner_ThreadMonitorCreation) {
+  auto thread_monitor = std::make_unique<ThreadMonitor>(cct.get());
+  ASSERT_NE(thread_monitor, nullptr);
+  EXPECT_NE(thread_monitor.get(), nullptr);
+}
+
+TEST_F(TestMgr, PyModuleRunner_MultipleLogChannels) {
+  auto clog1 = std::make_shared<LogChannel>(cct.get(), nullptr, "cluster");
+  auto clog2 = std::make_shared<LogChannel>(cct.get(), nullptr, "audit");
+
+  ASSERT_NE(clog1, nullptr);
+  ASSERT_NE(clog2, nullptr);
+  EXPECT_NE(clog1.get(), clog2.get());
+}
+
+TEST_F(TestMgr, PyModuleRunner_PyModuleRefCounting) {
+  auto py_module = std::make_shared<PyModule>("test_module");
+  EXPECT_EQ(py_module.use_count(), 1);
+
+  auto py_module_copy = py_module;
+  EXPECT_EQ(py_module.use_count(), 2);
+  EXPECT_EQ(py_module_copy.use_count(), 2);
+}
+
+TEST_F(TestMgr, PyModuleRunner_CephContextShared) {
+  ASSERT_NE(cct, nullptr);
+  EXPECT_NE(cct.get(), nullptr);
+}

--- a/src/test/mgr/test_pyosdmap.cc
+++ b/src/test/mgr/test_pyosdmap.cc
@@ -1,0 +1,173 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/PyOSDMap.h"
+#include "osd/OSDMap.h"
+
+TEST_F(PyOSDMapTest, OSDMapInitialized) {
+  ASSERT_EQ(osd_map.get_epoch(), 1);
+}
+
+TEST_F(PyOSDMapTest, GetEpoch) {
+  EXPECT_EQ(osd_map.get_epoch(), 1);
+  EXPECT_GT(osd_map.get_epoch(), 0);
+}
+
+TEST_F(PyOSDMapTest, GetMaxOSD) {
+  EXPECT_EQ(osd_map.get_max_osd(), 0);
+}
+
+TEST_F(PyOSDMapTest, GetNumPools) {
+  EXPECT_EQ(osd_map.get_pools().size(), 0);
+}
+
+TEST_F(PyOSDMapTest, GetFlags) {
+  EXPECT_EQ(osd_map.get_flags(), 0);
+}
+
+TEST_F(PyOSDMapTest, GetCreated) {
+  auto created = osd_map.get_created();
+  EXPECT_GE(created.sec(), 0);
+}
+
+TEST_F(PyOSDMapTest, GetModified) {
+  auto modified = osd_map.get_modified();
+  EXPECT_GE(modified.sec(), 0);
+}
+
+TEST_F(PyOSDMapTest, ApplyIncremental) {
+  OSDMap::Incremental inc(osd_map.get_epoch() + 1);
+  osd_map.apply_incremental(inc);
+  EXPECT_EQ(osd_map.get_epoch(), 2);
+}
+
+TEST_F(PyOSDMapTest, PoolOperations) {
+  OSDMap::Incremental inc(osd_map.get_epoch() + 1);
+  pg_pool_t pool;
+  pool.set_pg_num(8);
+  pool.set_pgp_num(8);
+  inc.new_pool_max = 1;
+  inc.new_pools[1] = pool;
+  osd_map.apply_incremental(inc);
+
+  EXPECT_EQ(osd_map.get_pools().size(), 1);
+  EXPECT_TRUE(osd_map.have_pg_pool(1));
+}
+
+TEST_F(PyOSDMapTest, OSDOperations) {
+  OSDMap::Incremental inc(osd_map.get_epoch() + 1);
+  inc.new_max_osd = 1;
+  inc.new_state[0] = CEPH_OSD_EXISTS | CEPH_OSD_UP;
+  inc.new_weight[0] = CEPH_OSD_IN;
+  inc.new_up_client[0] = entity_addrvec_t();
+  inc.new_up_cluster[0] = entity_addrvec_t();
+  inc.new_hb_back_up[0] = entity_addrvec_t();
+  inc.new_hb_front_up[0] = entity_addrvec_t();
+  osd_map.apply_incremental(inc);
+
+  EXPECT_EQ(osd_map.get_max_osd(), 1);
+  EXPECT_TRUE(osd_map.exists(0));
+  EXPECT_TRUE(osd_map.is_up(0));
+}
+
+TEST_F(PyOSDMapTest, GetPoolsType) {
+  const auto& pools = osd_map.get_pools();
+  EXPECT_TRUE(pools.empty());
+}
+
+TEST_F(PyOSDMapTest, GetFSID) {
+  EXPECT_EQ(osd_map.get_fsid(), uuid_d());
+}
+
+TEST_F(PyOSDMapTest, GetClusterSnapshot) {
+  EXPECT_EQ(osd_map.get_cluster_snapshot(), "");
+}
+
+TEST_F(PyOSDMapTest, PoolNameOperations) {
+  OSDMap::Incremental inc(osd_map.get_epoch() + 1);
+  pg_pool_t pool;
+  pool.set_pg_num(8);
+  inc.new_pool_max = 1;
+  inc.new_pools[1] = pool;
+  inc.new_pool_names[1] = "test_pool";
+  osd_map.apply_incremental(inc);
+
+  EXPECT_EQ(osd_map.get_pool_name(1), "test_pool");
+  EXPECT_TRUE(osd_map.have_pg_pool(1));
+}
+
+TEST_F(PyOSDMapTest, MultiplePools) {
+  OSDMap::Incremental inc(osd_map.get_epoch() + 1);
+  pg_pool_t pool1, pool2;
+  pool1.set_pg_num(8);
+  pool2.set_pg_num(16);
+  inc.new_pool_max = 2;
+  inc.new_pools[1] = pool1;
+  inc.new_pools[2] = pool2;
+  inc.new_pool_names[1] = "pool1";
+  inc.new_pool_names[2] = "pool2";
+  osd_map.apply_incremental(inc);
+
+  EXPECT_EQ(osd_map.get_pools().size(), 2);
+  EXPECT_TRUE(osd_map.have_pg_pool(1));
+  EXPECT_TRUE(osd_map.have_pg_pool(2));
+  EXPECT_EQ(osd_map.get_pool_name(1), "pool1");
+  EXPECT_EQ(osd_map.get_pool_name(2), "pool2");
+}
+
+TEST_F(PyOSDMapTest, EpochProgression) {
+  EXPECT_EQ(osd_map.get_epoch(), 1);
+  for (int i = 0; i < 5; i++) {
+    OSDMap::Incremental inc(osd_map.get_epoch() + 1);
+    osd_map.apply_incremental(inc);
+  }
+  EXPECT_EQ(osd_map.get_epoch(), 6);
+}
+
+TEST_F(PyOSDMapTest, OSDUpDown) {
+  OSDMap::Incremental inc(osd_map.get_epoch() + 1);
+  inc.new_max_osd = 1;
+  inc.new_state[0] = CEPH_OSD_EXISTS | CEPH_OSD_UP;
+  inc.new_weight[0] = CEPH_OSD_IN;
+  inc.new_up_client[0] = entity_addrvec_t();
+  inc.new_up_cluster[0] = entity_addrvec_t();
+  inc.new_hb_back_up[0] = entity_addrvec_t();
+  inc.new_hb_front_up[0] = entity_addrvec_t();
+  osd_map.apply_incremental(inc);
+
+  EXPECT_TRUE(osd_map.is_up(0));
+  EXPECT_FALSE(osd_map.is_down(0));
+}
+
+TEST_F(PyOSDMapTest, GetNumUpOSDs) {
+  EXPECT_EQ(osd_map.get_num_up_osds(), 0);
+
+  OSDMap::Incremental inc(osd_map.get_epoch() + 1);
+  inc.new_max_osd = 1;
+  inc.new_state[0] = CEPH_OSD_EXISTS | CEPH_OSD_UP;
+  inc.new_weight[0] = CEPH_OSD_IN;
+  inc.new_up_client[0] = entity_addrvec_t();
+  inc.new_up_cluster[0] = entity_addrvec_t();
+  inc.new_hb_back_up[0] = entity_addrvec_t();
+  inc.new_hb_front_up[0] = entity_addrvec_t();
+  osd_map.apply_incremental(inc);
+
+  EXPECT_EQ(osd_map.get_num_up_osds(), 1);
+}
+
+TEST_F(PyOSDMapTest, GetNumInOSDs) {
+  EXPECT_EQ(osd_map.get_num_in_osds(), 0);
+
+  OSDMap::Incremental inc(osd_map.get_epoch() + 1);
+  inc.new_max_osd = 1;
+  inc.new_state[0] = CEPH_OSD_EXISTS | CEPH_OSD_UP;
+  inc.new_weight[0] = CEPH_OSD_IN;
+  inc.new_up_client[0] = entity_addrvec_t();
+  inc.new_up_cluster[0] = entity_addrvec_t();
+  inc.new_hb_back_up[0] = entity_addrvec_t();
+  inc.new_hb_front_up[0] = entity_addrvec_t();
+  osd_map.apply_incremental(inc);
+
+  EXPECT_EQ(osd_map.get_num_in_osds(), 1);
+}

--- a/src/test/mgr/test_standbypymodules.cc
+++ b/src/test/mgr/test_standbypymodules.cc
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/StandbyPyModules.h"
+#include "common/Finisher.h"
+
+TEST_F(StandbyPyModulesTestHelper, BasicSetup) {
+  ASSERT_NE(py_registry, nullptr);
+  ASSERT_NE(mc, nullptr);
+  ASSERT_NE(cct, nullptr);
+  ASSERT_NE(clog, nullptr);
+}
+
+TEST_F(StandbyPyModulesTestHelper, Construction) {
+  MgrMap test_mgr_map;
+  PyModuleConfig module_config;
+  Finisher finisher(cct.get());
+  finisher.start();
+
+  {
+    StandbyPyModules standby_modules(
+        test_mgr_map,
+        module_config,
+        clog,
+        *mc,
+        finisher);
+
+    SUCCEED();
+  }
+
+  finisher.stop();
+}

--- a/src/test/mgr/test_threadmonitor.cc
+++ b/src/test/mgr/test_threadmonitor.cc
@@ -1,0 +1,15 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "TestMgr.h"
+#include "mgr/ThreadMonitor.h"
+
+TEST_F(ThreadMonitorTestHelper, BasicCreation) {
+  ASSERT_NE(thread_monitor, nullptr);
+  ASSERT_NE(cct, nullptr);
+}
+
+TEST_F(ThreadMonitorTestHelper, Construction) {
+  ThreadMonitor tm(cct.get());
+  // Should not crash
+}


### PR DESCRIPTION
So far, unit testing of the Mgr has been focused on writing tests for specific objects, adding scaffolding to TestMgr.h as needed. This PR introduces scaffolding needed to test objects within the Mgr so that parallel testing efforts can be undertaken, with a consistent starting point.

Each test file contains at minimum one SetUp/TearDown round trip, verifying that the object can be constructed and destroyed without crashing. PerfCounterInstance and PyModuleRegistry have deeper coverage of their public APIs (circular-buffer behaviour, client registration/replace semantics, module query methods).

These tests in these commits are meant to be a starting point to enable future testing efforts, and are by no means a complete or comprehensive testing effort.

Fixes: https://tracker.ceph.com/issues/77389

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
