### PR TITLE
mgr/pg_autoscaler: only treat target ratios as weights above 1.0

### DIFF
--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -390,6 +390,13 @@ the total cluster capacity. However, if the cluster contains a second pool that
 has ``target_size_ratio`` set to 1.0, then both pools are expected to use 50%
 of the total cluster capacity.
 
+The ratios are treated as relative weights only when in aggregate they ask for
+more than the whole cluster. When their sum is 1.0 or less, each ratio is taken
+as the fraction of the cluster that the pool is expected to consume, and the
+remainder is left for pools that have no target size set. A single pool with
+``target_size_ratio`` set to 0.1 is therefore expected to use a tenth of the
+cluster, rather than all of it.
+
 The ``ceph osd pool create`` command has two command-line options that can be
 used to set the target size of a pool at creation time: ``--target-size-bytes
 <bytes>`` and ``--target-size-ratio <ratio>``.

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -76,7 +76,11 @@ def effective_target_ratio(target_ratio: float,
     adjusting for capacity reserved by pools that have target_size_bytes set.
     """
     target_ratio = float(target_ratio)
-    if total_target_ratio:
+    if total_target_ratio > 1.0:
+        # The ratios are only relative weights once they ask for more than the
+        # cluster has. While they still fit, each pool gets the fraction it
+        # asked for, so a lone pool set to 0.1 does not end up claiming
+        # everything and then having to merge the PGs back down again.
         target_ratio = target_ratio / total_target_ratio
 
     if total_target_bytes and capacity:

--- a/src/pybind/mgr/pg_autoscaler/tests/test_cal_ratio.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_cal_ratio.py
@@ -4,22 +4,40 @@ from pytest import approx
 
 def check_simple_ratio(target_ratio, tot_ratio):
     etr = effective_target_ratio(target_ratio, tot_ratio, 0, 0)
-    assert (target_ratio / tot_ratio) == approx(etr)
+    if tot_ratio > 1.0:
+        assert (target_ratio / tot_ratio) == approx(etr)
+    else:
+        assert target_ratio == approx(etr)
     return etr
 
 
 def test_simple():
-    etr1 = check_simple_ratio(0.2, 0.9)
-    etr2 = check_simple_ratio(2, 9)
-    etr3 = check_simple_ratio(20, 90)
+    # Once the ratios add up to more than 1.0 they are relative weights, so
+    # scaling every ratio by the same factor leaves the result alone.
+    etr1 = check_simple_ratio(2, 9)
+    etr2 = check_simple_ratio(20, 90)
     assert etr1 == approx(etr2)
-    assert etr1 == approx(etr3)
 
-    etr = check_simple_ratio(0.9, 0.9)
-    assert etr == approx(1.0)
     etr1 = check_simple_ratio(1, 2)
     etr2 = check_simple_ratio(0.5, 1.0)
     assert etr1 == approx(etr2)
+
+
+def test_ratios_below_one_are_taken_as_given():
+    # A lone pool asking for a tenth of the cluster gets a tenth of it. The
+    # ratios only become relative weights once they add up to more than one.
+    assert effective_target_ratio(0.1, 0.1, 0, 0) == approx(0.1)
+    assert effective_target_ratio(0.5, 0.8, 0, 0) == approx(0.5)
+    assert effective_target_ratio(0.3, 0.8, 0, 0) == approx(0.3)
+    assert effective_target_ratio(0.9, 0.9, 0, 0) == approx(0.9)
+
+
+def test_ratios_above_one_are_weights():
+    assert effective_target_ratio(2, 9, 0, 0) == approx(2 / 9)
+    assert effective_target_ratio(20, 90, 0, 0) == approx(2 / 9)
+    assert effective_target_ratio(1, 2, 0, 0) == approx(0.5)
+    # Exactly one is the boundary: nothing to scale down.
+    assert effective_target_ratio(0.5, 1.0, 0, 0) == approx(0.5)
 
 
 def test_total_bytes():


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47613

`effective_target_ratio()` divides every `target_size_ratio` by the sum of all of them, whatever that sum is. Set it on a single pool of a fresh cluster and the sum is that pool's own ratio, so 0.1 normalises to 1.0 and the pool takes the whole PG budget. Put a target on a second pool later and the autoscaler has to merge it all back down.

This only normalises once the ratios ask for more than the cluster has. Neha's concern on the tracker was that it changes the meaning of the option, so to be concrete about how far it reaches: at a sum of 1.0 and above nothing moves, which covers both examples in the docs, two pools at 1.0 getting half each and a lone pool at 1.0 getting everything. The only inputs that change are the ones that used to be quietly scaled up.

`test_simple()` asserted the old behaviour for sums below 1.0, since its helper compared against `target_ratio / total_ratio` for every input. It now checks the rule that applies to the range it is given, and the sub-unity cases moved into a test of their own.

`run-tox-mgr`, the ctest gate that covers the mgr modules, passes in a build tree: 2637 tests. Reverting `module.py` to main and keeping the tests fails exactly one, the new `test_ratios_below_one_are_taken_as_given`, where `effective_target_ratio(0.1, 0.1, 0, 0)` returns 1.0 instead of 0.1.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
