### PR TITLE
squid: mds: account for header size during omap commit

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2489,6 +2489,10 @@ void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t vers
   }
 
   bufferlist bl;
+  // the last omap commit includes the omap header, so account for
+  // that size early on so that when we reach `commit_one(true)`,
+  // there is enough space for the header.
+  write_size += sizeof(fnode_t);
   using ceph::encode;
   for (auto &item : to_set) {
     encode(item.first, bl);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70046

---

backport of https://github.com/ceph/ceph/pull/58645
parent tracker: https://tracker.ceph.com/issues/67597

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh