### PR TITLE
mon: harmonize options fmt_desc with long_desc

### DIFF
--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -76,7 +76,7 @@ options:
 - name: mon_down_uptime_grace
   type: secs
   level: advanced
-  desc: Period in seconds that the cluster may have a mon down after this (leader) monitor comes up.
+  desc: Period in seconds that the cluster may have a mon down after this (leader) Monitor comes up.
   default: 1_min
   services:
   - mon
@@ -85,7 +85,7 @@ options:
 - name: mon_mgr_beacon_grace
   type: secs
   level: advanced
-  desc: Period in seconds from last beacon to monitor marking a manager daemon as
+  desc: Period in seconds from last beacon to Monitor marking a manager daemon as
     failed
   default: 30
   services:
@@ -93,7 +93,7 @@ options:
 - name: mon_nvmeofgw_beacon_grace
   type: secs
   level: advanced
-  desc: Period in seconds from last beacon to monitor marking a NVMeoF gateway as
+  desc: Period in seconds from last beacon to Monitor marking a NVMeoF gateway as
     failed
   default: 7
   services:
@@ -109,10 +109,10 @@ options:
 - name: mon_nvmeofgw_set_group_id_retry
   type: uint
   level: advanced
-  desc: Retry wait time in microseconds for set group ID between the monitor client
+  desc: Retry wait time in microseconds for set group ID between the Monitor client
     and gateway
-  long_desc: The monitor server determines the gateway's group ID. If the monitor client
-    receives a monitor group ID assignment before the gateway is fully up during
+  long_desc: The Monitor server determines the gateway's group ID. If the Monitor client
+    receives a Monitor group ID assignment before the gateway is fully up during
     initialization, a retry is required.
   default: 1000
 - name: mon_nvmeofgw_beacons_till_ack
@@ -172,7 +172,7 @@ options:
 - name: mon_cluster_log_to_stderr
   type: bool
   level: advanced
-  desc: Make monitor send cluster log messages to stderr (prefixed by channel)
+  desc: Make Monitor send cluster log messages to stderr (prefixed by channel)
   default: false
   services:
   - mon
@@ -184,7 +184,7 @@ options:
 - name: mon_cluster_log_to_syslog
   type: str
   level: advanced
-  desc: Make monitor send cluster log messages to syslog
+  desc: Make Monitor send cluster log messages to syslog
   fmt_desc: Determines if the cluster log should be output to the syslog.
   default: default=false
   services:
@@ -207,7 +207,7 @@ options:
 - name: mon_cluster_log_to_file
   type: bool
   level: advanced
-  desc: Make monitor send cluster log messages to file
+  desc: Make Monitor send cluster log messages to file
   default: true
   services:
   - mon
@@ -259,7 +259,7 @@ options:
 - name: mon_cluster_log_to_graylog
   type: str
   level: advanced
-  desc: Make monitor send cluster log to graylog
+  desc: Make Monitor send cluster log to graylog
   default: 'false'
   services:
   - mon
@@ -293,7 +293,7 @@ options:
 - name: mon_cluster_log_to_journald
   type: str
   level: advanced
-  desc: Make monitor send cluster log to journald
+  desc: Make Monitor send cluster log to journald
   default: 'false'
   services:
   - mon
@@ -334,7 +334,7 @@ options:
 - name: mon_health_to_clog
   type: bool
   level: advanced
-  desc: log monitor health to cluster log
+  desc: log Monitor health to cluster log
   fmt_desc: Enable sending a health summary to the cluster log periodically.
   default: true
   services:
@@ -343,8 +343,8 @@ options:
 - name: mon_health_to_clog_interval
   type: int
   level: advanced
-  desc: frequency to log monitor health to cluster log
-  fmt_desc: How often (in seconds) the monitor sends a health summary to the cluster
+  desc: frequency to log Monitor health to cluster log
+  fmt_desc: How often (in seconds) the Monitor sends a health summary to the cluster
     log (a non-positive number disables). Monitors will always
     send a summary to the cluster log whether or not it differs from
     the previous summary.
@@ -357,9 +357,9 @@ options:
 - name: mon_health_to_clog_tick_interval
   type: float
   level: dev
-  fmt_desc: How often (in seconds) the monitor sends a health summary to the cluster
+  fmt_desc: How often (in seconds) the Monitor sends a health summary to the cluster
     log (a non-positive number disables). If current health summary
-    is empty or identical to the last time, monitor will not send it
+    is empty or identical to the last time, Monitor will not send it
     to cluster log.
   default: 1_min
   services:
@@ -397,7 +397,7 @@ options:
   level: advanced
   desc: issue MON_DISK_CRIT health error when mon available space below this percentage
   fmt_desc: Raise ``HEALTH_ERR`` status when the filesystem that houses a
-    monitor's data store reports that its available capacity is
+    Monitor's data store reports that its available capacity is
     less than or equal to this percentage.
   default: 5
   services:
@@ -408,7 +408,7 @@ options:
   level: advanced
   desc: issue MON_DISK_LOW health warning when mon available space below this percentage
   fmt_desc: Raise ``HEALTH_WARN`` status when the filesystem that houses a
-    monitor's data store reports that its available capacity is
+    Monitor's data store reports that its available capacity is
     less than or equal to this percentage.
   default: 30
   services:
@@ -418,7 +418,7 @@ options:
   type: size
   level: advanced
   desc: issue MON_DISK_BIG health warning when mon database is above this size
-  fmt_desc: Raise ``HEALTH_WARN`` status when a monitor's data
+  fmt_desc: Raise ``HEALTH_WARN`` status when a Monitor's data
     store grows to be larger than this size, 15GB by default.
   default: 15_G
   services:
@@ -665,7 +665,7 @@ options:
 - name: mon_stretch_recovery_min_wait
   type: float
   level: advanced
-  desc: how long the monitors wait before considering fully-healthy PGs as evidence
+  desc: how long the Monitors wait before considering fully-healthy PGs as evidence
     the stretch mode is repaired
   default: 15
   services:
@@ -717,7 +717,7 @@ options:
 - name: mon_timecheck_interval
   type: float
   level: advanced
-  desc: frequency of clock synchronization checks between monitors (seconds)
+  desc: frequency of clock synchronization checks between Monitors (seconds)
   fmt_desc: The time check interval (clock drift check) in seconds
     for the Leader.
   default: 5_min
@@ -728,7 +728,7 @@ options:
 - name: mon_timecheck_skew_interval
   type: float
   level: advanced
-  desc: frequency of clock synchronization (re)checks between monitors while clocks
+  desc: frequency of clock synchronization (re)checks between Monitors while clocks
     are believed to be skewed (seconds)
   fmt_desc: The time check interval (clock drift check) in seconds when in
     presence of a skew in seconds for the Leader.
@@ -757,7 +757,7 @@ options:
   services:
   - mon
   fmt_desc: The maximum Paxos iterations before we must first sync the
-    monitor data stores. When a monitor finds that its peer is too
+    Monitor data stores. When a Monitor finds that its peer is too
     far ahead of it, it will first sync with data stores before moving
     on.
   with_legacy: true
@@ -873,7 +873,7 @@ options:
   type: bool
   level: advanced
   desc: Whether to parse non-monitor capabilities set by the 'ceph auth ...' commands.
-    Disabling this saves CPU on the monitor, but allows invalid capabilities to be
+    Disabling this saves CPU on the Monitor, but allows invalid capabilities to be
     set, and only be rejected later, when they are used.
   default: true
   services:
@@ -885,7 +885,7 @@ options:
   type: int
   level: dev
   desc: force mons to trim mdsmaps/fsmaps up to this epoch
-  fmt_desc: Force monitor to trim mdsmaps up to but not including this FSMap
+  fmt_desc: Force Monitor to trim mdsmaps up to but not including this FSMap
     epoch. A value of 0 disables (the default) this config. This command is
     potentially dangerous, use with care.
   default: 0
@@ -896,9 +896,9 @@ options:
   type: secs
   level: advanced
   desc: prune fsmap older than this threshold in seconds
-  fmt_desc: The monitors keep historical fsmaps in memory to optimize asking
+  fmt_desc: The Monitors keep historical fsmaps in memory to optimize asking
     when an MDS daemon was last seen in the FSMap. This option controls
-    how far back in time the monitors will look.
+    how far back in time the Monitors will look.
   default: 300
   flags:
   - runtime
@@ -907,9 +907,9 @@ options:
 - name: mds_beacon_mon_down_grace
   type: secs
   level: advanced
-  desc: tolerance in seconds for missed MDS beacons to monitors
+  desc: tolerance in seconds for missed MDS beacons to Monitors
   fmt_desc: The interval without beacons before Ceph declares an MDS laggy
-    when a monitor is down.
+    when a Monitor is down.
   default: 1_min
 # skip safety assertions on FSMap (in case of bugs where we want to continue anyway)
 - name: mon_mds_skip_sanity
@@ -1148,7 +1148,7 @@ options:
   type: float
   level: dev
   desc: maximum time to spend precalculating PG mappings on map change (seconds)
-  fmt_desc: How much time in seconds the monitor should spend trying to prime the
+  fmt_desc: How much time in seconds the Monitor should spend trying to prime the
     PGMap when an out OSD comes back into the cluster.
   default: 0.5
   services:
@@ -1207,7 +1207,7 @@ options:
   type: str
   level: advanced
   desc: path to mon database
-  fmt_desc: The monitor's data location.
+  fmt_desc: The Monitor's data location.
   default: /var/lib/ceph/mon/$cluster-$id
   services:
   - mon
@@ -1303,7 +1303,7 @@ options:
   - mon
   fmt_desc: Compact the database used as Ceph Monitor store on
     ``ceph-mon`` start. A manual compaction helps to shrink the
-    monitor database and improve the performance of it if the regular
+    Monitor database and improve the performance of it if the regular
     compaction fails to work.
   with_legacy: true
 # trigger RocksDB compaction on bootstrap
@@ -1315,7 +1315,7 @@ options:
   - mon
   fmt_desc: Compact the database used as Ceph Monitor store
     on bootstrap. Monitors probe each other to establish
-    a quorum after bootstrap. If a monitor times out before joining the
+    a quorum after bootstrap. If a Monitor times out before joining the
     quorum, it will start over and bootstrap again.
   with_legacy: true
 # compact (a prefix) when we trim old states
@@ -1330,7 +1330,7 @@ options:
 - name: mon_op_complaint_time
   type: secs
   level: advanced
-  desc: time after which to consider a monitor operation blocked after no updates
+  desc: time after which to consider a Monitor operation blocked after no updates
   default: 30
   services:
   - mon
@@ -1489,7 +1489,7 @@ options:
   type: int
   level: advanced
   desc: worker threads for CPU intensive background work
-  fmt_desc: Number of threads for performing CPU intensive work on monitor.
+  fmt_desc: Number of threads for performing CPU intensive work on Monitor.
   default: 4
   services:
   - mon
@@ -1498,7 +1498,7 @@ options:
   type: int
   level: advanced
   desc: interval for internal mon background checks
-  fmt_desc: A monitor's tick interval in seconds.
+  fmt_desc: A Monitor's tick interval in seconds.
   default: 5
   services:
   - mon
@@ -1536,14 +1536,14 @@ options:
   type: secs
   level: advanced
   desc: The duration, expressed in seconds, after which the NVMeoF gateway
-    should trigger a panic if it loses connection to the monitor
+    should trigger a panic if it loses connection to the Monitor
   default: 100
   services:
   - mon
 - name: nvmeof_mon_client_tick_period
   type: secs
   level: advanced
-  desc: Period in seconds of NVMeoF gateway beacon messages to monitor
+  desc: Period in seconds of NVMeoF gateway beacon messages to Monitor
   default: 1
   services:
   - mon
@@ -1561,7 +1561,7 @@ options:
   type: secs
   level: advanced
   desc: The duration, expressed in seconds, after which the NVMeoF gateway
-    should trigger a panic if it does not receive the initial map from the monitor
+    should trigger a panic if it does not receive the initial map from the Monitor
   default: 30
   services:
 - name: mon_netsplit_grace_period

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -17,18 +17,20 @@ options:
   type: size
   level: advanced
   desc: the amount of data (in bytes) in a data chunk, per stripe
-  fmt_desc: Sets the default size, in bytes, of a chunk of an object
-    stripe for erasure-coded pools. Every object of size S
-    will be stored as N stripes, with each data chunk
-    receiving ``stripe_unit`` bytes. Each stripe of ``N *
-    stripe_unit`` bytes will be encoded/decoded individually.
-    A value of 0 causes the code to select either a 4KB or 16KB
-    stripe_unit depending on whether ``allow_ec_optimizations``
-    is enabled.  If enabled, ``stripe_unit`` is set to 16KB, otherwise it
-    is set to 4KB. This option can be overridden by the ``stripe_unit``
-    setting in an erasure code profile.
-  long_desc: A value of 0 causes the code to select either a 4KB or 16KB stripe_unit
-    depending on whether allow_ec_optimizations is enabled.
+  fmt_desc: Sets the default size, in bytes, of a chunk of an object stripe for erasure-coded
+    pools. Every object of size S will be stored as N stripes, with each data chunk
+    receiving ``stripe_unit`` bytes. Each stripe of ``N * stripe_unit`` bytes will
+    be encoded/decoded individually. A value of 0 causes the code to select either
+    a 4KB or 16KB ``stripe_unit`` depending on whether ``allow_ec_optimizations`` is enabled.  If
+    enabled, ``stripe_unit`` is set to 16KB, otherwise it is set to 4KB. This option
+    can be overridden by the ``stripe_unit`` setting in an erasure code profile.
+  long_desc: Sets the default size, in bytes, of a chunk of an object stripe for erasure-coded
+    pools. Every object of size S will be stored as N stripes, with each data chunk
+    receiving stripe_unit bytes. Each stripe of N * stripe_unit bytes will be encoded/decoded
+    individually. A value of 0 causes the code to select either a 4KB or 16KB stripe_unit
+    depending on whether allow_ec_optimizations is enabled. If enabled, stripe_unit
+    is set to 16KB, otherwise it is set to 4KB. This option can be overridden by the
+    stripe_unit setting in an erasure code profile.
   default: 0
   services:
   - mon
@@ -217,19 +219,21 @@ options:
 - name: mon_cluster_log_file
   type: str
   level: advanced
-  desc: File(s) to write cluster log to
-  long_desc: This can either be a simple file name to receive all messages, or a list
-    of key/value pairs where the key is the log channel and the value is the filename,
-    which may include $cluster and $channel metavariables
-  fmt_desc: |
-    The locations of the cluster's log files. There are two channels in
-    Ceph: ``cluster`` and ``audit``. This option represents a mapping
-    from channels to log files, where the log entries of that
-    channel are sent to. The ``default`` entry is a fallback
-    mapping for channels not explicitly specified. So, the following
-    default setting will send cluster log to ``$cluster.log``, and
-    send audit log to ``$cluster.audit.log``, where ``$cluster`` will
-    be replaced with the actual cluster name.
+  desc: File(s) that receive the cluster log.
+  long_desc: Where the cluster log is written. This may be a single filename that receives
+    all messages, or a space-separated list of channel=filename pairs mapping each
+    log channel (such as cluster and audit) to a file. A default= entry is the fallback
+    for channels not named explicitly. Filenames may include the $cluster and $channel
+    metavariables. For example, the default configuration sends the cluster channel
+    to $cluster.log and the audit channel to $cluster.audit.log, with $cluster replaced
+    by the actual cluster name.
+  fmt_desc: Where the cluster log is written. This may be a single filename that receives
+    all messages, or a space-separated list of ``channel=filename`` pairs mapping each
+    log channel (such as ``cluster`` and ``audit``) to a file. A ``default`` entry
+    is the fallback for channels not named explicitly. Filenames may include the ``$cluster``
+    and ``$channel`` metavariables. For example, the default configuration sends the
+    ``cluster`` channel to ``$cluster.log`` and the ``audit`` channel to ``$cluster.audit.log``,
+    with ``$cluster`` replaced by the actual cluster name.
   default: default=/var/log/ceph/$cluster.$channel.log cluster=/var/log/ceph/$cluster.log
   services:
   - mon
@@ -448,10 +452,10 @@ options:
 - name: mon_lease
   type: float
   level: advanced
-  desc: lease interval between quorum monitors (seconds)
-  long_desc: This setting controls how sensitive your mon quorum is to intermittent
-    network issues or other failures.
-  fmt_desc: The length (in seconds) of the lease on the monitor's versions.
+  desc: Length of the Paxos version lease, in seconds.
+  long_desc: The length, in seconds, of the lease the leader grants on the Monitors'
+    versions. It controls how sensitive the Monitor quorum is to intermittent network issues
+    or other failures.
   default: 5
   services:
   - mon
@@ -459,13 +463,13 @@ options:
 - name: mon_lease_renew_interval_factor
   type: float
   level: advanced
-  desc: multiple of mon_lease for the lease renewal interval
-  long_desc: Leases must be renewed before they time out.  A smaller value means frequent
-    renewals, while a value close to 1 makes a lease expiration more likely.
-  fmt_desc: |
-    ``mon_lease`` \* ``mon_lease_renew_interval_factor`` will be the
-    interval for the Leader to renew the other monitor's leases. The
-    factor should be less than ``1.0``.
+  desc: Multiple of mon_lease giving the lease-renewal interval.
+  long_desc: The leader renews the other Monitors' leases every mon_lease * mon_lease_renew_interval_factor
+    seconds, before they time out. The factor must be less than 1.0; a smaller value
+    renews more often, while a value close to 1 makes lease expiration more likely.
+  fmt_desc: The leader renews the other Monitors' leases every ``mon_lease`` \* ``mon_lease_renew_interval_factor``
+    seconds, before they time out. The factor must be less than ``1.0``; a smaller
+    value renews more often, while a value close to 1 makes lease expiration more likely.
   default: 0.6
   services:
   - mon
@@ -596,15 +600,15 @@ options:
 - name: mon_warn_on_osd_down_out_interval_zero
   type: bool
   level: advanced
-  desc: issue OSD_NO_DOWN_OUT_INTERVAL health warning if mon_osd_down_out_interval
-    is zero
-  long_desc: Having mon_osd_down_out_interval set to 0 means that down OSDs are not
-    marked out automatically and the cluster does not heal itself without administrator
-    intervention.
-  fmt_desc: Raise ``HEALTH_WARN`` when ``mon_osd_down_out_interval`` is zero. Having this
-    option set to zero on the leader acts much like the ``noout`` flag. It's hard to figure
-    out what's going wrong with clusters without the ``noout`` flag set but acting like that
-    just the same, so we report a warning in this case.
+  desc: Warn (OSD_NO_DOWN_OUT_INTERVAL) when mon_osd_down_out_interval is zero.
+  long_desc: Raise a health warning when mon_osd_down_out_interval is zero. With it
+    at zero, down OSDs are never automatically marked out, so the cluster does not
+    heal itself without administrator intervention, effectively behaving like the noout
+    flag. Because that silent behavior is hard to diagnose, a warning is reported.
+  fmt_desc: Raise a health warning when ``mon_osd_down_out_interval`` is zero. With
+    it at zero, down OSDs are never automatically marked out, so the cluster does not
+    heal itself without administrator intervention, effectively behaving like the ``noout``
+    flag. Because that silent behavior is hard to diagnose, a warning is reported.
   default: true
   services:
   - mon
