### PR TITLE
rgw: parse the Range header field per RFC 9110

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -50,6 +50,17 @@
 * RGW: iam:RemoveClientIdFromOIDCProvider is now a recognized action for
   policy, corrected from a typo of iam:RemoveCientIdFromOIDCProvider
 
+* RGW: the Range header field of a GET request is now parsed against the grammar
+  in RFC 9110, so a malformed ranges-specifier is refused instead of being
+  reinterpreted. "Range: bytes=abc-def" used to be served as byte 0 and
+  "Range: bytes=0-100xyz" as bytes 0-100; both now fail with 416 InvalidRange.
+  Set "rgw ignore get invalid range" to "true" to have an invalid range ignored
+  and the whole object returned instead. A range unit is also matched in full,
+  so a header such as "Range: xbytes=0-100" is no longer treated as a byte
+  range; per RFC 9110 an unknown range unit is ignored and the whole object is
+  returned. Well formed byte ranges, including a range-set with several ranges,
+  are unaffected.
+
 * MGR: The default values of ``mon_target_pg_per_osd`` and ``mon_max_pg_per_osd``
   have been increased from 100 and 250 to 200 and 500, respectively. These values
   enhance the PG autoscaler's ability to calculate reasonable ``pg_num`` values

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2,12 +2,14 @@
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
 #include <cerrno>
+#include <limits>
 #include <optional>
 #include <cstdlib>
 #include <system_error>
 #include <span>
 #include <sstream>
 #include <string_view>
+#include <vector>
 
 #include <unistd.h>
 
@@ -31,6 +33,7 @@
 #include "rgw_cksum.h"
 #include "rgw_cksum_digest.h"
 #include "rgw_common.h"
+#include "rgw_range_parse.h"
 #include "common/split.h"
 #include "rgw_tracer.h"
 
@@ -202,55 +205,54 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
 int RGWGetObj::parse_range(void)
 {
   int r = -ERANGE;
-  string rs(range_str);
-  string ofs_str;
-  string end_str;
+  /* positions land in off_t, which is narrower than the uint64_t the grammar
+   * allows, so anything past its maximum is not a range we can serve */
+  constexpr uint64_t max_pos =
+      static_cast<uint64_t>(std::numeric_limits<off_t>::max());
+  std::vector<rgw_byte_range> ranges;
+  rgw_range_parse_result res;
 
   ignore_invalid_range = s->cct->_conf->rgw_ignore_get_invalid_range;
   partial_content = false;
 
-  size_t pos = rs.find("bytes=");
-  if (pos == string::npos) {
-    pos = 0;
-    while (isspace(rs[pos]))
-      pos++;
-    int end = pos;
-    while (isalpha(rs[end]))
-      end++;
-    if (strncasecmp(rs.c_str(), "bytes", end - pos) != 0)
-      return 0;
-    while (isspace(rs[end]))
-      end++;
-    if (rs[end] != '=')
-      return 0;
-    rs = rs.substr(end + 1);
-  } else {
-    rs = rs.substr(pos + 6); /* size of("bytes=")  */
+  res = rgw_parse_byte_ranges(range_str, 0, &ranges);
+  if (res == rgw_range_parse_result::not_bytes) {
+    /* RFC 9110 14.2 requires an origin server to ignore a Range header field
+     * whose range unit it does not understand, and serve the whole object */
+    return 0;
   }
-  pos = rs.find('-');
-  if (pos == string::npos)
+  if (res != rgw_range_parse_result::ok)
     goto done;
+
+  /* Only the first range-spec of the range-set is served. A range-set with
+   * more than one element is well formed, and RFC 9110 15.3.7 does let a
+   * server satisfy a subset of it, but multipart/byteranges is not
+   * implemented; see https://tracker.ceph.com/issues/13412 */
+  if (ranges.front().is_suffix) {
+    /* a suffix-range is carried to the object layer as a negative offset.
+     * RFC 9110 14.1.2 reads a suffix-length longer than the representation as
+     * the whole representation, so one too large for off_t is clamped rather
+     * than refused; range_to_ofs() then folds it back to offset 0. */
+    const uint64_t n = ranges.front().suffix_length;
+    ofs = -static_cast<off_t>(n > max_pos ? max_pos : n);
+    end = -1;
+  } else {
+    /* a first-pos at or past the end is unsatisfiable, which range_to_ofs()
+     * reports as -ERANGE once it knows the size of the object */
+    const uint64_t first = ranges.front().first;
+    ofs = static_cast<off_t>(first > max_pos ? max_pos : first);
+    if (!ranges.front().has_last) {
+      end = -1;
+    } else {
+      /* RFC 9110 14.1.2: a last-pos at or past the end means the remainder of
+       * the representation, so this is clamped too and range_to_ofs() brings
+       * it down to the last byte of the object */
+      const uint64_t last = ranges.front().last;
+      end = static_cast<off_t>(last > max_pos ? max_pos : last);
+    }
+  }
 
   partial_content = true;
-
-  ofs_str = rs.substr(0, pos);
-  end_str = rs.substr(pos + 1);
-  if (end_str.length()) {
-    end = atoll(end_str.c_str());
-    if (end < 0)
-      goto done;
-  }
-
-  if (ofs_str.length()) {
-    ofs = atoll(ofs_str.c_str());
-  } else { // RFC2616 suffix-byte-range-spec
-    ofs = -end;
-    end = -1;
-  }
-
-  if (end >= 0 && end < ofs)
-    goto done;
-
   range_parsed = true;
   return 0;
 

--- a/src/rgw/rgw_range_parse.h
+++ b/src/rgw/rgw_range_parse.h
@@ -1,0 +1,219 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+/*
+ * Parser for the HTTP Range header field, RFC 9110 Section 14.1.1:
+ *
+ *   ranges-specifier = range-unit "=" range-set
+ *   range-set        = 1#range-spec
+ *   range-spec       = int-range / suffix-range / other-range
+ *   int-range        = first-pos "-" [ last-pos ]
+ *   suffix-range     = "-" suffix-length
+ *
+ * The parser is purely syntactic: it does not resolve positions against the
+ * length of the selected representation, and it does not decide what to do
+ * with a range-set that holds more than one range-spec. Both are the caller's
+ * business.
+ */
+
+/* One range-spec. An int-range carries first and, when has_last is set, last.
+ * A suffix-range carries only suffix_length, meaning the final suffix_length
+ * bytes of the representation. */
+struct rgw_byte_range {
+  bool is_suffix = false;
+  bool has_last = false;
+  uint64_t first = 0;
+  uint64_t last = 0;
+  uint64_t suffix_length = 0;
+
+  friend bool operator==(const rgw_byte_range& l, const rgw_byte_range& r) {
+    if (l.is_suffix != r.is_suffix)
+      return false;
+    if (l.is_suffix)
+      return l.suffix_length == r.suffix_length;
+    if (l.first != r.first || l.has_last != r.has_last)
+      return false;
+    return !l.has_last || l.last == r.last;
+  }
+};
+
+enum class rgw_range_parse_result {
+  /* range-set held at least one range-spec and every one of them parsed */
+  ok,
+  /* the range-unit is not "bytes". RFC 9110 14.2 requires an origin server to
+   * ignore a Range header field whose range unit it does not understand, so
+   * this is not an error: the caller serves the whole representation. */
+  not_bytes,
+  /* syntactically invalid ranges-specifier. RFC 9110 14.2 lets a server ignore
+   * or reject one; which of the two happens is the caller's policy. */
+  invalid,
+  /* more range-specs than the caller is willing to hold. Called out separately
+   * from `invalid` because the request is well formed, and because a long
+   * range-set is the shape a denial-of-service attempt takes (RFC 9110 17.15). */
+  too_many,
+};
+
+namespace rgw_range_detail {
+
+inline bool is_ows(char c) { return c == ' ' || c == '\t'; }
+
+inline std::string_view trim_ows(std::string_view s) {
+  while (!s.empty() && is_ows(s.front()))
+    s.remove_prefix(1);
+  while (!s.empty() && is_ows(s.back()))
+    s.remove_suffix(1);
+  return s;
+}
+
+inline bool equals_ignore_case(std::string_view a, std::string_view b) {
+  if (a.size() != b.size())
+    return false;
+  for (size_t i = 0; i < a.size(); ++i) {
+    char l = a[i], r = b[i];
+    if (l >= 'A' && l <= 'Z') l = l - 'A' + 'a';
+    if (r >= 'A' && r <= 'Z') r = r - 'A' + 'a';
+    if (l != r)
+      return false;
+  }
+  return true;
+}
+
+/*
+ * 1*DIGIT with no sign, no whitespace and no trailing junk.
+ *
+ * first-pos, last-pos and suffix-length are 1*DIGIT with no upper bound, so a
+ * value too large for uint64_t is well formed and may not be rejected. It is
+ * saturated instead, which preserves its meaning in every position: RFC 9110
+ * 14.1.2 reads an out-of-length last-pos as the remainder of the
+ * representation and an over-long suffix-length as the whole representation,
+ * and a first-pos past the end is unsatisfiable either way.
+ */
+inline bool parse_digits(std::string_view s, uint64_t* out, bool* saturated) {
+  if (s.empty())
+    return false;
+  uint64_t v = 0;
+  bool sat = false;
+  for (char c : s) {
+    if (c < '0' || c > '9')
+      return false;
+    unsigned d = c - '0';
+    if (v > (UINT64_MAX - d) / 10)
+      sat = true;
+    else
+      v = v * 10 + d;
+  }
+  *out = sat ? UINT64_MAX : v;
+  *saturated = sat;
+  return true;
+}
+
+/* Order two 1*DIGIT strings by value without converting them, so that
+ * last-pos < first-pos can still be decided once either has saturated. */
+inline bool digits_less(std::string_view a, std::string_view b) {
+  while (a.size() > 1 && a.front() == '0')
+    a.remove_prefix(1);
+  while (b.size() > 1 && b.front() == '0')
+    b.remove_prefix(1);
+  if (a.size() != b.size())
+    return a.size() < b.size();
+  return a < b;
+}
+
+} // namespace rgw_range_detail
+
+/*
+ * Parse a Range header field value into `ranges`, which is cleared first.
+ * `max_ranges` bounds the number of range-specs accepted; 0 means unbounded.
+ *
+ * Empty list elements are skipped, as RFC 9110 5.6.1 requires of a recipient
+ * parsing a comma-separated list.
+ */
+inline rgw_range_parse_result rgw_parse_byte_ranges(
+    std::string_view spec, size_t max_ranges,
+    std::vector<rgw_byte_range>* ranges)
+{
+  using namespace rgw_range_detail;
+
+  ranges->clear();
+
+  const size_t eq = spec.find('=');
+  if (eq == std::string_view::npos)
+    return rgw_range_parse_result::not_bytes;
+  if (!equals_ignore_case(trim_ows(spec.substr(0, eq)), "bytes"))
+    return rgw_range_parse_result::not_bytes;
+
+  std::string_view set = spec.substr(eq + 1);
+  std::vector<rgw_byte_range> parsed;
+
+  while (!set.empty()) {
+    const size_t comma = set.find(',');
+    std::string_view elem = trim_ows(set.substr(0, comma));
+    set = (comma == std::string_view::npos) ? std::string_view{}
+                                            : set.substr(comma + 1);
+    if (elem.empty())
+      continue; /* legacy empty list element */
+
+    const size_t dash = elem.find('-');
+    if (dash == std::string_view::npos)
+      return rgw_range_parse_result::invalid;
+
+    rgw_byte_range r;
+    bool saturated = false;
+    if (dash == 0) {
+      /* suffix-range = "-" suffix-length */
+      r.is_suffix = true;
+      if (!parse_digits(elem.substr(1), &r.suffix_length, &saturated))
+        return rgw_range_parse_result::invalid;
+    } else {
+      /* int-range = first-pos "-" [ last-pos ] */
+      const std::string_view first = elem.substr(0, dash);
+      if (!parse_digits(first, &r.first, &saturated))
+        return rgw_range_parse_result::invalid;
+      const std::string_view last = elem.substr(dash + 1);
+      if (!last.empty()) {
+        bool last_saturated = false;
+        if (!parse_digits(last, &r.last, &last_saturated))
+          return rgw_range_parse_result::invalid;
+        r.has_last = true;
+        /* "An int-range is invalid if the last-pos value is present and less
+         * than the first-pos." RFC 9110 14.1.1. Once either position has
+         * saturated the stored values no longer order them, so fall back to
+         * comparing the digits. */
+        const bool reversed = (saturated || last_saturated)
+                                  ? digits_less(last, first)
+                                  : r.last < r.first;
+        if (reversed)
+          return rgw_range_parse_result::invalid;
+      }
+    }
+
+    if (max_ranges && parsed.size() == max_ranges)
+      return rgw_range_parse_result::too_many;
+    parsed.push_back(r);
+  }
+
+  /* range-set = 1#range-spec, so an empty set is invalid rather than ignorable */
+  if (parsed.empty())
+    return rgw_range_parse_result::invalid;
+
+  *ranges = std::move(parsed);
+  return rgw_range_parse_result::ok;
+}

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -271,6 +271,13 @@ target_link_libraries(unittest_rgw_range_projection
   ${UNITTEST_LIBS}
   )
 
+add_executable(unittest_rgw_range_parse test_rgw_range_parse.cc)
+add_ceph_unittest(unittest_rgw_range_parse)
+target_link_libraries(unittest_rgw_range_parse
+  ${rgw_libs}
+  ${UNITTEST_LIBS}
+  )
+
 if(WITH_RADOSGW_RADOS)
 set(test_rgw_reshard_srcs test_rgw_reshard.cc)
 add_executable(unittest_rgw_reshard

--- a/src/test/rgw/test_rgw_range_parse.cc
+++ b/src/test/rgw/test_rgw_range_parse.cc
@@ -1,0 +1,257 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+
+#include <gtest/gtest.h>
+#include "rgw_range_parse.h"
+
+using namespace std;
+
+static rgw_byte_range int_range(uint64_t first, uint64_t last) {
+  rgw_byte_range r;
+  r.first = first;
+  r.last = last;
+  r.has_last = true;
+  return r;
+}
+
+static rgw_byte_range open_range(uint64_t first) {
+  rgw_byte_range r;
+  r.first = first;
+  return r;
+}
+
+static rgw_byte_range suffix_range(uint64_t len) {
+  rgw_byte_range r;
+  r.is_suffix = true;
+  r.suffix_length = len;
+  return r;
+}
+
+namespace {
+
+struct parse_case {
+  const char* spec;
+  rgw_range_parse_result result;
+  vector<rgw_byte_range> ranges;
+};
+
+void run(const parse_case& c) {
+  vector<rgw_byte_range> ranges;
+  const auto r = rgw_parse_byte_ranges(c.spec, 0, &ranges);
+  EXPECT_EQ(c.result, r) << "spec: " << c.spec;
+  if (r == rgw_range_parse_result::ok) {
+    EXPECT_EQ(c.ranges, ranges) << "spec: " << c.spec;
+  } else {
+    EXPECT_TRUE(ranges.empty()) << "spec: " << c.spec;
+  }
+}
+
+} // namespace
+
+TEST(RGWRangeParse, SingleRange)
+{
+  const parse_case cases[] = {
+    {"bytes=0-100",  rgw_range_parse_result::ok, {int_range(0, 100)}},
+    {"bytes=0-0",    rgw_range_parse_result::ok, {int_range(0, 0)}},
+    {"bytes=100-100",rgw_range_parse_result::ok, {int_range(100, 100)}},
+    {"bytes=0-",     rgw_range_parse_result::ok, {open_range(0)}},
+    {"bytes=42-",    rgw_range_parse_result::ok, {open_range(42)}},
+    {"bytes=-100",   rgw_range_parse_result::ok, {suffix_range(100)}},
+    /* suffix-length is 1*DIGIT, so "-0" is syntax-valid; whether the resulting
+     * empty range is satisfiable is not the parser's call. */
+    {"bytes=-0",     rgw_range_parse_result::ok, {suffix_range(0)}},
+  };
+  for (const auto& c : cases)
+    run(c);
+}
+
+TEST(RGWRangeParse, MultipleRanges)
+{
+  const parse_case cases[] = {
+    {"bytes=0-100,300-400", rgw_range_parse_result::ok,
+     {int_range(0, 100), int_range(300, 400)}},
+    /* RFC 9110 5.6.1 permits optional whitespace around the list separator */
+    {"bytes=0-100, 300-400", rgw_range_parse_result::ok,
+     {int_range(0, 100), int_range(300, 400)}},
+    {"bytes=0-100 , 300-400", rgw_range_parse_result::ok,
+     {int_range(0, 100), int_range(300, 400)}},
+    /* and requires a recipient to skip empty list elements */
+    {"bytes=0-100,,300-400", rgw_range_parse_result::ok,
+     {int_range(0, 100), int_range(300, 400)}},
+    {"bytes=0-100,", rgw_range_parse_result::ok, {int_range(0, 100)}},
+    /* ascending order is a SHOULD for clients, not a MUST for servers */
+    {"bytes=300-400,0-100", rgw_range_parse_result::ok,
+     {int_range(300, 400), int_range(0, 100)}},
+    /* overlapping ranges are well formed */
+    {"bytes=0-100,50-150", rgw_range_parse_result::ok,
+     {int_range(0, 100), int_range(50, 150)}},
+    {"bytes=0-10,-5", rgw_range_parse_result::ok,
+     {int_range(0, 10), suffix_range(5)}},
+    {"bytes=0-1,2-3,4-5,6-7", rgw_range_parse_result::ok,
+     {int_range(0, 1), int_range(2, 3), int_range(4, 5), int_range(6, 7)}},
+  };
+  for (const auto& c : cases)
+    run(c);
+}
+
+TEST(RGWRangeParse, RangeUnit)
+{
+  const parse_case cases[] = {
+    /* range units are case-insensitive */
+    {"BYTES=0-100", rgw_range_parse_result::ok, {int_range(0, 100)}},
+    {"Bytes=0-100", rgw_range_parse_result::ok, {int_range(0, 100)}},
+    {"bytes = 0-100", rgw_range_parse_result::ok, {int_range(0, 100)}},
+    /* an unknown range unit must be ignored, not rejected: RFC 9110 14.2 */
+    {"items=0-100", rgw_range_parse_result::not_bytes, {}},
+    {"seconds=1-2", rgw_range_parse_result::not_bytes, {}},
+    /* the whole unit has to match. The previous parser searched for "bytes="
+     * anywhere in the value, so a unit merely ending in it was taken for a
+     * byte range; range-unit is a token and "xbytes" is not "bytes". */
+    {"xbytes=0-100", rgw_range_parse_result::not_bytes, {}},
+    {"kbytes=0-100", rgw_range_parse_result::not_bytes, {}},
+    {"bytesx=0-100", rgw_range_parse_result::not_bytes, {}},
+    /* no range-unit at all is likewise not a bytes range */
+    {"0-100", rgw_range_parse_result::not_bytes, {}},
+    {"", rgw_range_parse_result::not_bytes, {}},
+  };
+  for (const auto& c : cases)
+    run(c);
+}
+
+TEST(RGWRangeParse, Invalid)
+{
+  const parse_case cases[] = {
+    /* first-pos and last-pos are 1*DIGIT: no signs, no trailing junk.
+     * The previous parser ran these through atoll(), which stops at the first
+     * non-digit, so "abc-def" was accepted as byte 0 and "0-100xyz" as 0-100. */
+    {"bytes=abc-def",  rgw_range_parse_result::invalid, {}},
+    {"bytes=0-100xyz", rgw_range_parse_result::invalid, {}},
+    {"bytes=0x10-",    rgw_range_parse_result::invalid, {}},
+    {"bytes=+0-100",   rgw_range_parse_result::invalid, {}},
+    {"bytes=-1-2",     rgw_range_parse_result::invalid, {}},
+    {"bytes=1-2-3",    rgw_range_parse_result::invalid, {}},
+    {"bytes= 0 - 100", rgw_range_parse_result::invalid, {}},
+    /* "An int-range is invalid if the last-pos value is present and less than
+     * the first-pos." RFC 9110 14.1.1 */
+    {"bytes=5-2",      rgw_range_parse_result::invalid, {}},
+    /* range-set = 1#range-spec, so it may not be empty */
+    {"bytes=",         rgw_range_parse_result::invalid, {}},
+    {"bytes=,",        rgw_range_parse_result::invalid, {}},
+    {"bytes=,,",       rgw_range_parse_result::invalid, {}},
+    {"bytes=100",      rgw_range_parse_result::invalid, {}},
+    {"bytes=-",        rgw_range_parse_result::invalid, {}},
+    /* one bad range-spec invalidates the whole range-set */
+    {"bytes=0-100,bad", rgw_range_parse_result::invalid, {}},
+    {"bytes=bad,0-100", rgw_range_parse_result::invalid, {}},
+  };
+  for (const auto& c : cases)
+    run(c);
+}
+
+TEST(RGWRangeParse, Saturation)
+{
+  /* first-pos, last-pos and suffix-length are 1*DIGIT with no upper bound, so
+   * a value too large for uint64_t is well formed and may not be rejected.
+   * RFC 9110 14.1.2 gives it the same meaning as the largest representable
+   * one: an out-of-length last-pos is the remainder of the representation, an
+   * over-long suffix-length is the whole representation, and a first-pos past
+   * the end is unsatisfiable either way. */
+  const parse_case cases[] = {
+    {"bytes=99999999999999999999-", rgw_range_parse_result::ok,
+     {open_range(UINT64_MAX)}},
+    {"bytes=0-99999999999999999999", rgw_range_parse_result::ok,
+     {int_range(0, UINT64_MAX)}},
+    {"bytes=-99999999999999999999", rgw_range_parse_result::ok,
+     {suffix_range(UINT64_MAX)}},
+    /* the largest value that still fits is not saturated into something else */
+    {"bytes=18446744073709551615-", rgw_range_parse_result::ok,
+     {open_range(UINT64_MAX)}},
+    {"bytes=0-18446744073709551615", rgw_range_parse_result::ok,
+     {int_range(0, UINT64_MAX)}},
+  };
+  for (const auto& c : cases)
+    run(c);
+
+  /* saturating last-pos must not collide with an absent one: "0-<huge>" is a
+   * closed range, "0-" is open, and they are not the same range-spec */
+  vector<rgw_byte_range> closed, open;
+  ASSERT_EQ(rgw_range_parse_result::ok,
+            rgw_parse_byte_ranges("bytes=0-99999999999999999999", 0, &closed));
+  ASSERT_EQ(rgw_range_parse_result::ok,
+            rgw_parse_byte_ranges("bytes=0-", 0, &open));
+  ASSERT_EQ(1u, closed.size());
+  ASSERT_EQ(1u, open.size());
+  EXPECT_TRUE(closed[0].has_last);
+  EXPECT_FALSE(open[0].has_last);
+  EXPECT_FALSE(closed[0] == open[0]);
+
+  /* a saturated last-pos is still checked against first-pos, including when
+   * both saturate and the stored values no longer order them */
+  const parse_case ordering[] = {
+    {"bytes=99999999999999999999-5", rgw_range_parse_result::invalid, {}},
+    {"bytes=99999999999999999999-88888888888888888888",
+     rgw_range_parse_result::invalid, {}},
+    {"bytes=18446744073709551615-18446744073709551614",
+     rgw_range_parse_result::invalid, {}},
+    {"bytes=88888888888888888888-99999999999999999999",
+     rgw_range_parse_result::ok, {int_range(UINT64_MAX, UINT64_MAX)}},
+    {"bytes=99999999999999999999-99999999999999999999",
+     rgw_range_parse_result::ok, {int_range(UINT64_MAX, UINT64_MAX)}},
+    /* leading zeros must not make a value look smaller than it is */
+    {"bytes=0000000000000000000000005-2", rgw_range_parse_result::invalid, {}},
+    {"bytes=00005-00010", rgw_range_parse_result::ok, {int_range(5, 10)}},
+  };
+  for (const auto& c : ordering)
+    run(c);
+}
+
+TEST(RGWRangeParse, MaxRanges)
+{
+  vector<rgw_byte_range> ranges;
+
+  /* a range-set at the limit is accepted */
+  EXPECT_EQ(rgw_range_parse_result::ok,
+            rgw_parse_byte_ranges("bytes=0-1,2-3", 2, &ranges));
+  EXPECT_EQ(2u, ranges.size());
+
+  /* one past it is reported separately from a syntax error, because the
+   * request is well formed and a long range-set is the shape a
+   * denial-of-service attempt takes: RFC 9110 17.15 */
+  EXPECT_EQ(rgw_range_parse_result::too_many,
+            rgw_parse_byte_ranges("bytes=0-1,2-3,4-5", 2, &ranges));
+
+  /* max_ranges == 0 means unbounded */
+  EXPECT_EQ(rgw_range_parse_result::ok,
+            rgw_parse_byte_ranges("bytes=0-1,2-3,4-5", 0, &ranges));
+  EXPECT_EQ(3u, ranges.size());
+
+  /* the limit does not affect a single range */
+  EXPECT_EQ(rgw_range_parse_result::ok,
+            rgw_parse_byte_ranges("bytes=0-100", 1, &ranges));
+  EXPECT_EQ(1u, ranges.size());
+}
+
+TEST(RGWRangeParse, OutputIsClearedOnFailure)
+{
+  vector<rgw_byte_range> ranges{int_range(7, 9)};
+
+  EXPECT_EQ(rgw_range_parse_result::invalid,
+            rgw_parse_byte_ranges("bytes=5-2", 0, &ranges));
+  EXPECT_TRUE(ranges.empty());
+
+  ranges.push_back(int_range(7, 9));
+  EXPECT_EQ(rgw_range_parse_result::not_bytes,
+            rgw_parse_byte_ranges("items=0-1", 0, &ranges));
+  EXPECT_TRUE(ranges.empty());
+}


### PR DESCRIPTION
Related to: https://tracker.ceph.com/issues/13412

`RGWGetObj::parse_range()` searches the header value for `bytes=`, then finds the first `-` after it and runs `atoll()` over the text on each side. `atoll()` stops at the first character it cannot use and tells nobody, so a malformed range-spec comes out looking plausible. Driving the current parser over a table of headers: `bytes=abc-def` is served as byte 0, `bytes=0-100xyz` as 0-100, `bytes=bad,0-100` as 0-100, and `bytes=-` as byte 1 through the end of the object. The search for `bytes=` is unanchored too, so `xbytes=0-100` is taken for a byte range. And because it keys on a single `-`, a range-set with more than one range-spec is never recognised as one: `bytes=0-100,300-400` yields 0-100 and the rest of the header disappears during parsing.

The first commit adds `rgw_parse_byte_ranges()`, a header-only parser for the grammar in RFC 9110 14.1.1 that reads the whole range-set. It distinguishes the three outcomes a caller has to treat differently: a range unit that is not `bytes`, which 14.2 requires an origin server to ignore; an invalid ranges-specifier, which a server may ignore or reject; and a well formed range-set longer than the caller wants to hold, which is what a denial-of-service attempt looks like (17.15). The second commit moves `parse_range()` onto it. No caller is added in the first commit and nothing outside `parse_range()` changes in the second.

This does not implement `multipart/byteranges`, and multi-range behaviour is deliberately unchanged: the first range-spec is served and the rest ignored, which stays within 14.1.2 and 15.3.7 since a 206 is self-descriptive. I asked on the tracker which shape would be wanted for the real feature, because AWS does not support multi-range at all while upstream Swift does and `doc/radosgw/swift.rst` already advertises it. This series is the parsing groundwork either answer needs.

Positions too large for `off_t` are clamped, not refused. main gets that right by accident, since `atoll()` saturates at `LLONG_MAX` and `range_to_ofs()` then pulls the value back inside the object, and RFC 9110 14.1.2 requires it: an out-of-length last-pos means the remainder of the representation and an over-long suffix-length means the whole representation. Only first-pos is left for `range_to_ofs()` to reject once it knows the object size. Rejecting these would have turned a conformant 206 into a 416, so the parser saturates rather than failing, and the "invalid if last-pos is less than first-pos" rule falls back to comparing digits when either position has saturated.

Two classes of request change behaviour, both noted in `PendingReleaseNotes`. Malformed range-specs now take the path the function already used for the rejects it did catch, such as `bytes=5-2`, so `rgw_ignore_get_invalid_range` still decides between `-ERANGE` and ignoring the header; no second policy is introduced. And the range unit is matched in full rather than searched for, so a unit ending in but not equal to `bytes` is ignored per 14.2 instead of being parsed as a byte range.

To size the change, the text of `parse_range()` was compiled against stub members alongside a replica of the implementation it replaces and the two diffed over 45 header values under both settings of `rgw_ignore_get_invalid_range`: **65 of 90 outcomes identical**, the 25 that differ coming from 13 inputs, 11 of them malformed specifiers and 2 units ending in `bytes`. `bytesx=0-100` is unaffected, which pins that second class to exactly the shape it claims. Every well formed byte range and every out-of-range position produces identical state.

Against a vstart cluster serving a 100-byte object:

```
Range header                                   status Content-Range     body
bytes=0-99                                     206    bytes 0-99/100    100 B
bytes=-10                                      206    bytes 90-99/100    10 B
bytes=0-99999999999999999999                   206    bytes 0-99/100    100 B
bytes=-99999999999999999999                    206    bytes 0-99/100    100 B
bytes=100-                                     416    -
bytes=99999999999999999999-                    416    -
bytes=0-10,20-30                               206    bytes 0-10/100     11 B
bytes=abc-def                                  416    -
bytes=0-100xyz                                 416    -
bytes=5-2                                      416    -
xbytes=0-10                                    200    bytes 0-99/100    100 B
```

One thing that turned up while checking those responses and is worth raising separately: `rgw_rest_s3.cc` emits `Content-Range` under `if (range_str)`, keying on the header being present rather than on `partial_content`, so a request whose Range was ignored still carries a `Content-Range` alongside its 200. That is pre-existing, `items=0-10` behaves the same way on main, but this series does route a new class of request through it. I left it alone because the one-line fix would change every ignored-Range response, not just the ones here, and that seemed like a separate call to make.

The full s3-tests suite has not been run against this.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
