### PR TITLE
qa/tasks/workunit: skip keyring merge if ceph-authtool is absent

### DIFF
--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -468,32 +468,45 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                 except FileNotFoundError:
                     log.info("no cluster keyring found; skipping keyring imports")
                 else:
-                    client_keyring = f'/etc/ceph/{cluster}.client.{id_}.keyring'
-                    admin_keyring = f'/etc/ceph/{cluster}.client.admin.keyring'
-                    #tmp_keyring = f'{scratch_tmp}/workunit.client.{id_}.keyring'
-                    tmp_keyring = cluster_keyring
-                    remote.run(
-                        args=[
-                            'sudo',
-                            'ceph-authtool',
-                            tmp_keyring,
-                            '--import-keyring',
-                            client_keyring,
-                        ],
-                    )
-                    # admin_keyring may be a key type not understood
-                    try:
+                    have_authtool = remote.run(
+                        args=['sh', '-c', 'command -v ceph-authtool'],
+                        check_status=False,
+                    ).exitstatus == 0
+                    if not have_authtool:
+                        # workunits that only reach ceph via
+                        # `cephadm shell` (not CEPH_KEYRING/default identity
+                        # resolution on the host) don't need this merge
+                        log.info(
+                            "ceph-authtool not present on host; skipping"
+                            " keyring merge"
+                        )
+                    else:
+                        client_keyring = f'/etc/ceph/{cluster}.client.{id_}.keyring'
+                        admin_keyring = f'/etc/ceph/{cluster}.client.admin.keyring'
+                        #tmp_keyring = f'{scratch_tmp}/workunit.client.{id_}.keyring'
+                        tmp_keyring = cluster_keyring
                         remote.run(
                             args=[
                                 'sudo',
                                 'ceph-authtool',
                                 tmp_keyring,
                                 '--import-keyring',
-                                admin_keyring,
+                                client_keyring,
                             ],
                         )
-                    except:
-                        log.info("admin key type not understood")
+                        # admin_keyring may be a key type not understood
+                        try:
+                            remote.run(
+                                args=[
+                                    'sudo',
+                                    'ceph-authtool',
+                                    tmp_keyring,
+                                    '--import-keyring',
+                                    admin_keyring,
+                                ],
+                            )
+                        except:
+                            log.info("admin key type not understood")
 
                 args = [
                     'cd', '--', scratch_tmp,


### PR DESCRIPTION
## Problem

After the recent changed in [97e0bd33469]( https://github.com/ceph/ceph/commit/97e0bd334698852b0c33bbbe9ba62e9211ea7939) `qa/tasks/workunit.py` merges the assigned client's keyring and the admin keyring into `/etc/ceph/{cluster}.keyring` via `sudo ceph-authtool --import-keyring` on the bare test host, before running any workunit.

AFAIK `orch:cephadm` suites don't install ceph packages on the bare & everything runs in containers, so I believe `ceph-authtool` isn't present there. Any such suite that uses like for example `smb.workunit:` (without an `install:`) task fails with:
```
sudo: ceph-authtool: command not found
```
Here's one one of the recent teuthology run with same failure: 
https://pulpito-ng.ceph.com/runs/avan-2026-08-20_14:18:07-orch:cephadm:smb-wip-athakkar-testing-2026-08-20-1637-distro-default-trial 



## Fix

Check whether `ceph-authtool` is present on the remote host before attempting the merge; skip with a log message if it isn't, instead of failing.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
