### PR TITLE
node-proxy: refetch Thermal data on each poll

### DIFF
--- a/src/ceph-node-proxy/ceph_node_proxy/redfish.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/redfish.py
@@ -309,7 +309,7 @@ def get_component_data(
                 if attribute is None:
                     data = ep.get_members_data()
                 else:
-                    data = ep.data
+                    data = ep.get_data()
                 result[member] = build_data(
                     data=data, fields=fields, log=log, attribute=attribute
                 )

--- a/src/ceph-node-proxy/tests/test_redfish.py
+++ b/src/ceph-node-proxy/tests/test_redfish.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from ceph_node_proxy.redfish import build_data
+from ceph_node_proxy.redfish import build_data, get_component_data
 
 
 def test_build_data_thermal_fans_and_temperatures() -> None:
@@ -61,3 +61,47 @@ def test_build_data_skips_absent_members() -> None:
     temps = build_data(thermal, fields, log, attribute="Temperatures")
     assert list(temps.keys()) == ["0"]
     assert temps["0"]["name"] == "C1_DCSCM_TEMP"
+
+
+def test_get_component_data_refetches_attribute_endpoint() -> None:
+    """Fans/temps use attribute=Fans on Thermal; must not reuse cached Endpoint.data."""
+    log = MagicMock()
+    fields = ["Name", "PhysicalContext", "Reading", "ReadingUnits", "Status"]
+    thermal_ep = MagicMock()
+    thermal_ep.data = {
+        "Fans": [
+            {
+                "MemberId": "0",
+                "Name": "FAN1_TACH_IN",
+                "PhysicalContext": "Fan",
+                "Reading": 18480,
+                "ReadingUnits": "RPM",
+                "Status": {"Health": "OK", "State": "Enabled"},
+            }
+        ]
+    }
+    thermal_ep.get_data.return_value = {
+        "Fans": [
+            {
+                "MemberId": "0",
+                "Name": "FAN1_TACH_IN",
+                "PhysicalContext": "Fan",
+                "Status": {"State": "Absent"},
+            }
+        ]
+    }
+
+    member_ep = MagicMock()
+    member_ep.__getitem__.return_value = thermal_ep
+    collection_ep = MagicMock()
+    collection_ep.get_members_names.return_value = ["Self"]
+    collection_ep.__getitem__.return_value = member_ep
+    endpoints = MagicMock()
+    endpoints.__getitem__.return_value = collection_ep
+
+    result = get_component_data(
+        endpoints, "chassis", "Thermal", fields, log, attribute="Fans"
+    )
+
+    thermal_ep.get_data.assert_called_once()
+    assert result["Self"] == {}


### PR DESCRIPTION
Fans and temperatures were stuck on the first Redfish snapshot because we kept reusing Endpoint.data. Always GET again so a pulled fan actually shows up (or disappears once it's Absent).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