@@ -959,11 +963,15 @@ options:
 - name: mon_osd_laggy_weight
   type: float
   level: advanced
-  desc: how heavily to weight OSD marking itself back up in overall laggy_probability
-  long_desc: 1.0 means that an OSD marking itself back up (because it was marked down
-    but not actually dead) means a 100% laggy_probability; 0.0 effectively disables
-    tracking of laggy_probability.
-  fmt_desc: The weight for new samples in laggy estimation decay.
+  desc: Weight given to each new sample in the laggy_probability estimate.
+  long_desc: The weight given to a new sample (an OSD marking itself back up after
+    being marked down, implying it was laggy rather than dead) in the decaying laggy_probability
+    estimate. 1.0 makes a single such event imply a 100% laggy_probability; 0.0 effectively
+    disables laggy_probability tracking.
+  fmt_desc: The weight given to a new sample (an OSD marking itself back up after being
+    marked down, implying it was laggy rather than dead) in the decaying ``laggy_probability``
+    estimate. 1.0 makes a single such event imply a 100% ``laggy_probability``; 0.0
+    effectively disables ``laggy_probability`` tracking.
   default: 0.3
   services:
   - mon
@@ -985,15 +993,19 @@ options:
 - name: mon_osd_adjust_heartbeat_grace
   type: bool
   level: advanced
-  desc: increase OSD heartbeat grace if peers appear to be laggy
-  long_desc: If an OSD is marked down but then marks itself back up, it implies it
-    wasn't actually down but was unable to respond to heartbeats.  If this option
-    is true, we can use the laggy_probability and laggy_interval values calculated
-    to model this situation to increase the heartbeat grace period for this OSD so
-    that it isn't marked down again.  laggy_probability is an estimated probability
-    that the given OSD is down because it is laggy (not actually down), and laggy_interval
-    is an estimate on how long it stays down when it is laggy.
-  fmt_desc: If set to ``true``, Ceph will scale based on laggy estimations.
+  desc: Extend an OSD's heartbeat grace period when it appears laggy rather than down.
+  long_desc: When an OSD is marked down but then marks itself back up, it was likely
+    laggy (unable to respond to heartbeats) rather than actually down. If set, Ceph
+    uses the computed laggy_probability and laggy_interval to lengthen that OSD's heartbeat
+    grace period so it is not marked down again. laggy_probability estimates the chance
+    the OSD was merely laggy, and laggy_interval estimates how long it stays unresponsive
+    when laggy.
+  fmt_desc: When an OSD is marked down but then marks itself back up, it was likely
+    laggy (unable to respond to heartbeats) rather than actually down. If set, Ceph
+    uses the computed ``laggy_probability`` and ``laggy_interval`` to lengthen that
+    OSD's heartbeat grace period so it is not marked down again. ``laggy_probability``
+    estimates the chance the OSD was merely laggy, and ``laggy_interval`` estimates
+    how long it stays unresponsive when laggy.
   default: true
   services:
   - mon

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -452,7 +452,7 @@ options:
 - name: mon_lease
   type: float
   level: advanced
-  desc: Length of the Paxos version lease, in seconds.
+  desc: Length of the Monitor Paxos version lease, in seconds.
   long_desc: The length, in seconds, of the lease the leader grants on the Monitors'
     versions. It controls how sensitive the Monitor quorum is to intermittent network issues
     or other failures.


### PR DESCRIPTION
In `src/common/options/mon.yaml.in`, bring the doc-facing `fmt_desc` and the plain `long_desc` into agreement so both fields carry the same information: correct entries where one was wrong, union complementary text, and drop `fmt_desc` where it carried no RST markup (`confval` falls back to `long_desc`).

7 options harmonized; 1 fmt_desc fields dropped.

Fixes: https://tracker.ceph.com/issues/79826
Assisted by Claude Opus 4.8

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
