### PR TITLE
squid: rgw/admin: fix infinite loop in role list pagination

### DIFF
--- a/qa/suites/rgw/verify/tasks/admin-pagination.yaml
+++ b/qa/suites/rgw/verify/tasks/admin-pagination.yaml
@@ -3,3 +3,4 @@ tasks:
     clients:
       client.0:
         - rgw/run-admin-pagination.sh
+        - rgw/test_rgw_role_pagination.sh

--- a/qa/workunits/rgw/test_rgw_role_pagination.sh
+++ b/qa/workunits/rgw/test_rgw_role_pagination.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# test_rgw_role_pagination.sh
+# Verify that 'radosgw-admin role list' paginates correctly beyond the 100-item chunk limit.
+
+set -e
+
+# Fallback to standard command if the variable isn't provided by the environment
+RGW_ADMIN=${RGW_ADMIN:-radosgw-admin}
+
+NUM_ROLES=105
+PREFIX="TestRole"
+POLICY_DOC='{"Statement": [{"Effect": "Allow", "Principal": {"AWS": ["*"]}, "Action": ["sts:AssumeRole"]}]}'
+
+echo "Creating ${NUM_ROLES} roles to trigger pagination limit..."
+for i in $(seq 1 $NUM_ROLES); do
+    "$RGW_ADMIN" role create --role-name="${PREFIX}${i}" --assume-role-policy-doc="${POLICY_DOC}" > /dev/null
+done
+
+echo "Fetching role list (if the pagination bug exists, this will hang infinitely)..."
+# We pipe the JSON output into 'jq' to count the total number of objects in the 'Roles' array
+ROLE_COUNT=$("$RGW_ADMIN" role list 2>/dev/null | jq 'length')
+
+echo "Found ${ROLE_COUNT} roles."
+
+# Assert that we successfully retrieved at least the 105 roles we just created
+if [ "$ROLE_COUNT" -lt "$NUM_ROLES" ]; then
+    echo "FAIL: Expected at least ${NUM_ROLES} roles, but only retrieved ${ROLE_COUNT}."
+    exit 1
+fi
+
+echo "Cleaning up test roles..."
+for i in $(seq 1 $NUM_ROLES); do
+    "$RGW_ADMIN" role delete --role-name="${PREFIX}${i}" > /dev/null
+done
+
+echo "SUCCESS: Role pagination works correctly!"
+exit 0

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6935,15 +6935,21 @@ int main(int argc, const char **argv)
         constexpr int32_t max_chunk = 100;
         int32_t count = std::min(max_chunk, remaining);
 
+        // Copy the marker to a separate local variable to break the reference alias
+        std::string current_marker = listing.next_marker;
+        // Clear the roles list to prevent appending duplicates across loop iterations
+        listing.roles.clear();
+        listing.next_marker.clear();
+
         if (!account_id.empty()) {
           // list roles in the account
           ret = driver->list_account_roles(dpp(), null_yield, account_id,
-                                           path_prefix, listing.next_marker,
+                                           path_prefix, current_marker,
                                            count, listing);
         } else {
           // list roles in the tenant
           ret = driver->list_roles(dpp(), null_yield, tenant, path_prefix,
-                                   listing.next_marker, count, listing);
+                                   current_marker, count, listing);
         }
         if (ret < 0) {
           return -ret;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79324

---

backport of https://github.com/ceph/ceph/pull/69066
parent tracker: https://tracker.ceph.com/issues/76776

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh