### PR TITLE
mon: add POOL_MIXED_MIN_ALLOC_SIZE health warning

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1144,3 +1144,8 @@ Relevant tracker: https://tracker.ceph.com/issues/71677
   seconds, which matches the previously hardcoded behaviour.
 
   Relevant tracker: https://tracker.ceph.com/issues/78727
+* RADOS: A new ``POOL_MIXED_MIN_ALLOC_SIZE`` health warning reports pools
+  that span BlueStore OSDs using different allocation units
+  (``min_alloc_size``), leading to non-uniform space usage and performance
+  across the pool's PGs. It can be disabled with the new
+  ``mon_warn_on_pool_mixed_min_alloc_size`` option.

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1843,6 +1843,47 @@ you can label the pool by running the following low-level command:
 
 For more information, see :ref:`associate-pool-to-application`.
 
+POOL_MIXED_MIN_ALLOC_SIZE
+_________________________
+
+One or more pools span BlueStore OSDs that use different allocation units
+(``min_alloc_size``). The set of OSDs that can host a pool's PGs is
+determined by the pool's CRUSH rule; when these OSDs do not all use the same
+allocation unit, space usage and performance are not uniform across the
+pool's PGs.
+
+Such a mix usually results from OSDs having been created under different
+defaults, since the allocation unit is frozen when each OSD is created: the
+default was 64 KiB for HDD-backed OSDs prior to the Pacific release (and
+16 KiB for SSD-backed OSDs prior to Nautilus 14.2.8), whereas current
+releases default to 4 KiB. Typical scenarios include adding new nodes or
+OSDs to a cluster upgraded from an older release, redeploying only some of
+the older OSDs, or deploying some OSDs with an explicitly configured
+``bluestore_min_alloc_size``.
+
+The detail of the health warning lists, for each affected pool, the
+allocation units in use and the number of OSDs using each of them. To
+display the allocation unit of each OSD, run the following command:
+
+.. prompt:: bash #
+
+   ceph osd metadata | jq '.[] | {id, bluestore_min_alloc_size}'
+
+The warning is resolved by redeploying (destroying and re-creating) the OSDs
+that still use a legacy allocation unit. Make sure that the cluster is
+healthy and has enough free capacity before doing so, and redeploy only one
+OSD or failure domain at a time. If devices with different optimal
+allocation units are mixed deliberately — for example, QLC NVMe devices with
+a 64 KiB indirection unit alongside TLC devices — it is best to assign them
+to distinct CRUSH device classes and use separate CRUSH rules, so that no
+pool spans both types of devices.
+
+To disable this alert, run the following command:
+
+.. prompt:: bash #
+
+   ceph config set mon mon_warn_on_pool_mixed_min_alloc_size false
+
 POOL_FULL
 _________
 

--- a/qa/standalone/mon/mon-pool-mixed-min-alloc-size.sh
+++ b/qa/standalone/mon/mon-pool-mixed-min-alloc-size.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Clyso GmbH <contact@clyso.com>
+#
+# Author: Frédéric Nass <frederic.nass@clyso.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7148" # git grep '\<7148\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_pool_mixed_min_alloc_size() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 --bluestore-min-alloc-size=4096 || return 1
+    run_osd $dir 1 --bluestore-min-alloc-size=4096 || return 1
+
+    # force an osdmap change so that the health checks are recomputed
+    # from the latest committed OSD metadata
+    ceph osd pool create foo 8 || return 1
+    wait_for_clean || return 1
+    ceph health detail
+    ! ceph health detail | grep POOL_MIXED_MIN_ALLOC_SIZE || return 1
+
+    # add an OSD with a different (legacy) allocation unit; the pool's
+    # CRUSH rule spans all OSDs, so the pool now mixes 4 KiB and 64 KiB
+    run_osd $dir 2 --bluestore-min-alloc-size=65536 || return 1
+    ceph osd pool set foo pg_num 16 || return 1
+    wait_for_health "POOL_MIXED_MIN_ALLOC_SIZE" || return 1
+    ceph health detail | grep "pool 'foo' spans OSDs" || return 1
+
+    # the warning can be disabled at runtime
+    ceph config set mon mon_warn_on_pool_mixed_min_alloc_size false || return 1
+    ceph osd pool set foo pg_num 32 || return 1
+    wait_for_health_gone "POOL_MIXED_MIN_ALLOC_SIZE" || return 1
+}
+
+main mon-pool-mixed-min-alloc-size "$@"

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1724,6 +1724,20 @@ options:
   - mon
   see_also:
   - ms_bind_msgr2
+- name: mon_warn_on_pool_mixed_min_alloc_size
+  type: bool
+  level: advanced
+  desc: Raise the POOL_MIXED_MIN_ALLOC_SIZE health warning if a pool spans BlueStore
+    OSDs that use different allocation units (min_alloc_size)
+  long_desc: PGs of a pool that spans OSDs with different allocation units are
+    subject to non-uniform space usage and performance. Such a mix usually
+    results from OSDs created under different defaults (64 KiB for HDDs prior
+    to Pacific, 16 KiB for SSDs prior to Nautilus 14.2.8, 4 KiB since), e.g.
+    when new OSDs or nodes are added to an upgraded cluster or when only some
+    of the older OSDs have been redeployed.
+  default: true
+  services:
+  - mon
 - name: mon_warn_on_slow_ping_time
   type: float
   level: advanced

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2130,6 +2130,7 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   // health
   auto& next = get_health_checks_pending_writeable();
   tmp.check_health(cct, &next);
+  check_pool_mixed_min_alloc_size(tmp, &next);
 }
 
 int OSDMonitor::load_metadata(int osd, map<string, string>& m, ostream *err)
@@ -2175,6 +2176,69 @@ void OSDMonitor::count_metadata(const string& field, Formatter *f)
     f->dump_int(p.first.c_str(), p.second);
   }
   f->close_section();
+}
+
+void OSDMonitor::check_pool_mixed_min_alloc_size(const OSDMap& next_map,
+						 health_check_map_t *checks)
+{
+  if (!cct->_conf.get_val<bool>("mon_warn_on_pool_mixed_min_alloc_size")) {
+    return;
+  }
+  // BlueStore allocation unit of each up OSD, from the OSD metadata
+  map<int, string> osd_min_alloc_size;
+  for (int osd = 0; osd < next_map.get_max_osd(); ++osd) {
+    if (!next_map.is_up(osd)) {
+      continue;
+    }
+    map<string, string> meta;
+    if (load_metadata(osd, meta, nullptr) < 0) {
+      continue;
+    }
+    auto p = meta.find("bluestore_min_alloc_size");
+    if (p == meta.end()) {
+      // not a BlueStore OSD, or metadata not reported (yet)
+      continue;
+    }
+    osd_min_alloc_size[osd] = p->second;
+  }
+  list<string> details;
+  int64_t affected_pools = 0;
+  for (auto& [pool_id, pool] : next_map.get_pools()) {
+    // the OSDs that can host this pool's PGs, as determined by the
+    // pool's CRUSH rule
+    map<int, float> wm;
+    if (next_map.crush->get_rule_weight_osd_map(pool.get_crush_rule(),
+						&wm) < 0) {
+      continue;
+    }
+    // min_alloc_size -> number of the pool's OSDs using it
+    map<string, int> by_val;
+    for (auto& [osd, weight] : wm) {
+      auto p = osd_min_alloc_size.find(osd);
+      if (p != osd_min_alloc_size.end()) {
+	++by_val[p->second];
+      }
+    }
+    if (by_val.size() <= 1) {
+      continue;
+    }
+    ++affected_pools;
+    ostringstream ss;
+    ss << "pool '" << next_map.get_pool_name(pool_id)
+       << "' spans OSDs with different min_alloc_size values:";
+    for (auto& [val, count] : by_val) {
+      ss << " " << val << " (" << count << " OSD(s))";
+    }
+    details.push_back(ss.str());
+  }
+  if (affected_pools > 0) {
+    ostringstream ss;
+    ss << affected_pools << " pool(s) span OSDs with different BlueStore"
+       << " min_alloc_size values";
+    auto& d = checks->add("POOL_MIXED_MIN_ALLOC_SIZE", HEALTH_WARN,
+			  ss.str(), affected_pools);
+    d.detail.swap(details);
+  }
 }
 
 void OSDMonitor::get_versions(std::map<string, list<string>> &versions)

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -653,6 +653,8 @@ private:
   int load_metadata(int osd, std::map<std::string, std::string>& m,
 		    std::ostream *err);
   void count_metadata(const std::string& field, ceph::Formatter *f);
+  void check_pool_mixed_min_alloc_size(const OSDMap& next_map,
+				       health_check_map_t *checks);
 
   void reencode_incremental_map(ceph::buffer::list& bl, uint64_t features);
   void reencode_full_map(ceph::buffer::list& bl, uint64_t features);


### PR DESCRIPTION
Add a new POOL_MIXED_MIN_ALLOC_SIZE health warning, raised by the monitor when the BlueStore OSDs a pool spans (as determined by the pool's CRUSH rule) use different allocation units (min_alloc_size), e.g. when new OSDs are added to a cluster upgraded from an older release, or when only part of the older OSDs have been redeployed with the current 4 KiB default. PGs of such pools are subject to non-uniform space usage and performance.

The check is computed from the OSD metadata and only compares OSDs that can actually host the pool's PGs, so deliberately mixing devices with different optimal allocation units in a cluster does not raise the warning as long as they are kept in distinct CRUSH device classes / rules. min_alloc_size is the first divergence criterion considered; the check may later be extended to other capability divergences (e.g. compression settings or device capabilities).

Can be disabled with the new mon_warn_on_pool_mixed_min_alloc_size option (default: true).

Fixes: https://tracker.ceph.com/issues/79806

Assisted-by: Claude Fable 5 High.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [X] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
