### PR TITLE
cmake/boost: don't pass context-impl to the headers step

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -156,14 +156,17 @@ function(do_build_boost root_dir version)
   set(b2_targets stage)
   set(b2_install_targets install)
   if(WITH_ASAN)
-    list(APPEND b2 context-impl=ucontext)
+    # via boost_features, not ${b2}: the `headers` step lacks the
+    # libs/context/build target below
+    list(APPEND boost_features context-impl=ucontext)
     # build the library with the BOOST_USE_ASAN consumers get from Boost::context,
     # so fiber_activation_record has one layout (else heap-buffer-overflow)
-    list(APPEND b2 define=BOOST_USE_ASAN)
-    # `context-impl` is declared in libs/context/build/Jamfile.v2; the headers/stage
-    # and install targets never load it, so b2 aborts with `unknown feature
+    list(APPEND boost_features define=BOOST_USE_ASAN)
+    # `context-impl` is declared in libs/context/build/Jamfile.v2; the stage and
+    # install targets never load it, so b2 aborts with `unknown feature
     # "<context-impl>"`. Name the context project as a target so its Jamfile loads
-    # the feature first.
+    # the feature first. Fixed in Boost 1.88, drop it at that bump:
+    # https://github.com/boostorg/context/commit/12ac945158ae
     list(PREPEND b2_targets libs/context/build)
     list(PREPEND b2_install_targets libs/context/build)
   endif()


### PR DESCRIPTION
Since d56d3ea3b69 `headers` runs as a separate b2 step. With `WITH_ASAN`
that command line carries `context-impl=ucontext` but not the
`libs/context/build` target that declares the feature, so b2 aborts with:

```
error: unknown feature "<context-impl>"
```

Move the ASan properties into `boost_features`, which only the stage and
install commands use.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
