### PR TITLE
tentacle: mgr/volumes: use depth-first, non-recursive approach for cloning

### DIFF
--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -117,6 +117,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_openat(ceph_mount_info *cmount, int dirfd, const char *relpath, int flags, mode_t mode)
 
     int ceph_mkdir(ceph_mount_info *cmount, const char *path, mode_t mode)
+    int ceph_mkdirat(ceph_mount_info *cmount, int dirfd, const char *relpath, mode_t mode)
     int ceph_mksnap(ceph_mount_info *cmount, const char *path, const char *name, mode_t mode, snap_metadata *snap_metadata, size_t nr_snap_metadata)
     int ceph_rmsnap(ceph_mount_info *cmount, const char *path, const char *name)
     int ceph_get_snap_info(ceph_mount_info *cmount, const char *path, snap_info *snap_info)

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -167,12 +167,16 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int64_t ceph_lseek(ceph_mount_info *cmount, int fd, int64_t offset, int whence)
     void ceph_buffer_free(char *buf)
     mode_t ceph_umask(ceph_mount_info *cmount, mode_t mode)
+
     int ceph_utime(ceph_mount_info *cmount, const char *path, utimbuf *buf)
     int ceph_futime(ceph_mount_info *cmount, int fd, utimbuf *buf)
     int ceph_utimes(ceph_mount_info *cmount, const char *path, timeval times[2])
     int ceph_lutimes(ceph_mount_info *cmount, const char *path, timeval times[2])
     int ceph_futimes(ceph_mount_info *cmount, int fd, timeval times[2])
     int ceph_futimens(ceph_mount_info *cmount, int fd, timespec times[2])
+    int ceph_utimensat(ceph_mount_info* cmount, int fd, const char* relpath,
+                       timespec* times, int flags)
+
     int ceph_get_file_replication(ceph_mount_info *cmount, int fh)
     int ceph_get_path_replication(ceph_mount_info *cmount, const char *path)
     int ceph_get_pool_id(ceph_mount_info *cmount, const char *pool_name)

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -89,6 +89,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_unlinkat(ceph_mount_info *cmount, int dirfd, const char *relpath, int flags)
     int ceph_symlink(ceph_mount_info *cmount, const char *existing, const char *newname)
     int ceph_readlink(ceph_mount_info *cmount, const char *path, char *buf, int64_t size)
