### PR TITLE
qa/d4n: Fix valkey installation fallback on Debian-based distros

### DIFF
--- a/qa/suites/rgw/d4n/tasks/rgw_d4ntests.yaml
+++ b/qa/suites/rgw/d4n/tasks/rgw_d4ntests.yaml
@@ -2,7 +2,7 @@ tasks:
 - install:
     # extra packages added for the rgw-d4ntests task
     extra_system_packages:
-      deb: ['s3cmd'] # valkey not available by default
+      deb: ['s3cmd', 'valkey-server'] # valkey is named valkey-server on deb
       rpm: ['s3cmd', 'valkey']
 - ceph:
 - redis:

--- a/qa/tasks/redis.py
+++ b/qa/tasks/redis.py
@@ -2,7 +2,6 @@ import logging
 
 from teuthology import misc as teuthology
 from teuthology.task import Task
-from teuthology.packaging import remove_package
 
 log = logging.getLogger(__name__)
 
@@ -42,77 +41,30 @@ class Redis(Task):
 
         self.redis_shutdown()
 
-        for client in self.all_clients:
-            self.remove_redis_package(client)
-
-    def valkey_install_for_debian(self):
-        try:
-            for client in self.all_clients:
-                # Taken from https://www.percona.com/blog/new-valkey-packages-by-percona/
-                self.ctx.cluster.only(client).run(
-                    args=[
-                        'curl',
-                        '-O',
-                        'https://repo.percona.com/apt/percona-release_latest.generic_all.deb'
-                    ],
-                )
-                self.ctx.cluster.only(client).run(
-                    args=[
-                        'sudo',
-                        'apt',
-                        'install',
-                        'gnupg2',
-                        'lsb-release',
-                        './percona-release_latest.generic_all.deb',
-                        '-y'
-                    ],
-                )
-                self.ctx.cluster.only(client).run(
-                    args=[
-                        'sudo',
-                        'percona-release',
-                        'enable',
-                        'valkey',
-                        'testing'
-                    ],
-                )
-                self.ctx.cluster.only(client).run(
-                    args=[
-                        'sudo',
-                        'apt',
-                        'update'
-                    ],
-                )
-                self.ctx.cluster.only(client).run(
-                    args=[
-                        'sudo',
-                        'apt',
-                        'install',
-                        'valkey',
-                        '-y'
-                    ],
-                )
-    
-        except Exception as err:
-            log.debug('Redis Task: Error installing valkey package')
-            log.debug(err)
-            raise
+    def valkey_service(self, client):
+        # the unit is named after the package: valkey-server on deb,
+        # valkey on rpm
+        (remote,) = self.ctx.cluster.only(client).remotes.keys()
+        if remote.os.package_type == 'deb':
+            return 'valkey-server'
+        return 'valkey'
 
     def redis_startup(self):
         try:
             for client in self.all_clients:
+                # restart rather than start: the deb package's postinst
+                # already started the server, while the rpm package does
+                # not, and either way this leaves us with a fresh one.
+                # the units are Type=notify, so systemd waits for the
+                # server to report ready and this fails if it does not
                 self.ctx.cluster.only(client).run(
                     args=[
                         'sudo',
-                        'valkey-server',
-                        '--daemonize',
-                        'yes'
+                        'systemctl',
+                        'restart',
+                        self.valkey_service(client)
                         ],
                     )
-    
-
-        except FileNotFoundError:
-            self.valkey_install_for_debian()
 
         except Exception as err:
             log.debug('Redis Task: Error starting up a Redis server')
@@ -125,17 +77,14 @@ class Redis(Task):
                 self.ctx.cluster.only(client).run(
                     args=[
                         'sudo',
-                        'valkey-cli',
-                        'shutdown',
+                        'systemctl',
+                        'stop',
+                        self.valkey_service(client)
                         ],
                     )
-    
+
         except Exception as err:
             log.debug('Redis Task: Error shutting down a Redis server')
             log.debug(err)
-
-    def remove_redis_package(self, client):
-        (remote,) = self.ctx.cluster.only(client).remotes.keys()
-        remove_package('valkey', remote)
 
 task = Redis


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/79807
Related to    https://github.com/ceph/ceph/pull/68193

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests (already fixing an existing QA test)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
