### PR TITLE
test: Modify split_op_cxx to use pool chunk size instead of assuming 4k

### DIFF
--- a/src/test/librados/split_op_cxx.cc
+++ b/src/test/librados/split_op_cxx.cc
@@ -292,7 +292,7 @@ TEST_P(LibRadosSplitOpECPP, SmallRead) {
 TEST_P(LibRadosSplitOpECPP, ReadTwoShards) {
   SKIP_IF_CRIMSON();
   bufferlist bl;
-  bl.append_zero(8*1024);
+  bl.append_zero(2 * get_ec_stripe_unit());
   ObjectWriteOperation write1;
   write1.write(0, bl);
   ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "foo", &write1));
@@ -309,7 +309,7 @@ TEST_P(LibRadosSplitOpECPP, ReadTwoShards) {
 TEST_P(LibRadosSplitOpECPP, ReadSecondShard) {
   SKIP_IF_CRIMSON();
   bufferlist bl;
-  bl.append_zero(8*1024);
+  bl.append_zero(2 * get_ec_stripe_unit());
   ObjectWriteOperation write1;
   write1.write(0, bl);
   ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "foo", &write1));
@@ -318,7 +318,7 @@ TEST_P(LibRadosSplitOpECPP, ReadSecondShard) {
 
   ioctx.set_no_version_on_read(true);
   ObjectReadOperation read;
-  read.read(4*1024, 4*1024, NULL, NULL);
+  read.read(get_ec_stripe_unit(), get_ec_stripe_unit(), NULL, NULL);
   ASSERT_TRUE(AssertOperateWithSplitOp(0, "foo", &read, &bl, balanced_read_flags));
   ioctx.set_no_version_on_read(false);
 }
@@ -326,7 +326,7 @@ TEST_P(LibRadosSplitOpECPP, ReadSecondShard) {
 TEST_P(LibRadosSplitOpECPP, ReadSecondShardWithVersion) {
   SKIP_IF_CRIMSON();
   bufferlist bl;
-  bl.append_zero(8*1024);
+  bl.append_zero(2 * get_ec_stripe_unit());
   ObjectWriteOperation write1;
   write1.write(0, bl);
   ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "foo", &write1));
@@ -334,7 +334,7 @@ TEST_P(LibRadosSplitOpECPP, ReadSecondShardWithVersion) {
   ensure_log_committed("foo", 0, bl.length());
 
   ObjectReadOperation read;
-  read.read(4*1024, 4*1024, NULL, NULL);
+  read.read(get_ec_stripe_unit(), get_ec_stripe_unit(), NULL, NULL);
   ASSERT_TRUE(AssertOperateWithSplitOp(0, 2, "foo", &read, &bl, balanced_read_flags));
 }
 
