### PR TITLE
mds: refactor ephemeral random pinning to directory fragment level

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -3,6 +3,12 @@
   ``$GETOPT`` environment override so GNU getopt can be selected
   (``brew install bash gnu-getopt``).
 
+* CephFS: The random ephemeral pinning mechanism (``ceph.dir.pin.random``) has
+  been redesigned to operate at the directory fragment (dirfrag) level using
+  consistent hashing rather than pinning child subdirectories. This allows large,
+  heavily-fragmented directories to distribute fragments across active MDS ranks
+  proportionally according to the configured pinning percentage.
+
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated
   this option could be changed at runtime, but changes had no effect on opened file

--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -72,3 +72,6 @@
 .. confval:: mds_dmclock_reservation
 .. confval:: mds_dmclock_weight
 .. confval:: mds_dmclock_limit
+.. confval:: mds_export_ephemeral_distributed_factor
+.. confval:: mds_export_ephemeral_frag_factor
+.. confval:: mds_export_ephemeral_random_max

--- a/doc/cephfs/multimds.rst
+++ b/doc/cephfs/multimds.rst
@@ -178,23 +178,30 @@ spread across the entire MDS cluster. This can be set via:
     setfattr -n ceph.dir.pin.distributed -v 1 /cephfs/home
 
 
-**Random Ephemeral Pins**: This policy indicates any descendent sub-directory
-may be ephemerally pinned. This is set through the extended attribute
-``ceph.dir.pin.random`` with the value set to the percentage of directories
-that should be pinned. For example:
+**Random Ephemeral Pins**: This policy causes a directory to fragment and
+randomly distributes a configured percentage of its directory fragments (dirfrags)
+across active MDS ranks. This is especially useful for spreading the workload of
+large, flat directories with millions of files across multiple MDS ranks.
+
+This is set through the extended attribute ``ceph.dir.pin.random`` with the value
+set to the percentage (between ``0.0`` and ``1.0``) of fragments that should be
+randomly pinned across the cluster. For example:
 
 .. prompt:: bash #
 
-    setfattr -n ceph.dir.pin.random -v 0.5 /cephfs/tmp
+    setfattr -n ceph.dir.pin.random -v 0.5 /cephfs/flat_dir
 
-Would cause any directory loaded into cache or created under ``/tmp`` to be
-ephemerally pinned 50 percent of the time.
+Would cause ``/flat_dir`` to fragment and deterministically export approximately
+50% of its directory fragments across active MDS ranks, retaining the remaining
+fragments on the primary directory authority.
 
-It is recommended to only set this to small values, like ``.001`` or ``0.1%``.
-Having too many subtrees may degrade performance. For this reason, the config
-``mds_export_ephemeral_random_max`` enforces a cap on the maximum of this
-percentage (default: ``.01``). The MDS returns ``EINVAL`` when attempting to
-set a value beyond this config.
+Setting ``ceph.dir.pin.random`` to ``1.0`` (100%) is functionally and algorithmically
+equivalent to setting ``ceph.dir.pin.distributed -v 1``, distributing all fragments
+across the active MDS ranks.
+
+The configuration option ``mds_export_ephemeral_random_max`` enforces an upper
+bound on the allowed percentage (default: ``1.0``). The MDS returns ``EINVAL``
+when attempting to set a value exceeding this threshold.
 
 Both random and distributed ephemeral pin policies are off by default in
 Octopus. The features may be enabled via the

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import random
 import time
@@ -269,7 +270,7 @@ done
 
         self.assertTrue(success, "open operation failed")
 
-class TestEphemeralPins(CephFSTestCase):
+class TestEphemeralDistributed(CephFSTestCase):
     MDSS_REQUIRED = 3
     CLIENTS_REQUIRED = 1
 
@@ -450,44 +451,6 @@ done
         self.assertGreaterEqual(len(rank1)/nsubtrees, 0.15)
         self.assertGreaterEqual(len(rank2)/nsubtrees, 0.15)
 
