### PR TITLE
mgr/dashboard: Update host access status when initiator is not present

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.spec.ts
@@ -212,10 +212,17 @@ describe('NvmeofSubsystemOverviewComponent', () => {
       allow_any_host: false
     });
     // Both modes are valid configuration — neither should map to a health status icon.
-    expect(f.componentInstance.getHostAccessLabel(false)).toBe('Restrict to specific hosts');
-    expect(f.componentInstance.getHostAccessLabel(true)).toBe('Allow all hosts');
+    expect(f.componentInstance.getHostAccessLabel(false, 1)).toBe('Restrict to specific hosts');
+    expect(f.componentInstance.getHostAccessLabel(true, 0)).toBe('Allow all hosts');
     expect((f.componentInstance as any).getStatusIcon).toBeUndefined();
     expect(f.nativeElement.textContent).toContain('Restrict to specific hosts');
+  }));
+
+  it('should show N/A for host access when not allow-all and initiator list is empty', fakeAsync(async () => {
+    TestBed.resetTestingModule();
+    const f = await createTestBed([], { ...mockSubsystem, allow_any_host: false });
+    expect(f.nativeElement.textContent).toContain('N/A');
+    expect(f.nativeElement.textContent).not.toContain('Restrict to specific hosts');
   }));
 
   it('should show Allow all hosts when synthetic Any initiator is present', fakeAsync(async () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystem-overview/nvmeof-subsystem-overview.component.ts
@@ -90,12 +90,13 @@ export class NvmeofSubsystemOverviewComponent implements OnInit, OnDestroy {
       const initiatorList = normalizeInitiators(initiators);
       this.buildDetails(
         getSubsystemAuthStatus(this.subsystem, initiatorList),
-        isSubsystemAllowAllHosts(this.subsystem, initiatorList)
+        isSubsystemAllowAllHosts(this.subsystem, initiatorList),
+        initiatorList.length
       );
     });
   }
 
-  private buildDetails(authStatus: string, allowAllHosts: boolean) {
+  private buildDetails(authStatus: string, allowAllHosts: boolean, initiatorCount: number = 0) {
     this.details = [
       {
         label: $localize`Serial number`,
@@ -118,7 +119,7 @@ export class NvmeofSubsystemOverviewComponent implements OnInit, OnDestroy {
       },
       {
         label: $localize`Host access`,
-        value: this.getHostAccessLabel(allowAllHosts),
+        value: this.getHostAccessLabel(allowAllHosts, initiatorCount),
         type: 'host-access',
         row: 2
       },
@@ -176,8 +177,10 @@ export class NvmeofSubsystemOverviewComponent implements OnInit, OnDestroy {
   }
 
   /** Host access is configuration text, not a health state. */
-  getHostAccessLabel(allowAllHosts: boolean): string {
-    return allowAllHosts ? $localize`Allow all hosts` : $localize`Restrict to specific hosts`;
+  getHostAccessLabel(allowAllHosts: boolean, initiatorCount: number = 0): string {
+    if (allowAllHosts) return $localize`Allow all hosts`;
+    if (initiatorCount === 0) return $localize`N/A`;
+    return $localize`Restrict to specific hosts`;
   }
 
   getAuthStatusIcon(authStatus: string): keyof typeof ICON_TYPE {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.spec.ts
@@ -46,9 +46,16 @@ describe('NvmeofSubsystemsStepFourComponent', () => {
     expect(component.hostAccessLabel).toContain('All');
   });
 
-  it('should return correct host access label for SPECIFIC hosts', () => {
+  it('should return correct host access label for SPECIFIC hosts with hosts added', () => {
     component.hostType = HOST_TYPE.SPECIFIC;
+    component.addedHosts = ['nqn.2014-08.org.nvmexpress:uuid:host-1'];
     expect(component.hostAccessLabel).toContain('Restricted');
+  });
+
+  it('should return N/A for host access label when SPECIFIC hosts list is empty', () => {
+    component.hostType = HOST_TYPE.SPECIFIC;
+    component.addedHosts = [];
+    expect(component.hostAccessLabel).toBe('N/A');
   });
 
   it('should return correct auth type label', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystem-step-4/nvmeof-subsystem-step-4.component.ts
@@ -40,7 +40,9 @@ export class NvmeofSubsystemsStepFourComponent implements OnInit, TearsheetStep 
   }
 
   get hostAccessLabel(): string {
-    return this.hostType === HOST_TYPE.ALL ? $localize`All hosts` : $localize`Restricted`;
+    if (this.hostType === HOST_TYPE.ALL) return $localize`All hosts`;
+    if (!this.addedHosts?.length) return $localize`N/A`;
+    return $localize`Restricted`;
   }
 
   get hostCount(): number {


### PR DESCRIPTION


https://github.com/user-attachments/assets/63a0a3e0-a2b3-405f-a69e-81452b637069



Fixes: https://tracker.ceph.com/issues/79805

Signed-off-by: pujaoshahu <pshahu@redhat.com>

Regression of : https://tracker.ceph.com/issues/78953

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
