### PR TITLE
doc/mgr: improve nfs.rst

### DIFF
--- a/doc/cephadm/services/nfs.rst
+++ b/doc/cephadm/services/nfs.rst
@@ -151,6 +151,8 @@ These values are converted to bytes when written into a ``CEPH`` block in
 ``ganesha.conf`` (as ``client_oc``, ``client_oc_size``, and
 ``client_oc_max_dirty``) when object caching is enabled.
 
+.. _cephadm-nfs-colocation:
+
 NFS Daemon Colocation
 ----------------------
 

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -12,65 +12,69 @@ NFS exports of either CephFS directories or RGW buckets.  Exports can
 be managed either via the CLI ``ceph nfs export ...`` commands
 or via the dashboard.
 
-The deployment of the nfs-ganesha daemons can also be managed
+The deployment of the NFS-Ganesha daemons can also be managed
 automatically if either the :ref:`cephadm` or :ref:`mgr-rook`
 orchestrators are enabled.  If neither are in use (e.g., Ceph is
 deployed via an external orchestrator like Ansible or Puppet), the
-nfs-ganesha daemons must be manually deployed; for more information,
+NFS-Ganesha daemons must be manually deployed; for more information,
 see :ref:`nfs-ganesha-config`.
 
-.. note:: Starting with Ceph Pacific, the ``nfs`` mgr module must be enabled.
+.. note:: Starting with Ceph Pacific, the ``nfs`` Manager module must be enabled.
 
-NFS Cluster management
+NFS Cluster Management
 ======================
 
 .. _nfs-module-cluster-create:
 
-Create NFS Ganesha Cluster
+Create NFS-Ganesha Cluster
 --------------------------
 
 .. prompt:: bash #
 
-   ceph nfs cluster create <cluster_id> [<placement>] [--ingress] [--virtual_ip <value>] [--ingress-mode {default|keepalive-only|haproxy-standard|haproxy-protocol}] [--ingress-placement <placement>] [--port <int>] [--enable-rdma] [--rdma_port <int>] [--enable-nfsv3] [-i <spec_file>]
+   ceph nfs cluster create <cluster_id> [<placement>] [--ingress] [--virtual_ip <value>] \
+          [--ingress-mode {default|keepalive-only|haproxy-standard|haproxy-protocol}] \
+          [--ingress-placement <placement>] [--port <int>] \
+          [--enable-rdma] [--rdma_port <int>] [--enable-nfsv3] [-i <spec_file>]
 
-This creates a common recovery pool for all NFS Ganesha daemons, new user based on
-``cluster_id``, and a common NFS Ganesha config RADOS object.
+This creates a common recovery pool for all NFS-Ganesha daemons, a new user based on
+``cluster_id``, and a common NFS-Ganesha config RADOS object.
 
-.. note:: Since this command also brings up NFS Ganesha daemons using a ceph-mgr
-   orchestrator module (see :doc:`/mgr/orchestrator`) such as cephadm or rook, at
+.. note:: Since this command also brings up NFS-Ganesha daemons using a Manager
+   orchestrator module (see :doc:`/mgr/orchestrator`) such as ``cephadm`` or ``rook``, at
    least one such module must be enabled for it to work.
 
-   Currently, NFS Ganesha daemon deployed by cephadm listens on the standard
-   port. So only one daemon will be deployed on a host.
+   Beginning with the Umbrella release, NFS-Ganesha daemons deployed by cephadm
+   can be colocated and more than one daemon can be deployed on a host.
+   See :ref:`cephadm-nfs-colocation` for more details.
 
-``<cluster_id>`` is an arbitrary string by which this NFS Ganesha cluster will be
+``<cluster_id>`` is an arbitrary string by which this NFS-Ganesha cluster will be
 known (e.g., ``mynfs``).
 
-``<placement>`` is an optional string signifying which hosts should have NFS Ganesha
-daemon containers running on them and, optionally, the total number of NFS
-Ganesha daemons on the cluster (should you want to have more than one NFS Ganesha
+``<placement>`` is an optional string signifying which hosts should have NFS-Ganesha
+daemon containers running on them and, optionally, the total number of NFS-Ganesha
+daemons on the cluster (should you want to have more than one NFS-Ganesha
 daemon running per node). For example, the following placement string means
-"deploy NFS Ganesha daemons on nodes host1 and host2" (one daemon per host)::
+"deploy NFS-Ganesha daemons on nodes ``host1`` and ``host2``" (one daemon per host)::
 
     "host1,host2"
 
-and this placement specification says to deploy single NFS Ganesha daemon each
-on nodes host1 and host2 (for a total of two NFS Ganesha daemons in the
+and this placement specification says to deploy single NFS-Ganesha daemon each
+on nodes ``host1`` and ``host2`` (for a total of two NFS-Ganesha daemons in the
 cluster)::
 
     "2 host1,host2"
 
 NFS can be deployed on a port other than 2049 (the default) with ``--port <port>``.
 
-By default, only NFS v4 protocol is enabled. To enable both NFS v3 and v4 protocols,
+By default, only NFSv4 protocol is enabled. To enable both NFSv3 and NFSv4 protocols,
 add the ``--enable-nfsv3`` flag.
 
 To deploy NFS with a high-availability front-end (virtual IP and load balancer), add the
 ``--ingress`` flag and specify a virtual IP address. This will deploy a combination
-of keepalived and haproxy to provide an high-availability NFS frontend for the NFS
+of Keepalived and HAProxy to provide an high-availability NFS frontend for the NFS
 service.
 
-.. note:: Enabling ingress provides a stable virtual IP for the NFS
+.. note:: Enabling ingress provides a stable virtual IP address for the NFS
 	  service, failover between hosts if a host fails, and load
 	  distribution across the NFS gateways. Client recovery after a
 	  failover is still subject to the NFS grace period. See
@@ -95,29 +99,31 @@ When using cephadm orchestration, these commands check service status:
 Ingress
 -------
 
-The core *nfs* service will deploy one or more nfs-ganesha daemons,
-each of which will provide a working NFS endpoint.  The IP for each
-NFS endpoint will depend on which host the nfs-ganesha daemons are
+The core *nfs* service will deploy one or more NFS-Ganesha daemons,
+each of which will provide a working NFS endpoint.  The IP address for each
+NFS endpoint will depend on which host the NFS-Ganesha daemons are
 deployed.  By default, daemons are placed semi-randomly, but users can
 also explicitly control where daemons are placed; see
 :ref:`orchestrator-cli-placement-spec`.
 
 When a cluster is created with ``--ingress``, an *ingress* service is
 additionally deployed to provide load balancing and high-availability
-for the NFS servers.  A virtual IP is used to provide a known, stable
+for the NFS servers.  A virtual IP address is used to provide a known, stable
 NFS endpoint that all clients can use to mount.  Ceph will take care
-of the details of NFS redirecting traffic on the virtual IP to the
+of the details of NFS redirecting traffic on the virtual IP address to the
 appropriate backend NFS servers, and redeploying NFS servers when they
 fail.
 
-By default, the *ingress* service follows the same placement as the NFS
-Ganesha daemons (the optional ``<placement>`` argument).  To schedule
-keepalived and HAProxy on a different set of hosts, pass
+By default, the *ingress* service follows the same placement as the
+NFS-Ganesha daemons (the optional ``<placement>`` argument).  To schedule
+Keepalived and HAProxy on a different set of hosts, pass
 ``--ingress-placement`` with a separate placement string.  For example,
 to run three NFS daemons on ``host1`` and ``host2`` while colocating
-ingress on three dedicated nodes::
+ingress on three dedicated nodes:
 
-    ceph nfs cluster create mynfs "2 host1 host2" --ingress --virtual_ip 192.168.1.100/24 --ingress-placement "3 host3 host4 host5"
+.. prompt:: bash #
+
+   ceph nfs cluster create mynfs "2 host1 host2" --ingress --virtual_ip 192.168.1.100/24 --ingress-placement "3 host3 host4 host5"
 
 If ``--ingress-placement`` is omitted, both services share the NFS
 placement.
@@ -126,18 +132,18 @@ An optional ``--ingress-mode`` parameter can be provided to choose
 how the *ingress* service is configured:
 
 - Setting ``--ingress-mode keepalive-only`` deploys a simplified *ingress*
-  service that provides a virtual IP with the nfs server directly binding to
-  that virtual IP and leaves out any sort of load balancing or traffic
-  redirection. This setup will restrict users to deploying only 1 nfs daemon
-  as multiple cannot bind to the same port on the virtual IP.
+  service that provides a virtual IP address with the NFS server directly binding to
+  that virtual IP address and leaves out any sort of load balancing or traffic
+  redirection. This setup will restrict users to deploying only 1 NFS daemon
+  as multiple cannot bind to the same port on the virtual IP address.
 - Setting ``--ingress-mode haproxy-standard`` deploys a full *ingress* service
-  to provide load balancing and high-availability using HAProxy and keepalived.
-  Client IP addresses are not visible to the back-end NFS server and IP level
+  to provide load balancing and high-availability using HAProxy and Keepalived.
+  Client IP addresses are not visible to the back-end NFS server and IP-level
   restrictions on NFS exports will not function.
 - Setting ``--ingress-mode haproxy-protocol`` deploys a full *ingress* service
-  to provide load balancing and high-availability using HAProxy and keepalived.
-  Client IP addresses are visible to the back-end NFS server and IP level
-  restrictions on NFS exports are usable. This mode requires NFS Ganesha version
+  to provide load balancing and high-availability using HAProxy and Keepalived.
+  Client IP addresses are visible to the back-end NFS server and IP-level
+  restrictions on NFS exports are usable. This mode requires NFS-Ganesha version
   5.0 or later.
 - Setting ``--ingress-mode default`` is equivalent to not providing any other
   ingress mode by name. When no other ingress mode is specified by name
@@ -148,19 +154,21 @@ without the ``--ingress`` flag), and the basic NFS service can
 also be modified after the fact to include non-default options, by modifying
 the services directly.  For more information, see :ref:`cephadm-ha-nfs`.
 
+
 Show NFS Cluster IP(s)
 ----------------------
 
-To examine an NFS cluster's IP endpoints, including the IPs for the individual NFS
-daemons, and the virtual IP (if any) for the ingress service,
+To examine an NFS cluster's IP endpoints, including the IP addresses for the
+individual NFS daemons, and the virtual IP (if any) for the ingress service,
+run a command of the following form:
 
 .. prompt:: bash #
 
    ceph nfs cluster info [<cluster_id>]
 
-.. note:: This will not work with the rook backend. Instead, expose the port
-   with the kubectl patch command and fetch the port details with kubectl get
-   services command:
+.. note:: This will not work with the ``rook`` backend. Instead, expose the port
+   with the ``kubectl patch`` command and fetch the port details with ``kubectl get
+   services`` command:
 
    .. prompt:: bash #
 
@@ -168,7 +176,7 @@ daemons, and the virtual IP (if any) for the ingress service,
       kubectl get services -n rook-ceph rook-ceph-nfs-<cluster-name>-<node-id>
 
 
-Delete NFS Ganesha Cluster
+Delete NFS-Ganesha Cluster
 --------------------------
 
 .. prompt:: bash #
@@ -176,7 +184,6 @@ Delete NFS Ganesha Cluster
    ceph nfs cluster rm <cluster_id>
 
 This deletes the deployed cluster.
-
 
 Removal of NFS daemons and the ingress service is asynchronous: the
 command may return before the services have been completely deleted. You may
@@ -207,7 +214,8 @@ forms:
 For more information about the NFS service spec, see
 :ref:`deploy-cephadm-nfs-ganesha`.
 
-List NFS Ganesha Clusters
+
+List NFS-Ganesha Clusters
 -------------------------
 
 .. prompt:: bash #
@@ -218,15 +226,15 @@ This lists deployed clusters.
 
 .. _nfs-cluster-set:
 
-Set Customized NFS Ganesha Configuration
+Set Customized NFS-Ganesha Configuration
 ----------------------------------------
 
 .. prompt:: bash #
 
    ceph nfs cluster config set <cluster_id> -i <config_file>
 
-With this the nfs cluster will use the specified config and it will have
-precedence over default config blocks.
+With this command the NFS cluster will use the specified configuration and it will have
+precedence over default configuration blocks.
 
 Example use cases include:
 
@@ -262,49 +270,52 @@ Example use cases include:
     }
 
 .. note:: User specified in FSAL block should have proper caps for NFS-Ganesha
-   daemons to access ceph cluster. User can be created in following way using
-   `auth get-or-create`:
+   daemons to access Ceph cluster. User can be created in following way using
+   ``auth get-or-create``:
 
    .. prompt:: bash #
 
       ceph auth get-or-create client.<user_id> mon 'allow r' osd 'allow rw pool=.nfs namespace=<nfs_cluster_name>, allow rw tag cephfs data=<fs_name>' mds 'allow rw path=<export_path>'
 
-View Customized NFS Ganesha Configuration
+
+View Customized NFS-Ganesha Configuration
 -----------------------------------------
 
 .. prompt:: bash #
 
    ceph nfs cluster config get <cluster_id>
 
-This will output the user defined configuration (if any).
+This will output the user-defined configuration (if any).
 
-Reset NFS Ganesha Configuration
+
+Reset NFS-Ganesha Configuration
 -------------------------------
 
 .. prompt:: bash #
 
    ceph nfs cluster config reset <cluster_id>
 
-This removes the user defined configuration.
+This removes the user-defined configuration.
 
-.. note:: With a rook deployment, ganesha pods must be explicitly restarted
-   for the new config blocks to be effective.
+.. note:: With a Rook deployment, NFS-Ganesha pods must be explicitly restarted
+   for the new configuration blocks to be effective.
 
 
-Cluster QoS management
+Cluster QoS Management
 ======================
 
-NFS Ganesha supports cluster-wide and per-export Quality of Service (QoS) for
+NFS-Ganesha supports cluster-wide and per-export Quality of Service (QoS) for
 bandwidth and IOPS (operations per second).
 
 .. note:: Cluster-level QoS changes take effect after the NFS service is
    restarted. The ``ceph nfs cluster qos enable`` and ``ceph nfs cluster qos
    disable`` commands (for both bandwidth control and IOPS control), as well as
-   ``ceph nfs cluster qos set``, restart all NFS Ganesha daemons in the
+   ``ceph nfs cluster qos set``, restart all NFS-Ganesha daemons in the
    cluster automatically via ``ceph orch restart nfs.<cluster_id>``. Plan for
    a brief service interruption when running these commands on a live cluster.
 
-``qos_type`` values
+
+``qos_type`` Values
 -------------------
 
 All ``qos enable`` commands require a ``qos_type`` argument. Valid values are:
@@ -313,7 +324,8 @@ All ``qos enable`` commands require a ``qos_type`` argument. Valid values are:
 * ``PerClient`` — limits apply per NFS client.
 * ``PerShare_PerClient`` — limits apply per export and per client.
 
-Parameter constraints
+
+Parameter Constraints
 ---------------------
 
 Bandwidth parameters (``max_*_bw``) accept human-readable values with the
@@ -326,12 +338,13 @@ IOPS parameters (``max_*_iops``) must be integers in the range 10 to 1638400.
 The cluster QoS message interval (``cqos_msg_interval``) can be set with
 ``ceph nfs cluster qos set``. The valid range is 100 to 300 milliseconds.
 
-Deploy-time QoS via service spec
+
+Deploy-Time QoS via Service Spec
 --------------------------------
 
 When deploying an NFS cluster with cephadm, cluster-level QoS can be configured
 at creation time using the ``cluster_qos_config`` field in the NFS service
-spec, or via a command of the form ceph nfs cluster create -i foo.yml with a YAML input file.
+spec, or via a command of the form ``ceph nfs cluster create -i foo.yml`` with a YAML input file.
 
 ``cluster_qos_config`` is a dictionary. At least one of
 ``enable_bw_control`` or ``enable_iops_control`` must be ``true``. Supported
@@ -351,7 +364,7 @@ keys:
 * ``cqos_msg_interval`` (integer, 100–300 milliseconds)
 
 The NFS service spec also accepts ``cluster_qos_port`` (default ``31311``) to specify
-the cluster QoS messaging port used by Ganesha daemons.
+the cluster QoS messaging port used by NFS-Ganesha daemons.
 
 Example service spec with cluster QoS:
 
@@ -382,28 +395,32 @@ Example ``ceph nfs cluster create`` input file:
       max_export_write_bw: 100MB
       max_export_read_bw: 100MB
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph nfs cluster create mynfs "host1" -i cluster_qos.yaml
+   ceph nfs cluster create mynfs "host1" -i cluster_qos.yaml
 
 
-Enable QoS bandwidth control for an NFS Ganesha cluster
--------------------------------------------------------
+Enable QoS Bandwidth Control for NFS-Ganesha Cluster
+----------------------------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph nfs cluster qos enable bandwidth_control <cluster_id> <qos_type:PerShare|PerClient|PerShare_PerClient> [--combined-rw-bw-ctrl] [--max_export_write_bw <value>] [--max_export_read_bw <value>] [--max_client_write_bw <value>] [--max_client_read_bw <value>] [--max_export_combined_bw <value>] [--max_client_combined_bw <value>]
+   ceph nfs cluster qos enable bandwidth_control <cluster_id> \
+          <qos_type:PerShare|PerClient|PerShare_PerClient> [--combined-rw-bw-ctrl] \
+          [--max_export_write_bw <value>] [--max_export_read_bw <value>] \
+          [--max_client_write_bw <value>] [--max_client_read_bw <value>] \
+          [--max_export_combined_bw <value>] [--max_client_combined_bw <value>]
 
 This command enables or updates Quality of Service (QoS) bandwidth control for
-an NFS Ganesha cluster, where
+an NFS-Ganesha cluster, where
 
-``<cluster_id>`` is the NFS Ganesha cluster ID.
+``<cluster_id>`` is the NFS-Ganesha cluster ID.
 
 ``<qos_type>`` is the type of bandwidth control: ``PerShare``, ``PerClient``, or
 ``PerShare_PerClient``.
 
 If ``PerShare`` ``qos_type`` is selected, then the cluster-level QoS config is
-applicable to all exports on that NFS Ganesha cluster. It requires
+applicable to all exports on that NFS-Ganesha cluster. It requires
 ``max_export_write_bw`` and ``max_export_read_bw`` parameters if
 ``--combined-rw-bw-ctrl`` is not set, otherwise ``max_export_combined_bw`` is
 required.