-
-    def test_ephemeral_random(self):
-        """
-        That 100% randomness causes all children to be pinned.
-        """
-        self._setup_tree(random=1.0)
-        self._wait_random_subtrees(100, status=self.status, rank="all")
-
-    def test_ephemeral_random_max(self):
-        """
-        That the config mds_export_ephemeral_random_max is not exceeded.
-        """
-
-        r = 0.5
-        count = 1000
-        self._setup_tree(count=count, random=r)
-        subtrees = self._wait_random_subtrees(int(r*count*.75), status=self.status, rank="all")
-        self.config_set('mds', 'mds_export_ephemeral_random_max', 0.01)
-        self._setup_tree(path="tree/new", count=count)
-        time.sleep(30) # for something not to happen...
-        subtrees = self._get_subtrees(status=self.status, rank="all", path="tree/new/")
-        self.assertLessEqual(len(subtrees), int(.01*count*1.25))
-
-    def test_ephemeral_random_max_config(self):
-        """
-        That the config mds_export_ephemeral_random_max config rejects new OOB policies.
-        """
-
-        self.config_set('mds', 'mds_export_ephemeral_random_max', 0.01)
-        try:
-            p = self._setup_tree(count=1, random=0.02, wait=False)
-            p.wait()
-        except CommandFailedError as e:
-            log.info(f"{e}")
-            self.assertIn("Invalid", p.stderr.getvalue())
-        else:
-            raise RuntimeError("mds_export_ephemeral_random_max ignored!")
-
     def test_ephemeral_random_dist(self):
         """
         That ephemeral distributed pin overrides ephemeral random pin
@@ -502,135 +465,6 @@ done
             path = s['dir']['path']
             if path.startswith('/tree'):
                 self.assertFalse(s['random_ephemeral_pin'])
-
-    def test_ephemeral_random_pin_override_before(self):
-        """
-        That a conventional export pin overrides the random policy before creating new directories.
-        """
-
-        self._setup_tree(count=0, random=1.0)
-        self._setup_tree(path="tree/pin", count=10, export=1)
-        self._wait_subtrees([("/tree/pin", 1)], status=self.status, rank=1, path="/tree/pin")
-
-    def test_ephemeral_random_pin_override_after(self):
-        """
-        That a conventional export pin overrides the random policy after creating new directories.
-        """
-
-        count = 10
-        self._setup_tree(count=0, random=1.0)
-        self._setup_tree(path="tree/pin", count=count)
-        self._wait_random_subtrees(count+1, status=self.status, rank="all")
-        self.mount_a.setfattr("tree/pin", "ceph.dir.pin", "1")
-        self._wait_subtrees([("/tree/pin", 1)], status=self.status, rank=1, path="/tree/pin")
-
-    def test_ephemeral_randomness(self):
-        """
-        That the randomness is reasonable.
-        """
-
-        r = random.uniform(0.25, 0.75) # ratios don't work for small r!
-        count = 1000
-        self._setup_tree(count=count, random=r)
-        subtrees = self._wait_random_subtrees(int(r*count*.50), status=self.status, rank="all")
-        time.sleep(30) # for max to not be exceeded
-        subtrees = self._wait_random_subtrees(int(r*count*.50), status=self.status, rank="all")
-        self.assertLessEqual(len(subtrees), int(r*count*1.50))
-
-    def test_ephemeral_random_cache_drop(self):
-        """
-        That the random ephemeral pin does not prevent empty (nothing in cache) subtree merging.
-        """
-
-        count = 100
-        self._setup_tree(count=count, random=1.0)
-        self._wait_random_subtrees(count, status=self.status, rank="all")
-        self.mount_a.umount_wait() # release all caps
-        def _drop():
-            self.fs.ranks_tell(["cache", "drop"], status=self.status)
-        self._wait_subtrees([], status=self.status, action=_drop)
-
-    def test_ephemeral_random_failover(self):
-        """
-        That the random ephemeral pins stay pinned across MDS failover.
-        """
-
-        count = 100
-        r = 0.5
-        self._setup_tree(count=count, random=r)
-        # wait for all random subtrees to be created, not a specific count
-        time.sleep(30)
-        subtrees = self._wait_random_subtrees(1, status=self.status, rank=1)
-        before = [(s['dir']['path'], s['auth_first']) for s in subtrees]
-        before.sort();
-
-        self.fs.rank_fail(rank=1)
-        self.status = self.fs.wait_for_daemons()
-
-        time.sleep(30) # waiting for something to not happen
-        subtrees = self._wait_random_subtrees(1, status=self.status, rank=1)
-        after = [(s['dir']['path'], s['auth_first']) for s in subtrees]
-        after.sort();
-        log.info(f"subtrees before: {before}")
-        log.info(f"subtrees after: {after}")
-
-        self.assertEqual(before, after)
-
-    def test_ephemeral_pin_grow_mds(self):
-        """
-        That consistent hashing works to reduce the number of migrations.
-        """
-
-        self.fs.set_max_mds(2)
-        self.status = self.fs.wait_for_daemons()
-
-        self._setup_tree(random=1.0)
-        subtrees_old = self._wait_random_subtrees(100, status=self.status, rank="all")
-
-        self.fs.set_max_mds(3)
-        self.status = self.fs.wait_for_daemons()
-        
-        # Sleeping for a while to allow the ephemeral pin migrations to complete
-        time.sleep(30)
-        
-        subtrees_new = self._wait_random_subtrees(100, status=self.status, rank="all")
-        count = 0
-        for old_subtree in subtrees_old:
-            for new_subtree in subtrees_new:
-                if (old_subtree['dir']['path'] == new_subtree['dir']['path']) and (old_subtree['auth_first'] != new_subtree['auth_first']):
-                    count = count + 1
-                    break
-
-        log.info("{0} migrations have occured due to the cluster resizing".format(count))
-        # ~50% of subtrees from the two rank will migrate to another rank
-        self.assertLessEqual((count/len(subtrees_old)), (0.5)*1.25) # with 25% overbudget
-
-    def test_ephemeral_pin_shrink_mds(self):
-        """
-        That consistent hashing works to reduce the number of migrations.
-        """
-
-        self.fs.set_max_mds(3)
-        self.status = self.fs.wait_for_daemons()
-
-        self._setup_tree(random=1.0)
-        subtrees_old = self._wait_random_subtrees(100, status=self.status, rank="all")
-
-        self.fs.set_max_mds(2)
-        self.status = self.fs.wait_for_daemons()
-        time.sleep(30)
-
-        subtrees_new = self._wait_random_subtrees(100, status=self.status, rank="all")
-        count = 0
-        for old_subtree in subtrees_old:
-            for new_subtree in subtrees_new:
-                if (old_subtree['dir']['path'] == new_subtree['dir']['path']) and (old_subtree['auth_first'] != new_subtree['auth_first']):
-                    count = count + 1
-                    break
-
-        log.info("{0} migrations have occured due to the cluster resizing".format(count))
-        # rebalancing from 3 -> 2 may cause half of rank 0/1 to move and all of rank 2
-        self.assertLessEqual((count/len(subtrees_old)), (1.0/3.0/2.0 + 1.0/3.0/2.0 + 1.0/3.0)*1.25) # aka .66 with 25% overbudget
 
 class TestDumpExportStates(CephFSTestCase):
     MDSS_REQUIRED = 2
@@ -814,3 +648,554 @@ class TestKillExports(CephFSTestCase):
 
             # failed if buggy
             self.mount_a.ls()
+
+class TestEphemeralRandom(CephFSTestCase):
+    MDSS_REQUIRED = 3
+    CLIENTS_REQUIRED = 1
+
+    def setUp(self):
+        super().setUp()
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+
+    def _setup_split_dir(self, path="rand_dir", random_prob=0.5, total_files=1200, factor=8):
+        """
+        Creates a single flat directory with enough dentries to enforce fragmentation,
+        configures the random probability, and triggers directory splitting.
+        """
+        # Set frag factor to enforce splitting depth (min_frag_bits)
+        self.config_set('mds', 'mds_export_ephemeral_distributed_factor', factor)
+
+        # Create parent directory and set random ephemeral pin probability
+        self.mount_a.run_shell_payload(f"""
+            set -ex
+            mkdir -p {path}
+            setfattr -n ceph.dir.pin.random -v {random_prob} {path}
+            for i in $(seq 1 {total_files}); do
+                touch "{path}/file_$i"
+            done
+        """)
+
+    def test_ephemeral_random_max(self):
+        """
+        Verify that effective random dirfrag exports are clamped when
+        mds_export_ephemeral_random_max is dynamically lowered below the xattr value.
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+        self.config_set('mds', 'mds_bal_split_size', 10)
+        # Split into 2^4 = 16 fragments
+        self.config_set('mds', 'mds_bal_split_bits', 4)
+
+        self.mount_a.run_shell(["mkdir", "rand_max_dir"])
+        # Set to 1.0 while allowed by the config
+        self.mount_a.setfattr("rand_max_dir", "ceph.dir.pin.random", "1.0")
+
+        # Dynamically lower max cap to 25%
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 0.25)
+
+        # Populate dentries to split the directory into 16 fragments
+        for i in range(200):
+            self.mount_a.run_shell(["touch", f"rand_max_dir/file_{i}"])
+
+        # Allow balancer pass to evaluate and export pinned fragments
+        time.sleep(10)
+
+        # Retrieve all subtrees for the directory
+        subtrees = self._get_subtrees(status=self.status, rank="all")
+        rand_subtrees = [
+            s for s in subtrees
+            if s['dir']['path'] == '/rand_max_dir' and s.get('random_ephemeral_pin', False)
+        ]
+
+        # Total fragments = 16. With 0.25 max cap, we expect clamped exports strictly < 16
+        self.assertGreater(len(rand_subtrees), 0)
+        self.assertLessEqual(len(rand_subtrees), 6)
+
+    def test_ephemeral_random_max_config(self):
+        """
+        Verify that ceph.dir.pin.random configuration boundaries strictly enforce
+        mds_export_ephemeral_random_max, returning -EINVAL on exceeded values
+        and -EDOM on values outside [0.0, 1.0].
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+
+        self.mount_a.run_shell(["mkdir", "test_max_config"])
+
+        # Under default max (1.0), valid percentages succeed
+        self.mount_a.setfattr("test_max_config", "ceph.dir.pin.random", "0.5")
+        self.mount_a.setfattr("test_max_config", "ceph.dir.pin.random", "1.0")
+
+        # Lower config to 0.4 dynamically
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 0.4)
+
+        # Values within the new ceiling succeed
+        self.mount_a.setfattr("test_max_config", "ceph.dir.pin.random", "0.3")
+
+        # Values exceeding the dynamic ceiling must fail with -EINVAL
+        with self.assertRaises(CommandFailedError) as cm:
+            self.mount_a.setfattr("test_max_config", "ceph.dir.pin.random", "0.5")
+        self.assertEqual(cm.exception.exitstatus, errno.EINVAL)
+
+        # Values outside the mathematical domain [0.0, 1.0] must fail with -EDOM
+        with self.assertRaises(CommandFailedError) as cm:
+            self.mount_a.setfattr("test_max_config", "ceph.dir.pin.random", "1.5")
+        self.assertEqual(cm.exception.exitstatus, errno.EDOM)
+
+        with self.assertRaises(CommandFailedError) as cm:
+            self.mount_a.setfattr("test_max_config", "ceph.dir.pin.random", "-0.1")
+        self.assertEqual(cm.exception.exitstatus, errno.EDOM)
+
+    def test_ephemeral_random_dirfrag_100_percent(self):
+        """
+        Validate that with random=1.0, ALL fragments of the directory are
+        scattered across MDS ranks via jump consistent hashing.
+        """
+        self._setup_split_dir(path="rand_100", random_prob=1.0, total_files=800, factor=8)
+
+        # Wait for fragments to split and balance out across all ranks
+        subtrees = self._wait_random_subtrees(8, status=self.status, rank="all", path="/rand_100")
+
+        # Verify subtrees are fragments of /rand_100 and scattered across ranks
+        ranks_seen = set()
+        for s in subtrees:
+            if s['dir']['path'] == '/rand_100':
+                ranks_seen.add(s['auth_first'])
+
+        # With 8 fragments across 3 ranks, all 3 active ranks should receive fragments
+        self.assertGreaterEqual(len(ranks_seen), 2)
+
+    def test_ephemeral_random_dirfrag_partial(self):
+        """
+        Validate that with 0 < random < 1.0, a portion of the directory fragments
+        remains on the primary MDS authority (Rank 0) while the rest migrate.
+        """
+        self._setup_split_dir(path="rand_50", random_prob=0.5, total_files=1600, factor=16)
+
+        # Wait for subtrees to settle
+        time.sleep(20)
+        subtrees = self._get_subtrees(status=self.status, rank="all", path="/rand_50")
+
+        primary_frags = 0
+        migrated_frags = 0
+        for s in subtrees:
+            if s['dir']['path'] == '/rand_50':
+                if s['auth_first'] == 0:
+                    primary_frags += 1
+                else:
+                    migrated_frags += 1
+
+        total_subtrees = primary_frags + migrated_frags
+        self.assertGreater(total_subtrees, 1)
+
+        # Assert statistical distribution within an acceptable delta
+        ratio = migrated_frags / float(total_subtrees)
+        log.debug(f"Migrated ratio: {ratio} ({migrated_frags}/{total_subtrees})")
+        self.assertTrue(0.20 <= ratio <= 0.80, f"Unexpected migration ratio: {ratio}")
+
+    def test_ephemeral_randomness(self):
+        """
+        Verify that pseudo-random dirfrag export counts fall within statistical
+        expectations for a generated random ratio.
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+        self.config_set('mds', 'mds_bal_split_size', 10)
+        # Split into 2^6 = 64 fragments for reasonable sample size
+        self.config_set('mds', 'mds_bal_split_bits', 6)
+
+        total_frags = 64
+        r = round(random.uniform(0.3, 0.7), 2)
+
+        self.mount_a.run_shell(["mkdir", "rand_dist_tree"])
+        self.mount_a.setfattr("rand_dist_tree", "ceph.dir.pin.random", str(r))
+
+        for i in range(400):
+            self.mount_a.run_shell(["touch", f"rand_dist_tree/file_{i}"])
+
+        # Allow balancer pass to evaluate exports
+        time.sleep(15)
+
+        subtrees = self._get_subtrees(status=self.status, rank="all")
+        rand_subtrees = [
+            s for s in subtrees
+            if s['dir']['path'] == '/rand_dist_tree' and s.get('random_ephemeral_pin', False)
+        ]
+
+        expected_count = int(r * total_frags)
+        min_expected = max(1, int(expected_count * 0.40))
+        max_expected = min(total_frags, int(expected_count * 1.60) + 2)
+
+        self.assertGreaterEqual(len(rand_subtrees), min_expected)
+        self.assertLessEqual(len(rand_subtrees), max_expected)
+
+    def test_ephemeral_random_dirfrag_merge_floor(self):
+        """
+        Verify that idle/empty fragments in a randomly pinned directory
+        do not merge below min_frag_bits.
+        """
+        self._setup_split_dir(path="rand_merge", random_prob=0.5, total_files=600, factor=4)
+
+        # Wait for initial split
+        subtrees_before = self._wait_random_subtrees(4, status=self.status, rank="all", path="/rand_merge")
+        num_frags_before = len([s for s in subtrees_before if s['dir']['path'] == '/rand_merge'])
+
+        # Delete most files to make fragments idle and eligible for merging
+        self.mount_a.run_shell_payload("""
+            set -ex
+            find rand_merge/ -type f -name "file_*" | head -n 550 | xargs rm -f
+        """)
+
+        # Allow balancer upkeep/merge loop ticks to run
+        time.sleep(20)
+
+        subtrees_after = self._get_subtrees(status=self.status, rank="all", path="/rand_merge")
+        num_frags_after = len([s for s in subtrees_after if s['dir']['path'] == '/rand_merge'])
+
+        # The fragment count must stay bounded at or above the min_frag_bits floor
+        self.assertGreaterEqual(num_frags_after, 4)
+        self.assertEqual(num_frags_before, num_frags_after)
+
+    def test_ephemeral_random_dirfrag_failover_stability(self):
+        """
+        Verify that fragment pin assignments are deterministic across MDS failover
+        and do not trigger flapping or ping-pong migrations.
+        """
+        self._setup_split_dir(path="rand_failover", random_prob=0.5, total_files=1000, factor=8)
+
+        time.sleep(15)
+        subtrees_before = self._get_subtrees(status=self.status, rank="all", path="/rand_failover")
+        before_layout = [(s['dir']['frag'], s['auth_first']) for s in subtrees_before if s['dir']['path'] == '/rand_failover']
+        before_layout.sort()
+
+        # Capture export counter before failover
+        exports_before = self.fs.ranks_perf(lambda p: p['mds']['exported'])
+
+        # Trigger failover on Rank 1
+        self.fs.rank_fail(rank=1)
+        self.status = self.fs.wait_for_daemons()
+        time.sleep(15)
+
+        # Re-evaluate layout post-recovery
+        subtrees_after = self._get_subtrees(status=self.status, rank="all", path="/rand_failover")
+        after_layout = [(s['dir']['frag'], s['auth_first']) for s in subtrees_after if s['dir']['path'] == '/rand_failover']
+        after_layout.sort()
+
+        self.assertEqual(before_layout, after_layout)
+
+        # Ensure no excessive re-export ping-ponging occurred post-recovery
+        exports_after = sum(self.fs.ranks_perf(lambda p: p['mds']['exported']))
+        self.assertLessEqual(exports_after - exports_before, len(before_layout))
+
+    def test_ephemeral_random_dirfrag_under_export_pin(self):
+        """
+        Verify that a child directory with random ephemeral pinning overrides
+        an ancestor's static export pin and scatters its fragments across ranks.
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+        self.config_set('mds', 'mds_bal_split_size', 20)
+        self.config_set('mds', 'mds_bal_split_bits', 2)
+
+        # Parent is statically pinned to rank 1
+        self.mount_a.run_shell(["mkdir", "-p", "parent_pin/rand_child"])
+        self.mount_a.setfattr("parent_pin", "ceph.dir.pin", "1")
+
+        # Child overrides with 100% random fragment pinning
+        self.mount_a.setfattr("parent_pin/rand_child", "ceph.dir.pin.random", "1.0")
+
+        # Populate child to force fragmentation
+        for i in range(100):
+            self.mount_a.run_shell(["touch", f"parent_pin/rand_child/file_{i}"])
+
+        # Child fragments should be scattered across active ranks with random_ephemeral_pin
+        subtrees = self._wait_random_subtrees(
+            4,
+            status=self.status,
+            rank="all",
+            path="/parent_pin/rand_child"
+        )
+
+        ranks_seen = set()
+        for s in subtrees:
+            if s['dir']['path'] == '/parent_pin/rand_child':
+                self.assertTrue(s['random_ephemeral_pin'])
+                self.assertFalse(s['distributed_ephemeral_pin'])
+                ranks_seen.add(s['auth_first'])
+
+        # Multi-MDS cluster should have scattered fragments to ranks other than just parent's pin
+        self.assertGreaterEqual(len(ranks_seen), 1)
+
+    def test_ephemeral_random_dirfrag_under_distributed_pin(self):
+        """
+        Verify that a child directory configured with random ephemeral pinning
+        correctly fragments and evaluates its own random pin policy under a
+        distributed ephemeral pinned parent.
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_distributed', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+        self.config_set('mds', 'mds_bal_split_size', 20)
+        self.config_set('mds', 'mds_bal_split_bits', 2)
+
+        # Parent uses distributed pinning
+        self.mount_a.run_shell(["mkdir", "-p", "dist_parent/rand_child"])
+        self.mount_a.setfattr("dist_parent", "ceph.dir.pin.distributed", "1")
+
+        # Child sets random pinning
+        self.mount_a.setfattr("dist_parent/rand_child", "ceph.dir.pin.random", "1.0")
+
+        # Populate child to force fragment splitting
+        for i in range(100):
+            self.mount_a.run_shell(["touch", f"dist_parent/rand_child/file_{i}"])
+
+        # Subtrees generated for the child must have random_ephemeral_pin set
+        subtrees = self._wait_random_subtrees(
+            4,
+            status=self.status,
+            rank="all",
+            path="/dist_parent/rand_child"
+        )
+
+        for s in subtrees:
+            if s['dir']['path'] == '/dist_parent/rand_child':
+                self.assertTrue(s['random_ephemeral_pin'])
+                self.assertFalse(s['distributed_ephemeral_pin'])
+
+    def test_ephemeral_random_pin_override_before(self):
+        """
+        Verify that a static export pin on a child directory takes precedence
+        over an ancestor directory's ephemeral random dirfrag policy.
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+
+        # Parent directory has random pinning policy
+        self.mount_a.run_shell(["mkdir", "-p", "rand_parent/pinned_child"])
+        self.mount_a.setfattr("rand_parent", "ceph.dir.pin.random", "1.0")
+
+        # Child directory explicitly pinned to rank 1
+        self.mount_a.setfattr("rand_parent/pinned_child", "ceph.dir.pin", "1")
+
+        # Populate child with files
+        for i in range(50):
+            self.mount_a.run_shell(["touch", f"rand_parent/pinned_child/file_{i}"])
+
+        # Verify child directory is pinned statically to rank 1
+        subtrees = self._wait_subtrees(
+            [("rand_parent/pinned_child", 1)],
+            status=self.status,
+            rank=1,
+            path="rand_parent/pinned_child",
+        )
+
+        for s in subtrees:
+            if s['dir']['path'] == '/rand_parent/pinned_child':
+                self.assertEqual(s['export_pin'], 1)
+                self.assertFalse(s['random_ephemeral_pin'])
+
+    def test_ephemeral_random_pin_override_after(self):
+        """
+        Verify that setting a conventional export pin on an existing child directory
+        overrides the ancestor's random ephemeral policy and migrates the subtree.
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+        self.config_set('mds', 'mds_bal_split_size', 20)
+        self.config_set('mds', 'mds_bal_split_bits', 2)
+
+        # 1. Setup parent with 100% random pinning policy
+        self.mount_a.run_shell(["mkdir", "rand_tree"])
+        self.mount_a.setfattr("rand_tree", "ceph.dir.pin.random", "1.0")
+
+        # 2. Create child without an explicit pin initially
+        self.mount_a.run_shell(["mkdir", "rand_tree/pin_dir"])
+
+        # 3. Populate entries in both to trigger dirfrag splitting
+        for i in range(50):
+            self.mount_a.run_shell(["touch", f"rand_tree/file_{i}"])
+            self.mount_a.run_shell(["touch", f"rand_tree/pin_dir/file_{i}"])
+
+        # 4. Wait for parent's 4 dirfrags to form random subtrees
+        self._wait_random_subtrees(
+            4,
+            status=self.status,
+            rank="all",
+            path="/rand_tree"
+        )
+
+        # 5. Apply static export pin on the child directory AFTER population
+        self.mount_a.setfattr("rand_tree/pin_dir", "ceph.dir.pin", "1")
+
+        # 6. Verify child forms a static subtree on rank 1 and overrides random policy
+        subtrees = self._wait_subtrees(
+            [('/rand_tree/pin_dir', 1)],
+            status=self.status,
+            rank=1,
+            path="/rand_tree/pin_dir"
+        )
+
+        for s in subtrees:
+            if s['dir']['path'] == '/rand_tree/pin_dir':
+                self.assertEqual(s['export_pin'], 1)
+                self.assertFalse(s.get('random_ephemeral_pin', False))
+                self.assertFalse(s.get('distributed_ephemeral_pin', False))
+
+    def test_ephemeral_pin_grow_mds(self):
+        """
+        Verify that consistent hashing limits the fraction of dirfrag subtree
+        migrations when expanding the active MDS cluster size.
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+        self.config_set('mds', 'mds_bal_split_size', 5)
+        # Split into 2^6 = 64 fragments
+        self.config_set('mds', 'mds_bal_split_bits', 6)
+
+        self.fs.set_max_mds(2)
+        self.status = self.fs.wait_for_daemons()
+
+        self.mount_a.run_shell(["mkdir", - "grow_dir"])
+        self.mount_a.setfattr("grow_dir", "ceph.dir.pin.random", "1.0")
+
+        for i in range(350):
+            self.mount_a.run_shell(["touch", f"grow_dir/file_{i}"])
+
+        # Wait for all 64 fragment subtrees across ranks 0 and 1
+        subtrees_old = self._wait_random_subtrees(
+            64,
+            status=self.status,
+            rank="all",
+            path="/grow_dir"
+        )
+        old_map = {s['dir']['frag']: s['auth_first'] for s in subtrees_old if s['dir']['path'] == '/grow_dir'}
+        self.assertEqual(len(old_map), 64)
+
+        # Grow active cluster to 3 ranks
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+
+        # Allow balancer to evaluate consistent hash ring and perform migrations
+        time.sleep(30)
+
+        subtrees_new = self._wait_random_subtrees(
+            64,
+            status=self.status,
+            rank="all",
+            path="/grow_dir"
+        )
+        new_map = {s['dir']['frag']: s['auth_first'] for s in subtrees_new if s['dir']['path'] == '/grow_dir'}
+        self.assertEqual(len(new_map), 64)
+
+        # Count how many fragments migrated to a different rank
+        migrations = sum(1 for frag, auth in old_map.items() if new_map[frag] != auth)
+        migration_ratio = migrations / len(old_map)
+
+        log.info(f"Dirfrag migrations occurred: {migrations}/64 ({migration_ratio:.2%})")
+
+        # Ideal migration for 2 -> 3 ranks is ~33.3%. Bound with safety margin at <= 50%
+        self.assertLessEqual(migration_ratio, 0.50)
+        # Ensure at least some migrations occurred to the new rank
+        self.assertGreater(migrations, 0)
+
+    def test_ephemeral_pin_shrink_mds(self):
+        """
+        Verify that consistent hashing limits the fraction of dirfrag subtree
+        migrations when reducing the active MDS cluster size.
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+        self.config_set('mds', 'mds_bal_split_size', 5)
+        # Split into 2^6 = 64 fragments
+        self.config_set('mds', 'mds_bal_split_bits', 6)
+
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+
+        self.mount_a.run_shell(["mkdir", "shrink_dir"])
+        self.mount_a.setfattr("shrink_dir", "ceph.dir.pin.random", "1.0")
+
+        for i in range(350):
+            self.mount_a.run_shell(["touch", f"shrink_dir/file_{i}"])
+
+        # Wait for all 64 fragment subtrees across ranks 0, 1, and 2
+        subtrees_old = self._wait_random_subtrees(
+            64,
+            status=self.status,
+            rank="all",
+            path="/shrink_dir"
+        )
+        old_map = {s['dir']['frag']: s['auth_first'] for s in subtrees_old if s['dir']['path'] == '/shrink_dir'}
+        self.assertEqual(len(old_map), 64)
+
+        # Shrink active cluster to 2 ranks
+        self.fs.set_max_mds(2)
+        self.status = self.fs.wait_for_daemons()
+
+        # Allow balancer to drain rank 2 and re-hash remaining fragments
+        time.sleep(30)
+
+        subtrees_new = self._wait_random_subtrees(
+            64,
+            status=self.status,
+            rank="all",
+            path="/shrink_dir"
+        )
+        new_map = {s['dir']['frag']: s['auth_first'] for s in subtrees_new if s['dir']['path'] == '/shrink_dir'}
+        self.assertEqual(len(new_map), 64)
+
+        # Count how many fragments migrated
+        migrations = sum(1 for frag, auth in old_map.items() if new_map[frag] != auth)
+        migration_ratio = migrations / len(old_map)
+
+        log.info(f"Dirfrag migrations occurred during shrink: {migrations}/64 ({migration_ratio:.2%})")
+
+        # Rank 2 fragments (approx 1/3) must move, plus small hash churn between 0 and 1.
+        # Cap bounded at ~66% with safety tolerance.
+        self.assertLessEqual(migration_ratio, 0.66 * 1.25)
+        # Ensure migrations took place
+        self.assertGreater(migrations, 0)
+        # Ensure no subtrees remain on decommissioned rank 2
+        self.assertTrue(all(auth in (0, 1) for auth in new_map.values()))
+
+    def test_ephemeral_random_cache_drop(self):
+        """
+        Verify that random ephemeral dirfrag subtrees merge back and clear when
+        client caps are released and the MDS metadata cache is dropped.
+        """
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+        self.config_set('mds', 'mds_bal_split_size', 20)
+        self.config_set('mds', 'mds_bal_split_bits', 2)
+
+        self.mount_a.run_shell(["mkdir", "rand_drop_dir"])
+        self.mount_a.setfattr("rand_drop_dir", "ceph.dir.pin.random", "1.0")
+
+        for i in range(100):
+            self.mount_a.run_shell(["touch", f"rand_drop_dir/file_{i}"])
+
+        # Wait for all 4 dirfrag subtrees to be established
+        self._wait_random_subtrees(
+            4,
+            status=self.status,
+            rank="all",
+            path="/rand_drop_dir"
+        )
+
+        # Release all client caps
+        self.mount_a.umount_wait()
+
+        # Drop MDS cache periodically until the subtrees merge back
+        def _drop():
+            self.fs.ranks_tell(["cache", "drop"], status=self.status)
+
+        # Subtrees on /rand_drop_dir should collapse completely
+        self._wait_subtrees(
+            [],
+            status=self.status,
+            path="/rand_drop_dir",
+            action=_drop
+        )

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -644,7 +644,7 @@ options:
   type: float
   level: advanced
   desc: the maximum percent permitted for random ephemeral pin policy
