### PR TITLE
mon: do not ack osd new until cephx can auth as osd.N

### DIFF
--- a/qa/standalone/mon/osd-new-mkfs.sh
+++ b/qa/standalone/mon/osd-new-mkfs.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Regression for the `osd new` / cephx race: the command used to ack from
+# OSDMonitor::wait_for_commit during OSDMAP refresh, before AuthMonitor applied
+# the same plugged transaction into KeyServer. Immediate ceph-osd --mkfs --key
+# then failed with EACCES and left no type file.
+#
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7199" # git grep '\<7199\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth_cluster_required=none --auth_service_required=none --auth_client_required=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_osd_new_then_immediate_mkfs() {
+    local dir=$1
+
+    # Real cephx: this is the auth path that raced in CI.
+    ceph-authtool --create-keyring $dir/ceph.mon.keyring --gen-key -n mon. --cap mon 'allow *'
+    ceph-authtool --create-keyring $dir/ceph.client.admin.keyring --gen-key -n client.admin \
+        --cap mon 'allow *' --cap osd 'allow *' --cap mgr 'allow *'
+    ceph-authtool $dir/ceph.mon.keyring --import-keyring $dir/ceph.client.admin.keyring
+
+    local fsid=$(uuidgen)
+    local base_args="--fsid=$fsid --mon-host=$CEPH_MON"
+    base_args+=" --auth_cluster_required=cephx --auth_service_required=cephx --auth_client_required=cephx"
+    CEPH_ARGS="$base_args --keyring=$dir/ceph.mon.keyring"
+    run_mon $dir a || return 1
+    CEPH_ARGS="$base_args --keyring=$dir/ceph.client.admin.keyring"
+    timeout 60 ceph status || return 1
+
+    local n
+    for n in 0 1 2 3 4; do
+        local osd_data=$dir/$n
+        mkdir -p "$osd_data" || return 1
+        local uuid=$(uuidgen)
+        local secret=$(ceph-authtool --gen-print-key)
+        echo "{\"cephx_secret\": \"$secret\"}" > "$osd_data/new.json"
+        local id
+        id=$(ceph osd new $uuid -i "$osd_data/new.json") || return 1
+        rm -f "$osd_data/new.json"
+        [[ "$id" == "$n" ]] || return 1
+
+        # Same client, no delay: KeyServer must already have osd.N.
+        ceph auth get osd.$id || return 1
+
+        # Same sequence as vstart: osd new then immediate mkfs as that id.
+        # Do not pass --no-mon-config; mkfs must authenticate to the mon as osd.N.
+        # Isolate from CEPH_ARGS --keyring=client.admin so we actually use --key.
+        ceph-osd -i $id \
+            --mkfs --key $secret --name osd.$id --keyring /dev/null \
+            --osd-uuid $uuid \
+            --osd-data=$osd_data \
+            --osd-journal=${osd_data}/journal \
+            --osd-journal-size=100 \
+            --osd-failsafe-full-ratio=.99 \
+            --chdir= \
+            --run-dir=$dir \
+            --admin-socket=$(get_asok_path) \
+            --debug-osd=20 \
+            --debug-ms=1 \
+            --debug-monc=20 \
+            --log-file=$dir/\$name.log \
+            --pid-file=$dir/\$name.pid \
+            || return 1
+        [[ -f "$osd_data/type" ]] || return 1
+    done
+}
+
+main osd-new-mkfs "$@"
+
+# Local Variables:
+# compile-command: "cd ../.. ; make -j4 && test/mon/osd-new-mkfs.sh"
+# End:

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1402,6 +1402,10 @@ function test_mon_osd_create_destroy()
 
   ceph osd find $id
 
+  # osd new must not return until KeyServer can serve the new entity
+  ceph auth get osd.$id >/dev/null
+  ceph auth get client.osd-lockbox.$uuid >/dev/null
+
   # validate secrets and dm-crypt are set
   k=$(ceph auth get-key osd.$id --format=json-pretty 2>/dev/null | jq '.key')
   s=$(cat $all_secrets | jq '.cephx_secret')
@@ -1419,6 +1423,7 @@ function test_mon_osd_create_destroy()
   done
 
   ceph osd find $id2
+  ceph auth get osd.$id2 >/dev/null
   k=$(ceph auth get-key osd.$id --format=json-pretty 2>/dev/null | jq '.key')
   s=$(cat $all_secrets | jq '.cephx_secret')
   [[ $k == $s ]]

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -158,9 +158,7 @@ void PaxosService::refresh(bool *need_bootstrap)
   // update cached versions
   auto first_committed = mon.store->get(get_service_name(), first_committed_name);
   auto last_committed = mon.store->get(get_service_name(), last_committed_name);
-  if (last_committed > cached_last_committed) {
-    finish_contexts(g_ceph_context, waiting_for_commit, 0);
-  }
+  committed_this_cycle = last_committed > cached_last_committed;
   cached_first_committed = first_committed;
   cached_last_committed = last_committed;
 
@@ -171,7 +169,6 @@ void PaxosService::refresh(bool *need_bootstrap)
   }
   format_version = new_format;
 
-
   _update_from_paxos(need_bootstrap);
 }
 
@@ -180,6 +177,14 @@ void PaxosService::post_refresh()
   dout(10) << __func__ << dendl;
 
   post_paxos_update();
+
+  // After every service has applied this round. Completing waiters in
+  // refresh() would ack OSDMonitor before AuthMonitor updated KeyServer,
+  // and handle_auth_request() can run on the msgr path immediately.
+  if (committed_this_cycle) {
+    finish_contexts(g_ceph_context, waiting_for_commit, 0);
+    committed_this_cycle = false;
+  }
 
   if (mon.is_peon()) {
     finish_contexts(g_ceph_context, waiting_for_finished_proposal, -EAGAIN);

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -481,6 +481,8 @@ public:
    * Callback list to be used for waiting for the next proposal to commit.
    */
   std::vector<Context*> waiting_for_commit;
+  /// Set in refresh() when last_committed advanced; consumed in post_refresh().
+  bool committed_this_cycle = false;
 
   /**
    * Callback list to be used whenever we are running a proposal through
@@ -539,12 +541,16 @@ public:
   }
 
   /**
-   * Wait for a proposal to commit.
+   * Wait for a proposal to commit and for committed state to be applied.
    *
-   * Note: the proposal may not be signaled yet. This simply adds a context to
-   * be completed when the next proposal commits.
+   * The proposal may not be signaled yet. This queues @p c to run from
+   * post_refresh() after every PaxosService has run _update_from_paxos()
+   * for that round — not merely after the store write. Completing waiters
+   * earlier would let a client observe the ack (e.g. osd new) and use the
+   * new value (cephx as osd.N) while KeyServer is still at the previous version.
    *
-   * @param c The callback to be awaken once the proposal is committed.
+   * @param c The callback to be awaken once the proposal is committed
+   *          and applied.
    */
   void wait_for_commit(MonOpRequestRef op, Context *c) {
     if (op)

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -37,30 +37,6 @@ prun() {
     PATH=$CEPH_BIN:$PATH "$@"
 }
 
-# retry <max_attempts> <delay_secs> <description> <command> [args...]
-# Run the command until it succeeds or <max_attempts> attempts have been made
-# (use 0 for unlimited). Returns the command's last exit status.
-retry() {
-    local max=$1 delay=$2 what=$3
-    shift 3
-    local n=0 rc=0
-    while true; do
-        rc=0
-        "$@" || rc=$?
-        if [ "$rc" -eq 0 ]; then
-            return 0
-        fi
-        n=$((n + 1))
-        if [ "$max" -ne 0 ] && [ "$n" -ge "$max" ]; then
-            echo "$what failed after $n attempt(s) (rc=$rc)" >&2
-            return "$rc"
-        fi
-        echo "$what failed (rc=$rc), retry $n in ${delay}s" >&2
-        sleep "$delay"
-    done
-}
-
-
 if [ -n "$VSTART_DEST" ]; then
     SRC_PATH=`dirname $0`
     SRC_PATH=`(cd $SRC_PATH; pwd)`
@@ -1364,14 +1340,16 @@ EOF
             echo "{\"cephx_secret\": \"$OSD_SECRET\"}" > $CEPH_DEV_DIR/osd$osd/new.json
             ceph_adm osd new $uuid -i $CEPH_DEV_DIR/osd$osd/new.json
             rm $CEPH_DEV_DIR/osd$osd/new.json
-            # ceph-osd --mkfs authenticates to the monitor as the just-created
-            # osd.$osd entity, which the monitor can briefly reject with EACCES
-            # right after "osd new" (handle_auth_bad_method / failed to fetch
-            # mon config). Transient; retry past it.
-            retry 10 2 "ceph-osd --mkfs for osd.$osd" \
-                prun $SUDO $CEPH_BIN/$ceph_osd $extra_osd_args -i $osd $ARGS \
+            # osd new waits until KeyServer can auth as osd.N. Abort if mkfs
+            # wrote no type file. Replaces the 49e8a07 retry that only hid the
+            # window. mkfs still talks to the mon (classic and Crimson).
+            prun $SUDO $CEPH_BIN/$ceph_osd $extra_osd_args -i $osd $ARGS \
                 --mkfs --key $OSD_SECRET --osd-uuid $uuid $extra_seastar_args \
                 > $CEPH_OUT_DIR/osd-mkfs.$osd.log 2>&1 || exit $?
+            if [ ! -f "$CEPH_DEV_DIR/osd$osd/type" ]; then
+                echo "ERROR: osd.$osd mkfs did not write $CEPH_DEV_DIR/osd$osd/type" >&2
+                exit 1
+            fi
 
             local key_fn=$CEPH_DEV_DIR/osd$osd/keyring
             cat > $key_fn<<EOF


### PR DESCRIPTION
# mon: do not ack osd new until cephx can auth as osd.N

Until [PR #50503](https://github.com/ceph/ceph/pull/50503) (“mon: use wait_for_commit to reply”), osd new used wait_for_finished_proposal.

`osd new` mutates AuthMonitor (and KVMonitor for lockbox) in the same plugged Paxos transaction as the osdmap update, but the client waited on OSDMonitor::wait_for_commit. PaxosService::refresh also woke waiting_for_commit before _update_from_paxos(). With refresh order OSDMAP then AUTH, the command could return while KeyServer still lacked osd.N.

That race wedged ceph-nvmeof vstart CI: osd.2 mkfs authenticated 14ms before auth vN applied, failed with EACCES, wrote no `type` file, and vstart still started the OSD.

Seen in:
https://github.com/ceph/ceph-nvmeof/actions/runs/32452671723/job/97162876156 (pytest multi_gateway, tentacle_9.2, sha d7e3a1c)

Same-run sibling that got a healthy cluster:
https://github.com/ceph/ceph-nvmeof/actions/runs/32452671723/job/97162876249

- finish waiting_for_commit after _update_from_paxos()
- osd new waits on AuthMonitor (KVMonitor if lockbox)
- vstart: --no-mon-config on mkfs; abort if type is missing (replaces the retry that only hid the window)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