+    int ceph_readlinkat(ceph_mount_info *cmount, const int dirfd, char *path, char *buf, int64_t size)
     int ceph_setxattr(ceph_mount_info *cmount, const char *path, const char *name,
                       const void *value, size_t size, int flags)
     int ceph_fsetxattr(ceph_mount_info *cmount, int fd, const char *name,

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -161,6 +161,9 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_chown(ceph_mount_info *cmount, const char *path, int uid, int gid)
     int ceph_lchown(ceph_mount_info *cmount, const char *path, int uid, int gid)
     int ceph_fchown(ceph_mount_info *cmount, int fd, int uid, int gid)
+    int ceph_chownat(ceph_mount_info *cmount, int fd, const char *relpath,
+                     int uid, int gid, int flags)
+
     int64_t ceph_lseek(ceph_mount_info *cmount, int fd, int64_t offset, int whence)
     void ceph_buffer_free(char *buf)
     mode_t ceph_umask(ceph_mount_info *cmount, mode_t mode)

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -84,6 +84,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_rename(ceph_mount_info *cmount, const char *from_, const char *to)
     int ceph_link(ceph_mount_info *cmount, const char *existing, const char *newname)
     int ceph_unlink(ceph_mount_info *cmount, const char *path)
+    int ceph_unlinkat(ceph_mount_info *cmount, int dirfd, const char *relpath, int flags)
     int ceph_symlink(ceph_mount_info *cmount, const char *existing, const char *newname)
     int ceph_readlink(ceph_mount_info *cmount, const char *path, char *buf, int64_t size)
     int ceph_setxattr(ceph_mount_info *cmount, const char *path, const char *name,

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -121,6 +121,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_mkdirs(ceph_mount_info *cmount, const char *path, mode_t mode)
     int ceph_closedir(ceph_mount_info *cmount, ceph_dir_result *dirp)
     int ceph_opendir(ceph_mount_info *cmount, const char *name, ceph_dir_result **dirpp)
+    int ceph_fdopendir(ceph_mount_info *cmount, int dirfd, ceph_dir_result** dirpp)
     void ceph_rewinddir(ceph_mount_info *cmount, ceph_dir_result *dirp)
     int64_t ceph_telldir(ceph_mount_info *cmount, ceph_dir_result *dirp)
     void ceph_seekdir(ceph_mount_info *cmount, ceph_dir_result *dirp, int64_t offset)

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -70,6 +70,8 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     uint64_t ceph_get_instance_id(ceph_mount_info *cmount)
     int ceph_fstatx(ceph_mount_info *cmount, int fd, statx *stx, unsigned want, unsigned flags)
     int ceph_statx(ceph_mount_info *cmount, const char *path, statx *stx, unsigned want, unsigned flags)
+    int ceph_statxat(ceph_mount_info *cmount, int dirfd, const char *relpath,
+                     statx *stx, unsigned want, unsigned flags)
     int ceph_statfs(ceph_mount_info *cmount, const char *path, statvfs *stbuf)
 
     int ceph_setattrx(ceph_mount_info *cmount, const char *relpath, statx *stx, int mask, int flags)

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -111,8 +111,11 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_preadv(ceph_mount_info *cmount, int fd, iovec *iov, int iovcnt, int64_t offset)
     int ceph_flock(ceph_mount_info *cmount, int fd, int operation, uint64_t owner)
     int ceph_mknod(ceph_mount_info *cmount, const char *path, mode_t mode, dev_t rdev)
+
     int ceph_close(ceph_mount_info *cmount, int fd)
     int ceph_open(ceph_mount_info *cmount, const char *path, int flags, mode_t mode)
+    int ceph_openat(ceph_mount_info *cmount, int dirfd, const char *relpath, int flags, mode_t mode)
+
     int ceph_mkdir(ceph_mount_info *cmount, const char *path, mode_t mode)
     int ceph_mksnap(ceph_mount_info *cmount, const char *path, const char *name, mode_t mode, snap_metadata *snap_metadata, size_t nr_snap_metadata)
     int ceph_rmsnap(ceph_mount_info *cmount, const char *path, const char *name)

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -88,6 +88,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_unlink(ceph_mount_info *cmount, const char *path)
     int ceph_unlinkat(ceph_mount_info *cmount, int dirfd, const char *relpath, int flags)
     int ceph_symlink(ceph_mount_info *cmount, const char *existing, const char *newname)
+    int ceph_symlinkat(ceph_mount_info *cmount, const char *existing, int fd, const char *newname)
     int ceph_readlink(ceph_mount_info *cmount, const char *path, char *buf, int64_t size)
     int ceph_readlinkat(ceph_mount_info *cmount, const int dirfd, char *path, char *buf, int64_t size)
     int ceph_setxattr(ceph_mount_info *cmount, const char *path, const char *name,

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -151,9 +151,13 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_lazyio_propagate(ceph_mount_info *cmount, int fd, int64_t offset, size_t count)
     int ceph_lazyio_synchronize(ceph_mount_info *cmount, int fd, int64_t offset, size_t count)
     int ceph_fallocate(ceph_mount_info *cmount, int fd, int mode, int64_t offset, int64_t length)
+
     int ceph_chmod(ceph_mount_info *cmount, const char *path, mode_t mode)
     int ceph_lchmod(ceph_mount_info *cmount, const char *path, mode_t mode)
     int ceph_fchmod(ceph_mount_info *cmount, int fd, mode_t mode)
+    int ceph_chmodat(ceph_mount_info *cmount, int dirfd, const char *relpath,
+                     mode_t mode, int flags)
+
     int ceph_chown(ceph_mount_info *cmount, const char *path, int uid, int gid)
     int ceph_lchown(ceph_mount_info *cmount, const char *path, int uid, int gid)
     int ceph_fchown(ceph_mount_info *cmount, int fd, int uid, int gid)

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -1036,6 +1036,23 @@ cdef class LibCephFS(object):
         d.handle = handle
         return d
 
+    def fdopendir(self, dirfd):
+        self.require_state("mounted")
+
+        cdef:
+            int dirfd_ = dirfd
+            ceph_dir_result* handle
+
+        with nogil:
+            ret = ceph_fdopendir(self.cluster, dirfd_, &handle)
+        if ret < 0:
+            raise make_ex(ret, f'error in fdopendir when it was called for fd "{dirfd_}"')
+
+        d = DirResult()
+        d.lib = self
+        d.handle = handle
+        return d
+
     def readdir(self, DirResult handle) -> Optional[DirEntry]:
         """
         Get the next entry in an open directory.

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -3070,7 +3070,8 @@ class RmtreeDir:
 
         # XXX: exception (if) raised here should be handled by caller based on
         # the context.
-        self.handle = self.fs.opendir(self.path)
+        self.fd = self.fs.open(self.rel_path, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        self.handle = self.fs.fdopendir(self.fd)
 
         # Is this directory empty? It will be set by self.read_dir().
         self.is_empty = None

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -3419,6 +3419,9 @@ class RmtreeDir:
         and tell caller whether to continue or break loop based through the
         return value.
         '''
+        if self.name == b'/':
+            return
+
         try:
             self.fs.unlinkat(self.parent_dir_fd, self.name, AT_REMOVEDIR)
 

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -3117,7 +3117,7 @@ cdef class LibCephFS(object):
         finally:
            free(buf)
 
-    def rmtree(self, trash_path, should_cancel, suppress_errors=False):
+    def rmtree(self, trash_path, should_cancel=lambda: False, suppress_errors=False):
         '''
         Delete entire file hierarchy present under trash_path when trash_path is
         a dir. Do this deletion using depth-first (to prevent excessive memory

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2863,8 +2863,10 @@ cdef class LibCephFS(object):
         # st_b = stat buffer
         st_b = self.stat(trash_path, AT_SYMLINK_NOFOLLOW)
         if stat.S_ISDIR(st_b.st_mode):
-            NonRecursiveRmtree(self, trash_path, should_cancel,
-                               suppress_errors).rmtree()
+            unlink_tree_worker = UnlinkTreeWorker(self, trash_path,
+                                                  should_cancel,
+                                                  suppress_errors)
+            unlink_tree_worker.start()
         else:
             try:
                 self.unlink(trash_path)
@@ -2875,7 +2877,7 @@ cdef class LibCephFS(object):
                 raise
 
 
-class NonRecursiveRmtree:
+class UnlinkTreeWorker:
     '''
     Contains code to delete entire file tree under a directory with a
     depth-first, non-recursive approach along with some helper code.
@@ -2941,7 +2943,7 @@ class NonRecursiveRmtree:
         parent_dir = self.stack[-2]
         parent_dir.add_to_de_ignore_list(self.curr_dir.name)
 
-    def rmtree(self):
+    def start(self):
         '''
         This is where depth-first, non-recursive traversal is done.
         '''

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2827,6 +2827,46 @@ cdef class LibCephFS(object):
         if ret < 0:
             raise make_ex(ret, "error in futimens")
 
+    def utimensat(self, fd, relpath, times, flags):
+        """
+        Set access and modification time for a file pointer by descriptor
+
+        :param fd: file descriptor of the open file
+        :param relpath: path relative to file descriptor
+        :param times: if times is not None, it must be a tuple (atime, mtime)
+        :param flags: int value that can be used to set AT_* modifier flags
+                      (AT_SYMLINK_NOFOLLOW)
+        """
+        self.require_state("mounted")
+
+        if not isinstance(fd, int):
+            raise TypeError('"fd" must be an int')
+        if not isinstance(flags, int):
+            raise TypeError('"flags" must be an int')
+
+        if not isinstance(times, tuple):
+            raise TypeError('times must be a tuple')
+        if not isinstance(times[0], (int, float)):
+            raise TypeError('atime must be an int or a float')
+        if not isinstance(times[1], (int, float)):
+            raise TypeError('mtime must be an int or a float')
+
+        ac_time = float(times[0])
+        mod_time = float(times[1])
+
+        relpath = cstr(relpath, 'relpath')
+        cdef:
+            int _fd = fd
+            char* _relpath = relpath
+            timespec* _times = [to_timespec(ac_time), to_timespec(mod_time)]
+            int _flags = flags
+
+        with nogil:
+            ret = ceph_utimensat(self.cluster, _fd, _relpath, _times, _flags)
+
+        if ret < 0:
+            raise make_ex(ret, "error in utimensat")
+
     def get_file_replication(self, fd):
         """
         Get the file replication information from an open file descriptor.

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -1289,6 +1289,29 @@ cdef class LibCephFS(object):
         if ret < 0:
             raise make_ex(ret, "error in chmod {}".format(path.decode('utf-8')))
 
+    def chmodat(self, dirfd, relpath, mode, flags) -> None:
+        self.require_state("mounted")
+
+        if not isinstance(dirfd, int):
+            raise TypeError('"dirfd "must be an int')
+        if not isinstance(mode, int):
+            raise TypeError('mode must be an int')
+        if not isinstance(flags, int):
+            raise TypeError('flags must be an int')
+
+        relpath = cstr(relpath, 'relpath')
+        cdef:
+            int _dirfd = dirfd
+            char* _relpath = relpath
+            int _mode = mode
+            int _flags = flags
+
+        with nogil:
+            ret = ceph_chmodat(self.cluster, _dirfd, _relpath, _mode, _flags)
+
+        if ret < 0:
+            raise make_ex(ret, f"error in chmod {relpath.decode('utf-8')}")
+
     def lchmod(self, path, mode) -> None:
         """
         Change file mode. If the path is a symbolic link, it won't be dereferenced.

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2970,15 +2970,12 @@ class UnlinkTreeWorker:
                     raise OpCanceled('rmtree')
 
                 if de.is_dir():
-                    try:
-                        self.curr_dir.try_rmdir(de.d_name, self.suppress_errors)
-                    except ObjectNotEmpty:
-                        if self.add_dir_to_stack(de.d_name):
-                            # since adding new dir to stack was successful, stop
-                            # traversing the current dir and start traversing
-                            # the new dir that has been freshly added to the
-                            # stack.
-                            break
+                    if self.add_dir_to_stack(de.d_name):
+                        # since adding new dir to stack was successful, stop
+                        # traversing the current dir and start traversing
+                        # the new dir that has been freshly added to the
+                        # stack.
+                        break
                 else:
                     self.curr_dir.try_unlink(de.d_name, self.suppress_errors)
 

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -38,6 +38,7 @@ AT_STATX_SYNC_TYPE  = 0x6000
 AT_STATX_SYNC_AS_STAT = 0x0000
 AT_STATX_FORCE_SYNC = 0x2000
 AT_STATX_DONT_SYNC = 0x4000
+AT_FDCWD = -100
 cdef int AT_SYMLINK_NOFOLLOW_CDEF = AT_SYMLINK_NOFOLLOW
 CEPH_STATX_BASIC_STATS = 0x7ff
 cdef int CEPH_STATX_BASIC_STATS_CDEF = CEPH_STATX_BASIC_STATS
@@ -3142,6 +3143,56 @@ cdef class LibCephFS(object):
                          f'file at path {trash_path}: {e}')
                 raise
 
+    def cptree(self, src_path, dst_path, should_sync_attrs=False,
+               cp_src_dir=True, should_cancel=False, suppress_errors=False):
+        '''
+        Copy entire file hierarchy under src using depth-first (to prevent
+        excessive memory consumption) and non-recursive (to prevent hitting
+        Python's max recursion limit error) approach.
+
+        If src is regfile, symlink or something else, copy it to dst and return.
+        '''
+        if isinstance(src_path, str):
+            src_path = src_path.encode('utf-8')
+        else:
+            assert isinstance(src_path, bytes)
+
+        if isinstance(dst_path, str):
+            dst_path = dst_path.encode('utf-8')
+        else:
+            assert isinstance(dst_path, bytes)
+
+        if not should_cancel:
+            should_cancel = lambda: False
+
+        # stx_b = statx buffer
+        stx_b = self.statx(src_path, CEPH_STATX_MODE, AT_SYMLINK_NOFOLLOW)
+        if stat.S_ISDIR(stx_b['mode']):
+            cptree_worker = CptreeWorker(
+                self, src_path, dst_path, should_sync_attrs, cp_src_dir,
+                should_cancel, suppress_errors)
+
+            cptree_worker.start()
+        elif stat.S_ISREG(stx_b['mode']):
+            src_dir = os.path.dirname(src_path)
+            src_file_name = os.path.basename(src_path)
+
+            src_fd = self.open(src_dir, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+            dst_fd = self.open(dst_path, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+
+            copy_reg_file(self, src_fd, dst_fd, src_file_name, should_sync_attrs)
+        elif stat.S_ISLNK(stx_b['mode']):
+            src_dir = os.path.dirname(src_path)
+            src_link_name = os.path.basename(src_path)
+
+            src_fd = self.open(src_dir, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+            dst_fd = self.open(dst_path, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+
+            copy_sym_link(self, src_fd, dst_fd, src_link_name, should_sync_attrs)
+        else:
+            raise RuntimeError('expected a directory, regfile or symlink but '
+                               f'found something else. src = {self.src_path}')
+
 
 class UnlinkTreeWorker:
     '''
@@ -3397,3 +3448,344 @@ class RmtreeDir:
 
             if not suppress_errors:
                 raise
+
+
+# following code includes cptree() and related helper methods.
+
+class CptreeWorker:
+    '''
+    Contains code to non-recursively copy a file hierarchy present under a
+    given path with a depth-first approach. And while doing so, handle
+    case where a dir can't be copied due to permission issue.
+    '''
+
+    def __init__(self, fs, src_path, dst_path, should_sync_attrs=False,
+                 cp_src_dir=False, should_cancel=lambda: False,
+                 suppress_errors=False):
+        self.fs = fs
+
+        # source and destination path passed by the user.
+        self.src_path = src_path
+        self.dst_path = dst_path
+        self._do_sanity_check_for_paths()
+
+        # in case of subvolume snap clone, src's UUID dir is not copied, only
+        # its contents are copied to dst's UUID dir. This param is meant for
+        # indicating this.
+        self.cp_src_dir = cp_src_dir
+
+        # set attrs on dst files to same as src files.
+        self.should_sync_attrs = should_sync_attrs
+
+        self.should_cancel = should_cancel
+        self.suppress_errors = suppress_errors
+
+        # Stack needed for traversing/copying file hierarchy in non-recursive,
+        # depth-first fashion.
+        self.stack = deque([])
+
+        # Current dir that is being copied. It should always be topmost entry of
+        # stack.
+        self.curr_dir = None
+
+    def _do_sanity_check_for_paths(self):
+        if self.src_path == b'/':
+            raise PermissionError(1, 'can\'t copy dir into itself')
+
+        # check if self.src_path is ancestor of self.dst_path.
+        src_path_comp = self.src_path + b'/'
+        if src_path_comp in self.dst_path:
+            raise PermissionError(1, 'can\'t copy dir into itself')
+
+    def notify_parent_dir(self):
+        '''
+        Add current dir's name to parent dir's "de_ignore_list". This is
+        necessary since parent dir can't be copied when current dir can't be
+        copied.
+        '''
+        # ensure we are dealing with the dir at the top of the stack.
+        assert self.curr_dir is self.stack[-1]
+
+        if len(self.stack) < 2:
+            return
+
+        parent_dir = self.stack[-2]
+        parent_dir.add_to_de_ignore_list(self.curr_dir.name)
+
+    def add_dir_to_stack(self, de_name):
+        '''
+        Add new dir to stack and start traversing it. If it fails, add this
+        new dir to current dir's ignorelist since most likely we don't have
+        permissions for it.
+        '''
+        # ensure we are dealing with the dir at the top of the stack.
+        assert self.curr_dir is self.stack[-1]
+
+        try:
+            self.stack.append(CptreeDir(self.fs, de_name, de_name,
+                                        self.curr_dir,
+                                        should_sync_attrs=self.should_sync_attrs))
+            return True
+        except Error as e:
+            if self.suppress_errors:
+                # add to ignore list, traversal should continue for current dir.
+                log.info(f'dir "{de_name}" couldn\'t be opened and therefore '
+                          'it can\'t be removed. perhaps permissions for it '
+                          'are not granted.')
+                self.curr_dir.add_to_de_ignore_list(de_name)
+
+                return False
+            else:
+                raise
+
+    def start(self):
+        # initiate stack with first entry
+        try:
+            if self.cp_src_dir:
+                src_dir_name = os.path.basename(self.src_path)
+                dst_path = os.path.join(self.dst_path, src_dir_name)
+            else:
+                dst_path = self.dst_path
+            self.stack.append(CptreeDir(self.fs, self.src_path, dst_path,
+                                        parent_dir=None,
+                                        should_sync_attrs=self.should_sync_attrs,
+                                        cp_src_dir=self.cp_src_dir))
+        except Exception as e:
+            log.error('opening root dir of the file tree failed with exception '
+                      f'"{e}", exiting.')
+            if self.suppress_errors:
+                return
+            else:
+                raise
+
+        while self.stack:
+            if self.should_cancel():
+                raise OpCanceled('cptree')
+
+            self.curr_dir = self.stack[-1]
+            finished_copying_curr_dir = True
+
+            # de = directory entry
+            de = self.curr_dir.read_src_dir()
+            while de:
+                if self.should_cancel():
+                    raise OpCanceled('cptree')
+
+                if de.is_dir():
+                    if self.add_dir_to_stack(de.d_name):
+                        # since adding new dir to stack was successful, stop
+                        # traversing current dir and start traversing the new
+                        # dir that has been freshly added to the stack.
+                        finished_copying_curr_dir = False
+                        break
+                elif de.is_symbol_file():
+                    self.curr_dir.copy_sym_link(de.d_name)
+                else:
+                    self.curr_dir.copy_reg_file(de.d_name)
+
+                de = self.curr_dir.read_src_dir()
+
+            if finished_copying_curr_dir:
+                # XXX if attrs are sync-ed during creation of dir on destination
+                # side, it's mtime would change as files are copied underneath
+                # it. to avoid this, first copy all files and then sync attrs.
+                self.curr_dir.sync_attrs()
+
+                if self.curr_dir.has_any_fs_op_failed():
+                    self.notify_parent_dir()
+                self.stack.pop()
+
+
+class CptreeDir:
+    '''
+    Contains code for reading and copying dir entries and for handling cases
+    when it can't be done due to lack of permission.
+
+    Although named CptreeDir, this class's objects operates over a pair of dir
+    -- src dir as well as dst dir.
+    '''
+
+    def __init__(self, fs, src_rel_path, dst_rel_path, parent_dir=None,
+                 should_sync_attrs=False, cp_src_dir=True):
+        self.fs = fs
+
+        self.src_rel_path = src_rel_path
+        self.dst_rel_path = dst_rel_path
+
+        self.should_sync_attrs = should_sync_attrs
+        self.cp_src_dir = cp_src_dir
+
+        # needed to open src dir fd and dst dir fd.
+        self.parent_dir_src_fd = parent_dir.src_fd if parent_dir else AT_FDCWD
+        self.parent_dir_dst_fd = parent_dir.dst_fd if parent_dir else AT_FDCWD
+
+        self.copy_dir()
+
+        self.src_fd = self.fs.openat(self.parent_dir_src_fd, self.src_rel_path,
+                                     os.O_RDONLY | os.O_DIRECTORY, 0o755)
+
+        self.dst_fd = self.fs.openat(self.parent_dir_dst_fd, self.dst_rel_path,
+                                     os.O_RDONLY | os.O_DIRECTORY, 0o755)
+
+        self.src_handle = self.fs.fdopendir(self.src_fd)
+
+        # List of dir entries to be ignored instead of copying them.
+        self.de_ignore_list = []
+
+        # Indicates whether an error occured during call to readdir().
+        self.has_readdir_failed = False
+
+    def __str__(self):
+        return f'{self.src_rel_path}, {self.dst_rel_path}'
+
+    def add_to_de_ignore_list(self, de_name):
+        self.de_ignore_list.append(de_name)
+
+    def set_readdir_error(self):
+        self.has_readdir_failed = True
+
+    def should_skip_d_name(self, de_name):
+        return de_name in self.de_ignore_list
+
+    def has_any_fs_op_failed(self):
+        return self.has_readdir_failed or len(self.de_ignore_list) > 0
+
+    def read_src_dir(self):
+        '''
+        Get sub-directory of current directory.
+        '''
+        # Assuming True for now, if it's not empty it will be set to
+        # False by the following loop.
+        self.is_empty = True
+
+        try:
+            # de = directory entry
+            de = self.fs.readdir(self.src_handle)
+            while de:
+                if de.d_name in (b'.', b'..'):
+                    pass
+                elif de.d_name in self.de_ignore_list:
+                    self.is_empty = False
+                    log.debug(
+                        'readdir() has previously '
+                        f'failed for dir entry "{de.d_name}", avoiding '
+                        'running readdir() on it again.')
+                else:
+                    self.is_empty = False
+                    return de
+
+                de = self.fs.readdir(self.src_handle)
+        except Error as e:
+            # This is the tricky one: it's an error on this
+            # directory, not on a entry in this directory
+            log.error(f'Exception occured: "{e}"')
+            self.set_readdir_error()
+
+    def copy_dir(self):
+        # XXX: cp_src_dir=False implies don't copy dir, copy only its contents
+        # instead. This is used for subvolume cloning.
+        if not self.cp_src_dir:
+            return
+
+        # create dir on dst side.
+        self.fs.mkdirat(self.parent_dir_dst_fd, self.dst_rel_path, 0o755)
+
+    # XXX: Dir's mtime gets updated when a file is copied underneath it.
+    # Therefore, call this method only after all files have been copied
+    # underneath the dir on dst side so that mtime on it and mtime on src
+    # dir is the same.
+    def sync_attrs(self):
+        '''
+        Copy value of attributes from source side to the directory on
+        destination side.
+        '''
+        if self.should_sync_attrs:
+            sync_attrs(self.fs, self.parent_dir_src_fd, self.parent_dir_dst_fd,
+                       self.dst_rel_path)
+
+    def copy_reg_file(self, de_name):
+        copy_reg_file(self.fs, self.src_fd, self.dst_fd, de_name,
+                      self.should_sync_attrs)
+
+    def copy_sym_link(self, de_name):
+        copy_sym_link(self.fs, self.src_fd, self.dst_fd, de_name,
+                      self.should_sync_attrs)
+
+
+def sync_attrs(fs, src_fd, dst_fd, de_name, src_stx_b=None):
+    if not src_stx_b:
+        flags = (CEPH_STATX_UID | CEPH_STATX_GID | CEPH_STATX_MODE |
+                 CEPH_STATX_ATIME | CEPH_STATX_MTIME)
+        # src_stx_b = statx buffer for source path
+        src_stx_b = fs.statxat(src_fd, de_name, flags, AT_SYMLINK_NOFOLLOW)
+
+    src_uid = src_stx_b["uid"]
+    src_gid = src_stx_b["gid"]
+    src_mode = src_stx_b["mode"]
+    src_timestamps = (time.mktime(src_stx_b["atime"].timetuple()),
+                      time.mktime(src_stx_b["mtime"].timetuple()))
+
+    try:
+        fs.chownat(dst_fd, de_name, src_uid, src_gid, AT_SYMLINK_NOFOLLOW)
+        fs.chmodat(dst_fd, de_name, src_mode, AT_SYMLINK_NOFOLLOW)
+        fs.utimensat(dst_fd, de_name, src_timestamps, AT_SYMLINK_NOFOLLOW)
+    except Exception as e:
+        log.error('Exception occurred while synchronizing attrs for '
+                  f'"{de_name}". Exception: ({e})')
+        raise e
+
+
+def copy_reg_file(fs, src_fd, dst_fd, file_name, should_sync_attrs=False):
+    src_file_fd = dst_file_fd = None
+    try:
+        src_file_fd = fs.openat(src_fd, file_name, os.O_RDONLY, 0o755)
+        dst_file_fd = fs.openat(dst_fd, file_name, os.O_CREAT | os.O_TRUNC |
+                                os.O_WRONLY, 0o755)
+    except Exception:
+        if src_file_fd:
+            fs.close(src_file_fd)
+        if dst_file_fd:
+            fs.close(dst_file_fd)
+        raise
+
+    while True:
+        data = fs.read(src_file_fd, -1, 1 * 1024 * 1024)
+        if not len(data):
+            break
+
+        written = 0
+        while written < len(data):
+            written += fs.write(dst_file_fd, data[written:], -1)
+
+    if should_sync_attrs:
+        sync_attrs(fs, src_fd, dst_fd, file_name)
+
+    fs.fsync(dst_file_fd, 0)
+    fs.close(src_file_fd)
+    fs.close(dst_file_fd)
+
+
+def copy_sym_link(fs, src_fd, dst_fd, de_name, should_sync_attrs=False):
+    flags = (CEPH_STATX_UID | CEPH_STATX_GID | CEPH_STATX_MODE |
+             CEPH_STATX_ATIME | CEPH_STATX_MTIME | CEPH_STATX_SIZE)
+    # src_stx_b = statx buffer for source path
+    src_stx_b = fs.statxat(src_fd, de_name, flags, AT_SYMLINK_NOFOLLOW)
+    size = src_stx_b['size']
+
+    src_stx_b = fs.statxat(src_fd, de_name, flags, AT_SYMLINK_NOFOLLOW)
+    try:
+        target = fs.readlinkat(src_fd, de_name, size)
+    except Exception as e:
+        log.info('Following exception occurred while reading '
+                 f'symlink: {e}')
+        raise
+
+    try:
+        fs.symlinkat(target, dst_fd, de_name)
+    except Exception as e:
+        log.info('Following exception occurred while creating '
+                 f'symlink: {e}')
+        raise
+
+    if should_sync_attrs:
+        sync_attrs(fs, src_fd, dst_fd, de_name, src_stx_b)

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2336,7 +2336,26 @@ cdef class LibCephFS(object):
             ret = ceph_symlink(self.cluster, _existing, _newname)
         if ret < 0:
             raise make_ex(ret, "error in symlink")
-    
+
+    def symlinkat(self, existing, fd, newname):
+        self.require_state("mounted")
+
+        if not isinstance(fd, int):
+            raise TypeError('"fd" must be of type int')
+
+        existing = cstr(existing, 'existing')
+        newname = cstr(newname, 'newname')
+        cdef:
+            int _fd = fd
+            char* _existing = existing
+            char* _newname = newname
+
+        with nogil:
+            ret = ceph_symlinkat(self.cluster, _existing, _fd, _newname)
+
+        if ret < 0:
+            raise make_ex(ret, "error in symlinkat")
+
     def link(self, existing, newname):
         """
         Create a link.

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2940,6 +2940,8 @@ class UnlinkTreeWorker:
     def __init__(self, fs, trash_path, should_cancel, suppress_errors=False):
         self.fs = fs
         self.trash_path = trash_path
+        if isinstance(self.trash_path, str):
+            self.trash_path = self.trash_path.encode('utf-8')
 
         self.should_cancel = should_cancel
         self.suppress_errors = suppress_errors
@@ -2963,9 +2965,9 @@ class UnlinkTreeWorker:
         # ensure we are dealing with the dir at the top of the stack.
         assert self.curr_dir is self.stack[-1]
 
-        de_path = os.path.join(self.curr_dir.path, de_name)
         try:
-            self.stack.append(RmtreeDir(self.fs, de_path))
+            rel_path = os.path.join(self.curr_dir.rel_path, de_name)
+            self.stack.append(RmtreeDir(self.fs, rel_path))
             return True
         except Error as e:
             if self.suppress_errors:
@@ -3039,7 +3041,7 @@ class UnlinkTreeWorker:
 
                 if self.curr_dir.is_empty:
                     try:
-                        self.fs.rmdir(self.curr_dir.path)
+                        self.curr_dir.try_rmdir(self.suppress_errors)
                     except ObjectNotEmpty:
                         log.info(f'removing "{self.curr_dir.name}" failed with '
                                   'with ObjectNotEmpty even though dir empty '
@@ -3060,13 +3062,12 @@ class RmtreeDir:
     helper for class NonRecursiveRmtree.
     '''
 
-    def __init__(self, fs, path):
+    def __init__(self, fs, rel_path):
         self.fs = fs
+        self.rel_path = rel_path
 
-        self.path = path
-        if isinstance(self.path, str):
-            self.path = self.path.encode('utf-8')
-        self.name = os.path.basename(self.path)
+        self.name = os.path.basename(self.rel_path)
+
         # XXX: exception (if) raised here should be handled by caller based on
         # the context.
         self.handle = self.fs.opendir(self.path)
@@ -3090,7 +3091,7 @@ class RmtreeDir:
         self.de_has_been_removed = False
 
     def __str__(self):
-        return self.path
+        return self.name
 
     def add_to_de_ignore_list(self, de_name):
         self.de_ignore_list.append(de_name)
@@ -3141,7 +3142,7 @@ class RmtreeDir:
             log.error(f'Exception occured: "{e}"')
             self.set_readdir_error()
 
-    def try_rmdir(self, de_name, suppress_errors=False):
+    def try_rmdir(self, suppress_errors=False):
         '''
         Remove given directory. If that fails because its not empty, raise the
         exception, the caller should handle it.
@@ -3150,9 +3151,8 @@ class RmtreeDir:
         and tell caller whether to continue or break loop based through the
         return value.
         '''
-        de_path = os.path.join(self.path, de_name)
         try:
-            self.fs.rmdir(de_path)
+            self.fs.rmdir(self.rel_path)
             self.de_has_been_removed = True
         except ObjectNotEmpty:
             # XXX: push this dir to stack, done in the caller method
@@ -3160,7 +3160,7 @@ class RmtreeDir:
         except Error as e:
             log.error('Following exception occured while calling rmdir() for '
                       f'dir "{self.name}": "{e}"')
-            self.add_to_de_ignore_list(de_name)
+            self.add_to_de_ignore_list(self.name)
 
             if not suppress_errors:
                 raise
@@ -3169,9 +3169,8 @@ class RmtreeDir:
         '''
         Unlink given file and add it to the ignore list if that fails.
         '''
-        de_path = os.path.join(self.path, de_name)
         try:
-            self.fs.unlink(de_path)
+            self.fs.unlinkat(self.fd, de_name, 0)
             self.de_has_been_removed = True
         except Error as e:
             log.error('Following exception occured while calling unlink() for '

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -3152,7 +3152,8 @@ class RmtreeDir:
         return value.
         '''
         try:
-            self.fs.rmdir(self.rel_path)
+            self.fs.unlinkat(self.parent_dir_fd, self.name, AT_REMOVEDIR)
+
             self.de_has_been_removed = True
         except ObjectNotEmpty:
             # XXX: push this dir to stack, done in the caller method

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2966,8 +2966,7 @@ class UnlinkTreeWorker:
         assert self.curr_dir is self.stack[-1]
 
         try:
-            rel_path = os.path.join(self.curr_dir.rel_path, de_name)
-            self.stack.append(RmtreeDir(self.fs, rel_path))
+            self.stack.append(RmtreeDir(self.fs, de_name, self.curr_dir.fd))
             return True
         except Error as e:
             if self.suppress_errors:
@@ -3000,7 +2999,7 @@ class UnlinkTreeWorker:
         This is where depth-first, non-recursive traversal is done.
         '''
         try:
-            self.stack.append(RmtreeDir(self.fs, self.trash_path))
+            self.stack.append(RmtreeDir(self.fs, self.trash_path, AT_FDCWD))
         except Exception as e:
             log.error('opening root dir of the file tree failed with exception '
                       f'"{e}", exiting.')
@@ -3062,15 +3061,16 @@ class RmtreeDir:
     helper for class NonRecursiveRmtree.
     '''
 
-    def __init__(self, fs, rel_path):
+    def __init__(self, fs, name, parent_dir_fd=AT_FDCWD):
         self.fs = fs
-        self.rel_path = rel_path
 
-        self.name = os.path.basename(self.rel_path)
+        self.name = name
 
-        # XXX: exception (if) raised here should be handled by caller based on
-        # the context.
-        self.fd = self.fs.open(self.rel_path, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        self.parent_dir_fd = parent_dir_fd
+        # XXX: exception (if) raised in following two lines should be handled by
+        # caller based on the context.
+        self.fd = self.fs.openat(self.parent_dir_fd, self.name,
+                                 os.O_RDONLY | os.O_DIRECTORY, 0o755)
         self.handle = self.fs.fdopendir(self.fd)
 
         # Is this directory empty? It will be set by self.read_dir().

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -1417,6 +1417,41 @@ cdef class LibCephFS(object):
         if ret < 0:
             raise make_ex(ret, "error in fchown")
 
+    def chownat(self, fd, relpath, uid, gid, flags):
+        """
+        Change directory ownership
+
+        :param fd: the file descriptor
+        :param relpath: the path of the directory to change, relative to fd
+        :param uid: the uid to set
+        :param gid: the gid to set
+        :param flags: int value that can be used to set AT_* modifier flags
+                     (AT_SYMLINK_NOFOLLOW and AT_EMPTY_PATH)
+        """
+        self.require_state("mounted")
+
+        if not isinstance(uid, int):
+            raise TypeError('"uid" must be an int')
+        if not isinstance(gid, int):
+            raise TypeError('"gid" must be an int')
+        if not isinstance(flags, int):
+            raise TypeError('"flags" must be an int')
+
+        relpath = cstr(relpath, 'relpath')
+        cdef:
+            int _fd = fd
+            char* _relpath = relpath
+            # Avoid "OverflowError: can't convert negative value to uid_t."
+            uid_t _uid = uid if uid >= 0 else -1
+            # Avoid "OverflowError: can't convert negative value to gid_t."
+            gid_t _gid = gid if gid >= 0 else -1
+            int _flags = flags
+
+        with nogil:
+            ret = ceph_chownat(self.cluster, _fd, _relpath, _uid, _gid, _flags)
+        if ret < 0:
+            raise make_ex(ret, f"error in chownat {relpath.decode('utf-8')}")
+
     def mkdirs(self, path, mode):
         """
         Create multiple directories at once.

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -32,6 +32,8 @@ log = getLogger(__name__)
 
 
 AT_SYMLINK_NOFOLLOW = 0x0100
+AT_REMOVEDIR = 0x200
+AT_FDCWD = -100
 AT_STATX_SYNC_TYPE  = 0x6000
 AT_STATX_SYNC_AS_STAT = 0x0000
 AT_STATX_FORCE_SYNC = 0x2000
@@ -2287,6 +2289,20 @@ cdef class LibCephFS(object):
             ret = ceph_unlink(self.cluster, _path)
         if ret < 0:
             raise make_ex(ret, "error in unlink: {}".format(path.decode('utf-8')))
+
+    def unlinkat(self, dirfd, relpath, flags):
+        self.require_state("mounted")
+
+        relpath = cstr(relpath, 'relpath')
+        cdef:
+            int dirfd_ = dirfd
+            char* relpath_ = relpath
+            int flags_ = flags
+
+        with nogil:
+            ret = ceph_unlinkat(self.cluster, dirfd_, relpath_, flags_)
+        if ret < 0:
+            raise make_ex(ret, f"error in unlinkat: {relpath.decode('utf-8')}")
 
     def rename(self, src, dst):
         """

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -1158,6 +1158,25 @@ cdef class LibCephFS(object):
         if ret < 0:
             raise make_ex(ret, "error in mkdir {}".format(path.decode('utf-8')))
 
+    def mkdirat(self, dirfd, relpath, mode):
+        self.require_state("mounted")
+        if not isinstance(mode, int):
+            raise TypeError('"mode" must be an int')
+        if not isinstance(dirfd, int):
+            raise TypeError('"_dirfd" must be an int')
+
+        relpath = cstr(relpath, 'relpath')
+        cdef:
+            char* _relpath = relpath
+            int _mode = mode
+            int _dirfd = dirfd
+
+        with nogil:
+            ret = ceph_mkdirat(self.cluster, _dirfd, _relpath, _mode)
+
+        if ret < 0:
+            raise make_ex(ret, f"error in mkdirat: {relpath.decode('utf-8')}")
+
     def mksnap(self, path, name, mode, metadata={}) -> int:
         """
         Create a snapshot.

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2168,6 +2168,61 @@ cdef class LibCephFS(object):
 
         return dict_result
 
+    def statxat(self, fd, relpath, mask, flag):
+        self.require_state("mounted")
+
+        if not isinstance(fd, int):
+            raise TypeError('fd must be a int')
+        if not isinstance(mask, int):
+            raise TypeError('mask must be a int')
+        if not isinstance(flag, int):
+            raise TypeError('flag must be a int')
+
+        relpath = cstr(relpath, 'relpath')
+
+        cdef:
+            int _fd = fd
+            char* _relpath = relpath
+            statx stx
+            int _mask = mask
+            int _flag = flag
+
+        with nogil:
+            ret = ceph_statxat(self.cluster, _fd, _relpath, &stx, _mask, _flag)
+
+        if ret < 0:
+            raise make_ex(ret, f"error in statxat {relpath.decode('utf-8')}")
+
+        dict_result = dict()
+        if (_mask & CEPH_STATX_MODE):
+            dict_result["mode"] = stx.stx_mode
+        if (_mask & CEPH_STATX_NLINK):
+            dict_result["nlink"] = stx.stx_nlink
+        if (_mask & CEPH_STATX_UID):
+            dict_result["uid"] = stx.stx_uid
+        if (_mask & CEPH_STATX_GID):
+            dict_result["gid"] = stx.stx_gid
+        if (_mask & CEPH_STATX_RDEV):
+            dict_result["rdev"] = stx.stx_rdev
+        if (_mask & CEPH_STATX_ATIME):
+            dict_result["atime"] = datetime.fromtimestamp(stx.stx_atime.tv_sec)
+        if (_mask & CEPH_STATX_MTIME):
+            dict_result["mtime"] = datetime.fromtimestamp(stx.stx_mtime.tv_sec)
+        if (_mask & CEPH_STATX_CTIME):
+            dict_result["ctime"] = datetime.fromtimestamp(stx.stx_ctime.tv_sec)
+        if (_mask & CEPH_STATX_INO):
+            dict_result["ino"] = stx.stx_ino
+        if (_mask & CEPH_STATX_SIZE):
+            dict_result["size"] = stx.stx_size
+        if (_mask & CEPH_STATX_BLOCKS):
+            dict_result["blocks"] = stx.stx_blocks
+        if (_mask & CEPH_STATX_BTIME):
+            dict_result["btime"] = datetime.fromtimestamp(stx.stx_btime.tv_sec)
+        if (_mask & CEPH_STATX_VERSION):
+            dict_result["version"] = stx.stx_version
+
+        return dict_result
+
     def setattrx(self, path, dict_stx, mask, flags):
         """
         Set a file's attributes.

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -1466,6 +1466,23 @@ cdef class LibCephFS(object):
             raise make_ex(ret, "error in open {}".format(path.decode('utf-8')))
         return ret
 
+    def openat(self, dirfd, relpath, flags, mode):
+        self.require_state("mounted")
+
+        relpath = cstr(relpath, 'relpath')
+        cdef:
+            int dirfd_ = dirfd
+            int flags_ = flags
+            char* relpath_ = relpath
+            int mode_ = mode
+
+        with nogil:
+            ret = ceph_openat(self.cluster, dirfd_, relpath_, flags_, mode_)
+        if ret < 0:
+            raise make_ex(ret, f'error in openat {relpath}')
+        return ret
+
+
     def close(self, fd):
         """
         Close the open file.

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2383,6 +2383,31 @@ cdef class LibCephFS(object):
         finally:
             free(buf)
 
+    def readlinkat(self, dirfd, relpath, size) -> bytes:
+        self.require_state("mounted")
+
+        if not isinstance(dirfd, int):
+            raise TypeError('"dirfd" must be of type int')
+        if not isinstance(size, int):
+            raise TypeError('"size" must be of type int')
+
+        relpath = cstr(relpath, 'relpath')
+        cdef:
+            int _dirfd = dirfd
+            char* _relpath = relpath
+            int64_t _size = size
+            char *buf = NULL
+
+        try:
+            buf = <char *>realloc_chk(buf, _size)
+            with nogil:
+                ret = ceph_readlinkat(self.cluster, _dirfd, _relpath, buf, _size)
+            if ret < 0:
+                raise make_ex(ret, f"error in readlinkat: {relpath.decode('utf-8')}")
+            return buf[:ret]
+        finally:
+            free(buf)
+
     def unlink(self, path):
         """
         Removes a file, link, or symbolic link.  If the file/link has multiple links to it, the

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2962,6 +2962,7 @@ class UnlinkTreeWorker:
                 raise OpCanceled('rmtree')
 
             self.curr_dir = self.stack[-1]
+            finished_traversing_curr_dir = True
 
             # de = directory entry
             de = self.curr_dir.read_dir()
@@ -2975,13 +2976,14 @@ class UnlinkTreeWorker:
                         # traversing the current dir and start traversing
                         # the new dir that has been freshly added to the
                         # stack.
+                        finished_traversing_curr_dir = False
                         break
                 else:
                     self.curr_dir.try_unlink(de.d_name, self.suppress_errors)
 
                 de = self.curr_dir.read_dir()
 
-            if self.curr_dir.has_any_fs_op_failed() or self.curr_dir.is_empty:
+            if finished_traversing_curr_dir:
                 if self.curr_dir.has_any_fs_op_failed():
                     self.notify_parent_dir()
 

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -265,6 +265,10 @@ cdef nogil:
         pass
     int ceph_futimens(ceph_mount_info *cmount, int fd, timespec times[2]):
         pass
+    int ceph_utimensat(ceph_mount_info* cmount, int fd, const char* relpath,
+                       timespec* times, int flags):
+        pass
+
     int ceph_get_file_replication(ceph_mount_info *cmount, int fh):
         pass
     int ceph_get_path_replication(ceph_mount_info *cmount, const char *path):

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -166,6 +166,8 @@ cdef nogil:
 
     int ceph_mkdir(ceph_mount_info *cmount, const char *path, mode_t mode):
         pass
+    int ceph_mkdirat(ceph_mount_info *cmount, int dirfd, const char *relpath, mode_t mode):
+        pass
     int ceph_mksnap(ceph_mount_info *cmount, const char *path, const char *name, mode_t mode, snap_metadata *snap_metadata, size_t nr_snap_metadata):
         pass
     int ceph_rmsnap(ceph_mount_info *cmount, const char *path, const char *name):

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -225,12 +225,17 @@ cdef nogil:
         pass
     int ceph_fallocate(ceph_mount_info *cmount, int fd, int mode, int64_t offset, int64_t length):
         pass
+
     int ceph_chmod(ceph_mount_info *cmount, const char *path, mode_t mode):
         pass
     int ceph_lchmod(ceph_mount_info *cmount, const char *path, mode_t mode):
         pass
     int ceph_fchmod(ceph_mount_info *cmount, int fd, mode_t mode):
         pass
+    int ceph_chmodat(ceph_mount_info *cmount, int dirfd, const char *relpath,
+                     mode_t mode, int flags):
+        pass
+
     int ceph_chown(ceph_mount_info *cmount, const char *path, int uid, int gid):
         pass
     int ceph_lchown(ceph_mount_info *cmount, const char *path, int uid, int gid):

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -115,6 +115,9 @@ cdef nogil:
         pass
     int ceph_symlink(ceph_mount_info *cmount, const char *existing, const char *newname):
         pass
+    int ceph_symlinkat(ceph_mount_info *cmount, const char *existing, int fd,
+                       const char *newname):
+        pass
     int ceph_readlink(ceph_mount_info *cmount, const char *path, char *buf, int64_t size):
         pass
     int ceph_readlinkat(ceph_mount_info *cmount, const int dirfd, char *path,

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -176,6 +176,8 @@ cdef nogil:
         pass
     int ceph_opendir(ceph_mount_info *cmount, const char *name, ceph_dir_result **dirpp):
         pass
+    int ceph_fdopendir(ceph_mount_info *cmount, int dirfd, ceph_dir_result** dirpp):
+        pass
     void ceph_rewinddir(ceph_mount_info *cmount, ceph_dir_result *dirp):
         pass
     int64_t ceph_telldir(ceph_mount_info *cmount, ceph_dir_result *dirp):

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -242,12 +242,17 @@ cdef nogil:
         pass
     int ceph_fchown(ceph_mount_info *cmount, int fd, int uid, int gid):
         pass
+    int ceph_chownat(ceph_mount_info *cmount, int fd, const char *relpath,
+                     int uid, int gid, int flags):
+        pass
+
     int64_t ceph_lseek(ceph_mount_info *cmount, int fd, int64_t offset, int whence):
         pass
     void ceph_buffer_free(char *buf):
         pass
     mode_t ceph_umask(ceph_mount_info *cmount, mode_t mode):
         pass
+
     int ceph_utime(ceph_mount_info *cmount, const char *path, utimbuf *buf):
         pass
     int ceph_futime(ceph_mount_info *cmount, int fd, utimbuf *buf):

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -156,10 +156,14 @@ cdef nogil:
         pass
     int ceph_mknod(ceph_mount_info *cmount, const char *path, mode_t mode, dev_t rdev):
         pass
+
     int ceph_close(ceph_mount_info *cmount, int fd):
         pass
     int ceph_open(ceph_mount_info *cmount, const char *path, int flags, mode_t mode):
         pass
+    int ceph_openat(ceph_mount_info *cmount, int dirfd, const char *relpath, int flags, mode_t mode):
+        pass
+
     int ceph_mkdir(ceph_mount_info *cmount, const char *path, mode_t mode):
         pass
     int ceph_mksnap(ceph_mount_info *cmount, const char *path, const char *name, mode_t mode, snap_metadata *snap_metadata, size_t nr_snap_metadata):

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -88,6 +88,9 @@ cdef nogil:
         pass
     int ceph_statx(ceph_mount_info *cmount, const char *path, statx *stx, unsigned want, unsigned flags):
         pass
+    int ceph_statxat(ceph_mount_info *cmount, int dirfd, const char *path,
+                     statx *stx, unsigned want, unsigned flags):
+        pass
     int ceph_statfs(ceph_mount_info *cmount, const char *path, statvfs *stbuf):
         pass
 

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -108,6 +108,8 @@ cdef nogil:
         pass
     int ceph_unlink(ceph_mount_info *cmount, const char *path):
         pass
+    int ceph_unlinkat(ceph_mount_info *cmount, int dirfd, const char *relpath, int flags):
+        pass
     int ceph_symlink(ceph_mount_info *cmount, const char *existing, const char *newname):
         pass
     int ceph_readlink(ceph_mount_info *cmount, const char *path, char *buf, int64_t size):

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -117,6 +117,9 @@ cdef nogil:
         pass
     int ceph_readlink(ceph_mount_info *cmount, const char *path, char *buf, int64_t size):
         pass
+    int ceph_readlinkat(ceph_mount_info *cmount, const int dirfd, char *path,
+                        char *buf, int64_t size):
+        pass
     int ceph_setxattr(ceph_mount_info *cmount, const char *path, const char *name,
                       const void *value, size_t size, int flags):
         pass

--- a/src/pybind/mgr/volumes/fs/async_cloner.py
+++ b/src/pybind/mgr/volumes/fs/async_cloner.py
@@ -113,61 +113,26 @@ def bulk_copy(fs_handle, source_path, dst_path, should_cancel):
     and regular files are synced.
     """
     log.info("copying data from {0} to {1}".format(source_path, dst_path))
-    def cptree(src_root_path, dst_root_path):
-        log.debug("cptree: {0} -> {1}".format(src_root_path, dst_root_path))
-        try:
-            with fs_handle.opendir(src_root_path) as dir_handle:
-                d = fs_handle.readdir(dir_handle)
-                while d and not should_cancel():
-                    if d.d_name not in (b".", b".."):
-                        log.debug("d={0}".format(d))
-                        d_full_src = os.path.join(src_root_path, d.d_name)
-                        d_full_dst = os.path.join(dst_root_path, d.d_name)
-                        stx = fs_handle.statx(d_full_src, cephfs.CEPH_STATX_MODE  |
-                                                          cephfs.CEPH_STATX_UID   |
-                                                          cephfs.CEPH_STATX_GID   |
-                                                          cephfs.CEPH_STATX_ATIME |
-                                                          cephfs.CEPH_STATX_MTIME |
-                                                          cephfs.CEPH_STATX_SIZE,
-                                                          cephfs.AT_SYMLINK_NOFOLLOW)
-                        handled = True
-                        mo = stx["mode"] & ~stat.S_IFMT(stx["mode"])
-                        if stat.S_ISDIR(stx["mode"]):
-                            log.debug("cptree: (DIR) {0}".format(d_full_src))
-                            try:
-                                fs_handle.mkdir(d_full_dst, mo)
-                            except cephfs.Error as e:
-                                if not e.args[0] == errno.EEXIST:
-                                    raise
-                            cptree(d_full_src, d_full_dst)
-                        elif stat.S_ISLNK(stx["mode"]):
-                            log.debug("cptree: (SYMLINK) {0}".format(d_full_src))
-                            target = fs_handle.readlink(d_full_src, 4096)
-                            try:
-                                fs_handle.symlink(target[:stx["size"]], d_full_dst)
-                            except cephfs.Error as e:
-                                if not e.args[0] == errno.EEXIST:
-                                    raise
-                        elif stat.S_ISREG(stx["mode"]):
-                            log.debug("cptree: (REG) {0}".format(d_full_src))
-                            copy_file(fs_handle, d_full_src, d_full_dst, mo, cancel_check=should_cancel)
-                        else:
-                            handled = False
-                            log.warning("cptree: (IGNORE) {0}".format(d_full_src))
-                        if handled:
-                            sync_attrs(fs_handle, d_full_dst, stx)
-                    d = fs_handle.readdir(dir_handle)
-                stx_root = fs_handle.statx(src_root_path, cephfs.CEPH_STATX_ATIME |
-                                                          cephfs.CEPH_STATX_MTIME,
-                                                          cephfs.AT_SYMLINK_NOFOLLOW)
-                fs_handle.lutimes(dst_root_path, (time.mktime(stx_root["atime"].timetuple()),
-                                                  time.mktime(stx_root["mtime"].timetuple())))
-        except cephfs.Error as e:
-            if not e.args[0] == errno.ENOENT:
-                raise VolumeException(-e.args[0], e.args[1])
-    cptree(source_path, dst_path)
-    if should_cancel():
+    # TODO: add code set utime on each file
+    try:
+        # src subvol's UUID must not be copied, only its contents should be.
+        # therefore cp_src_dir is set to False.
+        fs_handle.cptree(source_path, dst_path, should_sync_attrs=True,
+                         cp_src_dir=False, should_cancel=should_cancel,
+                         suppress_errors=False)
+
+        stx_root = fs_handle.statx(source_path, cephfs.CEPH_STATX_ATIME |
+                                                cephfs.CEPH_STATX_MTIME,
+                                                cephfs.AT_SYMLINK_NOFOLLOW)
+        fs_handle.lutimes(dst_path, (time.mktime(stx_root["atime"].timetuple()),
+                                     time.mktime(stx_root["mtime"].timetuple())))
+
+        log.info(f'successfully finished copying data from {source_path} to {dst_path}')
+    except cephfs.OpCanceled:
         raise VolumeException(-errno.EINTR, "user interrupted clone operation")
+    except cephfs.Error as e:
+        if e.args[0] != errno.ENOENT:
+            raise VolumeException(-e.args[0], e.args[1])
 
 def set_quota_on_clone(fs_handle, clone_volumes_pair):
     src_path = clone_volumes_pair[1].snapshot_data_path(clone_volumes_pair[2])

--- a/src/test/pybind/assertions.py
+++ b/src/test/pybind/assertions.py
@@ -1,3 +1,6 @@
+def assert_lesser(a, b):
+    assert a < b
+
 def assert_equal(a, b):
     assert a == b
 

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1550,6 +1550,9 @@ class TestRmtree:
         # this will change return value of should_cancel and therefore halt
         # execution of rmtree()
         cancel_flag.set()
+        # give a little time for cephs.rmtree() to catch the raised exception
+        # due to cancel flag.
+        time.sleep(0.1)
         # ensure dir6 wasn't deleted
         cephfs.stat('dir6')
         # ensure that deletion had begun but hadn't finished and was halted
@@ -1562,6 +1565,8 @@ class TestRmtree:
         assert file_count > 0 and file_count < 100
 
         # cleanup
+
+        # clear flag so that coming call to rmtree() doesn't cancel.
         cancel_flag.clear()
         cephfs.rmtree('dir6', should_cancel)
         assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1341,16 +1341,28 @@ class TestRmtree:
             cephfs.write(fd, b'abcd', 0)
             cephfs.close(fd)
 
+        cephfs.mkdir('dir1/dir5', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/dir4/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.mkdir('dir1/dir6', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/dir4/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
         # actual test
-        cephfs.chmod('/dir1/dir3', 0o000)
+        cephfs.chmod('/dir1/dir4', 0o000)
         # Errors are expected from call to this method. Set suppress_errors to
         # True to confirm that this argument works.
         cephfs.rmtree('dir1', should_cancel, suppress_errors=True)
         # ensure /dir1/dir3 wasn't deleted
-        cephfs.stat('dir1/dir3')
-        cephfs.chmod('/dir1/dir3', 0o755)
+        cephfs.stat('dir1/dir4')
+        cephfs.chmod('/dir1/dir4', 0o755)
         for i in range(1, 6):
-            cephfs.stat(f'dir1/dir3/file{i}')
+            cephfs.stat(f'dir1/dir4/file{i}')
 
         # cleanup
         cephfs.rmtree('dir1', should_cancel)

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -891,7 +891,7 @@ class TestWithRootUser:
         cephfs.chown('/', int(uid), int(gid))
         cephfs.conf_set('client_permissions' , 'true')
 
-    def test_chown(testdir):
+    def test_chown(self, testdir):
         fd = cephfs.open('file1', 'w', 0o755)
         cephfs.write(fd, b'abcd', 0)
         cephfs.close(fd)
@@ -903,7 +903,7 @@ class TestWithRootUser:
         assert_equal(st.st_uid, uid)
         assert_equal(st.st_gid, gid)
 
-    def test_chown_change_uid_but_not_gid(testdir):
+    def test_chown_change_uid_but_not_gid(self, testdir):
         fd = cephfs.open('file1', 'w', 0o755)
         cephfs.write(fd, b'abcd', 0)
         cephfs.close(fd)
@@ -918,7 +918,7 @@ class TestWithRootUser:
         # ensure that gid is unchaged.
         assert_equal(st1.st_gid, st2.st_gid)
 
-    def test_chown_change_gid_but_not_uid(testdir):
+    def test_chown_change_gid_but_not_uid(self, testdir):
         fd = cephfs.open('file1', 'w', 0o755)
         cephfs.write(fd, b'abcd', 0)
         cephfs.close(fd)
@@ -933,7 +933,7 @@ class TestWithRootUser:
         # ensure that uid is unchaged.
         assert_equal(st1.st_uid, st2.st_uid)
 
-    def test_lchown(testdir):
+    def test_lchown(self, testdir):
         fd = cephfs.open('file1', 'w', 0o755)
         cephfs.write(fd, b'abcd', 0)
         cephfs.close(fd)
@@ -946,7 +946,7 @@ class TestWithRootUser:
         assert_equal(st.st_uid, uid)
         assert_equal(st.st_gid, gid)
 
-    def test_lchown_change_uid_but_not_gid(testdir):
+    def test_lchown_change_uid_but_not_gid(self, testdir):
         fd = cephfs.open('file2', 'w', 0o755)
         cephfs.write(fd, b'abcd', 0)
         cephfs.close(fd)
@@ -962,7 +962,7 @@ class TestWithRootUser:
         # ensure that gid is unchaged.
         assert_equal(st1.st_gid, st2.st_gid)
 
-    def test_lchown_change_gid_but_not_uid(testdir):
+    def test_lchown_change_gid_but_not_uid(self, testdir):
         fd = cephfs.open('file3', 'w', 0o755)
         cephfs.write(fd, b'abcd', 0)
         cephfs.close(fd)
@@ -978,7 +978,7 @@ class TestWithRootUser:
         # ensure that uid is unchaged.
         assert_equal(st1.st_uid, st2.st_uid)
 
-    def test_fchown(testdir):
+    def test_fchown(self, testdir):
         fd = cephfs.open(b'/file-fchown', 'w', 0o655)
         uid = os.getuid()
         gid = os.getgid()
@@ -995,7 +995,7 @@ class TestWithRootUser:
         cephfs.close(fd)
         cephfs.unlink(b'/file-fchown')
 
-    def test_fchown_change_uid_but_not_gid(testdir):
+    def test_fchown_change_uid_but_not_gid(self, testdir):
         fd = cephfs.open('file1', 'w', 0o755)
         cephfs.write(fd, b'abcd', 0)
 
@@ -1011,7 +1011,7 @@ class TestWithRootUser:
 
         cephfs.close(fd)
 
-    def test_fchown_change_gid_but_not_uid(testdir):
+    def test_fchown_change_gid_but_not_uid(self, testdir):
         fd = cephfs.open('file1', 'w', 0o755)
         cephfs.write(fd, b'abcd', 0)
 
@@ -1027,7 +1027,7 @@ class TestWithRootUser:
 
         cephfs.close(fd)
 
-    def test_setattrx(testdir):
+    def test_setattrx(self, testdir):
         fd = cephfs.open(b'file-setattrx', 'w', 0o655)
         cephfs.write(fd, b"1111", 0)
         cephfs.close(fd)
@@ -1072,7 +1072,7 @@ class TestWithRootUser:
         assert_equal(10, st1["size"])
         cephfs.unlink(b'file-setattrx')
 
-    def test_fsetattrx(testdir):
+    def test_fsetattrx(self, testdir):
         fd = cephfs.open(b'file-fsetattrx', 'w', 0o655)
         cephfs.write(fd, b"1111", 0)
         st = cephfs.statx(b'file-fsetattrx', libcephfs.CEPH_STATX_MODE, 0)

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -961,6 +961,33 @@ class TestFdopendir:
         dh.close()
 
 
+class TestOpenat:
+
+    def test_openat_for_child_subdir(self, testdir):
+        dir1 = 'dir1'
+        dir2 = 'dir2'
+
+        cephfs.mkdir(dir1, 0o755)
+        cephfs.mkdir(f'{dir1}/{dir2}', 0o755)
+
+        fd1 = cephfs.open(dir1, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        fd2 = cephfs.openat(fd1, dir2, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+
+        cephfs.close(fd1)
+        cephfs.close(fd2)
+
+    def test_openat_for_grandchild_subdir(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        cephfs.mkdir('dir1/dir2', 0o755)
+        cephfs.mkdir('dir1/dir2/dir3', 0o755)
+
+        fd1 = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        fd2 = cephfs.openat(fd1, 'dir2/dir3', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+
+        cephfs.close(fd1)
+        cephfs.close(fd2)
+
+
 class TestWithRootUser:
 
     def setup_method(self):

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1566,7 +1566,7 @@ class TestRmtree:
         cephfs.rmtree('dir6', should_cancel)
         assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
 
-    def test_rmtree_on_a_very_broad_tree(self, testdir):
+    def test_rmtree_on_a_200_dir_broad_tree(self, testdir):
         '''
         Test that rmtree() successfully deletes a file hierarchy with 200
         subdirectories on the same level.
@@ -1586,7 +1586,7 @@ class TestRmtree:
         cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
         assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
 
-    def test_rmtree_on_a_very_very_broad_tree(self, testdir):
+    def test_rmtree_on_a_2k_dir_broad_tree(self, testdir):
         '''
         Test that rmtree() successfully deletes a file hierarchy with 2000
         subdirectories on the same level.
@@ -1606,7 +1606,7 @@ class TestRmtree:
         cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
         assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
 
-    def test_rmtree_on_a_very_deep_tree(self, testdir):
+    def test_rmtree_on_a_200_dir_deep_tree(self, testdir):
         '''
         Test that rmtree() successfully deletes a file hierarchy with 2000
         levels.
@@ -1625,7 +1625,7 @@ class TestRmtree:
         cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
         assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
 
-    def test_rmtree_on_a_very_very_deep_tree(self, testdir):
+    def test_rmtree_on_a_2k_dir_deep_tree(self, testdir):
         '''
         Test that rmtree() successfully deletes a file hierarchy with 2000
         levels.

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -935,6 +935,32 @@ class TestUnlinkat:
         cephfs.close(fd)
 
 
+class TestFdopendir:
+    '''
+    Tests for libcephfs's fdopendir().
+    '''
+
+    def test_fdopendir_for_dir_at_CWD(self, testdir):
+        dirname = 'dir1'
+        cephfs.mkdir(dirname, 0o755)
+
+        fd = cephfs.open(dirname, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        dh = cephfs.fdopendir(fd)
+
+        dh.close()
+
+    def test_fdopendir_for_dir_not_at_CWD(self, testdir):
+        dirname = 'dir1/dir2/dir3'
+        cephfs.mkdir('dir1', 0o755)
+        cephfs.mkdir('dir1/dir2', 0o755)
+        cephfs.mkdir(dirname, 0o755)
+
+        fd = cephfs.open(dirname, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        dh = cephfs.fdopendir(fd)
+
+        dh.close()
+
+
 class TestWithRootUser:
 
     def setup_method(self):

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1245,6 +1245,25 @@ class TestRmtree:
         cephfs.rmtree('dir3', should_cancel, suppress_errors=False)
         assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir3')
 
+    def test_rmtree_when_path_has_trailing_slash(self, testdir):
+        '''
+        Test rmtree() successfully deletes the entire file hierarchy when path
+        passed to rmtree() ends with a slash
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir1', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir1/', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
     def test_rmtree_when_symlink_points_to_parent_dir(self, testdir):
         '''
         Test that rmtree() successfully deletes entire file hierarchy that

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -314,6 +314,22 @@ def test_readlink(testdir):
     cephfs.unlink(b'/file-2')
     cephfs.unlink(b'/file-1')
 
+def test_readlinkat(testdir):
+    cephfs.mkdir(b'dir1', 0o755)
+
+    fd = cephfs.open(b'dir1/file1', 'w', 0o755)
+    cephfs.write(fd, b'abcd', 0)
+    cephfs.close(fd)
+
+    cephfs.chdir('dir1')
+    cephfs.symlink('file1', 'slink1')
+    cephfs.chdir('..')
+
+    fd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+    o = cephfs.readlinkat(fd, 'slink1', 100)
+    assert_equal(o, b'file1')
+    cephfs.close(fd)
+
 def test_delete_cwd(testdir):
     assert_equal(b"/", cephfs.getcwd())
 

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -866,9 +866,6 @@ def test_snapdiff(testdir):
     assert_equal(cnt, 2)
     diff.close()
 
-    # remove directory
-    purge_dir(b"/snapdiff_test");
-
 def test_single_target_command():
     command = {'prefix': u'session ls', 'format': 'json'}
     mds_spec  = "a"

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1388,6 +1388,77 @@ class TestWithRootUser:
 
         cephfs.close(fd)
 
+    def test_chownat_on_regfile(self, testdir):
+        cephfs.mkdir(b'dir1', 0o755)
+
+        fd = cephfs.open(b'dir1/file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        st1 = cephfs.stat(b'dir1/file1')
+        old_uid = st1.st_uid
+        old_gid = st1.st_gid
+        new_uid = st1.st_uid + 1
+        new_gid = st1.st_gid + 1
+
+        dirfd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        cephfs.chownat(dirfd, 'file1', new_uid, new_gid, 0)
+
+        st2 = cephfs.stat(b'dir1/file1')
+        assert_equal(st2.st_uid, new_uid)
+        assert_equal(st2.st_gid, new_gid)
+
+        # reset to old uid & gid for sake of teardown.
+        cephfs.chownat(dirfd, b'file1', old_uid, old_gid, 0)
+        cephfs.close(dirfd)
+
+    def test_chownat_on_dir(self, testdir):
+        cephfs.mkdir(b'dir1', 0o755)
+        cephfs.mkdir(b'dir1/dir2', 0o755)
+
+        st1 = cephfs.stat(b'dir1/dir2')
+        old_uid = st1.st_uid
+        old_gid = st1.st_gid
+        new_uid = st1.st_uid + 1
+        new_gid = st1.st_gid + 1
+
+        dirfd = cephfs.open(b'dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        cephfs.chownat(dirfd, b'dir2', new_uid, new_gid, 0)
+
+        st2 = cephfs.stat(b'dir1/dir2')
+        assert_equal(st2.st_uid, new_uid)
+        assert_equal(st2.st_gid, new_gid)
+
+        # reset to old uid & gid for sake of teardown.
+        cephfs.chownat(dirfd, b'dir2', old_uid, old_gid, 0)
+        cephfs.close(dirfd)
+
+    def test_chownat_on_symlink(self, testdir):
+        cephfs.mkdir(b'dir1', 0o755)
+
+        fd = cephfs.open(b'dir1/file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.symlink('file1', b'dir1/slink1')
+
+        st1 = cephfs.stat(b'dir1/slink1', follow_symlink=False)
+        old_uid = st1.st_uid
+        old_gid = st1.st_gid
+        new_uid = st1.st_uid + 1
+        new_gid = st1.st_gid + 1
+
+        dirfd = cephfs.open(b'/dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        cephfs.chownat(dirfd, b'slink1', new_uid, new_gid, libcephfs.AT_SYMLINK_NOFOLLOW)
+
+        st2 = cephfs.stat(b'dir1/slink1', follow_symlink=False)
+        assert_equal(st2.st_uid, new_uid)
+        assert_equal(st2.st_gid, new_gid)
+
+        # reset to old uid & gid for sake of teardown.
+        cephfs.chownat(dirfd, b'slink1', old_uid, old_gid, 0)
+        cephfs.close(dirfd)
+
     def test_setattrx(self, testdir):
         fd = cephfs.open(b'file-setattrx', 'w', 0o655)
         cephfs.write(fd, b"1111", 0)

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -38,36 +38,10 @@ def teardown_module():
     global cephfs
     cephfs.shutdown()
 
-def purge_dir(path, is_snap = False):
-    print(b"Purge " + path)
-    d = cephfs.opendir(path)
-    if (not path.endswith(b"/")):
-        path = path + b"/"
-    dent = cephfs.readdir(d)
-    while dent:
-        if (dent.d_name not in [b".", b".."]):
-            print(path + dent.d_name)
-            if dent.is_dir():
-                if (not is_snap):
-                    try:
-                        snappath = path + dent.d_name + b"/.snap"
-                        cephfs.stat(snappath)
-                        purge_dir(snappath, True)
-                    except:
-                        pass
-                    purge_dir(path + dent.d_name, False)
-                    cephfs.rmdir(path + dent.d_name)
-                else:
-                    print("rmsnap on {} snap {}".format(path, dent.d_name))
-                    cephfs.rmsnap(path, dent.d_name);
-            else:
-                cephfs.unlink(path + dent.d_name)
-        dent = cephfs.readdir(d)
-    cephfs.closedir(d)
-
 @pytest.fixture
 def testdir():
-    purge_dir(b"/")
+    print(f'purging entire file hierarchy under "/"...')
+    cephfs.rmtree(b'/')
 
     cephfs.chdir(b"/")
     _, ret_buf = cephfs.listxattr("/")

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1157,6 +1157,74 @@ class TestStatxat:
         cephfs.close(fd)
 
 
+class TestChmodat:
+
+    def test_chmodat_on_file(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        fd = cephfs.open('dir1/file1', 'w')
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        fd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        cephfs.chmodat(fd, 'file1', 0o644, 0)
+
+        statx_buf = cephfs.statx(b'dir1/file1', libcephfs.CEPH_STATX_MODE, 0)
+        mode = statx_buf['mode'] & ~stat.S_IFMT(statx_buf['mode'])
+        assert_equal(0o644, mode)
+        cephfs.close(fd)
+
+    def test_chmodat_on_dir(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        cephfs.mkdir('dir1/dir2', 0o755)
+
+        fd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        cephfs.chmodat(fd, 'dir2', 0o644, 0)
+
+        statx_buf = cephfs.statx(b'dir1/dir2', libcephfs.CEPH_STATX_MODE, 0)
+        mode = statx_buf['mode'] & ~stat.S_IFMT(statx_buf['mode'])
+        assert_equal(0o644, mode)
+        cephfs.close(fd)
+
+    def test_chmodat_on_link(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        fd = cephfs.open('dir1/file1', 'w', 0o644)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.chdir('dir1')
+        cephfs.symlink('file1', 'slink1')
+        cephfs.chdir('..')
+
+        fd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        cephfs.chmodat(fd, 'slink1', 0o755, libcephfs.AT_SYMLINK_NOFOLLOW)
+
+        statx_buf = cephfs.statx(b'dir1/slink1', libcephfs.CEPH_STATX_MODE, libcephfs.AT_SYMLINK_NOFOLLOW)
+        mode = statx_buf['mode'] & ~stat.S_IFMT(statx_buf['mode'])
+        assert_equal(0o755, mode)
+        cephfs.close(fd)
+
+    def test_chmodat_on_link_follow_slink(self, testdir):
+        '''
+        Test chmodat() for a symlink without passing NOFOLLOW flag.
+        '''
+        cephfs.mkdir('dir1', 0o755)
+        fd = cephfs.open('dir1/file1', 'w', 0o644)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.chdir('dir1')
+        cephfs.symlink('file1', 'slink1')
+        cephfs.chdir('..')
+
+        fd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        cephfs.chmodat(fd, 'slink1', 0o755, 0)
+
+        statx_buf = cephfs.statx(b'dir1/file1', libcephfs.CEPH_STATX_MODE, libcephfs.AT_SYMLINK_NOFOLLOW)
+        mode = statx_buf['mode'] & ~stat.S_IFMT(statx_buf['mode'])
+        assert_equal(0o755, mode)
+        cephfs.close(fd)
+
+
 class TestWithRootUser:
 
     def setup_method(self):

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -988,6 +988,76 @@ class TestOpenat:
         cephfs.close(fd2)
 
 
+class TestMkdirat:
+    '''
+    Test mkdirat() of LibCephFS Python binding.
+    '''
+
+    def test_create_child_dir(self, testdir):
+        '''
+        Test that mkdirat() creates a child directory successfully.
+        '''
+        dir1_name = 'dir1'
+        dir2_name = 'dir2'
+        dir2_path = f'{dir1_name}/{dir2_name}'
+
+        cephfs.mkdir(dir1_name, 0o755)
+        fd = cephfs.open(dir1_name, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+
+        cephfs.mkdirat(fd, dir2_name, 0o755)
+
+        cephfs.close(fd)
+
+    def test_create_grandchild_dir(self, testdir):
+        '''
+        Test that mkdirat() creates a grandchild directory successfully.
+        '''
+        dir1_name = 'dir1'
+        dir2_name = 'dir2'
+        dir2_path = f'dir1/{dir2_name}'
+        dir3_name = 'dir3'
+        dir3_path = f'{dir1_name}/{dir2_name}/{dir3_name}'
+
+        cephfs.mkdir(dir1_name, 0o755)
+        cephfs.mkdir(dir2_path, 0o755)
+        fd = cephfs.open(dir1_name, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+
+        cephfs.mkdirat(fd, f'{dir2_name}/{dir3_name}', 0o755)
+
+        cephfs.close(fd)
+
+    def test_when_fd_is_root(self, testdir):
+        '''
+        Test that mkdirat() fails when the directory is already present.
+        '''
+        dir1_name = 'dir1'
+        dir2_name = 'dir2'
+        dir2_path = f'{dir1_name}/{dir2_name}'
+
+        cephfs.mkdir(dir1_name, 0o755)
+
+        fd = cephfs.open('/', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        cephfs.mkdirat(fd, dir2_path, 0o755)
+
+        cephfs.close(fd)
+
+    def test_when_file_exists(self, testdir):
+        '''
+        Test that mkdirat() fails when the directory is already present.
+        '''
+        dir1_name = 'dir1'
+        dir2_name = 'dir2'
+        dir2_path = f'{dir1_name}/{dir2_name}'
+
+        cephfs.mkdir(dir1_name, 0o755)
+        cephfs.mkdir(dir2_path, 0o755)
+
+        fd = cephfs.open(dir1_name, os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        assert_raises(libcephfs.ObjectExists, cephfs.mkdirat, fd, dir2_name, 0o755)
+
+        cephfs.close(fd)
+
+
 class TestWithRootUser:
 
     def setup_method(self):

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1225,6 +1225,56 @@ class TestChmodat:
         cephfs.close(fd)
 
 
+class TestUtimensat:
+
+    def test_utimensat_for_regfile(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        fd = cephfs.open('dir1/file1', 'w')
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+        st1 = cephfs.stat(b'dir1/file1')
+
+        dirfd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        time.sleep(2)
+        x = datetime.now()
+        timestamps = (time.mktime(x.timetuple()), time.mktime(x.timetuple()))
+        cephfs.utimensat(dirfd, 'file1', timestamps, 0)
+
+        st2 = cephfs.stat(b'dir1/file1')
+        assert_greater(st2.st_atime, st1.st_atime)
+
+    def test_utimensat_for_dir(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        cephfs.mkdir('dir1/dir2', 0o755)
+        st1 = cephfs.stat(b'dir1/dir2')
+
+        dirfd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        time.sleep(2)
+        x = datetime.now()
+        timestamps = (time.mktime(x.timetuple()), time.mktime(x.timetuple()))
+        cephfs.utimensat(dirfd, 'dir2', timestamps, 0)
+
+        st2 = cephfs.stat(b'dir1/dir2')
+        assert_greater(st2.st_atime, st1.st_atime)
+
+    def test_utimensat_for_symlink(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        fd = cephfs.open('dir1/file1', 'w', 0o644)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+        cephfs.symlink('file1', 'dir1/slink1')
+        st1 = cephfs.stat(b'dir1/slink1')
+
+        dirfd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        time.sleep(2)
+        x = datetime.now()
+        timestamps = (time.mktime(x.timetuple()), time.mktime(x.timetuple()))
+        cephfs.utimensat(dirfd, 'file1', timestamps, libcephfs.AT_SYMLINK_NOFOLLOW)
+
+        st2 = cephfs.stat(b'dir1/slink1')
+        assert_greater(st2.st_atime, st1.st_atime)
+
+
 class TestWithRootUser:
 
     def setup_method(self):

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1058,6 +1058,68 @@ class TestMkdirat:
         cephfs.close(fd)
 
 
+class TestStatxat:
+
+    def test_statxat_on_file(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        fd = cephfs.open('dir1/file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        fd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        statx_buf = cephfs.statxat(fd, b'file1', libcephfs.CEPH_STATX_MODE, 0)
+
+        mode = statx_buf['mode'] & ~stat.S_IFMT(statx_buf['mode'])
+        assert_equal(0o755, mode)
+        cephfs.close(fd)
+
+    def test_statxat_on_dir(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        cephfs.mkdir('dir1/dir2', 0o755)
+
+        fd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        statx_buf = cephfs.statxat(fd, b'dir2', libcephfs.CEPH_STATX_MODE, 0)
+
+        mode = statx_buf['mode'] & ~stat.S_IFMT(statx_buf['mode'])
+        assert_equal(0o755, mode)
+        cephfs.close(fd)
+
+    def test_statxat_on_link(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        fd = cephfs.open('dir1/file1', 'w', 0o644)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.chdir('dir1')
+        cephfs.symlink('file1', 'slink1')
+        cephfs.chdir('..')
+
+        fd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        statx_buf = cephfs.statxat(fd, b'slink1', libcephfs.CEPH_STATX_MODE,
+                                   libcephfs.AT_SYMLINK_NOFOLLOW)
+
+        mode = statx_buf['mode'] & ~stat.S_IFMT(statx_buf['mode'])
+        assert_equal(0o777, mode)
+        cephfs.close(fd)
+
+    def test_statxat_on_link_follow_slink(self, testdir):
+        cephfs.mkdir('dir1', 0o755)
+        fd = cephfs.open('dir1/file1', 'w', 0o644)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.chdir('dir1')
+        cephfs.symlink('file1', 'slink1')
+        cephfs.chdir('..')
+
+        fd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+        statx_buf = cephfs.statxat(fd, b'slink1', libcephfs.CEPH_STATX_MODE, 0)
+
+        mode = statx_buf['mode'] & ~stat.S_IFMT(statx_buf['mode'])
+        assert_equal(0o644, mode)
+        cephfs.close(fd)
+
+
 class TestWithRootUser:
 
     def setup_method(self):

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1728,6 +1728,20 @@ class TestRmtree:
         cephfs.rmtree('dir3', should_cancel, suppress_errors=False)
         assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir3')
 
+    def test_rmtree_on_root(self):
+        cephfs.mkdir('/dir1', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('/', suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, '/dir1/file1')
+
     def test_rmtree_with_and_without_should_cancel(self):
         cephfs.mkdir('dir1', 0o755)
         for i in range(1, 6):

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -304,6 +304,27 @@ def test_symlink(testdir):
     cephfs.close(fd)
     cephfs.unlink(b'file-2')
 
+def test_symlinkat(testdir):
+    cephfs.mkdir(b'dir1', 0o755)
+
+    fd = cephfs.open(b'dir1/file1', 'w', 0o755)
+    cephfs.write(fd, b'abcd', 0)
+    cephfs.close(fd)
+
+    fd = cephfs.open('dir1', os.O_RDONLY | os.O_DIRECTORY, 0o755)
+    cephfs.symlinkat('file1', fd, 'slink1')
+    cephfs.close(fd)
+
+    fd = cephfs.open('dir1/slink1', 'r+', 0o755)
+    data = cephfs.read(fd, 0, 4)
+    assert_equal(data, b'abcd')
+
+    cephfs.write(fd, b'efgh', 4)
+    data = cephfs.read(fd, 0, 8)
+    assert_equal(data, b'abcdefgh')
+
+    cephfs.close(fd)
+
 def test_readlink(testdir):
     fd = cephfs.open(b'/file-1', 'w', 0o755)
     cephfs.write(fd, b"1111", 0)

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1728,6 +1728,34 @@ class TestRmtree:
         cephfs.rmtree('dir3', should_cancel, suppress_errors=False)
         assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir3')
 
+    def test_rmtree_with_and_without_should_cancel(self):
+        cephfs.mkdir('dir1', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir1', suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, '/dir1/file1')
+
+        should_cancel = lambda: False
+        cephfs.mkdir('dir1', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, '/dir1/file1')
+
     def test_rmtree_when_path_has_trailing_slash(self, testdir):
         '''
         Test rmtree() successfully deletes the entire file hierarchy when path

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1506,7 +1506,7 @@ class TestWithRootUser:
         assert_equal(st2.st_gid, new_gid)
 
         # reset to old uid & gid for sake of teardown.
-        cephfs.chownat(dirfd, b'slink1', old_uid, old_gid, 0)
+        cephfs.chownat(dirfd, b'slink1', old_uid, old_gid, libcephfs.AT_SYMLINK_NOFOLLOW)
         cephfs.close(dirfd)
 
     def test_setattrx(self, testdir):

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1,7 +1,8 @@
 # vim: expandtab smarttab shiftwidth=4 softtabstop=4
 import collections
 collections.Callable = collections.abc.Callable
-from assertions import assert_raises, assert_equal, assert_not_equal, assert_greater
+from assertions import assert_raises, assert_equal, assert_not_equal, \
+                       assert_greater, assert_lesser
 import cephfs as libcephfs
 import fcntl
 import os

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -2143,3 +2143,973 @@ class TestRmtree:
         # occur.
         cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
         assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+
+class TestCptree:
+    '''
+    Test cptree() method of CephFS python bindings.
+    '''
+
+    def test_cptree_on_regfile(self, testdir):
+        '''
+        Test that cptree() copies a regular file too when src path passed to it
+        is that of a regular file.
+        '''
+        src = 'file1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(dst, 0o755)
+
+        fd = cephfs.open(f'{src}', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        cephfs.stat(dst)
+        cephfs.stat(f'{dst}/file1')
+
+        # ensure src file was left as it is.
+        cephfs.stat(src)
+
+    def test_cptree_on_regfile_no_perms(self, testdir):
+        '''
+        Test that cptree() fails when src path passed to it is that of a regular
+        file and permissions are not granted on it.
+        '''
+        src = 'file1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(dst, 0o755)
+
+        fd = cephfs.open(src, 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.chmod(src, 0o000)
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        assert_raises(libcephfs.PermissionDenied, cephfs.cptree, src, dst,
+                      should_cancel, suppress_errors=False)
+
+        # ensure src file was left as it is.
+        cephfs.stat(src)
+
+    def test_cptree_on_symlink(self, testdir):
+        '''
+        Test that cptree() copies a symbolic link too when src path passed to it
+        is that of a symbolic link.
+        '''
+        file = 'file1'
+        slink = 'slink1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(dst, 0o755)
+
+        fd = cephfs.open(file, 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.symlink(file, slink)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(slink, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        cephfs.stat(f'{dst}/{slink}', follow_symlink=False)
+        cephfs.stat(file)
+        cephfs.stat(slink)
+
+    def test_cptree_on_symlink_no_perms(self, testdir):
+        file = 'file1'
+        slink = 'slink1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(dst, 0o755)
+
+        fd = cephfs.open(file, 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.symlink(file, slink)
+
+        cephfs.chmod(slink, 0o000)
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(slink, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        cephfs.stat(f'{dst}/{slink}', follow_symlink=False)
+        cephfs.stat(file)
+        cephfs.stat(slink)
+
+    def test_cptree_when_tree_contains_only_regfiles(self, testdir):
+        '''
+        Test cptree() successfully copies entire file hierarchy that contains
+        only regular files.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 6):
+            fd = cephfs.open(f'/{src}/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        cephfs.stat(src)
+        cephfs.stat(dst)
+        for i in range(1, 6):
+            cephfs.stat(f'{src}/file{i}')
+            cephfs.stat(f'{dst}/{src}/file{i}')
+
+    def test_cptree_when_tree_contains_dirs_and_regfiles(self, testdir):
+        '''
+        Test that cptree() successfully copies entire file hierarchy that
+        contains only directories and regular files.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 6):
+            cephfs.mkdir(f'/{src}/{src}{i}', 0o755)
+            for j in range(1, 6):
+                fd = cephfs.open(f'/{src}/{src}{i}/file{j}', 'w', 0o755)
+                cephfs.write(fd, b'abcd', 0)
+                cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        # verify that files are copied to dst path
+        for i in range(1, 6):
+            cephfs.stat(f'{dst}/{src}/{src}{i}')
+            for j in range(1, 6):
+                cephfs.stat(f'{src}/{src}{i}/file{j}')
+
+        # verify that files are as it is in src path
+        for i in range(1, 6):
+            cephfs.stat(f'{src}/{src}{i}')
+            for j in range(1, 6):
+                cephfs.stat(f'{src}/{src}{i}/file{j}')
+
+    def test_cptree_when_tree_contains_dirs_regfiles_and_symlinks(self, testdir):
+        '''
+        Test that cptree() successfully copies entire file hierarchy that
+        contains directories, regular files as well as symbolic links.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/{src}/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+            file_name = f'file{i}'.encode('utf-8')
+            slink_name = f'/{src}/slink{i}'.encode('utf-8')
+            cephfs.symlink(file_name, slink_name)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        # verify that files are copied to dst path
+        for i in range(1, 6):
+            cephfs.stat(f'{dst}/{src}/file{i}')
+            cephfs.stat(f'{dst}/{src}/slink{i}')
+
+        # verify that files are as it is in src path
+        for i in range(1, 6):
+            cephfs.stat(f'{src}/file{i}')
+            cephfs.stat(f'{src}/slink{i}')
+
+    def test_cptree_path_is_bytes_type(self, testdir):
+        '''
+        Test that cptree() successfully copies entire file hierarchy that
+        contains directories, regular files as well as symbolic links **EVEN
+        WHEN** src and dst path passed to cptree() are of bytes type instead
+        of str type.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/{src}/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+            file_name = f'file{i}'.encode('utf-8')
+            slink_name = f'/{src}/slink{i}'.encode('utf-8')
+            cephfs.symlink(file_name, slink_name)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        # NOTE: str and dst are and should be bytes type (not str type) for
+        # this test!
+        cephfs.cptree(src.encode('utf-8'), dst.encode('utf-8'),
+                      should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        # verify that files are copied to dst path
+        for i in range(1, 6):
+            cephfs.stat(f'{dst}/{src}/file{i}')
+            cephfs.stat(f'{dst}/{src}/slink{i}')
+
+        # verify that files are as it is in src path
+        for i in range(1, 6):
+            cephfs.stat(f'{src}/file{i}')
+            cephfs.stat(f'{src}/slink{i}')
+
+    def test_cptree_when_symlink_points_to_parent_dir(self, testdir):
+        '''
+        Test that cptree() successfully copies entire file hierarchy that
+        contains directories, regular files as well as symbolic links.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir3', 0o755)
+        cephfs.mkdir('dir3/dir4', 0o755)
+        cephfs.mkdir('dir5', 0o755)
+        cephfs.symlink('../dir4', 'dir3/dir4/slink1')
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree('dir3', 'dir5', should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        cephfs.stat('dir3/dir4/slink1')
+        cephfs.stat('dir5/dir3/dir4/slink1')
+
+    def test_cptree_when_tree_contains_only_empty_dirs(self, testdir):
+        '''
+        Test that cptree() successfully copies entire file hierarchy that contains
+        only empty directories.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 6):
+            cephfs.mkdir(f'/{src}/{src}{i}', 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        for i in range(1, 6):
+            cephfs.stat(f'/{dst}/{src}/{src}{i}', 0o755)
+            cephfs.stat(f'/{src}/{src}{i}', 0o755)
+
+    def test_cptree_when_root_is_empty_dir(self, testdir):
+        '''
+        Test that cptree() successfully copies an empty directory too.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        cephfs.stat(src)
+        cephfs.stat(f'{dst}/{src}')
+
+    def test_cptree_when_dirs_are_not_in_cwd(self, testdir):
+        '''
+        Test cptree when src and dst dir are not directly presenmt in CWD.
+        '''
+        should_cancel = lambda: False
+
+        for i in range(1, 6):
+            cephfs.mkdir(f'dir{i}', 0o755)
+            cephfs.chdir(f'dir{i}')
+        for i in range(1, 6):
+            fd = cephfs.open(f'file{i}', 'w', 0o644)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+        cephfs.chdir('/')
+
+        for i in range(6, 11):
+            cephfs.mkdir(f'dir{i}', 0o755)
+            cephfs.chdir(f'dir{i}')
+        cephfs.chdir('/')
+
+        src = 'dir1/dir2/dir3/dir4/dir5'
+        dst = 'dir6/dir7/dir8/dir9/dir10'
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel, suppress_errors=False)
+
+    def test_cptree_when_src_dir_is_ancestor_of_dst_dir(self, testdir):
+        '''
+        Test that cptree() fails with EPERM/PermissionError when src dir is
+        ancestor of dst dir.
+        '''
+        src = 'dir1'
+        dst = 'dir1/dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        assert_raises(libcephfs.PermissionError, cephfs.cptree, src, dst,
+                      should_cancel=should_cancel, suppress_errors=False)
+
+    def test_cptree_when_without_passing_should_cancel(self, testdir):
+        '''
+        Test that cptree() works fine even when should_cancel parameter is not
+        passed.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 6):
+            fd = cephfs.open(f'{src}/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, suppress_errors=False)
+
+        cephfs.stat(src)
+        cephfs.stat(dst)
+        for i in range(1, 6):
+            cephfs.stat(f'{src}/file{i}')
+            cephfs.stat(f'{dst}/{src}/file{i}')
+
+    def test_cptree_simulate_subvol_clone(self, testdir):
+        '''
+        Test cptree when src and dst dir are not directly present in CWD. Also
+        test that cp_src_dir=False leads to copying contents of src dir without
+        copying src dir on dst side.
+
+        This simulates how subvolumes are cloned, src subvol's UUID dir is not
+        copied but rather its contents are copied to dst subvol's UUID  dir.
+        '''
+        should_cancel = lambda: False
+
+        for i in range(1, 6):
+            cephfs.mkdir(f'dir{i}', 0o755)
+            cephfs.chdir(f'dir{i}')
+        for i in range(1, 6):
+            fd = cephfs.open(f'file{i}', 'w', 0o644)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+        cephfs.chdir('/')
+
+        for i in range(6, 11):
+            cephfs.mkdir(f'dir{i}', 0o755)
+            cephfs.chdir(f'dir{i}')
+        cephfs.chdir('/')
+
+        src = 'dir1/dir2/dir3/dir4/dir5'
+        dst = 'dir6/dir7/dir8/dir9/dir10'
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, cp_src_dir=False,
+                      should_cancel=should_cancel, suppress_errors=False)
+
+    def test_cptree_no_perm_on_nonroot_dir_suppress_errors(self, testdir):
+        '''
+        Test that cptree() successfully copies the entire file hierarchy except
+        the branch where permission for one of the (non-root) directories is not
+        granted while suppressing/not raising any errors for the dir for which
+        permission is not granted.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 6):
+            cephfs.mkdir(f'{src}/{src}{i}', 0o755)
+            for j in range(1, 6):
+                fd = cephfs.open(f'/{src}/{src}{i}/file{j}', 'w', 0o755)
+                cephfs.write(fd, b'abcd', 0)
+                cephfs.close(fd)
+
+        # actual test
+        cephfs.chmod(f'/{src}/{src}3', 0o000)
+        # Errors are expected from call to this method. Set suppress_errors to
+        # True to confirm that this argument works.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=True)
+
+        # ensure /dir1/dir3 wasn't copied
+        for i in range(1, 6):
+            for j in range(1, 6):
+                if i == 3:
+                    cephfs.stat(f'{src}/{src}{i}')
+                    cephfs.stat(f'{dst}/{src}/{src}{i}')
+                    assert_raises(libcephfs.ObjectNotFound, cephfs.stat,
+                                  f'{dst}/{src}/{src}{i}/file{j}')
+                else:
+                    cephfs.stat(f'{src}/{src}{i}/file{j}')
+                    cephfs.stat(f'{dst}/{src}/{src}{i}/file{j}')
+
+        cephfs.chmod(f'/{src}/{src}3', 0o755)
+        cephfs.chmod(f'/{dst}/{src}/{src}3', 0o755)
+
+    def test_cptree_no_perm_on_nonroot_dir_dont_suppress_errors(self, testdir):
+        '''
+        Test that cptree() aborts its attempt to copy the entire file hierarchy
+        when it finds a non-root directory where permission is not granted.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 6):
+            cephfs.mkdir(f'{src}/{src}{i}', 0o755)
+            for j in range(1, 6):
+                fd = cephfs.open(f'/{src}/{src}{i}/file{j}', 'w', 0o755)
+                cephfs.write(fd, b'abcd', 0)
+                cephfs.close(fd)
+
+        # actual test
+        cephfs.chmod(f'/{src}/{src}3', 0o000)
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        assert_raises(libcephfs.PermissionDenied, cephfs.cptree, src, dst,
+                      should_cancel, suppress_errors=False)
+
+        cephfs.chmod(f'/{src}/{src}3', 0o755)
+        cephfs.chmod(f'/{dst}/{src}/{src}3', 0o755)
+
+    def test_cptree_no_perm_on_root_suppress_errors(self, testdir):
+        '''
+        Test cptree() exits without error when permission is not granted for
+        the root of the file hierarchy.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.chmod(src, 0o000)
+        # Errors are expected from call to this method. Set suppress_errors to
+        # True to confirm that this argument works.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=True)
+
+        # cleanup
+        cephfs.chmod('/dir1', 0o755)
+
+    def test_cptree_no_perm_on_root_dont_suppress_errors(self, testdir):
+        '''
+        Test cptree() aborts with error when permission is not granted for the
+        root of the file hierarchy.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.chmod('/dir1', 0o000)
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        assert_raises(libcephfs.PermissionDenied, cephfs.cptree, src, dst,
+                      should_cancel=should_cancel, suppress_errors=False)
+
+        # cleanup
+        cephfs.chmod('/dir1', 0o755)
+
+    def test_cptree_on_tree_with_snaps(self, testdir):
+        '''
+        Test that cptree() successfully copies the entire file hierarchy except
+        the snapshot.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        cephfs.mkdir('dir1/dir11', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/dir11/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.mksnap('/dir1/dir11', 'snap1', 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        for i in range(1, 6):
+            cephfs.stat(f'{dst}/{src}/dir11/file{i}')
+            # ensure src was left as it was.
+            cephfs.stat(f'{src}/dir11/file{i}')
+
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat,
+                      f'/{dst}/{src}/dir11/.snap/snap1')
+        # cleanup
+        cephfs.rmsnap('/dir1/dir11', 'snap1')
+
+    def test_cptree_on_tree_with_snaps_on_root(self, testdir):
+        '''
+        Test that cptree() successfully copies the entire file hierarchy except
+        the snapshot.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 6):
+            fd = cephfs.open(f'/{src}/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.mksnap(src, 'snap1', 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        for i in range(1, 6):
+            cephfs.stat(f'{dst}/{src}/file{i}')
+            # ensure src was left as it was.
+            cephfs.stat(f'{src}/file{i}')
+
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat,
+                      f'/{dst}/{src}/.snap/snap1')
+        # cleanup
+        cephfs.rmsnap('/dir1', 'snap1')
+
+    def get_file_count(self, dir_path):
+        '''
+        Return the number of files present in the given directory.
+        '''
+        i = 0
+        with cephfs.opendir(dir_path) as dir_handle:
+            de = cephfs.readdir(dir_handle)
+            while de:
+                if de.d_name not in (b'.', b'..'):
+                    i += 1
+                de = cephfs.readdir(dir_handle)
+        return i
+
+    def test_cptree_aborts_when_should_cancel_is_true(self, testdir):
+        '''
+        Test that cptree() stops copying the file hierarchy when the return
+        value of "should_cancel" becomes True.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        # populate with enough files that copying doesn't finish before
+        # cancel fag is set.
+        cephfs.chdir(src)
+        for i in range(1, 101):
+            fd = cephfs.open(f'file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+        cephfs.chdir('/')
+
+        # NOTE: this method is just a wrapper to provide an appropriate location
+        # to catch the exception OpCanceled. If left uncaught the test passes
+        # but pytest fails citing this exception.
+        def cptree_assert_wrapper(src, dst, should_cancel, suppress_error=False):
+            assert_raises(libcephfs.OpCanceled, cephfs.cptree, src, dst, False, True,
+                          should_cancel, suppress_error)
+
+        from threading import Event, Thread
+        cancel_flag = Event()
+        def should_cancel():
+            # this would force libcephfs's cptree() to sleep every time
+            # should_cancel is called. this is necessary to ensure copying
+            # won't finish before cancel flag is set.
+            time.sleep(0.1)
+            return cancel_flag.is_set()
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        Thread(target=cptree_assert_wrapper,
+               args=(src, dst, should_cancel, False)).start()
+        time.sleep(1)
+        # this will change return value of should_cancel and therefore halt
+        # execution of cptree()
+        cancel_flag.set()
+
+        # ensure that copying had begun
+        cephfs.stat(f'{dst}/{src}')
+        # ensure that deletion had begun but hadn't finished and was halted
+        file_count1 = self.get_file_count(f'{dst}/{src}')
+        assertion_msg = f'file_count1 = {file_count1}'
+        assert file_count1 > 0 and file_count1 < 100, assertion_msg
+
+        # ensure that deletion has made no progress since it was halted
+        time.sleep(2)
+        file_count2 = self.get_file_count(f'{dst}/{src}')
+        assertion_msg = f'file_count2 = {file_count2}'
+        assert file_count2 > 0 and file_count2 < 100, assertion_msg
+        assertion_msg = f'file_count1 = {file_count1} file_count2 = {file_count2}'
+        assert file_count1 == file_count2, assertion_msg
+
+    def test_cptree_with_sync_attrs(self, testdir):
+        '''
+        Test that when should_sync_attrs=True for cptree(), attributes
+        specifically uid, gid, owner, mode, atime and mtime) are synced
+        on dst files to match src files.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir(b'dir1', 0o755)
+        cephfs.mkdir(b'dir2', 0o755)
+
+        cephfs.mkdir(b'dir1/dir11', 0o755)
+
+        fd = cephfs.open(b'dir1/file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.symlink('file1', 'dir1/slink1')
+
+        # sleep before running cptree so that by default atime/mtime on dst
+        # side are different. this allows us to test whether attrs are sync'd
+        # by cptree.
+        time.sleep(2)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree('dir1', 'dir2', should_sync_attrs=True,
+                      should_cancel=should_cancel, suppress_errors=False)
+
+        # assert that attrs were synced
+
+        flags = (libcephfs.CEPH_STATX_UID | libcephfs.CEPH_STATX_GID |
+                 libcephfs.CEPH_STATX_MODE | libcephfs.CEPH_STATX_ATIME |
+                 libcephfs.CEPH_STATX_MTIME)
+
+        src_dir_stx_b = cephfs.statx('dir1/dir11', flags,
+                                     libcephfs.AT_SYMLINK_NOFOLLOW)
+        src_file_stx_b = cephfs.statx('dir1/file1', flags,
+                                      libcephfs.AT_SYMLINK_NOFOLLOW)
+        src_slink_stx_b = cephfs.statx('dir1/slink1', flags,
+                                       libcephfs.AT_SYMLINK_NOFOLLOW)
+
+        dst_dir_stx_b = cephfs.statx('dir2/dir1/dir11', flags,
+                                     libcephfs.AT_SYMLINK_NOFOLLOW)
+        dst_file_stx_b = cephfs.statx('dir2/dir1/file1', flags,
+                                      libcephfs.AT_SYMLINK_NOFOLLOW)
+        dst_slink_stx_b = cephfs.statx('dir2/dir1/slink1', flags,
+                                       libcephfs.AT_SYMLINK_NOFOLLOW)
+
+        assert_equal(src_file_stx_b['uid'], dst_file_stx_b['uid'])
+        assert_equal(src_slink_stx_b['uid'], dst_slink_stx_b['uid'])
+        assert_equal(src_dir_stx_b['uid'], dst_dir_stx_b['uid'])
+
+        assert_equal(src_file_stx_b['gid'], dst_file_stx_b['gid'])
+        assert_equal(src_slink_stx_b['gid'], dst_slink_stx_b['gid'])
+        assert_equal(src_dir_stx_b['gid'], dst_dir_stx_b['gid'])
+
+        assert_equal(src_file_stx_b['mode'], dst_file_stx_b['mode'])
+        assert_equal(src_slink_stx_b['mode'], dst_slink_stx_b['mode'])
+        assert_equal(src_dir_stx_b['mode'], dst_dir_stx_b['mode'])
+
+        assert_equal(src_file_stx_b['atime'], dst_file_stx_b['atime'])
+        assert_equal(src_slink_stx_b['atime'], dst_slink_stx_b['atime'])
+        assert_equal(src_dir_stx_b['atime'], dst_dir_stx_b['atime'])
+
+        assert_equal(src_file_stx_b['mtime'], dst_file_stx_b['mtime'])
+        assert_equal(src_slink_stx_b['mtime'], dst_slink_stx_b['mtime'])
+        assert_equal(src_dir_stx_b['mtime'], dst_dir_stx_b['mtime'])
+
+    def test_cptree_without_sync_attrs(self, testdir):
+        '''
+        Test that when should_sync_attrs=False for cptree(), attributes
+        (specifically uid, gid, owner, mode, atime and mtime) are synced on dst
+        files to match src files.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir(b'dir1', 0o755)
+        cephfs.mkdir(b'dir2', 0o755)
+
+        cephfs.mkdir(b'dir1/dir11', 0o755)
+
+        fd = cephfs.open(b'dir1/file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.symlink('file1', 'dir1/slink1')
+
+        # sleep before running cptree so that by default atime/mtime on dst
+        # side are different. this allows us to test whether attrs are sync'd
+        # by cptree().
+        time.sleep(2)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree('dir1', 'dir2', should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        # assert that attrs were not synced, for this test specifically atime
+        # and mtime would be different.
+
+        flags = (libcephfs.CEPH_STATX_UID | libcephfs.CEPH_STATX_GID |
+                 libcephfs.CEPH_STATX_MODE | libcephfs.CEPH_STATX_ATIME |
+                 libcephfs.CEPH_STATX_MTIME)
+
+        src_dir_stx_b = cephfs.statx('dir1/dir11', flags,
+                                     libcephfs.AT_SYMLINK_NOFOLLOW)
+        src_file_stx_b = cephfs.statx('dir1/file1', flags,
+                                      libcephfs.AT_SYMLINK_NOFOLLOW)
+        src_slink_stx_b = cephfs.statx('dir1/slink1', flags,
+                                       libcephfs.AT_SYMLINK_NOFOLLOW)
+
+        dst_dir_stx_b = cephfs.statx('dir2/dir1/dir11', flags,
+                                     libcephfs.AT_SYMLINK_NOFOLLOW)
+        dst_file_stx_b = cephfs.statx('dir2/dir1/file1', flags,
+                                      libcephfs.AT_SYMLINK_NOFOLLOW)
+        dst_slink_stx_b = cephfs.statx('dir2/dir1/slink1', flags,
+                                       libcephfs.AT_SYMLINK_NOFOLLOW)
+
+        assert_equal(src_file_stx_b['uid'], dst_file_stx_b['uid'])
+        assert_equal(src_slink_stx_b['uid'], dst_slink_stx_b['uid'])
+        assert_equal(src_dir_stx_b['uid'], dst_dir_stx_b['uid'])
+
+        assert_equal(src_file_stx_b['gid'], dst_file_stx_b['gid'])
+        assert_equal(src_slink_stx_b['gid'], dst_slink_stx_b['gid'])
+        assert_equal(src_dir_stx_b['gid'], dst_dir_stx_b['gid'])
+
+        assert_equal(src_file_stx_b['mode'], dst_file_stx_b['mode'])
+        assert_equal(src_slink_stx_b['mode'], dst_slink_stx_b['mode'])
+        assert_equal(src_dir_stx_b['mode'], dst_dir_stx_b['mode'])
+
+        assert_lesser(src_file_stx_b['atime'], dst_file_stx_b['atime'])
+        assert_lesser(src_slink_stx_b['atime'], dst_slink_stx_b['atime'])
+        assert_lesser(src_dir_stx_b['atime'], dst_dir_stx_b['atime'])
+
+        assert_lesser(src_file_stx_b['mtime'], dst_file_stx_b['mtime'])
+        assert_lesser(src_slink_stx_b['mtime'], dst_slink_stx_b['mtime'])
+        assert_lesser(src_dir_stx_b['mtime'], dst_dir_stx_b['mtime'])
+
+    def test_cptree_on_a_200_dir_broad_tree(self, testdir):
+        '''
+        Test that cptree() successfully copies a file hierarchy with 200
+        subdirectories on the same level.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 201):
+            cephfs.mkdir(f'{src}/{src}{i}', 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        for i in range(1, 201):
+            cephfs.stat(f'{src}/{src}{i}')
+            cephfs.stat(f'{dst}/{src}/{src}{i}')
+
+    def test_cptree_on_a_2k_dir_broad_tree(self, testdir):
+        '''
+        Test that cptree() successfully copies a file hierarchy with 2000
+        subdirectories on the same level.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        for i in range(1, 2001):
+            cephfs.mkdir(f'{src}/{src}{i}', 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        for i in range(1, 2001):
+            cephfs.stat(f'{src}/{src}{i}')
+            cephfs.stat(f'{dst}/{src}/{src}{i}')
+
+    def test_cptree_on_a_200_dir_deep_tree(self, testdir):
+        '''
+        Test that cptree() successfully copies a file hierarchy with 200
+        levels.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        cephfs.chdir(src)
+        for i in range(1, 201):
+            dirname = f'dir{i}'
+            cephfs.mkdir(dirname, 0o755)
+            cephfs.chdir(dirname)
+        cephfs.chdir('/')
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        # verify the dst has the entire file hierarchy cloned
+        cephfs.chdir(dst)
+        cephfs.chdir(src)
+        for i in range(1, 201):
+            dirname = f'dir{i}'
+            cephfs.stat(dirname, 0o755)
+            cephfs.chdir(dirname)
+        cephfs.chdir('/')
+
+        # verify the src has the entire file hierarchy as it was
+        cephfs.chdir(src)
+        for i in range(1, 201):
+            dirname = f'dir{i}'
+            cephfs.stat(dirname, 0o755)
+            cephfs.chdir(dirname)
+        cephfs.chdir('/')
+
+    def test_cptree_on_a_2k_dir_deep_tree(self, testdir):
+        '''
+        Test that cptree() successfully copies a file hierarchy with 2000
+        levels.
+        '''
+        src = 'dir1'
+        dst = 'dir2'
+        should_cancel = lambda: False
+
+        cephfs.mkdir(src, 0o755)
+        cephfs.mkdir(dst, 0o755)
+
+        cephfs.chdir(src)
+        for i in range(1, 2001):
+            dirname = f'dir{i}'
+            cephfs.mkdir(dirname, 0o755)
+            cephfs.chdir(dirname)
+        cephfs.chdir('/')
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.cptree(src, dst, should_cancel=should_cancel,
+                      suppress_errors=False)
+
+        # verify the dst has the entire file hierarchy cloned
+        cephfs.chdir(dst)
+        cephfs.chdir(src)
+        for i in range(1, 2001):
+            dirname = f'dir{i}'
+            cephfs.stat(dirname, 0o755)
+            cephfs.chdir(dirname)
+        cephfs.chdir('/')
+
+        # verify the src has the entire file hierarchy as it was
+        cephfs.chdir(src)
+        for i in range(1, 2001):
+            dirname = f'dir{i}'
+            cephfs.stat(dirname, 0o755)
+            cephfs.chdir(dirname)
+        cephfs.chdir('/')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76593, https://tracker.ceph.com/issues/79767

---

backport of https://github.com/ceph/ceph/pull/64774, https://github.com/ceph/ceph/pull/65496
parent tracker: https://tracker.ceph.com/issues/72357, https://tracker.ceph.com/issues/72992, https://tracker.ceph.com/issues/73998, https://tracker.ceph.com/issues/73999

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh