### PR TITLE
rgw/auth: don't require x-amz-content-sha256 in signed headers

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -807,6 +807,12 @@ get_v4_canonical_headers(CephContext* cct,
         boost::container::small_vector<char, 64> buf(env_key.size());
         lowercase_dash_transform(env_key, buf.begin(), true);
         std::string_view lower_key{buf.data(), buf.size()};
+        // S3 has an exception for x-amz-content-sha256 because it's already
+        // signed as part of the HashedPayload
+        // TODO: make this specific to CredentialScope:service == s3
+        if (lower_key == "x-amz-content-sha256") {
+          continue;
+        }
         if (!canonical_hdrs_map.contains(lower_key)) {
         dout(5) << "Signature rejected: '" << lower_key
         << "' supplied, but not in CanonicalHeaders." << dendl;

--- a/src/test/rgw/s3-tests/s3tests/functional/test_headers.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_headers.py
@@ -712,6 +712,38 @@ def test_sigv4_missing_header():
     assert(resp.status_code == 403)
 
 @pytest.mark.auth_aws4
+def test_sigv4_with_signed_content_sha256():
+    signer = _get_s3sigv4_signer()
+    req = AWSRequest(method="GET", url=get_config_endpoint() + "/")
+    signer.add_auth(req)
+    assert req.url is not None
+    assert 'x-amz-content-sha256' in req.headers
+    resp = requests.get(req.url, headers=dict(req.headers), verify=get_config_ssl_verify())
+    assert(resp.status_code == 200)
+
+@pytest.mark.auth_aws4
+def test_sigv4_without_signed_content_sha256():
+    # custom signer that excludes x-amz-content-sha256 from signed-headers
+    class CustomAuth(S3SigV4Auth):
+        def headers_to_sign(self, request):
+            saved = request.headers['x-amz-content-sha256']
+            del request.headers['x-amz-content-sha256']
+            result = super().headers_to_sign(request)
+            request.headers['x-amz-content-sha256'] = saved
+            return result
+
+    creds = Credentials(access_key=get_main_aws_access_key(),
+                        secret_key=get_main_aws_secret_key())
+    signer = CustomAuth(credentials=creds, service_name="s3",
+                        region_name=get_main_api_name())
+    req = AWSRequest(method="GET", url=get_config_endpoint() + "/")
+    signer.add_auth(req)
+    assert req.url is not None
+    assert 'x-amz-content-sha256' in req.headers
+    resp = requests.get(req.url, headers=dict(req.headers), verify=get_config_ssl_verify())
+    assert(resp.status_code == 200)
+
+@pytest.mark.auth_aws4
 def test_sigv4_xgoog_signed():
     signer = _get_s3sigv4_signer()
     req = AWSRequest(

--- a/src/test/rgw/test_rgw_auth_sigv4.cc
+++ b/src/test/rgw/test_rgw_auth_sigv4.cc
@@ -201,10 +201,6 @@ TEST_F(SigV4CanonicalHeaders, PresignedUnsignedXAmzHeadersAreRejected)
         canonicalize_presigned({{"HTTP_X_AMZ_ACL", "public-read"}}, boto2));
     EXPECT_FALSE(canonicalize_presigned(
         {{"HTTP_X_AMZ_COPY_SOURCE", "/victim/secret"}}, boto2));
-    /* botocore's query signer doesnt sign x-amz-content-sha256, so a
-     * presigned URL is exactly where forging it would matter. */
-    EXPECT_FALSE(canonicalize_presigned(
-        {{"HTTP_X_AMZ_CONTENT_SHA256", "UNSIGNED-PAYLOAD"}}, boto2));
     EXPECT_FALSE(canonicalize_presigned(
         {{"HTTP_X_AMZ_SECURITY_TOKEN", "forged"}}, boto2));
   }


### PR DESCRIPTION
aws sigv4 does not require s3 requests to sign x-amz-content-sha256 because it's already present in the canonical request as HashedPayload

Fixes: https://tracker.ceph.com/issues/79803

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
