### PR TITLE
rgw: accept tenant parameter on user info, modify and remove admin ops

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -82,6 +82,13 @@
     Configuration file syntax follows the OpenSSL standard (see https://github.com/openssl/openssl/blob/master/doc/man5/config.pod).
     If the default provider is required when also using custom providers,
     it must be explicitly loaded in the configuration file or code (see https://github.com/openssl/openssl/blob/master/README-PROVIDERS.md).
+* RGW: The Admin Ops user API now accepts the ``tenant`` request parameter on
+  user info, modify and remove, as user create already does. A tenant may
+  still be embedded in ``uid`` (``tenant$uid``) on all operations; if the
+  parameter and ``uid`` name different tenants, the request now fails with
+  ``EINVAL`` rather than one spelling being silently ignored. User create's
+  existing behavior (the parameter overwrites the tenant embedded in ``uid``)
+  is unchanged.
 * RGW: Fixed bucket notification events so the 'x_amz_request_id' in NotificationEvent now matches the 'x_amz_request_id' returned by the corresponding S3 operation.
 * RGW: The rgw_gc_max_deferred and rgw_gc_max_deferred_entries_size options have been removed, as they did not do anything.
   - Updated the default for rgw_gc_max_queue_size to account for the extra space from removing rgw_gc_max_deferred_entries_size.

--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -301,6 +301,18 @@ Request Parameters
 :Example: ``foo_user``
 :Required: Yes
 
+``tenant``
+
+:Description: The tenant of the user for which the information is requested.
+              A tenant may either be specified as a part of ``uid``, by
+              following the syntax ``tenant$user``, or by this parameter.
+              If ``uid`` already contains a tenant and this parameter names a
+              different one, the request fails with ``400 InvalidArgument``.
+              Requires ``uid``.
+:Type: String
+:Example: ``tenant1``
+:Required: No
+
 ``access-key``
 
 :Description: The S3 access key of the user for which the information is requested.
@@ -1332,6 +1344,17 @@ Request Parameters
 :Example: ``foo_user``
 :Required: Yes
 
+``tenant``
+
+:Description: The tenant of the user to be modified. A tenant may either be
+              specified as a part of ``uid``, by following the syntax
+              ``tenant$user``, or by this parameter. If ``uid`` already
+              contains a tenant and this parameter names a different one, the
+              request fails with ``400 InvalidArgument``.
+:Type: String
+:Example: ``tenant1``
+:Required: No
+
 ``display-name``
 
 :Description: The display name of the user to be modified.
@@ -1548,6 +1571,17 @@ Request Parameters
 :Type: String
 :Example: ``foo_user``
 :Required: Yes.
+
+``tenant``
+
+:Description: The tenant of the user to be removed. A tenant may either be
+              specified as a part of ``uid``, by following the syntax
+              ``tenant$user``, or by this parameter. If ``uid`` already
+              contains a tenant and this parameter names a different one, the
+              request fails with ``400 InvalidArgument``.
+:Type: String
+:Example: ``tenant1``
+:Required: No
 
 ``purge-data``
 

--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -415,6 +415,123 @@ def task(ctx, config):
     assert out['type'] == 'rgw'
     assert out['mfa_ids'] == []
 
+    # TESTCASES for the tenant parameter on user info, modify and remove
+    tenant_user = 'tuser'
+    tenant_name = 'ttenant'
+    combined_uid = tenant_name + '$' + tenant_user
+
+    # TESTCASE 'create-tenanted','user','create','tenant as request param','succeeds'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
+            ['user', 'create'],
+            {'uid' : tenant_user,
+             'tenant' : tenant_name,
+             'display-name' : 'Tenanted User'
+            })
+    assert ret == 200
+
+    # TESTCASE 'info-tenant-param','user','info','bare uid with tenant param','finds tenanted user'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'],
+            {'uid' : tenant_user, 'tenant' : tenant_name})
+    assert ret == 200
+    assert out['tenant'] == tenant_name
+
+    # TESTCASE 'info-tenant-match','user','info','tenanted uid with matching tenant param','succeeds'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'],
+            {'uid' : combined_uid, 'tenant' : tenant_name})
+    assert ret == 200
+    assert out['tenant'] == tenant_name
+
+    # TESTCASE 'info-tenant-mismatch','user','info','tenanted uid with different tenant param','fails'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'],
+            {'uid' : combined_uid, 'tenant' : 'othertenant'})
+    assert ret == 400
+
+    # TESTCASE 'modify-tenant-param','user','modify','bare uid with tenant param','modifies tenanted user'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'],
+            {'uid' : tenant_user, 'tenant' : tenant_name, 'display-name' : 'Tenanted User Two'})
+    assert ret == 200
+
+    # TESTCASE 'modify-tenant-match','user','modify','tenanted uid with matching tenant param','succeeds'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'],
+            {'uid' : combined_uid, 'tenant' : tenant_name, 'display-name' : 'Tenanted User Three'})
+    assert ret == 200
+
+    # TESTCASE 'modify-tenant-mismatch','user','modify','tenanted uid with different tenant param','fails'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'],
+            {'uid' : combined_uid, 'tenant' : 'othertenant', 'display-name' : 'Other User'})
+    assert ret == 400
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : combined_uid})
+    assert ret == 200
+    assert out['display_name'] == 'Tenanted User Three'
+
+    # TESTCASE 'rm-tenant-mismatch','user','rm','tenanted uid with different tenant param','fails'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'rm'],
+            {'uid' : combined_uid, 'tenant' : 'othertenant'})
+    assert ret == 400
+
+    # TESTCASE 'rm-tenant-match','user','rm','tenanted uid with matching tenant param','succeeds'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'rm'],
+            {'uid' : combined_uid, 'tenant' : tenant_name})
+    assert ret == 200
+
+    # TESTCASE 'rm-tenant-param','user','rm','bare uid with tenant param','removes tenanted user'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
+            ['user', 'create'],
+            {'uid' : tenant_user,
+             'tenant' : tenant_name,
+             'display-name' : 'Tenanted User'
+            })
+    assert ret == 200
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'rm'],
+            {'uid' : tenant_user, 'tenant' : tenant_name})
+    assert ret == 200
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : combined_uid})
+    assert ret == 404
+
+    # TESTCASE 'tenant-param-namesake','user','rm','untenanted namesake alongside','never touches the namesake'
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
+            ['user', 'create'],
+            {'uid' : tenant_user, 'display-name' : 'Bare Namesake'})
+    assert ret == 200
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds,
+            ['user', 'create'],
+            {'uid' : tenant_user,
+             'tenant' : tenant_name,
+             'display-name' : 'Tenanted User'
+            })
+    assert ret == 200
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'],
+            {'uid' : tenant_user, 'tenant' : tenant_name})
+    assert ret == 200
+    assert out['tenant'] == tenant_name
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'modify'],
+            {'uid' : tenant_user, 'tenant' : tenant_name, 'display-name' : 'Tenanted User Two'})
+    assert ret == 200
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : tenant_user})
+    assert ret == 200
+    assert out['display_name'] == 'Bare Namesake'
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'rm'],
+            {'uid' : tenant_user, 'tenant' : tenant_name})
+    assert ret == 200
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : combined_uid})
+    assert ret == 404
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'info'], {'uid' : tenant_user})
+    assert ret == 200
+    assert out['display_name'] == 'Bare Namesake'
+
+    (ret, out) = rgwadmin_rest(endpoint, admin_creds, ['user', 'rm'], {'uid' : tenant_user})
+    assert ret == 200
+
     # TESTCASES for cap user-info-without-keys
     test_cap_user_info_without_keys(ctx, client, endpoint, admin_creds, admin_user, user1)
 

--- a/src/rgw/driver/rados/rgw_rest_user.cc
+++ b/src/rgw/driver/rados/rgw_rest_user.cc
@@ -41,6 +41,21 @@ int fetch_access_keys_from_master(const DoutPrefixProvider* dpp, req_state* s,
   return 0;
 }
 
+// Unlike user create, where a 'tenant' request parameter overwrites any
+// tenant embedded in the 'uid' parameter, a conflict between the two
+// spellings is rejected here so that neither is silently ignored.
+static int apply_tenant_param(const DoutPrefixProvider* dpp,
+                              const std::string& tenant_name,
+                              const std::string& uid_str, rgw_user& uid)
+{
+  std::string err_msg;
+  int ret = rgw_apply_tenant_to_uid(tenant_name, uid_str, uid, err_msg);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "NOTICE: " << err_msg << dendl;
+  }
+  return ret;
+}
+
 class RGWOp_User_List : public RGWRESTOp {
 
 public:
@@ -92,13 +107,14 @@ void RGWOp_User_Info::execute(optional_yield y)
   RGWUserAdminOpState op_state(driver);
   op_state.set_system(s->system_request);
 
-  std::string uid_str, access_key_str;
+  std::string uid_str, access_key_str, tenant_name;
   bool fetch_stats;
   bool sync_stats;
   bool dump_keys = false;
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "access-key", access_key_str, &access_key_str);
+  RESTArgs::get_string(s, "tenant", tenant_name, &tenant_name);
 
   // if uid was not supplied in rest argument, error out now, otherwise we'll
   // end up initializing anonymous user, for which keys.init will eventually
@@ -109,6 +125,11 @@ void RGWOp_User_Info::execute(optional_yield y)
   }
 
   rgw_user uid(uid_str);
+
+  op_ret = apply_tenant_param(this, tenant_name, uid_str, uid);
+  if (op_ret < 0) {
+    return;
+  }
 
   RESTArgs::get_bool(s, "stats", false, &fetch_stats);
 
@@ -311,6 +332,7 @@ void RGWOp_User_Modify::execute(optional_yield y)
   std::string access_key;
   std::string secret_key;
   std::string key_type_str;
+  std::string tenant_name;
   std::string op_mask_str;
   std::string default_placement_str;
   std::string placement_tags_str;
@@ -337,6 +359,7 @@ void RGWOp_User_Modify::execute(optional_yield y)
   RESTArgs::get_bool(s, "suspended", false, &suspended);
   RESTArgs::get_int32(s, "max-buckets", RGW_DEFAULT_MAX_BUCKETS, &max_buckets, &quota_set);
   RESTArgs::get_string(s, "key-type", key_type_str, &key_type_str);
+  RESTArgs::get_string(s, "tenant", tenant_name, &tenant_name);
 
   RESTArgs::get_bool(s, "system", false, &system);
   RESTArgs::get_bool(s, "account-root", false, &account_root);
@@ -350,6 +373,11 @@ void RGWOp_User_Modify::execute(optional_yield y)
   if (!s->user->get_info().system && system) {
     ldpp_dout(this, 0) << "cannot set system flag by non-system user" << dendl;
     op_ret = -EINVAL;
+    return;
+  }
+
+  op_ret = apply_tenant_param(this, tenant_name, uid_str, uid);
+  if (op_ret < 0) {
     return;
   }
 
@@ -464,6 +492,7 @@ public:
 void RGWOp_User_Remove::execute(optional_yield y)
 {
   std::string uid_str;
+  std::string tenant_name;
   bool purge_data;
 
   RGWUserAdminOpState op_state(driver);
@@ -472,6 +501,12 @@ void RGWOp_User_Remove::execute(optional_yield y)
   rgw_user uid(uid_str);
 
   RESTArgs::get_bool(s, "purge-data", false, &purge_data);
+  RESTArgs::get_string(s, "tenant", tenant_name, &tenant_name);
+
+  op_ret = apply_tenant_param(this, tenant_name, uid_str, uid);
+  if (op_ret < 0) {
+    return;
+  }
 
   // FIXME: no double checking
   if (!uid.empty())

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -714,6 +714,25 @@ parse_key_value(const std::string_view& in_str)
   return parse_key_value(in_str, "=");
 }
 
+int rgw_apply_tenant_to_uid(const string& tenant, const string& uid_str,
+                            rgw_user& uid, string& err_msg)
+{
+  if (tenant.empty()) {
+    return 0;
+  }
+  if (uid_str.empty()) {
+    err_msg = "tenant requires uid";
+    return -EINVAL;
+  }
+  if (uid.tenant.empty()) {
+    uid.tenant = tenant;
+  } else if (uid.tenant != tenant) {
+    err_msg = "tenant " + tenant + " conflicts with tenant of uid " + uid_str;
+    return -EINVAL;
+  }
+  return 0;
+}
+
 int parse_time(const char *time_str, real_time *time)
 {
   struct tm tm;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1710,6 +1710,14 @@ parse_key_value(const std::string_view& in_str,
 extern boost::optional<std::pair<std::string_view,std::string_view>>
 parse_key_value(const std::string_view& in_str);
 
+/* Apply a tenant specified separately from uid_str to the uid parsed from
+ * uid_str. An empty tenant is a no-op; a non-empty tenant with an empty
+ * uid_str, or one conflicting with the tenant embedded in uid_str, fails
+ * with -EINVAL and a description in err_msg. */
+extern int rgw_apply_tenant_to_uid(const std::string& tenant,
+                                   const std::string& uid_str,
+                                   rgw_user& uid, std::string& err_msg);
+
 struct rgw_name_to_flag {
   const char *type_name;
   uint32_t flag;

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -322,6 +322,13 @@ target_include_directories(unittest_rgw_http_errors
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(unittest_rgw_http_errors rgw_common ${UNITTEST_LIBS})
 
+# unittest_rgw_user
+add_executable(unittest_rgw_user test_rgw_user.cc)
+add_ceph_unittest(unittest_rgw_user)
+target_include_directories(unittest_rgw_user
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_user rgw_common ${UNITTEST_LIBS})
+
 # unittest_rgw_dmclock_queue
 add_executable(unittest_rgw_dmclock_scheduler test_rgw_dmclock_scheduler.cc $<TARGET_OBJECTS:unit-main>)
 add_ceph_unittest(unittest_rgw_dmclock_scheduler)

--- a/src/test/rgw/test_rgw_user.cc
+++ b/src/test/rgw/test_rgw_user.cc
@@ -1,0 +1,83 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "rgw_common.h"
+
+#include <cerrno>
+#include <gtest/gtest.h>
+
+TEST(RGWApplyTenantToUid, EmptyTenantIsNoop)
+{
+  rgw_user uid("user1");
+  std::string err_msg;
+  ASSERT_EQ(0, rgw_apply_tenant_to_uid("", "user1", uid, err_msg));
+  EXPECT_EQ(rgw_user("user1"), uid);
+}
+
+TEST(RGWApplyTenantToUid, EmptyTenantEmptyUidIsNoop)
+{
+  rgw_user uid("");
+  std::string err_msg;
+  ASSERT_EQ(0, rgw_apply_tenant_to_uid("", "", uid, err_msg));
+  EXPECT_TRUE(uid.empty());
+}
+
+TEST(RGWApplyTenantToUid, TenantRequiresUid)
+{
+  rgw_user uid("");
+  std::string err_msg;
+  ASSERT_EQ(-EINVAL, rgw_apply_tenant_to_uid("tenanta", "", uid, err_msg));
+  EXPECT_FALSE(err_msg.empty());
+}
+
+TEST(RGWApplyTenantToUid, TenantAppliedToBareUid)
+{
+  rgw_user uid("user1");
+  std::string err_msg;
+  ASSERT_EQ(0, rgw_apply_tenant_to_uid("tenanta", "user1", uid, err_msg));
+  EXPECT_EQ("tenanta", uid.tenant);
+  EXPECT_EQ("user1", uid.id);
+}
+
+TEST(RGWApplyTenantToUid, MatchingEmbeddedTenantAccepted)
+{
+  rgw_user uid("tenanta$user1");
+  std::string err_msg;
+  ASSERT_EQ(0, rgw_apply_tenant_to_uid("tenanta", "tenanta$user1", uid,
+                                       err_msg));
+  EXPECT_EQ(rgw_user("tenanta$user1"), uid);
+}
+
+TEST(RGWApplyTenantToUid, ConflictingEmbeddedTenantRejected)
+{
+  rgw_user uid("tenanta$user1");
+  std::string err_msg;
+  ASSERT_EQ(-EINVAL, rgw_apply_tenant_to_uid("tenantb", "tenanta$user1", uid,
+                                             err_msg));
+  EXPECT_FALSE(err_msg.empty());
+  EXPECT_EQ(rgw_user("tenanta$user1"), uid);
+}
+
+// rgw_user::from_str() parses "$user1" as an empty tenant, so a tenant
+// parameter applies to it the same as to a bare uid.
+TEST(RGWApplyTenantToUid, LeadingDollarParsesAsEmptyTenant)
+{
+  rgw_user uid("$user1");
+  ASSERT_TRUE(uid.tenant.empty());
+  ASSERT_EQ("user1", uid.id);
+  std::string err_msg;
+  ASSERT_EQ(0, rgw_apply_tenant_to_uid("tenanta", "$user1", uid, err_msg));
+  EXPECT_EQ("tenanta", uid.tenant);
+  EXPECT_EQ("user1", uid.id);
+}
+
+// A tenant value that is itself a combined "tenant$uid" string gets no
+// special handling: it is compared verbatim against the embedded tenant.
+TEST(RGWApplyTenantToUid, CombinedStringAsTenantIsNotSpecialCased)
+{
+  rgw_user uid("tenanta$user1");
+  std::string err_msg;
+  ASSERT_EQ(-EINVAL, rgw_apply_tenant_to_uid("tenanta$user1", "tenanta$user1",
+                                             uid, err_msg));
+  EXPECT_FALSE(err_msg.empty());
+}


### PR DESCRIPTION
https://tracker.ceph.com/issues/79816

The Admin Ops user API accepts a separate `tenant` request parameter only on user create; user info, modify and remove could only express a tenant by embedding it in `uid` as `tenant$uid`. A client that sets a tenant field uniformly gets correct behavior on create and silently operates on the empty-tenant namesake on every other verb (go-ceph's admin client has exactly this shape today).

This accepts `tenant` on user info, modify and remove, with strict conflict semantics for the new parameter: a bare uid takes the tenant; a uid already carrying the same tenant is accepted; a uid carrying a different tenant fails with EINVAL rather than either spelling being silently ignored. User create's legacy behavior (the parameter overwrites any tenant embedded in `uid`) is deliberately unchanged.

Includes adminops docs for the three ops and a PendingReleaseNotes entry, following the shape of https://github.com/ceph/ceph/pull/71199, which touches the same handler for tracker 79090. The two changes are independent: that PR's diff still applies cleanly on top of this branch (`git apply --check`), so neither blocks the other.

Tests: the uid/tenant reconciliation is factored into `rgw_apply_tenant_to_uid()` in `rgw_common.cc` and unit-tested in the new `unittest_rgw_user` binary, which runs in `make check`; REST-level coverage -- including an untenanted namesake user surviving tenanted info, modify and remove -- is in `qa/tasks/radosgw_admin_rest.py` (teuthology `rgw/singleton` `radosgw-admin` task). Not compiled or run locally; `make check` CI verifies the build and unit tests, and the teuthology rgw suite the qa testcases.

AI assistance: this change was drafted by an AI agent under my direction and review.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>

