### PR TITLE
mgr/dashboard: fix osd_removal status dict serialization 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -218,7 +218,7 @@ class Osd(RESTController):
     def get_removing_osds() -> Optional[List[int]]:
         orch = OrchClient.instance()
         if orch.available(features=[OrchFeature.OSD_GET_REMOVE_STATUS]):
-            return [osd.osd_id for osd in orch.osds.removing_status()]
+            return [osd['osd_id'] for osd in orch.osds.removing_status()]
         return None
 
     @staticmethod
@@ -340,7 +340,7 @@ class Osd(RESTController):
         while True:
             removal_osds = orch.osds.removing_status()
             logger.info('Current removing OSDs %s', removal_osds)
-            pending = [osd for osd in removal_osds if osd.osd_id == int(svc_id)]
+            pending = [osd for osd in removal_osds if osd['osd_id'] == int(svc_id)]
             if not pending:
                 break
             logger.info('Wait until osd.%s is removed...', svc_id)

--- a/src/pybind/mgr/dashboard/tests/test_osd.py
+++ b/src/pybind/mgr/dashboard/tests/test_osd.py
@@ -495,3 +495,38 @@ class OsdTest(ControllerTestCase):
         self.assertFalse(res['options'][OsdDeploymentOptions.COST_CAPACITY]['available'])
         self.assertFalse(res['options'][OsdDeploymentOptions.THROUGHPUT]['available'])
         self.assertTrue(res['options'][OsdDeploymentOptions.IOPS]['available'])
+
+    @mock.patch('dashboard.controllers.osd.time.sleep')
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_osd_delete_with_dict_status(self, instance, mock_sleep):
+        fake_client = mock.Mock()
+        instance.return_value = fake_client
+        fake_client.get_missing_features.return_value = []
+
+        fake_client.osds.removing_status.side_effect = [
+            [{'osd_id': 7, 'started': True, 'draining': False}],
+            []
+        ]
+
+        self._task_delete('/api/osd/7?force=true&preserve_id=true')
+        self.assertStatus(204)
+
+        fake_client.osds.remove.assert_called_once_with(['7'], True)
+        self.assertEqual(fake_client.osds.removing_status.call_count, 2)
+        mock_sleep.assert_called_once_with(60)
+
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_get_removing_osds_with_dict_status(self, instance):
+        fake_client = mock.Mock()
+        instance.return_value = fake_client
+        fake_client.get_missing_features.return_value = []
+
+        fake_client.osds.removing_status.return_value = [
+            {'osd_id': 7, 'started': True},
+            {'osd_id': 8, 'started': False}
+        ]
+
+        osd = Osd()
+        removing_osds = osd.get_removing_osds()
+
+        self.assertEqual(removing_osds, [7, 8])


### PR DESCRIPTION
After https://github.com/ceph/ceph/pull/67858, the `orch.osds.removing_status()` has changed the way it gives the response. its now serializes the output and dashboard fails to deserialize that properly. Fixing that here..

Currently, when you try to delete osd from the UI, it raises the below traceback

```
2026-08-24T10:33:33.647+0000 7f15c16fc6c0  0 [dashboard ERROR dashboard.tools] Error while calling Task(ns=osd/delete, md={'svc_id': '7'})
Traceback (most recent call last):
  File "/usr/share/ceph/mgr/dashboard/tools.py", line 551, in _run
    val = self.task.fn(*self.task.fn_args, **self.task.fn_kwargs)  # type: ignore
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/ceph/mgr/dashboard/controllers/osd.py", line 343, in delete
    pending = [osd for osd in removal_osds if osd.osd_id == int(svc_id)]
                                              ^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'osd_id'
```

Fixes: https://tracker.ceph.com/issues/79802





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
