### PR TITLE
osdc/SplitOp: fix read corruption and crashes with replica split reads

### DIFF
--- a/src/osdc/SplitOp.cc
+++ b/src/osdc/SplitOp.cc
@@ -287,11 +287,12 @@ std::pair<SplitOp::extent_set, bufferlist> ReplicaSplitOp::assemble_buffer_spars
   extent_set extents_out;
   bufferlist bl_out;
 
-  for (auto && [acting_index, sr] : sub_reads) {
-    for (auto [off, len] : *sr.details.at(ops_index).e) {
+  for (int acting_index : read_order.at(ops_index)) {
+    auto &details = sub_reads.at(acting_index).details.at(ops_index);
+    for (auto [off, len] : *details.e) {
       extents_out.insert(off, len);
     }
-    bl_out.append(sr.details.at(ops_index).bl);
+    bl_out.append(details.bl);
   }
 
   return std::pair(extents_out, bl_out);
@@ -306,8 +307,8 @@ std::pair<SplitOp::extent_set, bufferlist> ReplicaSplitOp::assemble_buffer_spars
  * @param ops_index Index of the operation in the operation list
  */
 void ReplicaSplitOp::assemble_buffer_read(bufferlist &bl_out, int ops_index) const {
-  for (auto && [acting_index, sr] : sub_reads) {
-    bl_out.append(sr.details.at(ops_index).bl);
+  for (int acting_index : read_order.at(ops_index)) {
+    bl_out.append(sub_reads.at(acting_index).details.at(ops_index).bl);
   }
 }
 
@@ -353,11 +354,24 @@ void ReplicaSplitOp::init_read(OSDOp &op, bool sparse, int ops_index) {
   uint64_t slice_count = replica_min_shard_read_size == 0 ? 1 :
                           std::min(length / replica_min_shard_read_size,
                                    osds.size());
+  // validate() accepts the op as soon as *one* read is worth splitting, so a
+  // shorter read in the same op reaches this point with a slice count of zero.
+  if (slice_count == 0) {
+    slice_count = 1;
+  }
   uint64_t chunk_size = p2roundup(length / slice_count, (uint64_t)CEPH_PAGE_SIZE);
-  
+
+  auto &order = read_order[ops_index];
+
   // Use reference_sub_read (set in constructor) as the starting shard
   // This provides load balancing while ensuring reference_sub_read is always set
-  for (unsigned i = reference_sub_read; length > 0; i = (i + 1 == osds.size()) ? 0 : i + 1) {
+  // Bounding the loop by slice_count keeps each replica to a single extent:
+  // the quotient above truncates, so slice_count chunks can fall short of
+  // length, and wrapping onto a replica that already has an extent for this op
+  // would point two reads at one Details buffer.
+  for (uint64_t slice = 0, i = reference_sub_read;
+       slice < slice_count && length > 0;
+       slice++, i = (i + 1 == osds.size()) ? 0 : i + 1) {
     int acting_index = i;
     if (!sub_reads.contains(acting_index)) {
       sub_reads.emplace(acting_index, orig_op->ops.size() + 1);
@@ -365,13 +379,16 @@ void ReplicaSplitOp::init_read(OSDOp &op, bool sparse, int ops_index) {
     auto &sr = sub_reads.at(acting_index);
     auto bl = &sr.details[ops_index].bl;
     auto rval = &sr.details[ops_index].rval;
-    uint64_t len = std::min(length, chunk_size);
+    // The last slice absorbs what the truncated quotient left over.
+    uint64_t len = (slice + 1 == slice_count) ? length
+                                              : std::min(length, chunk_size);
     if (sparse) {
       sr.details[ops_index].e.emplace();
       sr.rd.sparse_read(offset, len, &(*sr.details[ops_index].e), bl, rval);
     } else {
       sr.rd.read(offset, len, &sr.details[ops_index].ec, bl);
     }
+    order.push_back(acting_index);
     offset += len;
     length -= len;
   }
@@ -894,6 +911,14 @@ void SplitOp::prepare_single_op(Objecter::Op *op, Objecter &objecter, CephContex
   uint64_t data_chunk_count = pi->get_ec_data_shard_count();
   uint32_t chunk_size = pi->get_stripe_width() / data_chunk_count;
 
+  if (chunk_size == 0) {
+    // Replicated pools carry no stripe width, so there is no shard for an
+    // offset to land on and the modulo below would divide by zero. The caller
+    // falls back to submitting the op normally, which is what we want here.
+    debug_op_summary("reuse_op(no stripe):", op, cct);
+    return;
+  }
+
   // Find the first read to work out where the IO goes.
   for (auto o : op->ops) {
     if (o.op.op == CEPH_OSD_OP_SPARSE_READ ||
@@ -1039,6 +1064,13 @@ bool SplitOp::create(Objecter::Op *op, Objecter &objecter,
   if (split_read->sub_reads.size() <= 1) {
     ldout(cct, DBG_LVL) << __func__ <<" reusing original op - inefficient" << dendl;
     prepare_single_op(op, objecter, cct);
+    if (!(target.flags & CEPH_OSD_FLAG_FORCE_OSD)) {
+      // Nothing was pinned to a particular OSD, so the op goes back through the
+      // ordinary path. Give it back the balance flag cleared above, which was
+      // only in the way of reading the acting set; validate_flags() rejects the
+      // op unless the caller set it.
+      target.flags |= CEPH_OSD_FLAG_BALANCE_READS;
+    }
     split_read->abort = true; // Required for destructor.
     return false;
   }

--- a/src/osdc/SplitOp.h
+++ b/src/osdc/SplitOp.h
@@ -342,7 +342,16 @@ class SplitOp {
   bool abort = false;
   int flags = 0;
   int reference_sub_read = -1;
-  std::map<int, std::vector<int>> op_offset_map;
+
+  /**
+   * @brief Sub-reads holding each read chunk, in ascending order of the range
+   *        they cover, keyed by index of the operation in the operation list.
+   *
+   * Chunks are handed out starting at reference_sub_read and wrap around the
+   * acting set, so the key order of sub_reads does not describe the order the
+   * chunks have to be concatenated in. Reassembly follows this list instead.
+   */
+  std::map<int, std::vector<int>> read_order;
 
  public:
  /**

--- a/src/test/librados/split_op_cxx.cc
+++ b/src/test/librados/split_op_cxx.cc
@@ -22,7 +22,45 @@ public:
     ASSERT_EQ("", create_pool_pp(pool_name_default, s_cluster, 3));
     s_cluster.wait_for_latest_osdmap();
   }
+
+protected:
+  // Writes bl to oid and forces the log commit the split op path needs, by
+  // writing a second object that hashes to the same PG. Same dance as BigRead.
+  void write_and_commit(const std::string &oid, bufferlist &bl) {
+    ObjectWriteOperation write1;
+    write1.write(0, bl);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, oid, &write1));
+
+    uint32_t hash_position;
+    ASSERT_EQ(0, ioctx.get_object_pg_hash_position2(oid, &hash_position));
+    std::string other_object = "other";
+    while (true) {
+      uint32_t hash_position2;
+      ASSERT_EQ(0, ioctx.get_object_pg_hash_position2(other_object, &hash_position2));
+      if (hash_position == hash_position2) {
+        break;
+      }
+      other_object += ".";
+    }
+    ObjectWriteOperation write2;
+    write2.write(0, bl);
+    ASSERT_TRUE(AssertOperateWithoutSplitOp(0, other_object, &write2));
+  }
 };
+
+// Byte pattern with a period of 251, which divides neither the page size nor
+// any chunk size derived from it. A reply built from the right chunks in the
+// wrong order therefore fails to compare equal. The zero fill the older tests
+// use cannot distinguish those two cases.
+static bufferlist patterned_bl(uint64_t length) {
+  bufferlist bl;
+  ceph::buffer::ptr p((unsigned)length);
+  for (uint64_t i = 0; i < length; i++) {
+    p[i] = (char)(i % 251);
+  }
+  bl.append(p);
+  return bl;
+}
 
 typedef RadosTestECPP LibRadosSplitOpECPP;
 
@@ -139,6 +177,183 @@ TEST_P(LibRadosSplitOpPP, ReadTwoShards) {
     bufferlist read_bl;
     read.read(0, min_split_size * 3, NULL, NULL);
     ASSERT_TRUE(AssertOperateWithSplitOp(0, 3, "foo", &read, &read_bl, balanced_read_flags));
+  }
+}
+
+TEST_P(LibRadosSplitOpPP, ReadChunkOrder) {
+  SKIP_IF_CRIMSON();
+  if (!split_ops) {
+    GTEST_SKIP() << "Chunk ordering only applies to split reads";
+  }
+  std::string min_split_size_str;
+  ASSERT_EQ(0, cluster.conf_get("osd_min_split_replica_read_size", min_split_size_str));
+  uint64_t min_split_size = std::stoull(min_split_size_str);
+
+  uint64_t length = min_split_size * 3;
+  bufferlist bl = patterned_bl(length);
+  write_and_commit("order", bl);
+
+  {
+    ObjectReadOperation read;
+    bufferlist read_bl;
+    read.read(0, length, NULL, NULL);
+    ASSERT_TRUE(AssertOperateWithSplitOp(0, 3, "order", &read, &read_bl, balanced_read_flags));
+    ASSERT_EQ(length, (uint64_t)read_bl.length());
+    ASSERT_TRUE(read_bl.contents_equal(bl));
+  }
+
+  // The replica handed the first chunk is drawn afresh for every operation, so
+  // one read has only a 2 in 3 chance of starting anywhere but replica 0. These
+  // repeats go straight through operate() rather than the assertion helper: the
+  // helper also demands an exact objecter.op_reply delta, and there is no
+  // reason to take that bet ten more times over just to vary the start replica.
+  for (int i = 0; i < 10; i++) {
+    ObjectReadOperation read;
+    bufferlist read_bl;
+    read.read(0, length, NULL, NULL);
+    ASSERT_EQ(0, ioctx.operate("order", &read, &read_bl, balanced_read_flags));
+    ASSERT_TRUE(read_bl.contents_equal(bl));
+  }
+}
+
+TEST_P(LibRadosSplitOpPP, ReadWithChunkRemainder) {
+  SKIP_IF_CRIMSON();
+  if (!split_ops) {
+    GTEST_SKIP() << "Chunk distribution only applies to split reads";
+  }
+  std::string min_split_size_str;
+  ASSERT_EQ(0, cluster.conf_get("osd_min_split_replica_read_size", min_split_size_str));
+  uint64_t min_split_size = std::stoull(min_split_size_str);
+
+  // min_split_size is page aligned, so length / slice_count is too and the
+  // chunk size is not rounded up any further. The trailing byte then gets no
+  // chunk of its own, and must not be handed to a replica that already holds
+  // one for this read.
+  uint64_t length = min_split_size * 3 + 1;
+  bufferlist bl = patterned_bl(length);
+  write_and_commit("remainder", bl);
+
+  {
+    ObjectReadOperation read;
+    bufferlist read_bl;
+    read.read(0, length, NULL, NULL);
+    ASSERT_TRUE(AssertOperateWithSplitOp(0, 3, "remainder", &read, &read_bl, balanced_read_flags));
+    ASSERT_EQ(length, (uint64_t)read_bl.length());
+    ASSERT_TRUE(read_bl.contents_equal(bl));
+  }
+
+  for (int i = 0; i < 10; i++) {
+    ObjectReadOperation read;
+    bufferlist read_bl;
+    read.read(0, length, NULL, NULL);
+    ASSERT_EQ(0, ioctx.operate("remainder", &read, &read_bl, balanced_read_flags));
+    ASSERT_TRUE(read_bl.contents_equal(bl));
+  }
+}
+
+TEST_P(LibRadosSplitOpPP, ShortReadAlongsideSplitRead) {
+  SKIP_IF_CRIMSON();
+  if (!split_ops) {
+    GTEST_SKIP() << "Requires split_ops";
+  }
+  std::string min_split_size_str;
+  ASSERT_EQ(0, cluster.conf_get("osd_min_split_replica_read_size", min_split_size_str));
+  uint64_t min_split_size = std::stoull(min_split_size_str);
+
+  uint64_t length = min_split_size * 3;
+  bufferlist bl = patterned_bl(length);
+  write_and_commit("sibling", bl);
+
+  // The first read is long enough for the operation to be split. The second is
+  // below osd_min_split_replica_read_size, so it is served whole by a single
+  // replica rather than being spread.
+  uint64_t big_len = min_split_size * 2;
+  uint64_t small_len = min_split_size / 2;
+  // Per-op return codes are deliberately not asserted: complete() leaves
+  // out_osd_op.rval untouched on the READ path, so they read back as 0
+  // whatever the replicas returned. The contents are the real check.
+  ObjectReadOperation read;
+  bufferlist big_bl, small_bl, read_bl;
+  read.read(0, big_len, &big_bl, NULL);
+  read.read(big_len, small_len, &small_bl, NULL);
+  ASSERT_TRUE(AssertOperateWithSplitOp(0, 2, "sibling", &read, &read_bl, balanced_read_flags));
+
+  bufferlist expect_big, expect_small;
+  expect_big.substr_of(bl, 0, big_len);
+  expect_small.substr_of(bl, big_len, small_len);
+  ASSERT_TRUE(big_bl.contents_equal(expect_big));
+  ASSERT_TRUE(small_bl.contents_equal(expect_small));
+}
+
+TEST_P(LibRadosSplitOpPP, TwoSplitReadsOfDifferentWidth) {
+  SKIP_IF_CRIMSON();
+  if (!split_ops) {
+    GTEST_SKIP() << "Requires split_ops";
+  }
+  std::string min_split_size_str;
+  ASSERT_EQ(0, cluster.conf_get("osd_min_split_replica_read_size", min_split_size_str));
+  uint64_t min_split_size = std::stoull(min_split_size_str);
+
+  uint64_t length = min_split_size * 3;
+  bufferlist bl = patterned_bl(length);
+  write_and_commit("widths", bl);
+
+  // Two reads that spread over a different number of replicas: the first takes
+  // three, the second two. The replica used only by the first read then holds
+  // no result for the second, which the reassembly must not trip over. Before
+  // the reassembly followed the recorded order it looked that replica up
+  // regardless, and the resulting out_of_range escaped ~ReplicaSplitOp().
+  uint64_t wide_len = min_split_size * 3;
+  uint64_t narrow_len = min_split_size * 2;
+  ObjectReadOperation read;
+  bufferlist wide_bl, narrow_bl, read_bl;
+  read.read(0, wide_len, &wide_bl, NULL);
+  read.read(0, narrow_len, &narrow_bl, NULL);
+  ASSERT_TRUE(AssertOperateWithSplitOp(0, 3, "widths", &read, &read_bl, balanced_read_flags));
+
+  bufferlist expect_narrow;
+  expect_narrow.substr_of(bl, 0, narrow_len);
+  ASSERT_TRUE(wide_bl.contents_equal(bl));
+  ASSERT_TRUE(narrow_bl.contents_equal(expect_narrow));
+}
+
+TEST_P(LibRadosSplitOpPP, SparseReadChunkOrder) {
+  SKIP_IF_CRIMSON();
+  if (!split_ops) {
+    GTEST_SKIP() << "Chunk ordering only applies to split reads";
+  }
+  std::string min_split_size_str;
+  ASSERT_EQ(0, cluster.conf_get("osd_min_split_replica_read_size", min_split_size_str));
+  uint64_t min_split_size = std::stoull(min_split_size_str);
+
+  uint64_t length = min_split_size * 3;
+  bufferlist bl = patterned_bl(length);
+  write_and_commit("sparse", bl);
+
+  // The sparse path assembles extents and buffers through the same recorded
+  // order as the dense one, and additionally dereferences the per-chunk extent
+  // map, so it is worth exercising separately. The first read goes through the
+  // assertion helper so that the test fails, rather than quietly passing, if
+  // sparse reads ever stop being split at all.
+  for (int i = 0; i < 10; i++) {
+    ObjectReadOperation read;
+    bufferlist read_bl, data_bl;
+    std::map<uint64_t, uint64_t> extents;
+    read.sparse_read(0, length, &extents, &data_bl, NULL);
+    if (i == 0) {
+      ASSERT_TRUE(AssertOperateWithSplitOp(0, 3, "sparse", &read, &read_bl, balanced_read_flags));
+    } else {
+      ASSERT_EQ(0, ioctx.operate("sparse", &read, &read_bl, balanced_read_flags));
+    }
+    ASSERT_TRUE(data_bl.contents_equal(bl));
+    // The object is written end to end, so however the store chooses to break
+    // the range up, the extents must come back contiguous and cover all of it.
+    uint64_t at = 0;
+    for (auto [off, len] : extents) {
+      ASSERT_EQ(at, off);
+      at += len;
+    }
+    ASSERT_EQ(length, at);
   }
 }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/78329

The three bugs in the tracker, plus a fourth on the same path. Chunks are handed out starting at a random replica and wrap around the acting set, but were reassembled in acting index order, so the reply came back rotated. The truncated quotient in the chunk size let the distribution loop wrap onto a replica that already held an extent for the op and alias its buffer. A read below `osd_min_split_replica_read_size` in the same op reaches `init_read()` with a slice count of zero and divides by it. And when a request ends up with a single sub-read, `prepare_single_op()` divides `stripe_width` by the data shard count, which is 0 for a replicated pool.

The tests write a byte pattern rather than zeros, since a zero filled object can't tell a rotated reply from a good one.

Run against a vstart cluster (1 mon, 1 mgr, 3 osds, aarch64): 14 passed, 0 failed with the series applied. Reverting `src/osdc/` to main and keeping the tests reproduces all three: `ReadChunkOrder` fails on `contents_equal`, `ReadWithChunkRemainder` returns 524289 bytes of a 786433 byte read, and `ShortReadAlongsideSplitRead` kills the process. That last one is not a SIGFPE on aarch64, where UDIV by zero yields zero instead of trapping, so the loop spins allocating sub-reads until the process is killed; on x86 it traps.

One thing worth knowing if you run the suite: wait for all OSDs to be up first. With one still coming up, every split test fails on the `objecter.op_reply` counter being one higher than expected, including the ones this series doesn't touch.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
