### PR TITLE
sudoers: do not open a PAM session for the smartctl invocation

### DIFF
--- a/sudoers.d/ceph-smartctl
+++ b/sudoers.d/ceph-smartctl
@@ -2,3 +2,21 @@
 
 ceph ALL=NOPASSWD: /usr/sbin/smartctl -x --json=o /dev/*
 ceph ALL=NOPASSWD: /usr/sbin/nvme * smart-log-add --json /dev/*
+
+## Do not open a PAM session for these commands.
+##
+## sudo's PAM session stage runs pam_systemd, which makes a dbus call to
+## systemd-logind.  The daemon invoking sudo runs in the SELinux ceph_t
+## domain, and although ceph_t is itself permissive, the reply from logind is
+## refused by a rule whose source domain -- and therefore whose permissive
+## flag -- is systemd_logind_t:
+##
+##   avc:  denied  { send_msg } for msgtype=method_return
+##     scontext=system_u:system_r:systemd_logind_t:s0
+##     tcontext=system_u:system_r:ceph_t:s0 tclass=dbus permissive=0
+##
+## sudo then waits for a reply that never arrives, until
+## osd_smart_report_timeout expires and its process group is killed.  Every
+## sample collected that way is a smartctl error stub rather than SMART data.
+## Neither command needs a session, so do not open one.
+Defaults:ceph !pam_session


### PR DESCRIPTION
block_device_get_metrics() collects device health metrics by running

  sudo smartctl -x --json=o /dev/<dev>

from the daemon, which runs as user ceph.  sudo's PAM session stage runs pam_systemd, which makes a dbus call to systemd-logind.  The daemon runs in the SELinux ceph_t domain, and although selinux/ceph.te marks ceph_t permissive, that flag belongs to the source domain of a decision -- so it does not cover logind's reply, which is refused by an enforcing rule whose source domain is systemd_logind_t:

  avc:  denied  { send_msg } for msgtype=method_return
    scontext=system_u:system_r:systemd_logind_t:s0
    tcontext=system_u:system_r:ceph_t:s0 tclass=dbus permissive=0

sudo waits for a reply that never arrives.  After osd_smart_report_timeout seconds SubProcessTimed kills its process group, join() reports exit status 137, and block_device_run_smartctl() turns that into -EINVAL, so what gets stored is

  {"error": "smartctl failed", "smartctl_error_code": -22, ...}

This affects every device on every scrape, and nothing surfaces it: the error document is valid JSON, so block_device_get_metrics() returns 0 and the OSD logs nothing, and the subprocess is created with stderr CLOSE so the "timed out" message is discarded.  'ceph device get-health-metrics' still returns a full sample history, which makes it look like monitoring is working, and a cluster can go a long time collecting nothing usable.

Neither of these commands needs a PAM session, so do not open one.  With this in place the affected devices report real SMART data again.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
