### PR TITLE
tentacle: doc/cephadm: document the cephfs-proxy sidecar

### DIFF
--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -261,6 +261,41 @@ exercise for the reader.
    scheme has different performance and security characteristics.
 
 
+.. _smb-cephfs-proxy:
+
+The CephFS Proxy Sidecar
+========================
+
+When a cluster hosts CephFS-backed shares that use the default
+``samba-vfs/proxied`` provider (see the ``provider`` share field in
+:ref:`mgr-smb`), cephadm automatically runs a ``cephfs-proxy``
+container alongside each Samba instance. No operator action is needed
+to deploy it, and it is not a separate orchestrator service: it
+appears as a sidecar of the ``smb`` daemon rather than as its own
+entry.
+
+The sidecar runs the ``libcephfsd`` daemon from the regular Ceph
+container image. Without the proxy, every SMB client connection opens
+its own ``libcephfs`` instance with its own private cache, which can
+consume large amounts of memory on busy servers. The proxy daemon
+holds the real CephFS mounts and shares them among connections with
+identical configuration, allowing a much greater number of
+simultaneous client connections at some cost in performance.
+
+Points useful when troubleshooting:
+
+* The proxy listens on the UNIX socket ``/run/libcephfsd.sock``
+  inside the shared ``/run`` mount of the Samba pod.
+* The daemon binary is ``/usr/sbin/libcephfsd``; its container is
+  named as a ``proxy`` sub-daemon of the parent ``smb`` daemon.
+* The proxy is only deployed when at least one share uses the
+  proxied provider. Shares using ``samba-vfs/classic`` or
+  ``samba-vfs/new`` connect to CephFS directly from the Samba
+  container.
+
+For design details, see the developer documentation in
+``doc/dev/libcephfs_proxy.rst``.
+
 Limitations
 ===========
 

--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -269,23 +269,27 @@ The CephFS Proxy Sidecar
 When a cluster hosts CephFS-backed shares that use the default
 ``samba-vfs/proxied`` provider (see the ``provider`` share field in
 :ref:`mgr-smb`), cephadm automatically runs a ``cephfs-proxy``
-container alongside each Samba instance. No operator action is needed
-to deploy it, and it is not a separate orchestrator service: it
-appears as a sidecar of the ``smb`` daemon rather than as its own
-entry.
+sidecar container alongside each Samba instance. No operator action
+is needed to deploy it, and it is not a separate orchestrator
+service.
 
-The sidecar runs the ``libcephfsd`` daemon from the regular Ceph
-container image. Without the proxy, every SMB client connection opens
-its own ``libcephfs`` instance with its own private cache, which can
-consume large amounts of memory on busy servers. The proxy daemon
-holds the real CephFS mounts and shares them among connections with
-identical configuration, allowing a much greater number of
-simultaneous client connections at some cost in performance.
+The sidecar container runs the ``libcephfsd`` daemon. Unlike the
+Samba containers, which use images from the samba-container project,
+the sidecar uses the regular Ceph container image; the ``smb``
+service intentionally runs containers from both images. Without the
+proxy, every SMB client connection opens its own ``libcephfs``
+instance with its own private cache, which can consume large amounts
+of memory on busy servers. The proxy multiplexes the client
+connections over shared CephFS mounts for connections with identical
+configuration, serving a greater number of concurrent clients with
+fewer server-side resources. When the number of clients is very
+large, there may be some impact to individual client performance.
 
 Points useful when troubleshooting:
 
 * The proxy listens on the UNIX socket ``/run/libcephfsd.sock``
-  inside the shared ``/run`` mount of the Samba pod.
+  inside the ``/run`` mount that the ``smb`` daemon's containers
+  share.
 * The daemon binary is ``/usr/sbin/libcephfsd``; its container is
   named as a ``proxy`` sub-daemon of the parent ``smb`` daemon.
 * The proxy is only deployed when at least one share uses the

--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -261,44 +261,15 @@ exercise for the reader.
    scheme has different performance and security characteristics.
 
 
-.. _smb-cephfs-proxy:
-
 The CephFS Proxy Sidecar
 ========================
 