-  default: 0.01
+  default: 1.0
   services:
   - mds
   see_also:

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -668,6 +668,24 @@ options:
   type: float
   level: advanced
   desc: multiple of max_mds for splitting and distributing directory
+  see_also:
+  -  mds_export_ephemeral_frag_factor
+  default: 2
+  services:
+  - mds
+  min: 1
+  max: 100
+  flags:
+  - runtime
+- name: mds_export_ephemeral_frag_factor
+  type: float
+  level: advanced
+  desc: Factor to multiply max_mds by to determine target dirfrag count for ephemeral pinning
+  long_desc: Factor multiplied by max_mds (the number of active MDS ranks) to calculate
+    the minimum target directory fragment count for directories configured with ephemeral
+    pinning (distributed or random). The MDS pre-splits directories until the fragment bit
+    depth provides at least (max_mds * mds_export_ephemeral_frag_factor) fragments, ensuring
+    subtrees are partitioned deeply enough to balance metadata load evenly across ranks.
   default: 2
   services:
   - mds

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1980,7 +1980,6 @@ CDentry *CDir::_load_dentry(
         if (in->get_inode()->is_dirty_rstat())
           in->mark_dirty_rstat();
 
-        in->maybe_ephemeral_rand(rand_threshold);
         //in->hack_accessed = false;
         //in->hack_load_stamp = ceph_clock_now();
         //num_new_inodes_loaded++;
@@ -2878,10 +2877,15 @@ void CDir::_committed(int r, version_t v)
 mds_rank_t CDir::get_export_pin(bool inherit) const
 {
   mds_rank_t export_pin = inode->get_export_pin(inherit);
-  if (export_pin == MDS_RANK_EPHEMERAL_DIST)
+  if (export_pin == MDS_RANK_EPHEMERAL_DIST) {
     export_pin = mdcache->hash_into_rank_bucket(ino(), get_frag());
-  else if (export_pin == MDS_RANK_EPHEMERAL_RAND)
-    export_pin = mdcache->hash_into_rank_bucket(ino());
+  } else if (export_pin == MDS_RANK_EPHEMERAL_RAND) {
+    if (inode->should_random_pin_frag(get_frag())) {
+      export_pin = mdcache->hash_into_rank_bucket(ino(), get_frag());
+    } else {
+      export_pin = MDS_RANK_NONE;
+    }
+  }
   return export_pin;
 }
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -522,7 +522,9 @@ void CInode::pop_and_dirty_projected_inode(LogSegmentRef const& ls, const Mutati
   bool pool_updated = get_inode()->layout.pool_id != front.inode->layout.pool_id;
   bool pin_updated = (get_inode()->export_pin != front.inode->export_pin) ||
 		     (get_inode()->get_ephemeral_distributed_pin() !=
-		      front.inode->get_ephemeral_distributed_pin());
+		      front.inode->get_ephemeral_distributed_pin()) ||
+                     (get_inode()->export_ephemeral_random_pin !=
+                      front.inode->export_ephemeral_random_pin);
 
   reset_inode(std::move(front.inode));
   if (front.xattrs != get_xattrs())
@@ -5541,25 +5543,27 @@ void CInode::queue_export_pin(mds_rank_t export_pin)
   mds_rank_t target;
   if (export_pin >= 0)
     target = export_pin;
-  else if (export_pin == MDS_RANK_EPHEMERAL_RAND)
-    target = mdcache->hash_into_rank_bucket(ino());
   else
     target = MDS_RANK_NONE;
 
-  unsigned min_frag_bits = mdcache->get_ephemeral_dist_frag_bits();
+  unsigned min_frag_bits = mdcache->get_ephemeral_frag_bits();
   bool queue = false;
   for (auto& p : dirfrags) {
     CDir *dir = p.second;
     if (!dir->is_auth())
       continue;
 
-    if (export_pin == MDS_RANK_EPHEMERAL_DIST) {
+    if (export_pin == MDS_RANK_EPHEMERAL_DIST || export_pin == MDS_RANK_EPHEMERAL_RAND) {
       if (dir->get_frag().bits() < min_frag_bits) {
 	// needs split
 	queue = true;
 	break;
       }
-      target = mdcache->hash_into_rank_bucket(ino(), dir->get_frag());
+      if (export_pin == MDS_RANK_EPHEMERAL_DIST || should_random_pin_frag(dir->get_frag())) {
+        target = mdcache->hash_into_rank_bucket(ino(), dir->get_frag());
+      } else {
+        target = MDS_RANK_NONE;
+      }
     }
 
     if (target != MDS_RANK_NONE) {
@@ -5644,43 +5648,22 @@ void CInode::clear_ephemeral_pin(bool dist, bool rand)
   }
 }
 
-void CInode::maybe_ephemeral_rand(double threshold)
+bool CInode::should_random_pin_frag(frag_t fg) const
 {
-  if (!mdcache->get_export_ephemeral_random_config()) {
-    dout(15) << __func__ << " config false: cannot ephemeral random pin " << *this << dendl;
-    clear_ephemeral_pin(false, true);
-    return;
-  } else if (!is_dir() || !is_normal()) {
-    dout(15) << __func__ << " !dir or !normal: cannot ephemeral random pin " << *this << dendl;
-    clear_ephemeral_pin(false, true);
-    return;
-  } else if (get_inode()->nlink == 0) {
-    dout(15) << __func__ << " unlinked directory: cannot ephemeral random pin " << *this << dendl;
-    clear_ephemeral_pin(false, true);
-    return;
-  } else if (state_test(CInode::STATE_RANDEPHEMERALPIN)) {
-    dout(10) << __func__ << " already ephemeral random pinned: requeueing " << *this << dendl;
-    queue_export_pin(MDS_RANK_EPHEMERAL_RAND);
-    return;
-  }
+  double threshold = get_inode()->export_ephemeral_random_pin;
+  if (threshold <= 0.0)
+    return false;
+  if (threshold >= 1.0)
+    return true;
 
-  /* not precomputed? */
-  if (threshold < 0.0) {
-    threshold = get_ephemeral_rand();
-  }
-  if (threshold <= 0.0) {
-    return;
-  }
-  double n = ceph::util::generate_random_number(0.0, 1.0);
+  // Combine inode number and fragment into a 64-bit pseudo-random hash
+  uint64_t h = rjhash64(ino());
+  h = rjhash64(h + rjhash64(fg.value()));
 
-  dout(15) << __func__ << " rand " << n << " <?= " << threshold
-           << " " << *this << dendl;
+  // Normalize uint64_t hash to [0.0, 1.0)
+  double normalized_val = (double)(h >> 11) * (1.0 / 9007199254740992.0); // 53-bit precision
 
-  if (n <= threshold) {
-    dout(10) << __func__ << " randomly export pinning " << *this << dendl;
-    set_ephemeral_pin(false, true);
-    queue_export_pin(MDS_RANK_EPHEMERAL_RAND);
-  }
+  return normalized_val < threshold;
 }
 
 void CInode::setxattr_ephemeral_rand(double probability)
@@ -5724,7 +5707,6 @@ mds_rank_t CInode::get_export_pin(bool inherit) const
    * N.B. inodes not yet linked into a dir (i.e. anonymous inodes) will not
    * have a parent yet.
    */
-  mds_rank_t r_target = MDS_RANK_NONE;
   const CInode *in = this;
   const CDir *dir = nullptr;
   while (true) {
@@ -5738,24 +5720,30 @@ mds_rank_t CInode::get_export_pin(bool inherit) const
       break;
     }
 
+    mds_rank_t epin;
     if (in->get_inode()->export_pin >= 0) {
-      return in->get_inode()->export_pin;
+      epin = in->get_inode()->export_pin;
+      dout(20) << __func__ << ": epin=" << epin << dendl;
+      return epin;
     } else if (in->get_inode()->get_ephemeral_distributed_pin() &&
 	       mdcache->get_export_ephemeral_distributed_config()) {
-      if (in != this)
-	return mdcache->hash_into_rank_bucket(in->ino(), dir->get_frag());
+      if (in != this) {
+        epin = mdcache->hash_into_rank_bucket(in->ino(), dir->get_frag());
+        dout(20) << __func__ << ": epin=" << epin << dendl;
+        return epin;
+      }
       return MDS_RANK_EPHEMERAL_DIST;
-    } else if (r_target != MDS_RANK_NONE && in->get_inode()->export_ephemeral_random_pin > 0.0) {
-      return r_target;
-    } else if (r_target == MDS_RANK_NONE && in->is_ephemeral_rand() &&
-	       mdcache->get_export_ephemeral_random_config()) {
-      /* If a parent overrides a grandparent ephemeral pin policy with an export pin, we use that export pin instead. */
-      if (!inherit)
-	return MDS_RANK_EPHEMERAL_RAND;
-      if (in == this)
-	r_target = MDS_RANK_EPHEMERAL_RAND;
-      else
-	r_target = mdcache->hash_into_rank_bucket(in->ino());
+    } else if (in->get_inode()->export_ephemeral_random_pin > 0.0 &&
+               mdcache->get_export_ephemeral_random_config()) {
+      if (in != this && dir) {
+        if (in->should_random_pin_frag(dir->get_frag())) {
+          epin = mdcache->hash_into_rank_bucket(in->ino(), dir->get_frag());
+          dout(20) << __func__ << ": epin=" << epin << dendl;
+          return epin;
+        }
+        return MDS_RANK_NONE;
+      }
+      return MDS_RANK_EPHEMERAL_RAND;
     }
 
     if (!inherit)

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -1030,7 +1030,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   }
 
   double get_ephemeral_rand() const;
-  void maybe_ephemeral_rand(double threshold=-1.0);
+  bool should_random_pin_frag(frag_t fg) const;
   void setxattr_ephemeral_rand(double prob=0.0);
   bool is_ephemeral_rand() const {
     return state_test(STATE_RANDEPHEMERALPIN);

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -174,19 +174,18 @@ void MDBalancer::handle_export_pins(void)
     dout(20) << " executing export_pin=" << export_pin << " on " << *in << dendl;
     unsigned min_frag_bits = 0;
     mds_rank_t target = MDS_RANK_NONE;
-    if (export_pin >= 0)
+    if (export_pin >= 0) {
       target = export_pin;
-    else if (export_pin == MDS_RANK_EPHEMERAL_RAND)
-      target = mdcache->hash_into_rank_bucket(in->ino());
-    else if (export_pin == MDS_RANK_EPHEMERAL_DIST)
-      min_frag_bits = mdcache->get_ephemeral_dist_frag_bits();
+    } else if (export_pin == MDS_RANK_EPHEMERAL_DIST || export_pin == MDS_RANK_EPHEMERAL_RAND) {
+      min_frag_bits = mdcache->get_ephemeral_frag_bits();
+    }
 
     bool remove = true;
     for (auto&& dir : in->get_dirfrags()) {
       if (!dir->is_auth())
 	continue;
 
-      if (export_pin == MDS_RANK_EPHEMERAL_DIST) {
+      if (export_pin == MDS_RANK_EPHEMERAL_DIST || export_pin == MDS_RANK_EPHEMERAL_RAND) {
 	if (dir->get_frag().bits() < min_frag_bits) {
 	  if (!dir->state_test(CDir::STATE_CREATING) &&
 	      !dir->is_frozen() && !dir->is_freezing()) {
@@ -195,7 +194,11 @@ void MDBalancer::handle_export_pins(void)
 	  remove = false;
 	  continue;
 	}
-	target = mdcache->hash_into_rank_bucket(in->ino(), dir->get_frag());
+        if (export_pin == MDS_RANK_EPHEMERAL_DIST || in->should_random_pin_frag(dir->get_frag())) {
+          target = mdcache->hash_into_rank_bucket(in->ino(), dir->get_frag());
+        } else {
+          target = MDS_RANK_NONE;
+        }
       }
 
       if (target == MDS_RANK_NONE) {
@@ -259,7 +262,11 @@ void MDBalancer::handle_export_pins(void)
     if (export_pin == MDS_RANK_EPHEMERAL_DIST) {
       export_pin = mdcache->hash_into_rank_bucket(cd->ino(), cd->get_frag());
     } else if (export_pin == MDS_RANK_EPHEMERAL_RAND) {
-      export_pin = mdcache->hash_into_rank_bucket(cd->ino());
+      if (cd->inode->should_random_pin_frag(cd->get_frag())) {
+        export_pin = mdcache->hash_into_rank_bucket(cd->ino(), cd->get_frag());
+      } else {
+        export_pin = cd->inode->authority().first;
+      }
     }
 
     if (print_auth_subtrees)
@@ -641,8 +648,8 @@ void MDBalancer::queue_split(const CDir *dir, bool fast)
     // happen if the checks in MDCache::can_fragment fail.
     dout(10) << _func_ << " splitting " << *dir << dendl;
     int bits = bal_split_bits;
-    if (dir->inode->is_ephemeral_dist()) {
-      unsigned min_frag_bits = mdcache->get_ephemeral_dist_frag_bits();
+    if (dir->inode->is_ephemerally_pinned()) {
+      unsigned min_frag_bits = mdcache->get_ephemeral_frag_bits();
       if (df.frag.bits() + bits < min_frag_bits)
 	bits = min_frag_bits - df.frag.bits();
     }
@@ -706,8 +713,9 @@ void MDBalancer::queue_merge(CDir *dir)
     CInode *diri = dir->get_inode();
 
     unsigned min_frag_bits = 0;
-    if (diri->is_ephemeral_dist())
-      min_frag_bits = mdcache->get_ephemeral_dist_frag_bits();
+    if (diri->is_ephemerally_pinned()) {
+      min_frag_bits = mdcache->get_ephemeral_frag_bits();
+    }
 
     frag_t fg = dir->get_frag();
     while (fg.bits() > min_frag_bits) {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -276,6 +276,10 @@ void MDCache::handle_conf_change(const std::set<std::string>& changed, const MDS
     use_global_snaprealm_seq = g_conf().get_val<bool>("mds_use_global_snaprealm_seq_for_subvol");
     dout(20) << __func__ << " mds_use_global_snaprealm_seq_for_subvol now " << use_global_snaprealm_seq << dendl;
   }
+  if (changed.count("mds_export_ephemeral_frag_factor") ||
+      changed.count("mds_export_ephemeral_distributed_factor")) {
+    handle_mdsmap(*mds->mdsmap, *mds->mdsmap);
+}
 
   migrator->handle_conf_change(changed, mdsmap);
   mds->balancer->handle_conf_change(changed, mdsmap);
@@ -14484,6 +14488,27 @@ void MDCache::dump_dir(Formatter *f, CDir *dir, bool dentry_dump) {
   f->close_section();
 }
 
+double MDCache::get_effective_ephemeral_frag_factor() const
+{
+  double factor = g_conf().get_val<double>("mds_export_ephemeral_frag_factor");
+
+  auto default_opt = g_conf().get_val_default("mds_export_ephemeral_frag_factor");
+  if (default_opt) {
+    double default_factor = std::stod(*default_opt);
+    if (factor == default_factor) {
+      auto legacy_default_opt = g_conf().get_val_default("mds_export_ephemeral_distributed_factor");
+      if (legacy_default_opt) {
+        double legacy_default = std::stod(*legacy_default_opt);
+        double legacy_factor = g_conf().get_val<double>("mds_export_ephemeral_distributed_factor");
+        if (legacy_factor != legacy_default) {
+          factor = legacy_factor;
+        }
+      }
+    }
+  }
+  return factor;
+}
+
 void MDCache::handle_mdsmap(const MDSMap &mdsmap, const MDSMap &oldmap) {
   const mds_rank_t max_mds = mdsmap.get_max_mds();
 
@@ -14517,12 +14542,11 @@ void MDCache::handle_mdsmap(const MDSMap &mdsmap, const MDSMap &oldmap) {
   if (max_mds <= 1) {
     export_ephemeral_dist_frag_bits = 0;
   } else {
-    double want = g_conf().get_val<double>("mds_export_ephemeral_distributed_factor");
-    want *= max_mds;
+    double want = get_effective_ephemeral_frag_factor() * max_mds;
     unsigned n = 0;
     while ((1U << n) < (unsigned)want)
       ++n;
-    export_ephemeral_dist_frag_bits = n;
+    export_ephemeral_frag_bits = n;
   }
 }
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -258,6 +258,10 @@ class MDCache {
     return export_ephemeral_distributed_config;
   }
 
+  unsigned get_ephemeral_frag_bits() const {
+    return export_ephemeral_frag_bits;
+  }
+
   bool get_export_ephemeral_random_config(void) const {
     return export_ephemeral_random_config;
   }
@@ -1577,6 +1581,8 @@ private:
 
   bool is_ready_to_trim_cache(void);
 
+  double get_effective_ephemeral_frag_factor() const;
+
   uint64_t cache_memory_limit;
   double cache_reservation;
   double cache_health_threshold;
@@ -1585,6 +1591,7 @@ private:
   bool export_ephemeral_distributed_config;
   bool export_ephemeral_random_config;
   unsigned export_ephemeral_dist_frag_bits;
+  unsigned export_ephemeral_frag_bits = 0;
 
   // Stores the symlink target on the file object's head
   bool symlink_recovery;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7459,9 +7459,6 @@ public:
 
     if (newi->is_file()) {
       get_mds()->locker->share_inode_max_size(newi);
-    } else if (newi->is_dir()) {
-      // We do this now so that the linkages on the new directory are stable.
-      newi->maybe_ephemeral_rand();
     }
 
     // hit pop


### PR DESCRIPTION
https://tracker.ceph.com/issues/73940

(DRAFT for now -- need to cleanup some rough edges).

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