@@ -399,9 +399,9 @@ TEST_P(LibRadosSplitOpECPP, Stat) {
 
 TEST_P(LibRadosSplitOpECPP, StatBeforeRead) {
   SKIP_IF_CRIMSON();
-  // Use 8KB buffer to ensure the read spans multiple EC chunks and triggers split op
+  // Read spans multiple EC chunks and triggers split op
   bufferlist bl;
-  bl.append_zero(8*1024);
+  bl.append_zero(2 * get_ec_stripe_unit());
   ObjectWriteOperation write1;
   write1.write(0, bl);
   ASSERT_TRUE(AssertOperateWithoutSplitOp(0, "foo", &write1));
@@ -427,25 +427,25 @@ TEST_P(LibRadosSplitOpECPP, StatBeforeRead) {
   int read_rval;
   
   read.stat2(&size, &time, &stat_rval);  // STAT comes FIRST
-  read.read(0, bl.length(), &read_bl, &read_rval);  // READ comes SECOND (8KB, spans multiple chunks)
+  read.read(0, bl.length(), &read_bl, &read_rval);  // READ comes SECOND (spans multiple chunks)
 
   // This operation should fail or demonstrate the bug
   bufferlist result_bl;
   ASSERT_TRUE(AssertOperateWithSplitOp(0, 2, "foo", &read, &result_bl, balanced_read_flags));
   ASSERT_EQ(0, stat_rval);
   ASSERT_EQ(0, read_rval);
-  ASSERT_EQ(8*1024, size);
-  ASSERT_EQ(8*1024, read_bl.length());
+  ASSERT_EQ(2 * get_ec_stripe_unit(), size);
+  ASSERT_EQ(2 * get_ec_stripe_unit(), read_bl.length());
 }
 
 TEST_P(LibRadosSplitOpECPP, GetXattrBeforeRead) {
   SKIP_IF_CRIMSON();
-  // Use 8KB buffer to ensure the read spans multiple EC chunks and triggers split op
+  // Read spans multiple EC chunks and triggers split op
   bufferlist bl, attr_bl, attr_read_bl;
   std::string attr_key = "my_key";
   std::string attr_value = "my_attr";
 
-  bl.append_zero(8*1024);
+  bl.append_zero(2 * get_ec_stripe_unit());
   ObjectWriteOperation write1;
   write1.write(0, bl);
   encode(attr_value, attr_bl);
@@ -461,13 +461,13 @@ TEST_P(LibRadosSplitOpECPP, GetXattrBeforeRead) {
   int read_rval;
   
   read.getxattr(attr_key.c_str(), &attr_read_bl, &getxattr_rval);  // GETXATTR FIRST
-  read.read(0, bl.length(), &read_bl, &read_rval);  // READ SECOND (8KB, spans multiple chunks)
+  read.read(0, bl.length(), &read_bl, &read_rval); // READ SECOND (spans multiple chunks)
 
   bufferlist result_bl;
   ASSERT_TRUE(AssertOperateWithSplitOp(0, 2, "foo", &read, &result_bl, balanced_read_flags));
   ASSERT_EQ(0, getxattr_rval);
   ASSERT_EQ(0, read_rval);
-  ASSERT_EQ(8*1024, read_bl.length());
+  ASSERT_EQ(2 * get_ec_stripe_unit(), read_bl.length());
 }
 
 TEST_P(LibRadosSplitOpPP, CancelReplica)

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -474,6 +474,32 @@ void RadosTestECPP::set_allow_ec_overwrites()
   }
 }
 
+// Query the stripe_unit for an EC pool via "ceph osd dump".
+// Don't use erasure-code profile as that doesn't always contain the stripe_unit.
+uint64_t RadosTestECPP::get_ec_stripe_unit()
+{
+  bufferlist outbl;
+  EXPECT_EQ(0, cluster.mon_command(
+    "{\"prefix\": \"osd dump\", \"format\": \"json\"}", {}, &outbl, nullptr));
+
+  JSONParser p;
+  ceph_assert(p.parse(outbl.c_str(), outbl.length()));
+  JSONObj *pools_obj = p.find_obj("pools");
+  ceph_assert(pools_obj);
+  for (JSONObjIter it = pools_obj->find_first(); !it.end(); ++it) {
+    JSONObj *pool = *it;
+    std::string name;
+    JSONDecoder::decode_json("pool_name", name, pool, true);
+    if (name == pool_name) {
+      uint64_t stripe_width, k;
+      JSONDecoder::decode_json("stripe_width", stripe_width, pool, true);
+      JSONDecoder::decode_json("ec_data_shard_count", k, pool, true);
+      return stripe_width / k;
+    }
+  }
+  ceph_abort_msg("pool not found in osd dump");
+}
+
 void RadosTestECPP::wait_for_stable_acting_set(const std::string &objname) {
   ceph::consistency::RadosCommands ec_commands(s_cluster);
 

--- a/src/test/librados/testcase_cxx.h
+++ b/src/test/librados/testcase_cxx.h
@@ -205,6 +205,7 @@ protected:
   static void SetUpTestCase();
   static void TearDownTestCase();
   void set_allow_ec_overwrites();
+  uint64_t get_ec_stripe_unit();
   static std::string pool_name_default;
   static std::string pool_name_fast;
   void inject_ec_read_error(const std::string &objname);


### PR DESCRIPTION
When creating new EC pools, we no longer use 4k statically as the default value if nothing is set. Instead, in OSDMonitor::prepare_pool_stripe_width we choose eith 4K or 16K based on whether we support optimisations and have optimisations enabled on the pool. Because of this, when running split_op_cxx tests without osd_pool_erasure_code_stripe_unit set, you would see some failures where the test was trying to send an IO that should be split, but was not split due to the 16K chunk size.

This fixes the issue by determining the stripe unit of the pool before deciding on the size of the IO so we can always send two chunks worth of data, and should protect the tests if the default chunk size is increased again in the future as well.


Assisted-by: IBM Bob 2.0.4





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