-When a cluster hosts CephFS-backed shares that use the default
-``samba-vfs/proxied`` provider (see the ``provider`` share field in
-:ref:`mgr-smb`), cephadm automatically runs a ``cephfs-proxy``
-sidecar container alongside each Samba instance. No operator action
-is needed to deploy it, and it is not a separate orchestrator
-service.
-
-The sidecar container runs the ``libcephfsd`` daemon. Unlike the
-Samba containers, which use images from the samba-container project,
-the sidecar uses the regular Ceph container image; the ``smb``
-service intentionally runs containers from both images. Without the
-proxy, every SMB client connection opens its own ``libcephfs``
-instance with its own private cache, which can consume large amounts
-of memory on busy servers. The proxy multiplexes the client
-connections over shared CephFS mounts for connections with identical
-configuration, serving a greater number of concurrent clients with
-fewer server-side resources. When the number of clients is very
-large, there may be some impact to individual client performance.
-
-Points useful when troubleshooting:
-
-* The proxy listens on the UNIX socket ``/run/libcephfsd.sock``
-  inside the ``/run`` mount that the ``smb`` daemon's containers
-  share.
-* The daemon binary is ``/usr/sbin/libcephfsd``; its container is
-  named as a ``proxy`` sub-daemon of the parent ``smb`` daemon.
-* The proxy is only deployed when at least one share uses the
-  proxied provider. Shares using ``samba-vfs/classic`` or
-  ``samba-vfs/new`` connect to CephFS directly from the Samba
-  container.
-
-For design details, see the developer documentation in
-``doc/dev/libcephfs_proxy.rst``.
+When at least one CephFS-backed share uses a proxied provider, the
+smb manager module includes the ``cephfs-proxy`` feature in the
+``features`` parameter of the smb service specification, and cephadm
+deploys a ``cephfs-proxy`` sidecar container alongside each Samba
+instance. See :ref:`smb-cephfs-proxy` for a description of the
+sidecar and troubleshooting pointers.
 
 Limitations
 ===========

--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -701,7 +701,9 @@ cephfs
         connect to CephFS. ``samba-vfs`` automatically selects the preferred VFS
         based implementation, currently ``samba-vfs/proxied``. This option is
         suitable for the majority of use cases and can be left unspecified for most
-        shares.
+        shares. When a proxied provider is in use, cephadm automatically
+        deploys a ``cephfs-proxy`` sidecar next to each Samba instance;
+        see :ref:`smb-cephfs-proxy`.
 restrict_access
     Optional boolean, defaulting to false. If true the share will only permit
     access by users explicitly listed in ``login_control``.

--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -1036,3 +1036,46 @@ at the prompt. Refer to the `smbclient documentation`_ for more details.
 
 .. _smbclient documentation:
    https://www.samba.org/samba/docs/current/man-html/smbclient.1.html
+
+.. _smb-cephfs-proxy:
+
+The CephFS Proxy Sidecar
+========================
+
+When a cluster hosts CephFS-backed shares that use the default
+``samba-vfs/proxied`` provider (see the ``provider`` share field
+above), the smb module adds the ``cephfs-proxy`` feature to the smb
+service specification that it generates, and cephadm deploys a
+``cephfs-proxy`` sidecar container alongside each Samba instance. No
+operator action is needed, and the sidecar is not a separate
+orchestrator service. The sidecar always runs on the same host as
+its Samba instance and shares that instance's ``/run`` mount and
+namespaces.
+
+The sidecar container runs the ``libcephfsd`` daemon. Unlike the
+Samba containers, which use images from the samba-container project,
+the sidecar uses the Ceph container image; the ``smb`` service
+intentionally runs containers from both images. Without the proxy,
+every SMB client connection opens its own ``libcephfs`` instance
+with its own private cache, which can consume large amounts of
+memory on busy servers. The proxy multiplexes the client connections
+over shared CephFS mounts for connections with identical
+configuration, serving a greater number of concurrent clients with
+fewer server-side resources. When the number of clients is very
+large, there may be some impact to individual client performance.
+
+Points useful when troubleshooting:
+
+* The proxy listens on the UNIX socket ``/run/libcephfsd.sock``
+  inside the ``/run`` mount that the smb instance's containers
+  share.
+* The daemon binary is ``/usr/sbin/libcephfsd``. It runs as a
+  sidecar container in the ``smb`` service, with a ``proxy`` suffix
+  in the container name.
+* The proxy is only deployed when at least one share uses the
+  proxied provider. Shares using ``samba-vfs/classic`` or
+  ``samba-vfs/new`` connect to CephFS directly from the Samba
+  container.
+
+For design details, see the developer documentation in
+``doc/dev/libcephfs_proxy.rst``.


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/71082 to tentacle: operator documentation for the cephfs-proxy sidecar.

Conflicts resolved during cherry-pick: the release-notes hunk was dropped (stable branches do not carry doc/releases), and the smb module page hunks were adapted because tentacle does not have the qos/fscrypt/rgw share fields or the SMB Remote Control section that exist on main; only the CephFS proxy section itself is backported.

backport tracker: https://tracker.ceph.com/issues/79761

Fixes: https://tracker.ceph.com/issues/79761

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
