### PR TITLE
squid: rbd-mirror: take MirrorStatusUpdater lock by value in queue_update_task

### DIFF
--- a/src/tools/rbd_mirror/MirrorStatusUpdater.cc
+++ b/src/tools/rbd_mirror/MirrorStatusUpdater.cc
@@ -277,7 +277,7 @@ void MirrorStatusUpdater<I>::handle_timer_task(int r) {
 
 template <typename I>
 void MirrorStatusUpdater<I>::queue_update_task(
-  std::unique_lock<ceph::mutex>&& locker) {
+  std::unique_lock<ceph::mutex> locker) {
   if (!m_initialized) {
     return;
   }

--- a/src/tools/rbd_mirror/MirrorStatusUpdater.h
+++ b/src/tools/rbd_mirror/MirrorStatusUpdater.h
@@ -105,7 +105,7 @@ private:
   void schedule_timer_task();
   void handle_timer_task(int r);
 
-  void queue_update_task(std::unique_lock<ceph::mutex>&& locker);
+  void queue_update_task(std::unique_lock<ceph::mutex> locker);
   void update_task(int r);
   void handle_update_task(int r);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78275

---

backport of https://github.com/ceph/ceph/pull/70033
parent tracker: https://tracker.ceph.com/issues/78047