### PR TITLE
squid: qa: write out ESubtreeMap more frequently to find large events

### DIFF
--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -153,6 +153,10 @@ class TestExportPin(CephFSTestCase):
         # vstart.sh sets mds_debug_subtrees to True. That causes a ESubtreeMap
         # to be written out every event. Yuck!
         self.config_set('mds', 'mds_debug_subtrees', False)
+
+        # make sure ESubtreeMap is written frequently enough:
+        self.config_set('mds', 'mds_log_minor_segments_per_major_segment', '4')
+        self.config_rm('mds', 'mds bal split size') # don't split /top
         self.mount_a.run_shell_payload("rm -rf 1")
 
         # flush everything out so ESubtreeMap is the only event in the log

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1700,13 +1700,4 @@ options:
   default: 16
   services:
   - mds
-  min: 8
-- name: mds_file_blockdiff_max_concurrent_object_scans
-  type: uint
-  level: advanced
-  desc: maximum number of concurrent object scans
-  long_desc: Maximum number of concurrent listsnaps operations sent to RADOS.
-  default: 16
-  services:
-  - mds
-  min: 1
+  min: 4


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69426

---

backport of https://github.com/ceph/ceph/pull/60720
parent tracker: https://tracker.ceph.com/issues/68913

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh