### PR TITLE
rgw: harmonize options fmt_desc with long_desc

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -156,7 +156,7 @@ options:
     multi-part upload (MPU) for S3 and DLO and SLO for Swift.  Note that this
     value also limits the size of individual chunks uploaded for MPU and
     DLO/SLO objects, thus the largest composite object that can be uploaded is
-    of size ``rgw_max_put_size`` * ``rgw_multipart_part_upload_limit``
+    of size rgw_max_put_size * rgw_multipart_part_upload_limit
   default: 5_G
   services:
   - rgw
@@ -725,12 +725,12 @@ options:
   desc: Swift URL prefix
   long_desc: 'The URL prefix for the Swift API, to distinguish it from the S3 API endpoint.
     The default is swift, which makes the Swift API available at the URL http://host:port/swift/v1
-    (or http://host:port/swift/v1/AUTH_%(tenant_id)s if ``rgw_swift_account_in_url`` is
+    (or http://host:port/swift/v1/AUTH_%(tenant_id)s if rgw_swift_account_in_url is
     enabled). For compatibility, setting this configuration variable to the empty string
     causes the default swift to be used; if you do want an empty prefix, set this option
     to /. Warning: If you set this option to /, you must disable the S3 API by modifying
-    ``rgw_enable_apis`` to exclude ``s3``. It is not possible to operate radosgw with
-    ``rgw_swift_url_prefix`` = ``/`` and simultaneously support both the S3 and Swift
+    rgw_enable_apis to exclude s3. It is not possible to operate radosgw with
+    rgw_swift_url_prefix = / and simultaneously support both the S3 and Swift
     APIs. If you do
     need to support both APIs without prefixes, deploy multiple radosgw instances to
     listen on different hosts (or ports) instead, enabling some for S3 and some for
@@ -1790,8 +1790,10 @@ options:
 - name: rgw_usage_max_user_shards
   type: int
   level: advanced
-  desc: Number of shards for single user in usage log
-  long_desc: The number of shards that a single user will span over in the usage log.
+  desc: Maximum number of usage-log shards a single user's records span.
+  long_desc: The maximum number of usage-log shards over which a single user's records
+    are spread. A user's entries start at a hash of the user name and wrap within this
+    many shards, so it bounds the fan-out per user rather than the size of the log.
   default: 1
   services:
   - rgw
@@ -1951,9 +1953,12 @@ options:
   desc: The number of shards (RADOS objects) across which the garbage collector stores
     its data.
   long_desc: The number of shards (RADOS objects) across which the garbage collector
-    stores its data; read once at daemon startup. It may be increased after initial
-    deployment, but must not be decreased without first ensuring all GC data shards
-    are completely empty.
+    stores its data; read once at daemon startup. More shards spread the GC queue more
+    widely and let garbage collection proceed with more parallelism, so this bounds GC
+    throughput rather than the number of objects GC can ever reclaim. The effective
+    value is capped by the maximum shard count RGW supports. It may be increased after
+    initial deployment, but must not be decreased without first ensuring all GC data
+    shards are completely empty.
   default: 32
   services:
   - rgw
@@ -2080,11 +2085,11 @@ options:
   type: bool
   level: advanced
   desc: Resolve DNS CNAMEs to support vanity bucket domains.
-  long_desc: If set, when the request hostname differs from rgw dns name, RGW queries
-    DNS for a CNAME record on that hostname and, if present, follows it. This lets
+  long_desc: If set, when the request hostname differs from rgw_dns_name, RGW queries
+    DNS for a CNAME record on that hostname and, if present, uses it instead. This lets
     users point a domain of their own at data in their bucket (vanity domains).
-  fmt_desc: If set, when the request hostname differs from ``rgw dns name``, RGW queries
-    DNS for a CNAME record on that hostname and, if present, follows it. This lets
+  fmt_desc: If set, when the request hostname differs from ``rgw_dns_name``, RGW queries
+    DNS for a CNAME record on that hostname and, if present, uses it instead. This lets
     users point a domain of their own at data in their bucket (vanity domains).
   default: false
   services:
@@ -2194,8 +2199,9 @@ options:
 - name: rgw_relaxed_s3_bucket_names
   type: bool
   level: advanced
-  desc: RGW enable relaxed S3 bucket names
-  long_desc: RGW enable relaxed S3 bucket name rules for US region buckets.
+  desc: Enables relaxed S3 bucket naming rules for US-region buckets.
+  long_desc: Enables the relaxed S3 bucket naming rules that AWS permits for buckets
+    in the US region, which allow names that the standard rules reject.
   default: false
   services:
   - rgw
@@ -2213,7 +2219,7 @@ options:
 - name: rgw_list_buckets_max_chunk
   type: int
   level: advanced
-  desc: Maximum buckets fetched per operation when listing a user's buckets.
+  desc: Maximum number of buckets fetched per operation when listing a user's buckets.
   long_desc: When RGW lists a user's buckets from the backend, the maximum number of
     entries it retrieves in a single operation. The backend may return fewer entries.
   default: 1000
@@ -2284,8 +2290,8 @@ options:
 - name: rgw_copy_obj_progress
   type: bool
   level: advanced
-  desc: Send progress report through copy operation
-  long_desc: If true, RGW will send progress information when copy operation is executed.
+  desc: Send progress reports through a copy operation
+  long_desc: If true, RGW sends progress information while a copy operation runs.
   default: true
   services:
   - rgw
@@ -2344,9 +2350,9 @@ options:
 - name: rgw_data_log_changes_size
   type: int
   level: dev
-  desc: Max size of pending changes in data log
-  long_desc: RGW will trigger update to the data log if the number of pending entries
-    reached this number.
+  desc: Maximum number of pending data-log entries before an update is triggered
+  long_desc: RGW triggers an update to the data log once the number of pending entries
+    reaches this number.
   default: 1000
   services:
   - rgw
@@ -2354,10 +2360,10 @@ options:
 - name: rgw_data_log_num_shards
   type: int
   level: advanced
-  desc: Number of data log shards
-  long_desc: The number of shards the RGW data log entries will reside in. This affects
-    the data sync parallelism as a shard can only be processed by a single RGW at a
-    time.
+  desc: Number of data-log shards
+  long_desc: The number of shards (RADOS objects) across which the RGW data-log entries
+    are spread. This bounds data sync parallelism, as a shard can only be processed by
+    a single RGW at a time.
   default: 128
   services:
   - rgw
@@ -3445,11 +3451,11 @@ options:
   level: advanced
   desc: template for per-bucket SSE-S3 keys in Vault.
   long_desc: This is the template for per-bucket sse-s3 keys.
-    This string may include ``%bucket_id`` which will be expanded out to
+    This string may include %bucket_id which will be expanded out to
     the bucket marker, a unique uuid assigned to that bucket.
-    It could contain ``%owner_id``, which will expand out to the owner's id.
+    It could contain %owner_id, which will expand out to the owner's id.
     Any other use of % is reserved and should not be used.
-    If the template contains ``%bucket_id``, associated bucket keys
+    If the template contains %bucket_id, associated bucket keys
     will be automatically removed when the bucket is removed.
   services:
   - rgw

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -324,8 +324,8 @@ options:
 - name: rgw_data
   type: str
   level: advanced
-  desc: Local data directory for the RADOS Gateway daemon.
-  long_desc: The local directory where the RADOS Gateway daemon keeps its per-daemon
+  desc: Data directory for the RADOS Gateway daemon.
+  long_desc: The directory where the RADOS Gateway daemon keeps its per-daemon
     files, such as its keyring.
   default: /var/lib/ceph/radosgw/$cluster-$id
   services:
@@ -725,28 +725,35 @@ options:
   desc: Swift URL prefix
   long_desc: 'The URL prefix for the Swift API, to distinguish it from the S3 API endpoint.
     The default is swift, which makes the Swift API available at the URL http://host:port/swift/v1
-    (or http://host:port/swift/v1/AUTH_%(tenant_id)s if rgw swift account in url is
+    (or http://host:port/swift/v1/AUTH_%(tenant_id)s if ``rgw_swift_account_in_url`` is
     enabled). For compatibility, setting this configuration variable to the empty string
     causes the default swift to be used; if you do want an empty prefix, set this option
     to /. Warning: If you set this option to /, you must disable the S3 API by modifying
-    rgw enable apis to exclude s3. It is not possible to operate radosgw with rgw swift
-    url prefix = / and simultaneously support both the S3 and Swift APIs. If you do
+    ``rgw_enable_apis`` to exclude ``s3``. It is not possible to operate radosgw with
+    ``rgw_swift_url_prefix`` = ``/`` and simultaneously support both the S3 and Swift
+    APIs. If you do
     need to support both APIs without prefixes, deploy multiple radosgw instances to
     listen on different hosts (or ports) instead, enabling some for S3 and some for
     Swift.'
-  fmt_desc: "The URL prefix for the Swift API, to distinguish it from\nthe S3 API endpoint.\
-    \ The default is ``swift``, which\nmakes the Swift API available at the URL\n``http://host:port/swift/v1``\
-    \ (or\n``http://host:port/swift/v1/AUTH_%(tenant_id)s`` if\n``rgw swift account\
-    \ in url`` is enabled).\n\nFor compatibility, setting this configuration variable\n\
-    to the empty string causes the default ``swift`` to be\nused; if you do want an\
-    \ empty prefix, set this option to\n``/``.\n\n.. warning:: If you set this option\
-    \ to ``/``, you must\n             disable the S3 API by modifying ``rgw\n    \
-    \         enable apis`` to exclude ``s3``. It is not\n             possible to\
-    \ operate radosgw with ``rgw\n             swift url prefix = /`` and simultaneously\n\
-    \             support both the S3 and Swift APIs. If you\n             do need\
-    \ to support both APIs without\n             prefixes, deploy multiple radosgw\
-    \ instances\n             to listen on different hosts (or ports)\n           \
-    \  instead, enabling some for S3 and some for\n             Swift.\n"
+  fmt_desc: |
+    The URL prefix for the Swift API, to distinguish it from the S3 API endpoint.
+    The default is ``swift``, which makes the Swift API available at the URL
+    ``http://host:port/swift/v1`` (or
+    ``http://host:port/swift/v1/AUTH_%(tenant_id)s`` if ``rgw_swift_account_in_url``
+    is enabled).
+
+    For compatibility, setting this configuration variable to the empty string causes
+    the default ``swift`` to be used; if you do want an empty prefix, set this option
+    to ``/``.
+
+    .. warning::
+
+       If you set this option to ``/``, you must disable the S3 API by modifying
+       ``rgw_enable_apis`` to exclude ``s3``. It is not possible to operate radosgw
+       with ``rgw_swift_url_prefix = /`` and simultaneously support both the S3 and
+       Swift APIs. If you do need to support both APIs without prefixes, deploy
+       multiple radosgw instances to listen on different hosts (or ports) instead,
+       enabling some for S3 and some for Swift.
   example: /swift-testing
   default: swift
   services:
@@ -794,49 +801,25 @@ options:
     (or http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<keystone_project_id>) instead,
     and the Keystone object-store endpoint must accordingly be configured to include
     the AUTH_%(tenant_id)s suffix. You must set this option to true (and update the
-    Keystone service catalog) if you want radosgw to support publicly-readable containers
+    Keystone service catalog) if you want radosgw to support publicly readable containers
     and temporary URLs.
-  fmt_desc: 'Whether or not the Swift account name should be included
-  
-    in the Swift API URL.
-  
-    If set to ``false`` (the default), then the Swift API
-  
-    will listen on a URL formed like
-  
-    ``http://host:port/<rgw_swift_url_prefix>/v1``, and the
-  
-    account name (commonly a Keystone project UUID if
-  
-    radosgw is configured with `Keystone integration
-  
-    <../keystone>`_) will be inferred from request
-  
-    headers.
-  
+  fmt_desc: |
+    Whether or not the Swift account name should be included in the Swift API URL.
+
+    If set to ``false`` (the default), then the Swift API will listen on a URL formed
+    like ``http://host:port/<rgw_swift_url_prefix>/v1``, and the account name (commonly
+    a Keystone project UUID if radosgw is configured with `Keystone integration
+    <../keystone>`_) will be inferred from request headers.
+
     If set to ``true``, the Swift API URL will be
-  
-    ``http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<account_name>``
-  
-    (or
-  
-    ``http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<keystone_project_id>``)
-  
-    instead, and the Keystone ``object-store`` endpoint must
-  
-    accordingly be configured to include the
-  
-    ``AUTH_%(tenant_id)s`` suffix.
-  
-    You **must** set this option to ``true`` (and update the
-  
-    Keystone service catalog) if you want radosgw to support
-  
-    publicly-readable containers and `temporary URLs
-  
+    ``http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<account_name>`` (or
+    ``http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<keystone_project_id>``) instead,
+    and the Keystone ``object-store`` endpoint must accordingly be configured to include
+    the ``AUTH_%(tenant_id)s`` suffix.
+
+    You **must** set this option to ``true`` (and update the Keystone service catalog)
+    if you want radosgw to support publicly readable containers and `temporary URLs
     <../swift/tempurl>`_.
-  
-    '
   default: false
   services:
   - rgw
@@ -1747,7 +1730,7 @@ options:
 - name: rgw_log_nonexistent_bucket
   type: bool
   level: advanced
-  desc: Log ops-log requests to nonexistent buckets.
+  desc: Record requests to nonexistent buckets in the ops log.
   long_desc: When set, the ops log records operations sent to nonexistent buckets.
     Such operations inherently fail and do not correspond to a specific user.
   default: false
@@ -1787,7 +1770,7 @@ options:
 - name: rgw_usage_max_shards
   type: int
   level: advanced
-  desc: Number of RADOS shards for the usage log (must be uniform cluster-wide).
+  desc: Number of RADOS objects for the usage log (must be uniform cluster-wide).
   long_desc: The number of RADOS objects across which RGW stores the usage-log data.
     All RGW daemons and radosgw-admin commands must use the same value; if they differ,
     writes and reads/clears target different objects, so usage data appears empty or
@@ -1866,9 +1849,9 @@ options:
 - name: rgw_ops_log_socket_path
   type: str
   level: advanced
-  desc: Unix domain socket path for ops log.
-  long_desc: Path to unix domain socket that RGW will listen for connection on. When
-    connected, RGW will send ops log data through it.
+  desc: Unix domain socket path for the ops log.
+  long_desc: Path to the Unix domain socket that RGW will listen for a connection. When
+    connected, RGW sends ops-log data through it.
   services:
   - rgw
   see_also:
@@ -1899,7 +1882,7 @@ options:
   desc: Maximum ops-log backlog for the Unix-domain-socket sink.
   long_desc: The maximum amount of buffered ops-log data RGW retains when the ops log
     is written to a Unix domain socket. If the backlog exceeds this, ops-log entries
-    are dropped, so the listening consumer must read the socket quickly enough to avoid
+    are dropped, so the consumer must read the socket quickly enough to avoid
     loss.
   default: 5_M
   services:
@@ -1954,8 +1937,8 @@ options:
 - name: rgw_mime_types_file
   type: str
   level: basic
-  desc: Path to local mime types file
-  long_desc: The mime types file is needed in Swift when uploading an object. If object's
+  desc: Path to local MIME types file
+  long_desc: The MIME types file is needed in Swift when uploading an object. If object's
     content type is not specified, RGW will use data from this file to assign a content
     type to the object.
   default: /etc/mime.types

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -324,9 +324,9 @@ options:
 - name: rgw_data
   type: str
   level: advanced
-  desc: Alternative location for RGW configuration.
-  long_desc: If this is set, the different Ceph system configurables (such as the keyring file) will be located in the path that is specified here.
-  fmt_desc: Sets the location of the data files for Ceph RADOS Gateway.
+  desc: Local data directory for the RADOS Gateway daemon.
+  long_desc: The local directory where the RADOS Gateway daemon keeps its per-daemon
+    files, such as its keyring.
   default: /var/lib/ceph/radosgw/$cluster-$id
   services:
   - rgw
@@ -347,12 +347,10 @@ options:
 - name: rgw_cache_enabled
   type: bool
   level: advanced
-  desc: Enable RGW metadata cache.
-  long_desc: The metadata cache holds metadata entries that RGW requires for processing
-    requests. Metadata entries can be user info, bucket info, and bucket instance
-    info. If not found in the cache, entries will be fetched from the backing RADOS
-    store.
-  fmt_desc: Whether the Ceph Object Gateway cache is enabled.
+  desc: Enable the RGW metadata cache.
+  long_desc: Whether the RGW metadata cache is enabled. The cache holds metadata that
+    RGW needs to process requests, such as user info, bucket info, and bucket instance
+    info; entries not present in the cache are fetched from the backing RADOS store.
   default: true
   services:
   - rgw
@@ -362,9 +360,9 @@ options:
 - name: rgw_cache_lru_size
   type: int
   level: advanced
-  desc: Max number of items in RGW metadata cache.
-  long_desc: When full, the RGW metadata cache evicts least recently used entries.
-  fmt_desc: The number of entries in the Ceph Object Gateway cache.
+  desc: Maximum number of entries in the RGW metadata cache.
+  long_desc: The maximum number of entries held in the RGW metadata cache. When full,
+    the cache evicts the least recently used entries.
   default: 25000
   services:
   - rgw
@@ -412,8 +410,8 @@ options:
   type: bool
   level: advanced
   desc: Multiple content length headers compatibility
-  long_desc: Try to handle requests with ambiguous multiple content length headers
-    (Content-Length, Http-Content-Length).
+  long_desc: Enable compatibility handling of FCGI requests with both CONTENT_LENGTH
+    and HTTP_CONTENT_LENGTH set.
   fmt_desc: Enable compatibility handling of FCGI requests with both ``CONTENT_LENGTH``
     and ``HTTP_CONTENT_LENGTH`` set.
   default: false
@@ -461,11 +459,8 @@ options:
   type: int
   level: advanced
   desc: Number of LCWorker tasks that will be run in parallel
-  long_desc: Number of LCWorker tasks that will run in parallel. Used to permit >1
-    bucket/index shards to be processed simultaneously.
-  fmt_desc: This option specifies the number of lifecycle worker threads
-    to run in parallel, thereby processing bucket and index
-    shards simultaneously.
+  long_desc: This option specifies the number of lifecycle worker threads to run in
+    parallel, thereby processing bucket and index shards simultaneously.
   default: 3
   services:
   - rgw
@@ -474,10 +469,8 @@ options:
   type: int
   level: advanced
   desc: Number of workpool coroutines per LCWorker
-  long_desc: Number of coroutines in per-LCWorker workpools. Used to accelerate per-bucket
-    processing.
-  fmt_desc: This option specifies the number of coroutines in each lifecycle
-    workers work pool. This option can help accelerate processing each bucket.
+  long_desc: This option specifies the number of coroutines in each lifecycle workers
+    work pool. This option can help accelerate processing each bucket.
   default: 128
   services:
   - rgw
@@ -652,11 +645,10 @@ options:
 - name: rgw_restore_processor_period
   type: int
   level: advanced
-  desc: Restore cycle run time
-  long_desc: The amount of time between the start of consecutive runs of the restore
-    processing threads. If the thread runs more than this period, it will
-    not wait before running again.
-  fmt_desc: The cycle time for restore state processing.
+  desc: Interval between restore-processor runs, in seconds.
+  long_desc: The time between the start of consecutive runs of the restore-processing
+    threads. If a run takes longer than this period, the next run starts immediately
+    without waiting.
   default: 15_min
   services:
   - rgw
@@ -715,10 +707,13 @@ options:
 - name: rgw_swift_url
   type: str
   level: advanced
-  desc: Swift-auth storage URL
-  long_desc: Used in conjunction with rgw internal swift authentication. This affects
-    the X-Storage-Url response header value.
-  fmt_desc: The URL for the Ceph Object Gateway Swift API.
+  desc: URL advertised for the Ceph Object Gateway Swift API.
+  long_desc: The URL for the Ceph Object Gateway Swift API, used with RGW's internal
+    Swift authentication. Its value is returned to clients in the X-Storage-Url response
+    header.
+  fmt_desc: The URL for the Ceph Object Gateway Swift API, used with RGW's internal
+    Swift authentication. Its value is returned to clients in the ``X-Storage-Url``
+    response header.
   services:
   - rgw
   see_also:
@@ -728,31 +723,30 @@ options:
   type: str
   level: advanced
   desc: Swift URL prefix
-  long_desc: The URL path prefix for swift requests.
-  fmt_desc: |
-    The URL prefix for the Swift API, to distinguish it from
-    the S3 API endpoint. The default is ``swift``, which
-    makes the Swift API available at the URL
-    ``http://host:port/swift/v1`` (or
-    ``http://host:port/swift/v1/AUTH_%(tenant_id)s`` if
-    ``rgw swift account in url`` is enabled).
-
-    For compatibility, setting this configuration variable
-    to the empty string causes the default ``swift`` to be
-    used; if you do want an empty prefix, set this option to
-    ``/``.
-
-    .. warning:: If you set this option to ``/``, you must
-                 disable the S3 API by modifying ``rgw
-                 enable apis`` to exclude ``s3``. It is not
-                 possible to operate radosgw with ``rgw
-                 swift url prefix = /`` and simultaneously
-                 support both the S3 and Swift APIs. If you
-                 do need to support both APIs without
-                 prefixes, deploy multiple radosgw instances
-                 to listen on different hosts (or ports)
-                 instead, enabling some for S3 and some for
-                 Swift.
+  long_desc: 'The URL prefix for the Swift API, to distinguish it from the S3 API endpoint.
+    The default is swift, which makes the Swift API available at the URL http://host:port/swift/v1
+    (or http://host:port/swift/v1/AUTH_%(tenant_id)s if rgw swift account in url is
+    enabled). For compatibility, setting this configuration variable to the empty string
+    causes the default swift to be used; if you do want an empty prefix, set this option
+    to /. Warning: If you set this option to /, you must disable the S3 API by modifying
+    rgw enable apis to exclude s3. It is not possible to operate radosgw with rgw swift
+    url prefix = / and simultaneously support both the S3 and Swift APIs. If you do
+    need to support both APIs without prefixes, deploy multiple radosgw instances to
+    listen on different hosts (or ports) instead, enabling some for S3 and some for
+    Swift.'
+  fmt_desc: "The URL prefix for the Swift API, to distinguish it from\nthe S3 API endpoint.\
+    \ The default is ``swift``, which\nmakes the Swift API available at the URL\n``http://host:port/swift/v1``\
+    \ (or\n``http://host:port/swift/v1/AUTH_%(tenant_id)s`` if\n``rgw swift account\
+    \ in url`` is enabled).\n\nFor compatibility, setting this configuration variable\n\
+    to the empty string causes the default ``swift`` to be\nused; if you do want an\
+    \ empty prefix, set this option to\n``/``.\n\n.. warning:: If you set this option\
+    \ to ``/``, you must\n             disable the S3 API by modifying ``rgw\n    \
+    \         enable apis`` to exclude ``s3``. It is not\n             possible to\
+    \ operate radosgw with ``rgw\n             swift url prefix = /`` and simultaneously\n\
+    \             support both the S3 and Swift APIs. If you\n             do need\
+    \ to support both APIs without\n             prefixes, deploy multiple radosgw\
+    \ instances\n             to listen on different hosts (or ports)\n           \
+    \  instead, enabling some for S3 and some for\n             Swift.\n"
   example: /swift-testing
   default: swift
   services:
@@ -772,7 +766,6 @@ options:
   level: advanced
   desc: Swift auth URL prefix
   long_desc: URL path prefix for internal swift auth requests.
-  fmt_desc: The entry point for a Swift auth URL.
   default: auth
   services:
   - rgw
@@ -793,28 +786,57 @@ options:
   type: bool
   level: advanced
   desc: Swift account encoded in URL
-  long_desc: Whether the swift account is encoded in the uri path (AUTH_<account>).
-  fmt_desc: |
-    Whether or not the Swift account name should be included
+  long_desc: Whether or not the Swift account name should be included in the Swift
+    API URL. If set to false (the default), then the Swift API will listen on a URL
+    formed like http://host:port/<rgw_swift_url_prefix>/v1, and the account name (commonly
+    a Keystone project UUID if radosgw is configured with Keystone integration) will
+    be inferred from request headers. If set to true, the Swift API URL will be http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<account_name>
+    (or http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<keystone_project_id>) instead,
+    and the Keystone object-store endpoint must accordingly be configured to include
+    the AUTH_%(tenant_id)s suffix. You must set this option to true (and update the
+    Keystone service catalog) if you want radosgw to support publicly-readable containers
+    and temporary URLs.
+  fmt_desc: 'Whether or not the Swift account name should be included
+  
     in the Swift API URL.
+  
     If set to ``false`` (the default), then the Swift API
+  
     will listen on a URL formed like
+  
     ``http://host:port/<rgw_swift_url_prefix>/v1``, and the
+  
     account name (commonly a Keystone project UUID if
+  
     radosgw is configured with `Keystone integration
+  
     <../keystone>`_) will be inferred from request
+  
     headers.
+  
     If set to ``true``, the Swift API URL will be
+  
     ``http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<account_name>``
+  
     (or
+  
     ``http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<keystone_project_id>``)
+  
     instead, and the Keystone ``object-store`` endpoint must
+  
     accordingly be configured to include the
+  
     ``AUTH_%(tenant_id)s`` suffix.
+  
     You **must** set this option to ``true`` (and update the
+  
     Keystone service catalog) if you want radosgw to support
+  
     publicly-readable containers and `temporary URLs
+  
     <../swift/tempurl>`_.
+  
+    '
   default: false
   services:
   - rgw
@@ -1004,9 +1026,8 @@ options:
   type: int
   level: advanced
   desc: Keystone token cache size
-  long_desc: Max number of Keystone tokens that will be cached. Token that is not
-    cached requires RGW to access the Keystone server when authenticating.
-  fmt_desc: The maximum number of entries in each Keystone token cache.
+  long_desc: Max number of Keystone tokens that will be cached. Token that is not cached
+    requires RGW to access the Keystone server when authenticating.
   default: 10000
   services:
   - rgw
@@ -1015,8 +1036,8 @@ options:
   type: int
   level: advanced
   desc: Keystone token secret key cache TTL
-  long_desc: The TTL for secret keys that are loaded from Keystone and stored in the cache system.
-  fmt_desc: The maximum TTL that a secret loaded from Keystone is maintained in the token cache system.
+  long_desc: The maximum TTL that a secret loaded from Keystone is maintained in the
+    token cache system.
   default: 300
   services:
   - rgw
@@ -1236,10 +1257,13 @@ options:
 - name: rgw_admin_entry
   type: str
   level: advanced
-  desc: Path prefix to be used for accessing RGW RESTful admin API.
-  fmt_desc: The entry point for an admin request URL.
-  long_desc: Note that multisite replication requires the value admin,
-    so this option must be left at the default in such deployments.
+  desc: URL entry point (path prefix) for the RGW admin API.
+  fmt_desc: The entry point (URL path prefix) for requests to the RGW RESTful admin
+    API. Multisite replication requires the value ``admin``, so leave this at the default
+    in multisite deployments.
+  long_desc: The entry point (URL path prefix) for requests to the RGW RESTful admin
+    API. Multisite replication requires the value 'admin', so leave this at the default
+    in multisite deployments.
   default: admin
   services:
   - rgw
@@ -1250,7 +1274,6 @@ options:
   desc: RGW enforce swift acls
   long_desc: Should RGW enforce special Swift-only ACLs. Swift has a special ACL that
     gives permission to access all objects in a container.
-  fmt_desc: Enforces the Swift Access Control List (ACL) settings.
   default: true
   services:
   - rgw
@@ -1267,10 +1290,11 @@ options:
 - name: rgw_print_continue
   type: bool
   level: advanced
-  desc: RGW support of 100-continue
-  long_desc: Should RGW explicitly send 100 (continue) responses. This is mainly relevant
-    when using FastCGI, as some FastCGI modules do not fully support this feature.
-  fmt_desc: Enable ``100-continue`` if it is operational.
+  desc: Whether RGW sends HTTP 100-continue responses.
+  long_desc: Whether RGW explicitly sends HTTP 100 (continue) responses. This mainly
+    matters with FastCGI, since some FastCGI modules do not fully support the feature.
+  fmt_desc: Whether RGW explicitly sends HTTP ``100-continue`` responses. This mainly
+    matters with FastCGI, since some FastCGI modules do not fully support the feature.
   default: true
   services:
   - rgw
@@ -1288,15 +1312,17 @@ options:
 - name: rgw_remote_addr_param
   type: str
   level: advanced
-  desc: HTTP header that holds the remote address in incoming requests.
-  long_desc: RGW will use this header to extract requests origin. When RGW runs behind
-    a reverse proxy, the remote address header will point at the proxy's address and
-    not at the originator's address. Therefore it is sometimes possible to have the
-    proxy add the originator's address in a separate HTTP header, which will allow
-    RGW to log it correctly.
-  fmt_desc: The remote address parameter. For example, the HTTP field
-    containing the remote address, or the ``X-Forwarded-For``
-    address if a reverse proxy is operational.
+  desc: HTTP header from which RGW reads the client's remote address.
+  long_desc: The HTTP header RGW uses to determine a request's origin address. Behind
+    a reverse proxy, the normal remote-address header holds the proxy's address rather
+    than the originator's, so you can configure the proxy to add the originator's address
+    in a separate header (such as X-Forwarded-For) and point this option at it so RGW
+    logs the correct address.
+  fmt_desc: The HTTP header RGW uses to determine a request's origin address. Behind
+    a reverse proxy, the normal remote-address header holds the proxy's address rather
+    than the originator's, so you can configure the proxy to add the originator's address
+    in a separate header (such as ``X-Forwarded-For``) and point this option at it
+    so RGW logs the correct address.
   default: REMOTE_ADDR
   services:
   - rgw
@@ -1324,12 +1350,10 @@ options:
 - name: rgw_thread_pool_size
   type: int
   level: basic
-  desc: RGW requests handling thread pool size.
-  long_desc: This parameter determines the number of concurrent requests RGW can process
-    when using either the civetweb, or the fastcgi frontends. The higher this number
-    is, RGW will be able to deal with more concurrent requests at the cost of more
-    resource utilization.
-  fmt_desc: The size of the thread pool.
+  desc: Number of RGW request-handling threads.
+  long_desc: The size of the thread pool RGW uses to handle requests, i.e. the number
+    of requests it can process concurrently. A larger pool handles more concurrent
+    requests at the cost of higher resource usage.
   default: 128
   services:
   - rgw
@@ -1339,14 +1363,15 @@ options:
 - name: rgw_num_control_oids
   type: int
   level: advanced
-  desc: Number of control objects used for cross-RGW communication.
-  long_desc: RGW uses certain control objects to send messages between different RGW
-    processes running on the same zone. These messages include metadata cache invalidation
-    info that is being sent when metadata is modified (such as user or bucket information).
-    A higher number of control objects allows better concurrency of these messages,
-    at the cost of more resource utilization.
-  fmt_desc: The number of notification objects used for cache synchronization
-    between different ``rgw`` instances.
+  desc: Number of control objects used for cross-RGW cache synchronization.
+  long_desc: The number of control objects RGW uses to pass messages between RGW processes
+    in the same zone, chiefly metadata-cache invalidations sent when metadata (such
+    as user or bucket info) changes. More control objects allow greater message concurrency
+    at the cost of more resource usage.
+  fmt_desc: The number of control objects RGW uses to pass messages between ``rgw``
+    processes in the same zone, chiefly metadata-cache invalidations sent when metadata
+    (such as user or bucket info) changes. More control objects allow greater message
+    concurrency at the cost of more resource usage.
   default: 8
   services:
   - rgw
@@ -1370,11 +1395,9 @@ options:
 - name: rgw_verify_ssl
   type: bool
   level: advanced
-  desc: Should RGW verify SSL when connecting to a remote HTTP server
-  long_desc: RGW can send requests to other RGW servers (e.g., in multi-site sync
-    work). This configurable selects whether RGW should verify the certificate for
-    the remote peer and host.
-  fmt_desc: Verify SSL certificates while making requests.
+  desc: Whether RGW verifies SSL certificates on outgoing requests.
+  long_desc: Whether RGW verifies the SSL certificate of a remote peer when it makes
+    outgoing requests, for example to other RGW servers during multisite sync.
   default: true
   services:
   - rgw
@@ -1513,15 +1536,13 @@ options:
 - name: rgw_nfs_frontends
   type: str
   level: basic
-  desc: RGW frontends configuration when running as librgw/nfs
-  long_desc: A comma-delimited list of frontends configuration. Each configuration
-    contains the type of the frontend followed by an optional space delimited set
-    of key=value config parameters.
-  fmt_desc: Configures the HTTP frontend(s). The configuration for multiple
-    frontends can be provided in a comma-delimited list. Each frontend
-    configuration may include a list of options separated by spaces,
-    where each option is in the form "key=value" or "key". See
-    `HTTP Frontends`_ for more on supported options.
+  desc: RGW frontend configuration when running as librgw/NFS.
+  long_desc: Configures the frontend(s) used when RGW runs as librgw (the NFS interface);
+    the default is rgw-nfs. Provide a comma-delimited list, each entry a frontend type
+    followed by optional space-separated key=value parameters.
+  fmt_desc: Configures the frontend(s) used when RGW runs as librgw (the NFS interface);
+    the default is ``rgw-nfs``. Provide a comma-delimited list, each entry a frontend
+    type followed by optional space-separated ``key=value`` parameters.
   default: rgw-nfs
   services:
   - rgw
@@ -1726,12 +1747,9 @@ options:
 - name: rgw_log_nonexistent_bucket
   type: bool
   level: advanced
-  desc: Should RGW log operations on bucket that does not exist
-  long_desc: This config option applies to the ops log. When this option is set, the
-    ops log will log operations that are sent to nonexistent buckets. These operations
-    inherently fail, and do not correspond to a specific user.
-  fmt_desc: Enables Ceph Object Gateway to log a request for a non-existent
-    bucket.
+  desc: Log ops-log requests to nonexistent buckets.
+  long_desc: When set, the ops log records operations sent to nonexistent buckets.
+    Such operations inherently fail and do not correspond to a specific user.
   default: false
   services:
   - rgw
@@ -1742,11 +1760,11 @@ options:
 - name: rgw_log_object_name
   type: str
   level: advanced
-  desc: Ops log object name format
-  long_desc: Defines the format of the RADOS objects names that ops log uses to store
-    ops log data
-  fmt_desc: The logging format for an object name. See man page
-    :manpage:`date` for details about format specifiers.
+  desc: Name format for ops-log RADOS objects.
+  long_desc: The format for the names of the RADOS objects that the ops log writes
+    its data to. See the date(1) man page for the available format specifiers.
+  fmt_desc: The format for the names of the RADOS objects that the ops log writes its
+    data to. See the :manpage:`date` man page for the available format specifiers.
   default: '%Y-%m-%d-%H-%i-%n'
   services:
   - rgw
@@ -1759,8 +1777,6 @@ options:
   desc: Should ops log object name based on UTC
   long_desc: If set, the names of the RADOS objects that hold the ops log data will
     be based on UTC time zone. If not set, it will use the local time zone.
-  fmt_desc: Whether a logged object name includes a UTC time.
-    If ``false``, it uses the local time.
   default: false
   services:
   - rgw
@@ -1771,15 +1787,17 @@ options:
 - name: rgw_usage_max_shards
   type: int
   level: advanced
-  desc: Number of shards for usage log.
-  long_desc: The number of RADOS objects that RGW will use in order to store the usage
-    log data. All RGW daemons and radosgw-admin commands must use the same value
-    for this option. If values differ, writes and reads/clears will target
-    different objects, causing usage data to appear empty or not be cleared.
-    Use ``ceph config set global rgw_usage_max_shards <N>`` to ensure consistency
-    across the cluster. Alternatively, ``radosgw-admin`` supports the
-    ``--rgw-usage-max-shards`` command-line parameter.
-  fmt_desc: The maximum number of shards for usage logging.
+  desc: Number of RADOS shards for the usage log (must be uniform cluster-wide).
+  long_desc: The number of RADOS objects across which RGW stores the usage-log data.
+    All RGW daemons and radosgw-admin commands must use the same value; if they differ,
+    writes and reads/clears target different objects, so usage data appears empty or
+    is not cleared. Set it consistently across the cluster with 'ceph config set global
+    rgw_usage_max_shards <N>', or pass --rgw-usage-max-shards to radosgw-admin.
+  fmt_desc: The number of RADOS objects across which RGW stores the usage-log data.
+    All RGW daemons and ``radosgw-admin`` commands must use the same value; if they
+    differ, writes and reads/clears target different objects, so usage data appears
+    empty or is not cleared. Set it consistently across the cluster with ``ceph config
+    set global rgw_usage_max_shards <N>``, or pass ``--rgw-usage-max-shards`` to ``radosgw-admin``.
   default: 32
   services:
   - rgw
@@ -1791,8 +1809,6 @@ options:
   level: advanced
   desc: Number of shards for single user in usage log
   long_desc: The number of shards that a single user will span over in the usage log.
-  fmt_desc: The maximum number of shards used for a single user's
-    usage logging.
   default: 1
   services:
   - rgw
@@ -1831,13 +1847,13 @@ options:
 - name: rgw_ops_log_rados
   type: bool
   level: advanced
-  desc: Use RADOS for ops log
-  long_desc: If set, RGW will store ops log information in RADOS. WARNING,
-    there is no automation to clean up these log entries, so by default they
-    will pile up without bound. This MUST NOT be enabled unless the admin has
-    a strategy to manage and trim these log entries with `radosgw-admin log rm`.
-  fmt_desc: Whether the operations log should be written to the
-    Ceph Storage Cluster backend.
+  desc: Write the ops log to RADOS.
+  long_desc: 'When set, RGW stores ops-log entries in RADOS. Warning: nothing trims
+    these entries automatically, so they grow without bound. Do not enable this unless
+    you have a strategy to manage and trim them with radosgw-admin log rm.'
+  fmt_desc: 'When set, RGW stores ops-log entries in RADOS. Warning: nothing trims
+    these entries automatically, so they grow without bound. Do not enable this unless
+    you have a strategy to manage and trim them with ``radosgw-admin log rm``.'
   default: false
   services:
   - rgw
@@ -1853,7 +1869,6 @@ options:
   desc: Unix domain socket path for ops log.
   long_desc: Path to unix domain socket that RGW will listen for connection on. When
     connected, RGW will send ops log data through it.
-  fmt_desc: The Unix domain socket for writing operations logs.
   services:
   - rgw
   see_also:
@@ -1864,10 +1879,13 @@ options:
 - name: rgw_ops_log_file_path
   type: str
   level: advanced
-  desc: File-system path for ops log.
-  long_desc: Path to file that RGW will log ops logs to. A cephadm deployment will automatically
-    rotate these logs under /var/log/ceph/. Other deployments should arrange for similar log rotation.
-  fmt_desc: The file-system path for writing operations logs.
+  desc: Filesystem path for the ops log.
+  long_desc: The filesystem path to which RGW writes the ops log. A cephadm deployment
+    rotates these logs automatically under /var/log/ceph/; other deployments should
+    arrange similar log rotation.
+  fmt_desc: The filesystem path to which RGW writes the ops log. A cephadm deployment
+    rotates these logs automatically under ``/var/log/ceph/``; other deployments should
+    arrange similar log rotation.
   daemon_default: /var/log/ceph/ops-log-$cluster-$name.log
   services:
   - rgw
@@ -1878,13 +1896,11 @@ options:
 - name: rgw_ops_log_data_backlog
   type: size
   level: advanced
-  desc: Ops log socket backlog
-  long_desc: Maximum amount of data backlog that RGW can keep when ops log is configured
-    to send info through unix domain socket. When data backlog is higher than this,
-    ops log entries will be lost. In order to avoid ops log information loss, the
-    listener needs to clear data (by reading it) quickly enough.
-  fmt_desc: The maximum data backlog data size for operations logs written
-    to a Unix domain socket.
+  desc: Maximum ops-log backlog for the Unix-domain-socket sink.
+  long_desc: The maximum amount of buffered ops-log data RGW retains when the ops log
+    is written to a Unix domain socket. If the backlog exceeds this, ops-log entries
+    are dropped, so the listening consumer must read the socket quickly enough to avoid
+    loss.
   default: 5_M
   services:
   - rgw
@@ -1895,13 +1911,11 @@ options:
 - name: rgw_usage_log_flush_threshold
   type: int
   level: advanced
-  desc: Number of entries in usage log before flushing
-  long_desc: This is the max number of entries that will be held in the usage log,
-    before it will be flushed to the backend. Note that the usage log is periodically
-    flushed, even if number of entries does not reach this threshold. A usage log
-    entry corresponds to one or more operations on a single bucket.
-  fmt_desc: The number of dirty merged entries in the usage log before
-    flushing synchronously.
+  desc: Pending usage-log entries before a synchronous flush.
+  long_desc: The number of pending (dirty, merged) usage-log entries that triggers
+    a synchronous flush to the backend. The usage log is also flushed periodically
+    even if this threshold is not reached. A usage-log entry corresponds to one or
+    more operations on a single bucket.
   default: 1024
   services:
   - rgw
@@ -1912,11 +1926,13 @@ options:
 - name: rgw_usage_log_tick_interval
   type: int
   level: advanced
-  desc: Number of seconds between usage log flush cycles
-  long_desc: The number of seconds between consecutive usage log flushes. The usage
-    log will also flush itself to the backend if the number of pending entries reaches
-    a certain threshold.
-  fmt_desc: Flush pending usage log data every ``n`` seconds.
+  desc: Seconds between periodic usage-log flushes.
+  long_desc: The number of seconds between periodic usage-log flushes to the backend.
+    The usage log is also flushed sooner when the number of pending entries reaches
+    rgw_usage_log_flush_threshold.
+  fmt_desc: The number of seconds between periodic usage-log flushes to the backend.
+    The usage log is also flushed sooner when the number of pending entries reaches
+    ``rgw_usage_log_flush_threshold``.
   default: 30
   services:
   - rgw
@@ -1931,8 +1947,6 @@ options:
   long_desc: The time length (in seconds) that RGW will allow for its initialization.
     RGW process will give up and quit if initialization is not complete after this
     amount of time.
-  fmt_desc: The number of seconds before Ceph Object Gateway gives up on
-    initialization.
   default: 5_min
   services:
   - rgw
@@ -1944,8 +1958,6 @@ options:
   long_desc: The mime types file is needed in Swift when uploading an object. If object's
     content type is not specified, RGW will use data from this file to assign a content
     type to the object.
-  fmt_desc: The path and location of the MIME-types file. Used for Swift
-    auto-detection of object types.
   default: /etc/mime.types
   services:
   - rgw
@@ -1953,15 +1965,12 @@ options:
 - name: rgw_gc_max_objs
   type: int
   level: advanced
-  desc: Number of shards for garbage collector data
-  long_desc: The number of garbage collector data shards, is the number of RADOS objects
-    that RGW will use to store the garbage collection information on. This value is
-    read once at daemon startup.
-  fmt_desc: The maximum number of objects that may be handled by
-    garbage collection in one garbage collection processing cycle.
-    This value can be increased after first deployment, please do
-    not decrease this value without ensuring all data shards are
-    completely empty.
+  desc: The number of shards (RADOS objects) across which the garbage collector stores
+    its data.
+  long_desc: The number of shards (RADOS objects) across which the garbage collector
+    stores its data; read once at daemon startup. It may be increased after initial
+    deployment, but must not be decreased without first ensuring all GC data shards
+    are completely empty.
   default: 32
   services:
   - rgw
@@ -1977,13 +1986,11 @@ options:
 - name: rgw_gc_obj_min_wait
   type: int
   level: advanced
-  desc: Garbage collection object expiration time
-  long_desc: The length of time (in seconds) that the RGW collector will wait before
-    purging a deleted object's data. RGW will not remove object immediately, as object
-    could still have readers. A mechanism exists to increase the object's expiration
-    time when it's being read. The recommended value of its lower limit is 30 minutes
-  fmt_desc: The minimum wait time before a deleted object may be removed
-    and handled by garbage collection processing.
+  desc: Minimum wait before a deleted object's data is garbage-collected.
+  long_desc: The minimum time, in seconds, that RGW waits before purging a deleted
+    object's data via garbage collection. Removal is delayed because the object may
+    still have readers, and its expiration is extended while it is being read. The
+    recommended lower limit is 30 minutes.
   default: 2_hr
   services:
   - rgw
@@ -1996,16 +2003,12 @@ options:
 - name: rgw_gc_processor_max_time
   type: int
   level: advanced
-  desc: Length of time GC processor can lease shard
-  long_desc: Garbage collection thread in RGW process holds a lease on its data shards.
-    These objects contain the information about the objects that need to be removed.
-    RGW takes a lease in order to prevent multiple RGW processes from handling the
-    same objects concurrently. This time signifies that maximum amount of time (in
-    seconds) that RGW is allowed to hold that lease. In the case where RGW goes down
-    uncleanly, this is the amount of time where processing of that data shard will
-    be blocked.
-  fmt_desc: The maximum time between the beginning of two consecutive garbage
-    collection processing cycles.
+  desc: The maximum time an RGW may hold the lease on a GC data shard.
+  long_desc: The garbage-collection thread holds a lease on each GC data shard (the
+    RADOS objects recording which objects need removal) to keep multiple RGW processes
+    from handling the same shard at once. This is the maximum time (in seconds) an
+    RGW may hold that lease; if an RGW exits uncleanly, processing of that shard is
+    blocked for this long.
   default: 1_hr
   services:
   - rgw
@@ -2022,7 +2025,6 @@ options:
   long_desc: The amount of time between the start of consecutive runs of the garbage
     collector threads. If garbage collector runs takes more than this period, it will
     not wait before running again.
-  fmt_desc: The cycle time for garbage collection processing.
   default: 1_hr
   services:
   - rgw
@@ -2077,9 +2079,8 @@ options:
   type: int
   level: advanced
   desc: HTTP return code override for object creation
-  long_desc: If not zero, this is the HTTP return code that will be returned on a
-    successful S3 object creation.
-  fmt_desc: The alternate success status response for ``create-obj``.
+  long_desc: If not zero, this is the HTTP return code that will be returned on a successful
+    S3 object creation.
   default: 0
   services:
   - rgw
@@ -2095,13 +2096,13 @@ options:
 - name: rgw_resolve_cname
   type: bool
   level: advanced
-  desc: Support vanity domain names via CNAME
-  long_desc: If true, RGW will query DNS when detecting that it's serving a request
-    that was sent to a host in another domain. If a CNAME record is configured for
-    that domain it will use it instead. This gives user to have the ability of creating
-    a unique domain of their own to point at data in their bucket.
-  fmt_desc: Whether ``rgw`` should use DNS CNAME record of the request
-    hostname field (if hostname is not equal to ``rgw dns name``).
+  desc: Resolve DNS CNAMEs to support vanity bucket domains.
+  long_desc: If set, when the request hostname differs from rgw dns name, RGW queries
+    DNS for a CNAME record on that hostname and, if present, follows it. This lets
+    users point a domain of their own at data in their bucket (vanity domains).
+  fmt_desc: If set, when the request hostname differs from ``rgw dns name``, RGW queries
+    DNS for a CNAME record on that hostname and, if present, follows it. This lets
+    users point a domain of their own at data in their bucket (vanity domains).
   default: false
   services:
   - rgw
@@ -2143,11 +2144,12 @@ options:
 - name: rgw_obj_stripe_size
   type: size
   level: advanced
-  desc: RGW object stripe size
-  long_desc: The size of an object stripe for RGW objects. This is the maximum size
-    a backing RADOS object will have. RGW objects that are larger than this will span
-    over multiple objects.
-  fmt_desc: The size of an object stripe for Ceph Object Gateway objects.
+  desc: Stripe size for RGW objects (max size of each backing RADOS object).
+  long_desc: The stripe size for RGW objects, which is the maximum size of each backing
+    RADOS object; RGW objects larger than this are split across multiple RADOS objects.
+    See the Architecture documentation for details on striping.
+  fmt_desc: The stripe size for RGW objects, which is the maximum size of each backing
+    RADOS object; RGW objects larger than this are split across multiple RADOS objects.
     See `Architecture`_ for details on striping.
   default: 4_M
   services:
@@ -2158,14 +2160,10 @@ options:
   type: str
   level: advanced
   desc: RGW support extended HTTP attrs
-  long_desc: Add new set of attributes that could be set on an object. These extra
-    attributes can be set through HTTP header fields when putting the objects. If
-    set, these attributes will return as HTTP fields when doing GET/HEAD on the object.
-  fmt_desc: Add new set of attributes that could be set on an entity
-    (user, bucket or object). These extra attributes can be set
-    through HTTP header fields when putting the entity or modifying
-    it using POST method. If set, these attributes will return as
-    HTTP  fields when doing GET/HEAD on the entity.
+  long_desc: Add new set of attributes that could be set on an entity (user, bucket
+    or object). These extra attributes can be set through HTTP header fields when putting
+    the entity or modifying it using POST method. If set, these attributes will return
+    as HTTP fields when doing GET/HEAD on the entity.
   services:
   - rgw
   example: content_foo, content_bar, x-foo-bar
@@ -2204,9 +2202,8 @@ options:
   type: size
   level: advanced
   desc: RGW object read chunk size
-  long_desc: The maximum request size of a single object read operation sent to RADOS
-  fmt_desc: The maximum request size of a single get operation sent to the
-    Ceph Storage Cluster.
+  long_desc: The maximum request size of a single get operation sent to the Ceph Storage
+    Cluster.
   default: 4_M
   services:
   - rgw
@@ -2216,7 +2213,6 @@ options:
   level: advanced
   desc: RGW enable relaxed S3 bucket names
   long_desc: RGW enable relaxed S3 bucket name rules for US region buckets.
-  fmt_desc: Enables relaxed S3 bucket names rules for US region buckets.
   default: false
   services:
   - rgw
@@ -2234,12 +2230,9 @@ options:
 - name: rgw_list_buckets_max_chunk
   type: int
   level: advanced
-  desc: Max number of buckets to retrieve in a single listing operation
-  long_desc: When RGW fetches lists of user's buckets from the backend, this is the
-    max number of entries it will try to retrieve in a single operation. Note that
-    the backend may choose to return a smaller number of entries.
-  fmt_desc: The maximum number of buckets to retrieve in a single operation
-    when listing user buckets.
+  desc: Maximum buckets fetched per operation when listing a user's buckets.
+  long_desc: When RGW lists a user's buckets from the backend, the maximum number of
+    entries it retrieves in a single operation. The backend may return fewer entries.
   default: 1000
   services:
   - rgw
@@ -2251,7 +2244,6 @@ options:
   long_desc: The number of shards the RGW metadata log entries will reside in. This
     affects the metadata sync parallelism as a shard can only be processed by a single
     RGW at a time
-  fmt_desc: The maximum number of shards for the metadata log.
   default: 64
   services:
   - rgw
@@ -2311,7 +2303,6 @@ options:
   level: advanced
   desc: Send progress report through copy operation
   long_desc: If true, RGW will send progress information when copy operation is executed.
-  fmt_desc: Enables output of object progress during long copy operations.
   default: true
   services:
   - rgw
@@ -2359,11 +2350,10 @@ options:
 - name: rgw_data_log_window
   type: int
   level: advanced
-  desc: Data log time window
-  long_desc: The data log keeps information about buckets that have objects that
-    were modified within a specific timeframe. The sync process then knows which buckets
-    are needed to be scanned for data sync.
-  fmt_desc: The data log entries window in seconds.
+  desc: Data-log entry window, in seconds.
+  long_desc: The time window, in seconds, covered by the data log. The data log records
+    which buckets had objects modified within this window so that the multisite sync
+    process knows which buckets to scan for data sync.
   default: 30
   services:
   - rgw
@@ -2374,7 +2364,6 @@ options:
   desc: Max size of pending changes in data log
   long_desc: RGW will trigger update to the data log if the number of pending entries
     reached this number.
-  fmt_desc: The number of in-memory entries to hold for the data changes log.
   default: 1000
   services:
   - rgw
@@ -2384,10 +2373,8 @@ options:
   level: advanced
   desc: Number of data log shards
   long_desc: The number of shards the RGW data log entries will reside in. This affects
-    the data sync parallelism as a shard can only be processed by a single RGW at
-    a time.
-  fmt_desc: The number of shards (objects) on which to keep the
-    data changes log.
+    the data sync parallelism as a shard can only be processed by a single RGW at a
+    time.
   default: 128
   services:
   - rgw
@@ -2456,10 +2443,8 @@ options:
   type: int
   level: advanced
   desc: Bucket quota stats cache TTL
-  long_desc: Length of time for bucket stats to be cached within RGW instance.
-  fmt_desc: The amount of time in seconds cached quota information is
-    trusted.  After this timeout, the quota information will be
-    re-fetched from the cluster.
+  long_desc: The amount of time in seconds cached quota information is trusted. After
+    this timeout, the quota information will be re-fetched from the cluster.
   default: 10_min
   services:
   - rgw
@@ -2476,13 +2461,11 @@ options:
 - name: rgw_bucket_default_quota_max_objects
   type: int
   level: basic
-  desc: Default quota for max objects in a bucket
-  long_desc: The default quota configuration for max number of objects in a bucket.
-    A negative number means 'unlimited'.
-  fmt_desc: Default max number of objects per bucket. Set on new users,
-    if no other quota is specified. Has no effect on existing users.
-    This variable should be set in the client or global sections
-    so that it is automatically applied to radosgw-admin commands.
+  desc: Default per-bucket object-count quota for new users (negative = unlimited).
+  long_desc: The default per-bucket object-count quota applied to a newly created user's
+    buckets when no other quota is specified. A negative value means unlimited. Has
+    no effect on existing users. Set it in the client or global section so it is applied
+    automatically by radosgw-admin.
   default: -1
   services:
   - rgw
@@ -2490,11 +2473,10 @@ options:
 - name: rgw_bucket_default_quota_max_size
   type: int
   level: advanced
-  desc: Default quota for total size in a bucket
-  long_desc: The default quota configuration for total size of objects in a bucket.
-    A negative number means 'unlimited'.
-  fmt_desc: Default max capacity per bucket, in bytes. Set on new users,
-    if no other quota is specified. Has no effect on existing users.
+  desc: Default per-bucket total-size quota (bytes) for new users (negative = unlimited).
+  long_desc: The default per-bucket total-size quota, in bytes, applied to a newly
+    created user's buckets when no other quota is specified. A negative value means
+    unlimited. Has no effect on existing users.
   default: -1
   services:
   - rgw
@@ -2512,15 +2494,15 @@ options:
 - name: rgw_frontends
   type: str
   level: basic
-  desc: RGW frontends configuration
-  long_desc: A comma delimited list of frontends configuration. Each configuration
-    contains the type of the frontend followed by an optional space delimited set
-    of key=value config parameters.
-  fmt_desc: Configures the HTTP frontend(s). The configuration for multiple
-    frontends can be provided in a comma-delimited list. Each frontend
-    configuration may include a list of options separated by spaces,
-    where each option is in the form "key=value" or "key". See
-    `HTTP Frontends`_ for more on supported options.
+  desc: RGW HTTP frontend configuration.
+  long_desc: Configures the HTTP frontend(s). Provide a comma-delimited list, each
+    entry a frontend type followed by an optional space-separated set of options, each
+    of the form key=value or key. The default is beast. See the HTTP Frontends documentation
+    for the supported options.
+  fmt_desc: Configures the HTTP frontend(s). Provide a comma-delimited list, each entry
+    a frontend type followed by an optional space-separated set of options, each of
+    the form ``key=value`` or ``key``. The default is ``beast``. See `HTTP Frontends`_
+    for the supported options.
   default: beast port=7480
   services:
   - rgw
@@ -2557,12 +2539,10 @@ options:
 - name: rgw_user_quota_bucket_sync_interval
   type: int
   level: advanced
-  desc: User quota bucket sync interval
-  long_desc: Time period for accumulating modified buckets before syncing these stats.
-  fmt_desc: The amount of time in seconds bucket quota information is
-    accumulated before syncing to the cluster.  During this time,
-    other RGW instances will not see the changes in bucket quota
-    stats from operations on this instance.
+  desc: Interval for syncing per-bucket quota stats to the cluster.
+  long_desc: The time, in seconds, that per-bucket quota stats for modified buckets
+    are accumulated on this RGW before being synced to the cluster. Until the sync
+    happens, other RGW instances do not see this instance's bucket-quota changes.
   default: 3_min
   services:
   - rgw
@@ -2570,13 +2550,10 @@ options:
 - name: rgw_user_quota_sync_interval
   type: int
   level: advanced
-  desc: User quota sync interval
-  long_desc: Time period for accumulating modified buckets before syncing entire user
-    stats.
-  fmt_desc: The amount of time in seconds user quota information is
-    accumulated before syncing to the cluster.  During this time,
-    other RGW instances will not see the changes in user quota stats
-    from operations on this instance.
+  desc: Interval for syncing whole-user quota stats to the cluster.
+  long_desc: The time, in seconds, that user quota stats (across the user's modified
+    buckets) are accumulated on this RGW before being synced to the cluster. Until
+    the sync happens, other RGW instances do not see this instance's user-quota changes.
   default: 1_day
   services:
   - rgw
@@ -2602,12 +2579,10 @@ options:
 - name: rgw_user_default_quota_max_objects
   type: int
   level: basic
-  desc: User quota max objects
-  long_desc: The default quota configuration for total number of objects for a single
-    user. A negative number means 'unlimited'.
-  fmt_desc: Default max number of objects for a user. This includes all
-    objects in all buckets owned by the user. Set on new users,
-    if no other quota is specified. Has no effect on existing users.
+  desc: Default object-count quota for a new user (negative = unlimited).
+  long_desc: The default object-count quota applied to a newly created user when no
+    other quota is specified, counting all objects across every bucket the user owns.
+    A negative value means unlimited. Has no effect on existing users.
   default: -1
   services:
   - rgw
@@ -2615,11 +2590,10 @@ options:
 - name: rgw_user_default_quota_max_size
   type: int
   level: basic
-  desc: User quota max size
-  long_desc: The default quota configuration for total size of objects for a single
-    user. A negative number means 'unlimited'.
-  fmt_desc: The value for user max size quota in bytes set on new users,
-    if no other quota is specified.  Has no effect on existing users.
+  desc: Default total-size quota (bytes) for a new user (negative = unlimited).
+  long_desc: The default total-size quota, in bytes, applied to a newly created user
+    when no other quota is specified, covering all objects across every bucket the
+    user owns. A negative value means unlimited. Has no effect on existing users.
   default: -1
   services:
   - rgw
@@ -2627,12 +2601,10 @@ options:
 - name: rgw_account_default_quota_max_objects
   type: int
   level: basic
-  desc: Account quota max objects
-  long_desc: The default quota configuration for total number of objects for a single
-    account. A negative number means 'unlimited'.
-  fmt_desc: Default max number of objects for a account. This includes all
-    objects in all buckets owned by the account. Set on new accounts
-    if no other quota is specified. Has no effect on existing accounts.
+  desc: Default object-count quota for a new account (negative = unlimited).
+  long_desc: The default object-count quota applied to a newly created account when
+    no other quota is specified, counting all objects across every bucket the account
+    owns. A negative value means unlimited. Has no effect on existing accounts.
   default: -1
   services:
   - rgw
@@ -2640,11 +2612,10 @@ options:
 - name: rgw_account_default_quota_max_size
   type: int
   level: basic
-  desc: Account quota max size
-  long_desc: The default quota configuration for total size of objects for a single
-    account. A negative number means 'unlimited'.
-  fmt_desc: The value for account max size quota in bytes set on new accounts,
-    if no other quota is specified.  Has no effect on existing accounts.
+  desc: Default total-size quota (bytes) for a new account (negative = unlimited).
+  long_desc: The default total-size quota, in bytes, applied to a newly created account
+    when no other quota is specified, covering all objects across every bucket the
+    account owns. A negative value means unlimited. Has no effect on existing accounts.
   default: -1
   services:
   - rgw
@@ -2754,12 +2725,13 @@ options:
 - name: rgw_log_http_headers
   type: str
   level: basic
-  desc: List of HTTP headers to log
-  long_desc: A comma delimited list of HTTP headers to log when seen, ignores case
-    (e.g., http_x_forwarded_for).
-  fmt_desc: Comma-delimited list of HTTP headers to include with ops
-    log entries.  Header names are case insensitive, and use
-    the full header name with words separated by underscores.
+  desc: HTTP headers to include in ops-log entries.
+  long_desc: A comma-delimited list of HTTP headers to include with ops-log entries.
+    Header names are case-insensitive and use the full header name with words separated
+    by underscores (for example, http_x_forwarded_for).
+  fmt_desc: A comma-delimited list of HTTP headers to include with ops-log entries.
+    Header names are case-insensitive and use the full header name with words separated
+    by underscores (for example, ``http_x_forwarded_for``).
   example: http_x_forwarded_for, http_x_special_k
   services:
   - rgw
@@ -4959,12 +4931,10 @@ options:
 - name: rgw_redis_connection_pool_size
   type: int
   level: basic
-  desc: RGW connection pool size for Redis operation per D4N
-  long_desc: This option sets the size of the connection pool for Redis operations
-    in D4N. It is used to manage the number of concurrent connections to Redis.
-    A larger pool size can improve performance when multiple threads are accessing
-    Redis simultaneously, but it also increases resource usage.
-  fmt_desc: The size of the redis connection pool.
+  desc: Size of the Redis connection pool used by D4N.
+  long_desc: The size of the connection pool for Redis operations in D4N, controlling
+    the number of concurrent connections to Redis. A larger pool can improve performance
+    when many threads access Redis at once, at the cost of higher resource usage.
   default: 512
   services:
   - rgw
@@ -4982,13 +4952,11 @@ options:
 - name: rgw_usage_log_key_transition
   type: bool
   level: advanced
-  desc: Handle the co-existence of both old and new name-by-user keys
-  long_desc: The new usage log keyed by owner/payer ID has the prefix of "~"
-    for IDs starting with '0'.  This prefix is absent from the old scheme.
-    This option instructs RGW to handle the old keys if they still exist.
-    It should be set false when the old keys no longer exist to avoid
-    performance penalty.
-  fmt_desc: To handle the co-existence of both old and new name-by-user keys
+  desc: Support both old and new usage-log key schemes.
+  long_desc: When set, RGW handles usage-log entries stored under the old key scheme
+    as well as the new one. The new scheme keys entries by owner/payer ID and prefixes
+    IDs beginning with '0' with '~', which the old scheme lacks. Set this to false
+    once no old keys remain, to avoid a performance penalty.
   default: true
   services:
   - rgw

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1009,8 +1009,8 @@ options:
   type: int
   level: advanced
   desc: Keystone token cache size
-  long_desc: Max number of Keystone tokens that will be cached. Token that is not cached
-    requires RGW to access the Keystone server when authenticating.
+  long_desc: The maximum number of Keystone tokens that RGW caches. A token that is not
+    cached requires RGW to contact the Keystone server to authenticate.
   default: 10000
   services:
   - rgw
@@ -1346,7 +1346,7 @@ options:
 - name: rgw_num_control_oids
   type: int
   level: advanced
-  desc: Number of control objects used for cross-RGW cache synchronization.
+  desc: Number of control objects used for inter-RGW communication.
   long_desc: The number of control objects RGW uses to pass messages between RGW processes
     in the same zone, chiefly metadata-cache invalidations sent when metadata (such
     as user or bucket info) changes. More control objects allow greater message concurrency
@@ -1378,9 +1378,9 @@ options:
 - name: rgw_verify_ssl
   type: bool
   level: advanced
-  desc: Whether RGW verifies SSL certificates on outgoing requests.
+  desc: Whether RGW verifies SSL certificates on outgoing connections.
   long_desc: Whether RGW verifies the SSL certificate of a remote peer when it makes
-    outgoing requests, for example to other RGW servers during multisite sync.
+    outgoing connections, for example to other RGW servers during multisite sync.
   default: true
   services:
   - rgw
@@ -1757,7 +1757,7 @@ options:
 - name: rgw_log_object_name_utc
   type: bool
   level: advanced
-  desc: Should ops log object name based on UTC
+  desc: Whether ops-log object names use UTC
   long_desc: If set, the names of the RADOS objects that hold the ops log data will
     be based on UTC time zone. If not set, it will use the local time zone.
   default: false
@@ -1770,13 +1770,13 @@ options:
 - name: rgw_usage_max_shards
   type: int
   level: advanced
-  desc: Number of RADOS objects for the usage log (must be uniform cluster-wide).
-  long_desc: The number of RADOS objects across which RGW stores the usage-log data.
+  desc: Maximum number of RADOS objects for the usage log (must be uniform cluster-wide).
+  long_desc: The maximum number of RADOS objects across which RGW stores the usage-log data.
     All RGW daemons and radosgw-admin commands must use the same value; if they differ,
     writes and reads/clears target different objects, so usage data appears empty or
     is not cleared. Set it consistently across the cluster with 'ceph config set global
     rgw_usage_max_shards <N>', or pass --rgw-usage-max-shards to radosgw-admin.
-  fmt_desc: The number of RADOS objects across which RGW stores the usage-log data.
+  fmt_desc: The maximum number of RADOS objects across which RGW stores the usage-log data.
     All RGW daemons and ``radosgw-admin`` commands must use the same value; if they
     differ, writes and reads/clears target different objects, so usage data appears
     empty or is not cleared. Set it consistently across the cluster with ``ceph config
@@ -1938,9 +1938,9 @@ options:
   type: str
   level: basic
   desc: Path to local MIME types file
-  long_desc: The MIME types file is needed in Swift when uploading an object. If object's
-    content type is not specified, RGW will use data from this file to assign a content
-    type to the object.
+  long_desc: The file RGW uses to map filename extensions to MIME content types. When a
+    client uploads an object without specifying a content type, RGW derives one from
+    this file. It applies to both the S3 and Swift APIs.
   default: /etc/mime.types
   services:
   - rgw
@@ -1987,11 +1987,11 @@ options:
   type: int
   level: advanced
   desc: The maximum time an RGW may hold the lease on a GC data shard.
-  long_desc: The garbage-collection thread holds a lease on each GC data shard (the
-    RADOS objects recording which objects need removal) to keep multiple RGW processes
-    from handling the same shard at once. This is the maximum time (in seconds) an
-    RGW may hold that lease; if an RGW exits uncleanly, processing of that shard is
-    blocked for this long.
+  long_desc: The garbage-collection thread holds a lease on the GC data shards it is
+    processing (the RADOS objects recording which objects need removal) to keep
+    multiple RGW processes from handling the same shard at once. This is the maximum
+    time (in seconds) an RGW may hold that lease; if an RGW exits uncleanly,
+    processing of that shard is blocked for this long.
   default: 1_hr
   services:
   - rgw


### PR DESCRIPTION
In `src/common/options/rgw.yaml.in`, bring the doc-facing `fmt_desc` and the plain `long_desc` into agreement so both fields carry the same information: correct entries where one was wrong, union complementary text, and drop `fmt_desc` where it carried no RST markup (`confval` falls back to `long_desc`).

63 options harmonized; 45 fmt_desc fields dropped.
Notable: rgw_gc_max_objs, rgw_gc_processor_max_time and rgw_nfs_frontends had fmt_desc describing a different option.

Fixes: https://tracker.ceph.com/issues/79823
Assisted by Claude Opus 4.8

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