@@ -415,7 +432,7 @@ applicable to all clients accessing exports on that cluster. It requires
 required.
 
 If ``PerShare_PerClient`` ``qos_type`` is selected, then the cluster-level
-config applies to all exports and all clients on that NFS Ganesha cluster.
+config applies to all exports and all clients on that NFS-Ganesha cluster.
 It requires ``max_export_write_bw``, ``max_export_read_bw``,
 ``max_client_write_bw``, and ``max_client_read_bw`` parameters if
 ``--combined-rw-bw-ctrl`` is not set, otherwise ``max_export_combined_bw`` and
@@ -440,9 +457,11 @@ may be specified.
 The bandwidth value can be specified using any supported bandwidth unit: bytes/s,
 KB/s, KiB/s, MB/s, MiB/s, GB/s, or GiB/s.
 
-For example::
+For example:
 
-    $ ceph nfs cluster qos enable bandwidth_control nfs_clust PerShare --max_export_write_bw 100MB --max_export_read_bw 100MB
+.. prompt:: bash #
+
+   ceph nfs cluster qos enable bandwidth_control nfs_clust PerShare --max_export_write_bw 100MB --max_export_read_bw 100MB
 
 .. note:: If this command is used to update ``qos_type``, update all exports
    with the required parameters as well.
@@ -450,102 +469,122 @@ For example::
 By default, exports inherit the cluster-level QoS setting when no
 ``QOS_BLOCK`` is present in the export block.
 
-Disable QoS bandwidth control for NFS Ganesha cluster
+
+Disable QoS Bandwidth Control for NFS-Ganesha Cluster
 -----------------------------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph nfs cluster qos disable bandwidth_control <cluster_id>
+   ceph nfs cluster qos disable bandwidth_control <cluster_id>
 
 This command disables bandwidth control QoS at the cluster level. If
 cluster-level bandwidth control is disabled, export-level bandwidth control
 has no effect even when enabled on an export.
 
-For example::
+For example:
 
-    $ ceph nfs cluster qos disable bandwidth_control nfs_clust
+.. prompt:: bash #
 
-Enable QoS IOPS control for NFS Ganesha cluster
+   ceph nfs cluster qos disable bandwidth_control nfs_clust
+
+
+Enable QoS IOPS Control for NFS-Ganesha Cluster
 -----------------------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-   $ ceph nfs cluster qos enable ops_control <cluster_id> <qos_type:PerShare|PerClient|PerShare_PerClient> [--max_export_iops <int>] [--max_client_iops <int>]
+   ceph nfs cluster qos enable ops_control <cluster_id> \
+          <qos_type:PerShare|PerClient|PerShare_PerClient> \
+          [--max_export_iops <int>] [--max_client_iops <int>]
 
 This command enables or updates IOPS control for an NFS cluster.
 
-``<cluster_id>`` is the NFS Ganesha cluster ID.
+``<cluster_id>`` is the NFS-Ganesha cluster ID.
 
 ``<qos_type>`` is the type of ops control: ``PerShare``, ``PerClient``, or
 ``PerShare_PerClient``.
 
 If ``PerShare`` ``qos_type`` is selected, the cluster-level QoS config applies
-to all exports on that NFS Ganesha cluster and requires ``--max_export_iops``.
+to all exports on that NFS-Ganesha cluster and requires ``--max_export_iops``.
 
 If ``PerClient`` ``qos_type`` is selected, the cluster-level QoS config
 applies to all clients accessing exports on that cluster and requires
 ``--max_client_iops``.
 
 If ``PerShare_PerClient`` ``qos_type`` is selected, the cluster-level config
-applies to all exports and all clients on that NFS Ganesha cluster and
+applies to all exports and all clients on that NFS-Ganesha cluster and
 requires both ``--max_export_iops`` and ``--max_client_iops``.
 
 ``--max_export_iops`` is the IOPS limit per export.
 
 ``--max_client_iops`` is the IOPS limit per client.
 
-For example::
+For example:
 
-    $ ceph nfs cluster qos enable ops_control nfs_clust PerShare --max_export_iops 1000
+.. prompt:: bash #
+
+   ceph nfs cluster qos enable ops_control nfs_clust PerShare --max_export_iops 1000
 
 .. note:: If this command is used to update ``qos_type``, update all exports
    with the required parameters as well.
 
-Disable QoS IOPS control for NFS Ganesha cluster
+
+Disable QoS IOPS Control for NFS-Ganesha Cluster
 ------------------------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-   $ ceph nfs cluster qos disable ops_control <cluster_id>
+   ceph nfs cluster qos disable ops_control <cluster_id>
 
-This command disables IOPS control for an NFS Ganesha cluster. After disabling
-ops control at the cluster level, export-level IOPS control has no effect even
+This command disables IOPS control for an NFS-Ganesha cluster. After disabling
+IOPS control at the cluster level, export-level IOPS control has no effect even
 when enabled on an export.
 
-For example::
+For example:
 
-    $ ceph nfs cluster qos disable ops_control nfs_clust
+.. prompt:: bash #
 
-Set cluster QoS message interval
+   ceph nfs cluster qos disable ops_control nfs_clust
+
+
+Set Cluster QoS Message Interval
 --------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-   $ ceph nfs cluster qos set <cluster_id> <msg_interval>
+   ceph nfs cluster qos set <cluster_id> <msg_interval>
 
 This command sets ``cqos_msg_interval``, the message interval (in
-milliseconds) used for cluster QoS synchronization among NFS Ganesha hosts.
+milliseconds) used for cluster QoS synchronization among NFS-Ganesha hosts.
 The valid range is 100 to 300. Cluster-level QoS must already be configured
 (using ``enable bandwidth_control`` or ``enable ops_control``) before this
 command can be used.
 
-For example::
+For example:
 
-    $ ceph nfs cluster qos set nfs_clust 200
+.. prompt:: bash #
 
-Get QoS configuration for NFS Ganesha cluster
+   ceph nfs cluster qos set nfs_clust 200
+
+
+Get QoS Configuration for NFS-Ganesha Cluster
 ---------------------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-   $ ceph nfs cluster qos get <cluster_id>
+   ceph nfs cluster qos get <cluster_id>
 
 This command displays the cluster-level QoS configuration. Use ``ceph -f
 json`` (or ``json-pretty``, ``yaml``, etc.) to control output formatting.
 
-For example::
+For example:
 
-    $ ceph nfs cluster qos get nfs_clust
+.. prompt:: bash #
+
+   ceph nfs cluster qos get nfs_clust
+
+::
+
      {
        "combined_rw_bw_control": false,
        "enable_bw_control": true,
@@ -563,29 +602,35 @@ When ``cqos_msg_interval`` has been set, it also appears in the output.
 Export Management
 =================
 
-.. warning:: Currently, the nfs interface is not integrated with dashboard. Both
-   dashboard and nfs interface have different export requirements and
-   create exports differently. Management of dashboard created exports is not
+.. warning:: Currently, the ``ceph nfs`` interface is not integrated with dashboard. Both
+   dashboard and the ``ceph nfs`` interface have different export requirements and
+   create exports differently. Management of dashboard-created exports is not
    supported.
+
 
 Create CephFS Export
 --------------------
 
 .. prompt:: bash #
 
-   ceph nfs export create cephfs --cluster-id <cluster_id> --pseudo-path <pseudo_path> --fsname <fsname> [--readonly] [--path=/path/in/cephfs] [--client_addr <value>...] [--squash <value>] [--sectype <value>...] [--cmount_path <value>] [--xprtsec <value>] [--transports <value>...]
+   ceph nfs export create cephfs --cluster-id <cluster_id> \
+          --pseudo-path <pseudo_path> --fsname <fsname> [--readonly] \
+          [--path=/path/in/cephfs] [--client_addr <value>...] [--squash <value>] \
+          [--sectype <value>...] [--cmount_path <value>] [--xprtsec <value>] [--transports <value>...]
 
 This creates export RADOS objects containing the export block, where
 
-``<cluster_id>`` is the NFS Ganesha cluster ID.
+``<cluster_id>`` is the NFS-Ganesha cluster ID.
 
-``<pseudo_path>`` is the export position within the NFS v4 Pseudo Filesystem where the export will be available on the server. It must be an absolute path and unique.
+``<pseudo_path>`` is the export position within the NFSv4 Pseudo Filesystem
+where the export will be available on the server. It must be an absolute path
+and unique.
 
-``<fsname>`` is the name of the FS volume used by the NFS Ganesha cluster
+``<fsname>`` is the name of the FS volume used by the NFS-Ganesha cluster
 that will serve this export.
 
-``<path>`` is the path within cephfs. Valid path should be given and default
-path is '/'. It need not be unique. Subvolume path can be fetched using:
+``<path>`` is the path within CephFS. Valid path should be given and default
+path is ``/``. It need not be unique. Subvolume path can be fetched using:
 
 .. prompt:: bash #
 
@@ -596,7 +641,7 @@ permissions will be applicable. By default all clients can access the export
 according to specified export permissions. See the `NFS-Ganesha Export Sample`_
 for permissible values.
 
-``<squash>`` defines the kind of user id squashing to be performed. The default
+``<squash>`` defines the kind of user ID squashing to be performed. The default
 value is ``no_root_squash``. See the `NFS-Ganesha Export Sample`_ for
 permissible values.
 
@@ -608,14 +653,22 @@ values may be separated by a comma (example: ``--sectype krb5p,krb5i``). The
 server will negotatiate a supported security type with the client preferring
 the supplied methods left-to-right.
 
+.. note:: Specifying values for ``sectype`` that require Kerberos will only
+          function on servers that are configured to support Kerberos. Setting
+          up NFS-Ganesha to support Kerberos can be found
+          here: `Kerberos setup for NFS-Ganesha in Ceph <https://github.com/nfs-ganesha/nfs-ganesha/wiki/Kerberos-setup-for-NFS-Ganesha-in-Ceph>`_.
+
 ``<xprtsec>`` defines how traffic is secured at the transport layer.
 Valid values are ``tls``, ``mtls`` and ``none``.
 
-``<cmount_path>`` specifies the path within the CephFS to mount this export on. It is
-allowed to be any complete path hierarchy between ``/`` and the ``EXPORT {path}``. (i.e. if ``EXPORT { Path }`` parameter is ``/foo/bar`` then cmount_path could be ``/``, ``/foo`` or ``/foo/bar``).
+``<cmount_path>`` specifies the path within the CephFS to mount this export on.
+It is allowed to be any complete path hierarchy between ``/`` and the
+``EXPORT {path}``. (i.e. if ``EXPORT { Path }`` parameter is ``/foo/bar``
+then ``cmount_path`` could be ``/``, ``/foo`` or ``/foo/bar``).
 
-.. note:: If this and the other ``EXPORT { FSAL {} }`` options are the same between multiple exports, those exports will share a single CephFS client.
-          If not specified, the default is ``/``.
+.. note:: If this and the other ``EXPORT { FSAL {} }`` options are the same
+          between multiple exports, those exports will share a single
+          CephFS client. If not specified, the default is ``/``.
 
 ``<transports>`` is optional. List of NFS transport protocols. Valid values are
 ``TCP``, ``UDP``, and ``RDMA``. Multiple values may be passed (e.g.
@@ -623,12 +676,8 @@ allowed to be any complete path hierarchy between ``/`` and the ``EXPORT {path}`
 the export uses the default (e.g. TCP only, or TCP and RDMA when the cluster
 has RDMA enabled).
 
-.. note:: Specifying values for sectype that require Kerberos will only function on servers
-          that are configured to support Kerberos. Setting up NFS-Ganesha to support Kerberos
-          can be found here `Kerberos setup for NFS Ganesha in Ceph <https://github.com/nfs-ganesha/nfs-ganesha/wiki/Kerberos-setup-for-NFS-Ganesha-in-Ceph>`_.
-
-
-.. note:: Export creation is supported only for NFS Ganesha clusters deployed using nfs interface.
+.. note:: Export creation is supported only for NFS-Ganesha clusters deployed
+          using the ``ceph nfs`` interface.
 
 Create RGW Export
 -----------------
@@ -640,14 +689,18 @@ There are two kinds of RGW exports:
 - a *bucket* export will export a single bucket, where the top-level directory contains
   the objects in the bucket.
 
-RGW bucket export
+
+RGW Bucket Export
 ^^^^^^^^^^^^^^^^^
 
 To export a *bucket*:
 
 .. prompt:: bash #
 
-   ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --bucket <bucket_name> [--user-id <user-id>] [--readonly] [--client_addr <value>...] [--squash <value>] [--sectype <value>...] [--xprtsec <value>] [--transports <value>...]
+   ceph nfs export create rgw --cluster-id <cluster_id> \
+          --pseudo-path <pseudo_path> --bucket <bucket_name> \
+          [--user-id <user-id>] [--readonly] [--client_addr <value>...] [--squash <value>] \
+          [--sectype <value>...] [--xprtsec <value>] [--transports <value>...]
 
 For example, to export ``mybucket`` via NFS cluster ``mynfs`` at the
 pseudo-path ``/bucketdata`` to any host in the ``192.168.10.0/24`` network
@@ -656,12 +709,12 @@ pseudo-path ``/bucketdata`` to any host in the ``192.168.10.0/24`` network
 
    ceph nfs export create rgw --cluster-id mynfs --pseudo-path /bucketdata --bucket mybucket --client_addr 192.168.10.0/24
 
-.. note:: Export creation is supported only for NFS Ganesha clusters deployed
-   using nfs interface.
+.. note:: Export creation is supported only for NFS-Ganesha clusters deployed
+   using the ``ceph nfs`` interface.
 
-``<cluster_id>`` is the NFS Ganesha cluster ID.
+``<cluster_id>`` is the NFS-Ganesha cluster ID.
 
-``<pseudo_path>`` is the export position within the NFS v4 Pseudo Filesystem
+``<pseudo_path>`` is the export position within the NFSv4 Pseudo Filesystem
 where the export will be available on the server. It must be an absolute path
 and unique.
 
@@ -679,7 +732,7 @@ permissions will be applicable. By default all clients can access the export
 according to specified export permissions. See the `NFS-Ganesha Export
 Sample`_ for permissible values.
 
-``<squash>`` defines the kind of user id squashing to be performed. The
+``<squash>`` defines the kind of user ID squashing to be performed. The
 default value is ``no_root_squash``. See the `NFS-Ganesha Export Sample`_ for
 permissible values.
 
@@ -691,28 +744,31 @@ multiple values may be separated by a comma (example: ``--sectype
 krb5p,krb5i``). The server will negotatiate a supported security type with the
 client preferring the supplied methods left-to-right.
 
+.. note:: Specifying values for ``sectype`` that require Kerberos will only
+   function on servers that are configured to support Kerberos. Setting up
+   NFS-Ganesha to support Kerberos is outside the scope of this document.
+
 ``<transports>`` is optional. Valid values are ``TCP``, ``UDP``, and ``RDMA``.
 Multiple values may be passed. If omitted, defaults apply (e.g. TCP and RDMA
 when the cluster has RDMA enabled).
-
-.. note:: Specifying values for sectype that require Kerberos will only
-   function on servers that are configured to support Kerberos. Setting up
-   NFS-Ganesha to support Kerberos is outside the scope of this document.
 
 ``<xprtsec>`` defines how traffic is secured at the transport layer.
 Valid values are ``tls``, ``mtls`` and ``none``.
 
 
-RGW user export
+RGW User Export
 ^^^^^^^^^^^^^^^
 
 To export an RGW *user*:
 
 .. prompt:: bash #
 
-   ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --user-id <user-id> [--readonly] [--client_addr <value>...] [--squash <value>] [--transports <value>...]
+   ceph nfs export create rgw --cluster-id <cluster_id> \
+          --pseudo-path <pseudo_path> --user-id <user-id> \
+          [--readonly] [--client_addr <value>...] [--squash <value>] [--transports <value>...]
 
-For example, to export *myuser* via NFS cluster *mynfs* at the pseudo-path */myuser* to any host in the ``192.168.10.0/24`` network
+For example, to export ``myuser`` via NFS cluster ``mynfs`` at the
+pseudo-path ``/myuser`` to any host in the ``192.168.10.0/24`` network
 
 .. prompt:: bash #
 
@@ -726,11 +782,12 @@ Delete Export
 
    ceph nfs export rm <cluster_id> <pseudo_path>
 
-This deletes an export in an NFS Ganesha cluster, where:
+This deletes an export in an NFS-Ganesha cluster, where:
 
-``<cluster_id>`` is the NFS Ganesha cluster ID.
+``<cluster_id>`` is the NFS-Ganesha cluster ID.
 
-``<pseudo_path>`` is the pseudo root path (must be an absolute path).
+``<pseudo_path>`` is the pseudo-root path (must be an absolute path).
+
 
 List Exports
 ------------
@@ -741,9 +798,10 @@ List Exports
 
 It lists exports for a cluster, where:
 
-``<cluster_id>`` is the NFS Ganesha cluster ID.
+``<cluster_id>`` is the NFS-Ganesha cluster ID.
 
 With the ``--detailed`` option enabled it shows entire export block.
+
 
 Get Export
 ----------
@@ -752,25 +810,29 @@ Get Export
 
    ceph nfs export info <cluster_id> <pseudo_path>
 
-This displays export block for a cluster based on pseudo root name, where:
+This displays export block for a cluster based on pseudo-root name, where:
 
-``<cluster_id>`` is the NFS Ganesha cluster ID.
+``<cluster_id>`` is the NFS-Ganesha cluster ID.
 
-``<pseudo_path>`` is the pseudo root path (must be an absolute path).
+``<pseudo_path>`` is the pseudo-root path (must be an absolute path).
 
-Enable QoS bandwidth control for a specific export
+
+Enable QoS Bandwidth Control for a Specific Export
 --------------------------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph nfs export qos enable bandwidth_control <cluster_id> <pseudo_path> [--combined-rw-bw-ctrl] [--max_export_write_bw <value>] [--max_export_read_bw <value>] [--max_client_write_bw <value>] [--max_client_read_bw <value>] [--max_export_combined_bw <value>] [--max_client_combined_bw <value>] [--skip-notify-nfs-server]
+   ceph nfs export qos enable bandwidth_control <cluster_id> <pseudo_path> \
+          [--combined-rw-bw-ctrl] [--max_export_write_bw <value>] [--max_export_read_bw <value>] \
+          [--max_client_write_bw <value>] [--max_client_read_bw <value>] \
+          [--max_export_combined_bw <value>] [--max_client_combined_bw <value>] [--skip-notify-nfs-server]
 
 This command enables or updates QoS bandwidth control for an export. Enable
 cluster-level bandwidth control with ``qos_type`` ``PerShare`` or
 ``PerShare_PerClient`` before enabling export-level bandwidth control. This
 creates a ``QOS_BLOCK`` in the export block, where
 
-``<cluster_id>`` is the NFS Ganesha cluster ID.
+``<cluster_id>`` is the NFS-Ganesha cluster ID.
 
 ``<pseudo_path>`` is the pseudo-root path (must be an absolute path).
 
@@ -790,50 +852,57 @@ be specified.
 
 ``--max_client_combined_bw`` is the maximum combined read/write bandwidth for each client.
 
-``--skip-notify-nfs-server`` skips notifying running NFS Ganesha daemons after
+``--skip-notify-nfs-server`` skips notifying running NFS-Ganesha daemons after
 the change (useful for batch updates).
 
 The bandwidth value can be specified using any supported bandwidth unit: bytes/s,
 KB/s, KiB/s, MB/s, MiB/s, GB/s, or GiB/s.
 
-For example::
+For example:
 
-   $ ceph nfs export qos enable bandwidth_control nfs_clust /export1 --combined-rw-bw-ctrl --max_export_combined_bw 200MB
+.. prompt:: bash #
+
+   ceph nfs export qos enable bandwidth_control nfs_clust /export1 --combined-rw-bw-ctrl --max_export_combined_bw 200MB
 
 .. note:: Export-level bandwidth control cannot be enabled if the cluster-level
    ``qos_type`` is ``PerClient``.
 
-Disable QoS bandwidth control for a specific export
+
+Disable QoS Bandwidth Control for a Specific Export
 ---------------------------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-   $ ceph nfs export qos disable bandwidth_control <cluster_id> <pseudo_path> [--skip-notify-nfs-server]
+   ceph nfs export qos disable bandwidth_control <cluster_id> <pseudo_path> [--skip-notify-nfs-server]
 
 This disables export-level bandwidth control. After disabling, the export no
 longer has export-specific bandwidth limits. If the export has no
 ``QOS_BLOCK``, it inherits cluster-level bandwidth control again.
 
-For example::
+For example:
 
-   $ ceph nfs export qos disable bandwidth_control nfs_clust /export1
+.. prompt:: bash #
+
+   ceph nfs export qos disable bandwidth_control nfs_clust /export1
 
 .. note:: To restore cluster-level QoS defaults for an export, use
    ``ceph nfs export apply <cluster_id>`` with an export definition that does
    not include a ``QOS_BLOCK``.
 
-Enable QoS IOPS control for a specific export
+
+Enable QoS IOPS Control for a Specific Export
 ---------------------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-   $ ceph nfs export qos enable ops_control <cluster_id> <pseudo_path> [--max_export_iops <int>] [--max_client_iops <int>] [--skip-notify-nfs-server]
+   ceph nfs export qos enable ops_control <cluster_id> <pseudo_path> \
+          [--max_export_iops <int>] [--max_client_iops <int>] [--skip-notify-nfs-server]
 
 This enables IOPS control for a specified export. The same command can be used
 to update an existing IOPS limit. Enable cluster-level IOPS control with ``qos_type``
 ``PerShare`` or ``PerShare_PerClient`` before enabling export-level IOPS control.
 
-``<cluster_id>`` is the NFS Ganesha cluster ID.
+``<cluster_id>`` is the NFS-Ganesha cluster ID.
 
 ``<pseudo_path>`` is the pseudo-root path (must be an absolute path).
 
@@ -841,36 +910,42 @@ to update an existing IOPS limit. Enable cluster-level IOPS control with ``qos_t
 
 ``--max_client_iops`` is the IOPS limit per client of the export.
 
-``--skip-notify-nfs-server`` skips notifying running NFS Ganesha daemons after
+``--skip-notify-nfs-server`` skips notifying running NFS-Ganesha daemons after
 the change.
 
-For example::
+For example:
 
-   $ ceph nfs export qos enable ops_control nfs_clust /export1 --max_export_iops 2000
+.. prompt:: bash #
+
+   ceph nfs export qos enable ops_control nfs_clust /export1 --max_export_iops 2000
 
 .. note:: Export-level IOPS control cannot be enabled if the cluster-level
    ``qos_type`` is ``PerClient``.
 
-Disable QoS IOPS control for a specific export
+
+Disable QoS IOPS Control for a Specific Export
 ----------------------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-   $ ceph nfs export qos disable ops_control <cluster_id> <pseudo_path> [--skip-notify-nfs-server]
+   ceph nfs export qos disable ops_control <cluster_id> <pseudo_path> [--skip-notify-nfs-server]
 
 This command disables export-level IOPS control. After disabling, the export no
 longer has export-specific IOPS limits.
 
-For example::
+For example:
 
-   $ ceph nfs export qos disable ops_control nfs_clust /export1
+.. prompt:: bash #
 
-Get QoS configuration for export
+   ceph nfs export qos disable ops_control nfs_clust /export1
+
+
+Get QoS Configuration for Export
 --------------------------------
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph nfs export qos get <cluster_id> <pseudo_path>
+   ceph nfs export qos get <cluster_id> <pseudo_path>
 
 This command displays the export-level QoS configuration. Use ``ceph -f
 json`` (or ``json-pretty``, ``yaml``, ``xml``, ``xml-pretty``) to control output formatting.
@@ -881,9 +956,14 @@ the cluster defaults (``global_enable_qos``, ``global_enable_bw_control``,
 export. If the export has no ``QOS_BLOCK``, an empty object ``{}`` is
 returned.
 
-For example::
+For example:
 
-   $ ceph nfs export qos get nfs_clust /export1
+.. prompt:: bash #
+
+   ceph nfs export qos get nfs_clust /export1
+
+::
+
      {
        "global_enable_bw_control": true,
        "global_enable_iops_control": true,
@@ -897,17 +977,17 @@ For example::
      }
 
 Export QoS can also be set via ``ceph nfs export apply`` by including a
-``qos_block`` key in the export JSON, or a ``QOS_BLOCK`` section in a Ganesha
+``qos_block`` key in the export JSON, or a ``QOS_BLOCK`` section in a NFS-Ganesha
 EXPORT config fragment.
 
-Create or update export via JSON specification
+Create or Update Export via JSON Specification
 ----------------------------------------------
 
 An existing export can be dumped in JSON format with:
 
 .. prompt:: bash #
 
-    ceph nfs export info <cluster_id> <pseudo_path>
+   ceph nfs export info <cluster_id> <pseudo_path>
 
 An export can be created or modified by importing a JSON description in the
 same format:
@@ -951,8 +1031,8 @@ For example:
 The imported JSON can be a single dict describing a single export, or a JSON
 list containing multiple export dicts.
 
-The exported JSON can be modified and then reapplied.  Below, *pseudo*
-and *access_type* are modified.  When modifying an export, the
+The exported JSON can be modified and then reapplied.  Below, ``pseudo``
+and ``access_type`` are modified.  When modifying an export, the
 provided JSON should fully describe the new state of the export (just
 as when creating a new export), with the exception of the
 authentication credentials, which will be carried over from the
@@ -1022,7 +1102,7 @@ config fragment. For example:
 Mounting
 ========
 
-After the exports are successfully created and NFS Ganesha daemons are
+After the exports are successfully created and NFS-Ganesha daemons are
 deployed, exports can be mounted with:
 
 .. prompt:: bash #
@@ -1043,79 +1123,80 @@ If the NFS service is running on a non-standard port number:
 
    mount -t nfs -o port=<ganesha-port> <ganesha-host-name>:<ganesha-pseudo_path> <mount-point>
 
-.. note:: Only NFS v4.0+ is supported.
+.. note:: Only NFSv4.0+ is supported.
 
 .. note:: As of this writing (01 Jan 2024), no version of Microsoft Windows
-   supports mouting an NFS v4.x export natively.
+   supports mouting an NFSv4.x export natively.
+
 
 Troubleshooting
 ===============
 
-There are two methds for examining NFS-Ganesha logs:
+There are two methods for examining NFS-Ganesha logs:
 
 #. ``cephadm``: List the NFS daemons by running the following command:
 
-    .. prompt:: bash #
+   .. prompt:: bash #
 
-       ceph orch ps --daemon-type nfs
+      ceph orch ps --daemon-type nfs
 
    You can search via the logs for a specific daemon (e.g.,
    ``nfs.mynfs.0.0.myhost.xkfzal``) on the relevant host with:
 
-    .. prompt:: bash #
+   .. prompt:: bash #
 
-       cephadm logs --fsid <fsid> --name nfs.mynfs.0.0.myhost.xkfzal
+      cephadm logs --fsid <fsid> --name nfs.mynfs.0.0.myhost.xkfzal
 
 #. ``rook``:
 
-    .. prompt:: bash #
+   .. prompt:: bash #
 
-       kubectl logs -n rook-ceph rook-ceph-nfs-<cluster_id>-<node_id> nfs-ganesha
+      kubectl logs -n rook-ceph rook-ceph-nfs-<cluster_id>-<node_id> nfs-ganesha
 
 The NFS log level can be adjusted using the ``nfs cluster config set`` command
 (see :ref:`nfs-cluster-set`).
 
-
 .. _nfs-ganesha-config:
 
+Manual NFS-Ganesha Deployment
+=============================
 
-Manual Ganesha deployment
-=========================
-
-It may be possible to deploy and manage the NFS ganesha daemons without
-orchestration frameworks such as cephadm or rook.
+It may be possible to deploy and manage the NFS-Ganesha daemons without
+orchestration frameworks such as cephadm or Rook.
 
 .. note:: Manual configuration is not tested or fully documented; your
           mileage may vary. If you make this work, please help us by
           updating this documentation.
 
+
 Limitations
 ------------
 
-If no orchestrator module is enabled for the Ceph Manager the NFS cluster
+If no orchestrator module is enabled for the Manager, the NFS cluster
 management commands, such as those starting with ``ceph nfs cluster``, will not
 function. However, commands that manage NFS exports, like those prefixed with
 ``ceph nfs export`` are expected to work as long as the necessary RADOS objects
 have already been created. The exact RADOS objects required are not documented
 at this time as support for this feature is incomplete. A curious reader can
 find some details about the object by reading the source code for the
-``mgr/nfs`` module (found in the ceph source tree under
+``mgr/nfs`` module (found in the Ceph source tree under
 ``src/pybind/mgr/nfs``).
 
 
 Requirements
 ------------
 
-The following packages are required to enable CephFS and RGW exports with nfs-ganesha:
+The following packages are required to enable CephFS and RGW exports with NFS-Ganesha:
 
 -  ``nfs-ganesha``, ``nfs-ganesha-ceph``, ``nfs-ganesha-rados-grace`` and
    ``nfs-ganesha-rados-urls`` packages (version 3.3 and above)
 
+
 Ganesha Configuration Hierarchy
 -------------------------------
 
-Cephadm and rook start each nfs-ganesha daemon with a minimal
-`bootstrap` configuration file that pulls from a shared `common`
+Cephadm and Rook start each NFS-Ganesha daemon with a minimal
+*bootstrap* configuration file that pulls from a shared *common*
 configuration stored in the ``.nfs`` RADOS pool and watches the common
 config for changes.  Each export is written to a separate RADOS object
 that is referenced by URL from the common config.


### PR DESCRIPTION
Note that NFS [can be colocated](https://github.com/ceph/ceph/commit/8699699c50900efaa346b4abedd7aeaad4604ba8) from Umbrella instead of claiming it isn't supported. Add a label in `doc/cephadm/service/nfs.rst` for linking to more info.  
Call it NFS-Ganesha consistently.  
Use the `prompt` directive consistently for CLI commands and improve markup.  
Some minor capitalization, punctuation, etc. improvements.

- Original: https://docs.ceph.com/en/latest/mgr/nfs/
- Rendered PR: https://ceph--71269.org.readthedocs.build/en/71269/mgr/nfs/






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
