### PR TITLE
common/options: harmonize scrub conf attributes in osd.yaml.in

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -342,9 +342,13 @@ options:
 - name: osd_scrub_min_interval
   type: float
   level: advanced
-  desc: The desired interval between scrubs of a specific PG. Note that this option
-    must be set at the ``global`` scope, or for both ``mgr`` and ``osd``.
+  desc: The desired interval in seconds between scrubs of a specific PG.
+  long_desc: The desired interval in seconds between scrubs of a specific PG.
+    Note that this option must be set at the global scope, or for
+    both mgr and osd.
   fmt_desc: The desired interval in seconds between scrubs of a specific PG.
+    Note that this option must be set at the ``global`` scope, or for
+    both ``mgr`` and ``osd``.
   default: 1_day
   see_also:
   - osd_scrub_max_interval
@@ -352,9 +356,11 @@ options:
 - name: osd_scrub_max_interval
   type: float
   level: advanced
-  desc: Scrub each PG no less often than this interval. Note that this option
+  desc: The maximum interval in seconds for scrubbing each PG.
+  long_desc: Scrub each PG no less often than this interval. Note that this option
+    must be set at the global scope, or for both mgr and osd.
+  fmt_desc: Scrub each PG no less often than this interval. Note that this option
     must be set at the ``global`` scope, or for both ``mgr`` and ``osd``.
-  fmt_desc: The maximum interval in seconds for scrubbing each PG.
   default: 7_day
   see_also:
   - osd_scrub_min_interval
@@ -494,9 +500,13 @@ options:
 - name: osd_deep_scrub_interval
   type: float
   level: advanced
-  desc: Deep scrub each PG (i.e., verify data checksums) at least this often. Note that this option
-    must be set at the ``global`` scope, or for both ``mgr`` and ``osd``.
-  fmt_desc: The interval for "deep" scrubbing (fully reading all data).
+  desc: The interval for "deep" scrubbing (fully reading all data).
+  long_desc: Deep scrub each PG (i.e., verify data checksums) at least this
+    often. Note that this option must be set at the global scope, or for
+    both mgr and osd.
+  fmt_desc: Deep scrub each PG (i.e., verify data checksums) at least this
+    often. Note that this option must be set at the ``global`` scope, or for
+    both ``mgr`` and ``osd``.
   default: 7_day
   with_legacy: true
 - name: osd_deep_scrub_interval_cv


### PR DESCRIPTION
Additional description with RST markup was added to the `desc` attribute in commit 1a2290d85af6840000e97cfd0a11c574da419c15. RST markup should be used on the `fmt_desc` attribute. Additionally, `fmt_desc` attribute, which overrides the `desc` attribute in the web docs, already existed for the configurables so the added text would not be visible in the web docs.

Use the same long description in both `long_desc` and `fmt_desc`, with some formatting in the latter. Keep short description in `desc`.

- Original: https://docs.ceph.com/en/latest/rados/configuration/osd-config-ref/#confval-osd_scrub_min_interval
- Rendered PR: https://ceph--71256.org.readthedocs.build/en/71256/rados/configuration/osd-config-ref/#confval-osd_scrub_min_interval
- Original: https://docs.ceph.com/en/latest/rados/configuration/osd-config-ref/#confval-osd_deep_scrub_interval
- Rendered PR: https://ceph--71256.org.readthedocs.build/en/71256/rados/configuration/osd-config-ref/#confval-osd_deep_scrub_interval




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
