### PR TITLE
tentacle: doc/man: document ceph-bluestore-tool set-label-key and rm-label-key

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -22,6 +22,8 @@ Synopsis
 | **ceph-bluestore-tool** restore_cfb --path *osd path*
 | **ceph-bluestore-tool** show-label --dev *device* ...
 | **ceph-bluestore-tool** show-label-at --dev *device* --offset *lba*...
+| **ceph-bluestore-tool** set-label-key --dev *device* -k *key* -v *value*
+| **ceph-bluestore-tool** rm-label-key --dev *device* -k *key*
 | **ceph-bluestore-tool** prime-osd-dir --dev *device* --path *osd path*
 | **ceph-bluestore-tool** bluefs-export --path *osd path* --out-dir *dir*
 | **ceph-bluestore-tool** bluefs-bdev-new-wal --path *osd path* --dev-target *new-device*
@@ -123,6 +125,21 @@ Commands
    The labels at some locations might not exist though. 
    The label may be printed while an OSD is running.
 
+:command:`set-label-key` --dev *device* -k *key* -v *value*
+
+   Set a label field or metadata key to *value*. The *size*, *osd_uuid*,
+   *btime* and *description* fields of the label are set directly; any other
+   *key* is stored as a free-form metadata entry. The value is written to every
+   valid label location on the device.
+   The OSD must be stopped before modifying its label.
+
+:command:`rm-label-key` --dev *device* -k *key*
+
+   Remove the metadata key *key* from the label, and fail if it is not present.
+   Only the free-form metadata entries can be removed this way; the fields
+   listed under *set-label-key* are always present.
+   The OSD must be stopped before modifying its label.
+
 :command:`free-dump` --path *osd path* [ --allocator block/bluefs-wal/bluefs-db/bluefs-slow ]
 
    Dump all free regions in allocator.
@@ -212,6 +229,16 @@ Options
 
    deep scrub/repair (read and validate object data, not just metadata)
 
+.. option:: -k, --key *key*
+
+   Label field or metadata key name. Useful for *set-label-key* and
+   *rm-label-key* actions.
+
+.. option:: -v, --value *value*
+
+   Value to store for the key named by --key. Useful for the *set-label-key*
+   action.
+
 .. option:: --allocator *name*
 
    Useful for *free-dump* and *free-score* actions. Selects allocator(s).
@@ -247,6 +274,11 @@ The main device contains additional label copies at offsets: 1GiB, 10GiB, 100GiB
 Corrupted labels are fixed as part of repair::
 
   ceph-bluestore-tool repair --dev *device*
+
+Individual label entries can be changed or removed while the OSD is stopped::
+
+  ceph-bluestore-tool set-label-key --dev *device* -k *key* -v *value*
+  ceph-bluestore-tool rm-label-key --dev *device* -k *key*
 
 OSD directory priming
 =====================


### PR DESCRIPTION
Backport of #71240 to `tentacle`, tracked by https://tracker.ceph.com/issues/79740.

**What is fixed:** the `ceph-bluestore-tool` man page does not document `set-label-key` or `rm-label-key`, nor the `-k`/`--key` and `-v`/`--value` options both commands require. Someone reading the `tentacle` docs has no way to learn these commands exist.

**Why this is the minimal fix:** it is a documentation-only change to a single file, `doc/man/8/ceph-bluestore-tool.rst`. No code is touched, so there is no regression risk to the stable branch. The diff is +32 lines and 0 deletions, identical in content to the change that landed in `main`.

**Why it is needed in `tentacle`:** `set-label-key` and `rm-label-key` are both present and accepted by `ceph-bluestore-tool` in this release — I checked `src/os/bluestore/bluestore_tool.cc` on the `tentacle` branch. The commands work here, only the documentation for them is missing, so the gap affects `tentacle` users exactly as it affected `main`.

**Conflicts:** the cherry-pick needed one manual resolution, recorded in the commit message. This branch words the `show-label-at` synopsis line as `--offset *lba*...` where `main` has `--offset *lba* ...`; I kept this branch's existing wording and added the two new synopsis lines below it rather than reformatting a stable branch. Nothing else differed. The branch is a clean fast-forward on top of the base with no merge conflicts.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
