### PR TITLE
umbrella: pybind/cephfs: drop redundant int32_t typedef

### DIFF
--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -26,7 +26,6 @@ cdef extern from *:
     unsigned long DIRENT_D_OFF(dirent *d)
 
 cdef extern from "../include/platform_errno.h":
-    ctypedef signed int int32_t;
     int32_t ceph_to_hostos_errno(int32_t e)
 
 cdef extern from "cephfs/ceph_ll_client.h":


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77490

---

backport of https://github.com/ceph/ceph/pull/69521
parent tracker: https://tracker.ceph.com/issues/77440

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh