### PR TITLE
squid: rbd-mirror: return after finishing on unsupported mirror mode

### DIFF
--- a/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.cc
@@ -153,7 +153,7 @@ void PrepareLocalImageRequest<I>::handle_get_mirror_info(int r) {
     derr << "unsupported mirror image mode " << m_mirror_image.mode << " "
          << "for image " << m_global_image_id << dendl;
     finish(-EOPNOTSUPP);
-    break;
+    return;
   }
 
   dout(10) << "local_image_id=" << m_local_image_id << ", "


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78278

---

backport of https://github.com/ceph/ceph/pull/69992
parent tracker: https://tracker.ceph.com/issues/78043