### PR TITLE
mgr/dashboard: support customer-managed policies in RGW accounts

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw_iam.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw_iam.py
@@ -1,10 +1,11 @@
-from typing import Optional
+from typing import Dict, List, Optional
 
 from ..controllers.rgw import RgwRESTController
 from ..exceptions import DashboardException
 from ..rest_client import RequestException
 from ..security import Scope
 from ..services.rgw_iam import RgwAccounts
+from ..services.rgw_iam_policy import RgwIamPolicies
 from ..tools import str_to_bool
 from . import APIDoc, APIRouter, EndpointDoc, RESTController, allow_empty_body
 
@@ -192,3 +193,123 @@ class RgwUserAccountsController(RgwRESTController):
         :rtype: Dict[str, Any]
         """
         return RgwAccounts.set_quota_status(quota_type, account_id, quota_status)
+
+
+@APIRouter('/rgw/accounts/{account_id}/policies', Scope.RGW)
+@APIDoc("RGW IAM Managed Policies API", "RgwIamPolicy")
+class RgwAccountPoliciesController(RESTController):
+    RESOURCE_ID = 'policy_name'
+    def list(self, account_id: str, daemon_name=None):
+        """
+        List managed policies for an account.
+        """
+        return RgwIamPolicies.list_policies(account_id)
+
+    @EndpointDoc("Create managed policy",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_name': (str, 'Policy name'),
+                             'policy_doc': (str, 'Policy document JSON'),
+                             'path': (str, 'Policy path'),
+                             'description': (str, 'Policy description')})
+    @allow_empty_body
+    def create(self, account_id: str, policy_name: str, policy_doc: str,
+               path: str = '/', description: str = '', daemon_name=None):
+        """
+        Create a customer managed policy.
+        """
+        return RgwIamPolicies.create_policy(
+            policy_name, policy_doc, account_id=account_id,
+            path=path, description=description)
+
+    @EndpointDoc("Get managed policy by ARN",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_arn': (str, 'Policy ARN')})
+    @RESTController.Collection(method='GET', path='/get')
+    def get_policy(self, account_id: str, policy_arn: str, daemon_name=None):
+        """
+        Get policy details and document.
+        """
+        return RgwIamPolicies.get_policy(policy_arn)
+
+    @EndpointDoc("Delete managed policy",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_name': (str, 'Policy name')})
+    def delete(self, account_id: str, policy_name: str, daemon_name=None):
+        """
+        Delete a managed policy.
+        """
+        return RgwIamPolicies.delete_policy_by_name(account_id, policy_name)
+
+    @EndpointDoc("List policy versions",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_arn': (str, 'Policy ARN')})
+    @RESTController.Collection(method='GET', path='/versions')
+    def list_versions(self, account_id: str, policy_arn: str, daemon_name=None):
+        return RgwIamPolicies.list_policy_versions(policy_arn)
+
+    @EndpointDoc("Get policy version",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_arn': (str, 'Policy ARN'),
+                             'version_id': (str, 'Version ID')})
+    @RESTController.Collection(method='GET', path='/versions/get')
+    def get_version(self, account_id: str, policy_arn: str, version_id: str,
+                    daemon_name=None):
+        return RgwIamPolicies.get_policy_version(policy_arn, version_id)
+
+    @EndpointDoc("Create policy version",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_arn': (str, 'Policy ARN'),
+                             'policy_doc': (str, 'Policy document JSON'),
+                             'set_as_default': (bool, 'Set as default version')})
+    @RESTController.Collection(method='POST', path='/versions')
+    @allow_empty_body
+    def create_version(self, account_id: str, policy_arn: str, policy_doc: str,
+                       set_as_default: bool = False, daemon_name=None):
+        return RgwIamPolicies.create_policy_version(
+            policy_arn, policy_doc, set_as_default)
+
+    @EndpointDoc("Delete policy version",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_arn': (str, 'Policy ARN'),
+                             'version_id': (str, 'Version ID')})
+    @RESTController.Collection(method='DELETE', path='/versions')
+    def remove_version(self, account_id: str, policy_arn: str, version_id: str,
+                       daemon_name=None):
+        return RgwIamPolicies.delete_policy_version(policy_arn, version_id)
+
+    @EndpointDoc("Set default policy version",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_arn': (str, 'Policy ARN'),
+                             'version_id': (str, 'Version ID')})
+    @RESTController.Collection(method='PUT', path='/versions/default')
+    @allow_empty_body
+    def set_default_version(self, account_id: str, policy_arn: str, version_id: str,
+                            daemon_name=None):
+        return RgwIamPolicies.set_default_policy_version(policy_arn, version_id)
+
+    @EndpointDoc("List policy tags",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_arn': (str, 'Policy ARN')})
+    @RESTController.Collection(method='GET', path='/tags')
+    def list_tags(self, account_id: str, policy_arn: str, daemon_name=None):
+        return RgwIamPolicies.list_policy_tags(policy_arn)
+
+    @EndpointDoc("Tag policy",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_arn': (str, 'Policy ARN'),
+                             'tags': (list, 'Policy tags')})
+    @RESTController.Collection(method='POST', path='/tags')
+    @allow_empty_body
+    def add_tags(self, account_id: str, policy_arn: str,
+                 tags: List[Dict[str, str]], daemon_name=None):
+        return RgwIamPolicies.tag_policy(policy_arn, tags)
+
+    @EndpointDoc("Untag policy",
+                 parameters={'account_id': (str, 'Account ID'),
+                             'policy_arn': (str, 'Policy ARN'),
+                             'tag_keys': (str, 'Comma-separated tag keys')})
+    @RESTController.Collection(method='DELETE', path='/tags')
+    def remove_tags(self, account_id: str, policy_arn: str, tag_keys: str,
+                    daemon_name=None):
+        keys = [key.strip() for key in tag_keys.split(',') if key.strip()]
+        return RgwIamPolicies.untag_policy(policy_arn, keys)

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/policies.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/policies.e2e-spec.ts
@@ -1,0 +1,80 @@
+import { PoliciesPageHelper } from './policies.po';
+import { AccountsPageHelper } from './accounts.po';
+
+describe('RGW policies page', () => {
+  const policies = new PoliciesPageHelper();
+  const accounts = new AccountsPageHelper();
+  const accountName = 'policies-test-account';
+  const policyName = 'TestReadOnlyPolicy';
+  const policyDocument = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket", "s3:GetObject"],
+      "Resource": "*"
+    }
+  ]
+}`;
+
+  before(() => {
+    cy.login();
+    accounts.navigateTo();
+    cy.get('body').then(($body) => {
+      if (!$body.text().includes(accountName)) {
+        accounts.navigateTo('create');
+        accounts.create({ name: accountName, email: 'policies-test@example.com' });
+      }
+    });
+  });
+
+  after(() => {
+    cy.login();
+    accounts.navigateTo();
+    cy.get('body').then(($body) => {
+      if ($body.text().includes(accountName)) {
+        accounts.delete(accountName, null, null, true, false, false, false);
+      }
+    });
+  });
+
+  beforeEach(() => {
+    cy.login();
+    accounts.navigateTo();
+    accounts.getResourcePage(accountName).click();
+    cy.contains('cds-sidenav-item a', /^Policies$/).click();
+    cy.location('hash').should('include', '/policies');
+    cy.get('cd-rgw-account-policies-list').should('exist');
+  });
+
+  describe('Create, View & Delete IAM policies', () => {
+    it('should create IAM policy', () => {
+      policies.create(policyName, '/', policyDocument);
+      policies.checkExist(policyName, true);
+    });
+
+    it('should open IAM policy details', () => {
+      policies.openPolicy(policyName);
+    });
+
+    it('should test policy versions and tags in details modal', () => {
+      const versionDoc = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:*"],
+      "Resource": "*"
+    }
+  ]
+}`;
+      policies.testVersions(policyName, versionDoc);
+      policies.testTags(policyName, 'Environment', 'Testing');
+    });
+
+    it('should delete IAM policy', () => {
+      policies.deletePolicy(policyName);
+      policies.checkExist(policyName, false);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/policies.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/policies.po.ts
@@ -1,0 +1,122 @@
+import { PageHelper } from '../page-helper.po';
+
+export class PoliciesPageHelper extends PageHelper {
+  columnIndex = {
+    policyName: 1,
+    arn: 2,
+    defaultVersion: 3,
+    createDate: 4
+  };
+
+  create(name: string, path: string, policyDocument: string) {
+    cy.get('cd-rgw-account-policies-list cd-table-actions button[aria-label="Create"]')
+      .should('exist')
+      .click();
+    cy.get('cds-modal').should('be.visible');
+    cy.get('#policy_name').type(name);
+    cy.get('#policy_path').clear().type(path);
+    cy.get('#policy_doc')
+      .clear()
+      .type(policyDocument, { parseSpecialCharSequences: false, delay: 0 });
+    cy.get('cds-modal').contains('button', 'Create').click();
+    cy.get('cds-modal').should('not.exist');
+  }
+
+  openPolicy(name: string) {
+    this.getPoliciesTableCell(this.columnIndex.policyName, name).click();
+    this.getPoliciesTableCell(this.columnIndex.policyName, name)
+      .parent('tr')
+      .find('[data-testid="table-action-btn"]')
+      .should('exist')
+      .click();
+    cy.get('cds-overflow-menu-option[aria-label="View policy"]').should('exist').click();
+    cy.get('cds-modal').should('be.visible');
+    cy.get('cds-modal').contains('button', 'Close').click();
+    cy.get('cds-modal').should('not.exist');
+  }
+
+  deletePolicy(name: string) {
+    this.getPoliciesTableCell(this.columnIndex.policyName, name).click();
+    this.getPoliciesTableCell(this.columnIndex.policyName, name)
+      .parent('tr')
+      .find('[data-testid="table-action-btn"]')
+      .should('exist')
+      .click();
+    cy.get('cds-overflow-menu-option[aria-label="Delete"]').should('exist').click();
+    cy.get('cds-modal').should('be.visible');
+    cy.get('cds-modal [aria-label="confirmation"]').click({ force: true });
+    cy.get('cds-modal').contains('button', 'Delete IAM Policy').click();
+    cy.get('cds-modal').should('not.exist');
+  }
+
+  testVersions(name: string, newPolicyDoc: string) {
+    this.getPoliciesTableCell(this.columnIndex.policyName, name).click();
+    this.getPoliciesTableCell(this.columnIndex.policyName, name)
+      .parent('tr')
+      .find('[data-testid="table-action-btn"]')
+      .should('exist')
+      .click();
+    cy.get('cds-overflow-menu-option[aria-label="View policy"]').should('exist').click();
+    cy.get('cds-modal').should('be.visible');
+    cy.get('cds-modal cds-loading').should('not.exist');
+
+    this.getCdsTab('Versions').click({ force: true });
+    cy.get('cds-modal').contains('button', 'Create policy version').click();
+    cy.get('#version_policy_doc')
+      .clear()
+      .type(newPolicyDoc, { parseSpecialCharSequences: false, delay: 0 });
+    cy.get('cds-modal').contains('button', 'Save version').click();
+    cy.get('cds-modal cds-loading').should('not.exist');
+
+    cy.get('cds-modal table').contains('td', 'v2').should('exist');
+
+    cy.get('cds-modal').contains('button', 'Close').click();
+    cy.get('cds-modal').should('not.exist');
+  }
+
+  testTags(name: string, key: string, value: string) {
+    this.getPoliciesTableCell(this.columnIndex.policyName, name).click();
+    this.getPoliciesTableCell(this.columnIndex.policyName, name)
+      .parent('tr')
+      .find('[data-testid="table-action-btn"]')
+      .should('exist')
+      .click();
+    cy.get('cds-overflow-menu-option[aria-label="View policy"]').should('exist').click();
+    cy.get('cds-modal').should('be.visible');
+    cy.get('cds-modal cds-loading').should('not.exist');
+
+    this.getCdsTab('Tags').click({ force: true });
+    cy.get('input[formcontrolname="tag_key"]').type(key);
+    cy.get('input[formcontrolname="tag_value"]').type(value);
+    cy.get('cds-modal').contains('button', 'Add tag').click();
+    cy.get('cds-modal cds-loading').should('not.exist');
+
+    cy.get('cds-modal table').contains('td', key).should('exist');
+    cy.get('cds-modal table').contains('td', value).should('exist');
+
+    cy.get('cds-modal table').contains('button', 'Remove').click();
+    cy.get('cds-modal cds-loading').should('not.exist');
+
+    cy.get('cds-modal').contains('button', 'Close').click();
+    cy.get('cds-modal').should('not.exist');
+  }
+
+  private getPoliciesTableCell(columnIndex: number, exactContent: string) {
+    cy.get('cd-rgw-account-policies-list').within(() => {
+      cy.get('.cds--search-close').first().click({ force: true });
+    });
+    cy.get('.cds--search-input').first().clear({ force: true }).type(exactContent, { delay: 35 });
+    const selector = `tbody tr td:nth-child(${columnIndex})`;
+    return cy
+      .get('cd-rgw-account-policies-list')
+      .contains(selector, new RegExp(`^\\s*${exactContent}\\s*$`, 'i'));
+  }
+
+  checkExist(name: string, exist: boolean) {
+    if (exist) {
+      this.getPoliciesTableCell(this.columnIndex.policyName, name).should('exist');
+    } else {
+      cy.get('cd-rgw-account-policies-list').contains(name).should('not.exist');
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-iam-policy.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-iam-policy.ts
@@ -1,0 +1,42 @@
+export interface IamPolicy {
+  PolicyName: string;
+  PolicyId?: string;
+  Arn: string;
+  Path?: string;
+  DefaultVersionId?: string;
+  AttachmentCount?: number;
+  CreateDate?: string;
+  UpdateDate?: string;
+  Description?: string;
+  PolicyDocument?: string | Record<string, unknown>;
+}
+
+export interface IamPolicyVersion {
+  VersionId: string;
+  IsDefaultVersion?: boolean | string;
+  CreateDate?: string;
+  Document?: string | Record<string, unknown>;
+}
+
+export interface IamPolicyTag {
+  Key: string;
+  Value: string;
+}
+
+export interface IamPolicyCreatePayload {
+  policy_name: string;
+  policy_doc: string;
+  path?: string;
+  description?: string;
+}
+
+export const DEFAULT_IAM_POLICY_DOCUMENT = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket", "s3:GetObject"],
+      "Resource": "*"
+    }
+  ]
+}`;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policies-list/rgw-account-policies-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policies-list/rgw-account-policies-list.component.html
@@ -1,0 +1,18 @@
+<cd-table
+  #table
+  [autoReload]="true"
+  [data]="data$ | async"
+  [columns]="columns"
+  selectionType="single"
+  columnMode="flex"
+  (updateSelection)="updateSelection($event)"
+  identifier="PolicyName"
+>
+  <cd-table-actions
+    class="table-actions"
+    [permission]="permission"
+    [selection]="selection"
+    [tableActions]="tableActions"
+  >
+  </cd-table-actions>
+</cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policies-list/rgw-account-policies-list.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policies-list/rgw-account-policies-list.component.scss
@@ -1,0 +1,8 @@
+:host {
+  display: block;
+}
+
+pre {
+  max-height: 400px;
+  overflow-y: auto;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policies-list/rgw-account-policies-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policies-list/rgw-account-policies-list.component.ts
@@ -1,0 +1,173 @@
+import { Component, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import { Observable, Subscriber, of } from 'rxjs';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { TableComponent } from '~/app/shared/datatable/table/table.component';
+import { Icons } from '~/app/shared/enum/icons.enum';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { CdTableAction } from '~/app/shared/models/cd-table-action';
+import { CdTableColumn } from '~/app/shared/models/cd-table-column';
+import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
+import { Permission } from '~/app/shared/models/permissions';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { CdDatePipe } from '~/app/shared/pipes/cd-date.pipe';
+import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
+import { RgwIamPolicyService } from '~/app/shared/api/rgw-iam-policy.service';
+import { IamPolicy } from '../models/rgw-iam-policy';
+import { RgwAccountPolicyFormComponent } from '../rgw-account-policy-form/rgw-account-policy-form.component';
+import { RgwAccountPolicyDetailModalComponent } from '../rgw-account-policy-detail-modal/rgw-account-policy-detail-modal.component';
+
+@Component({
+  selector: 'cd-rgw-account-policies-list',
+  templateUrl: './rgw-account-policies-list.component.html',
+  styleUrls: ['./rgw-account-policies-list.component.scss'],
+  standalone: false
+})
+export class RgwAccountPoliciesListComponent implements OnInit, OnChanges {
+  @Input()
+  accountId: string;
+
+  @Input()
+  accountName: string;
+
+  @ViewChild('table')
+  table: TableComponent;
+
+  columns: CdTableColumn[] = [];
+  data$: Observable<IamPolicy[]>;
+  tableActions: CdTableAction[] = [];
+  selection: CdTableSelection = new CdTableSelection();
+  permission: Permission;
+
+  constructor(
+    public actionLabels: ActionLabelsI18n,
+    private rgwIamPolicyService: RgwIamPolicyService,
+    private modalService: ModalCdsService,
+    private authStorageService: AuthStorageService,
+    private cdDatePipe: CdDatePipe,
+    private notificationService: NotificationService
+  ) {
+    this.permission = this.authStorageService.getPermissions().rgw;
+  }
+
+  ngOnInit(): void {
+    this.loadPolicies();
+    this.columns = [
+      {
+        name: $localize`Policy Name`,
+        prop: 'PolicyName',
+        flexGrow: 2
+      },
+      {
+        name: $localize`Arn`,
+        prop: 'Arn',
+        flexGrow: 3
+      },
+      {
+        name: $localize`Default Version`,
+        prop: 'DefaultVersionId',
+        flexGrow: 1
+      },
+      {
+        name: $localize`Created at`,
+        prop: 'CreateDate',
+        flexGrow: 2,
+        pipe: this.cdDatePipe
+      }
+    ];
+
+    this.tableActions = [
+      {
+        permission: 'create',
+        icon: Icons.add,
+        click: () => this.openPolicyForm(),
+        name: this.actionLabels.CREATE,
+        canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
+      },
+      {
+        permission: 'read',
+        icon: Icons.search,
+        click: () => this.viewPolicyDetails(),
+        name: $localize`View policy`,
+        disable: () => !this.selection.hasSelection
+      },
+      {
+        permission: 'delete',
+        icon: Icons.destroy,
+        click: () => this.deletePolicy(),
+        name: this.actionLabels.DELETE,
+        disable: () => !this.selection.hasSelection
+      }
+    ];
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.accountId) {
+      this.loadPolicies();
+    }
+  }
+
+  loadPolicies(): void {
+    if (!this.accountId) {
+      this.data$ = of([]);
+      return;
+    }
+    this.data$ = this.rgwIamPolicyService.list(this.accountId);
+  }
+
+  updateSelection(selection: CdTableSelection): void {
+    this.selection = selection;
+  }
+
+  openPolicyForm(): void {
+    const modalRef = this.modalService.show(RgwAccountPolicyFormComponent, {
+      accountId: this.accountId,
+      accountName: this.accountName
+    });
+    modalRef?.close?.subscribe(() => this.loadPolicies());
+  }
+
+  viewPolicyDetails(): void {
+    const policy = this.selection.first() as IamPolicy;
+    if (!policy) {
+      return;
+    }
+
+    const modalRef = this.modalService.show(RgwAccountPolicyDetailModalComponent, {
+      policy,
+      accountId: this.accountId
+    });
+    modalRef?.close?.subscribe(() => this.loadPolicies());
+  }
+
+  deletePolicy(): void {
+    const policy = this.selection.first() as IamPolicy;
+    if (!policy) {
+      return;
+    }
+
+    this.modalService.show(DeleteConfirmationModalComponent, {
+      itemDescription: $localize`IAM Policy`,
+      itemNames: [policy.PolicyName],
+      submitActionObservable: () => {
+        return new Observable((observer: Subscriber<any>) => {
+          this.rgwIamPolicyService.delete(this.accountId, policy.PolicyName).subscribe({
+            next: () => {
+              this.notificationService.show(
+                NotificationType.success,
+                $localize`Policy deleted successfully`
+              );
+              observer.next();
+              observer.complete();
+              this.loadPolicies();
+            },
+            error: (err) => {
+              observer.error(err);
+            }
+          });
+        });
+      }
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policy-detail-modal/rgw-account-policy-detail-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policy-detail-modal/rgw-account-policy-detail-modal.component.html
@@ -1,0 +1,236 @@
+<cds-modal
+  size="lg"
+  [open]="open"
+  [hasScrollingContent]="true"
+  (overlaySelected)="closeModal()"
+>
+  <cds-modal-header (closeSelect)="closeModal()">
+    <h4
+      cdsModalHeaderLabel
+      class="cds--type-label-01"
+      i18n
+    >
+      IAM policy
+    </h4>
+    <h3 cdsModalHeaderHeading>{{ policy.PolicyName }}</h3>
+    <p class="cds--modal-header__description cds--type-body-01 cds-mt-3">
+      {{ policy.Arn }}
+    </p>
+  </cds-modal-header>
+
+  <div cdsModalContent>
+    @if (loading) {
+      <cds-loading [isActive]="true"></cds-loading>
+    } @else {
+      <cds-tabs>
+        <cds-tab heading="Policy document">
+          <div class="cds-mt-4">
+            <p
+              class="cds--type-label-01 cds-mb-2"
+              i18n
+            >
+              Default version (iam:GetPolicy)
+            </p>
+            <pre class="policy-document-panel"><code>{{ policyDocument }}</code></pre>
+          </div>
+        </cds-tab>
+
+        <cds-tab heading="Versions">
+          <div class="cds-mt-4">
+            <div class="cds-mb-4">
+              <button
+                cdsButton="tertiary"
+                size="sm"
+                type="button"
+                (click)="toggleVersionForm()"
+                i18n
+              >
+                Create policy version
+              </button>
+            </div>
+
+            @if (showVersionForm) {
+              <form
+                class="version-form cds-mb-4"
+                [formGroup]="versionForm"
+                (ngSubmit)="createVersion()"
+              >
+                <cds-textarea-label labelInputID="version_policy_doc">
+                  Policy document
+                  <textarea
+                    cdsTextArea
+                    id="version_policy_doc"
+                    formControlName="policy_doc"
+                    rows="8"
+                  ></textarea>
+                </cds-textarea-label>
+                <cds-checkbox formControlName="set_as_default">
+                  <span i18n>Set as default version</span>
+                </cds-checkbox>
+                <div class="cds-mt-3">
+                  <button
+                    cdsButton="primary"
+                    size="sm"
+                    type="submit"
+                    i18n
+                  >
+                    Save version
+                  </button>
+                </div>
+              </form>
+            }
+
+            @if (versions.length === 0) {
+              <p
+                class="cds--type-body-01"
+                i18n
+              >
+                No policy versions found.
+              </p>
+            } @else {
+              <table class="cds--data-table cds--data-table--no-border">
+                <thead>
+                  <tr>
+                    <th i18n>Version</th>
+                    <th i18n>Default</th>
+                    <th i18n>Created at</th>
+                    <th i18n>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (version of versions; track version.VersionId) {
+                    <tr [class.selected-row]="version.VersionId === selectedVersionId">
+                      <td>{{ version.VersionId }}</td>
+                      <td>{{ isDefaultVersion(version) ? 'Yes' : 'No' }}</td>
+                      <td>{{ version.CreateDate | cdDate }}</td>
+                      <td class="version-actions">
+                        <button
+                          cdsButton="ghost"
+                          size="sm"
+                          type="button"
+                          (click)="selectVersion(version.VersionId)"
+                          i18n
+                        >
+                          View
+                        </button>
+                        @if (!isDefaultVersion(version)) {
+                          <button
+                            cdsButton="ghost"
+                            size="sm"
+                            type="button"
+                            (click)="setDefaultVersion(version.VersionId)"
+                            i18n
+                          >
+                            Set default
+                          </button>
+                          <button
+                            cdsButton="ghost"
+                            size="sm"
+                            type="button"
+                            (click)="deleteVersion(version.VersionId)"
+                            i18n
+                          >
+                            Delete
+                          </button>
+                        }
+                      </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+              @if (selectedVersionDocument) {
+                <pre
+                  class="policy-document-panel cds-mt-4"
+                ><code>{{ selectedVersionDocument }}</code></pre>
+              }
+            }
+          </div>
+        </cds-tab>
+
+        <cds-tab heading="Tags">
+          <div class="cds-mt-4">
+            <form
+              class="tag-form cds-mb-4"
+              [formGroup]="tagForm"
+              (ngSubmit)="addTag()"
+            >
+              <div class="tag-form__fields">
+                <cds-text-label label="Tag key">
+                  <input
+                    cdsText
+                    formControlName="tag_key"
+                    placeholder="Key"
+                  />
+                </cds-text-label>
+                <cds-text-label label="Tag value">
+                  <input
+                    cdsText
+                    formControlName="tag_value"
+                    placeholder="Value"
+                  />
+                </cds-text-label>
+              </div>
+              <button
+                cdsButton="primary"
+                size="sm"
+                type="submit"
+                i18n
+              >
+                Add tag
+              </button>
+            </form>
+
+            @if (tags.length === 0) {
+              <p
+                class="cds--type-body-01"
+                i18n
+              >
+                No tags on this policy.
+              </p>
+            } @else {
+              <table class="cds--data-table cds--data-table--no-border">
+                <thead>
+                  <tr>
+                    <th i18n>Key</th>
+                    <th i18n>Value</th>
+                    <th i18n>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (tag of tags; track tag.Key) {
+                    <tr>
+                      <td>{{ tag.Key }}</td>
+                      <td>{{ tag.Value }}</td>
+                      <td>
+                        <button
+                          cdsButton="ghost"
+                          size="sm"
+                          type="button"
+                          (click)="removeTag(tag.Key)"
+                          i18n
+                        >
+                          Remove
+                        </button>
+                      </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            }
+          </div>
+        </cds-tab>
+      </cds-tabs>
+    }
+  </div>
+
+  <cds-modal-footer>
+    <button
+      cdsButton="secondary"
+      type="button"
+      (click)="closeModal()"
+      i18n
+    >
+      Close
+    </button>
+  </cds-modal-footer>
+</cds-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policy-detail-modal/rgw-account-policy-detail-modal.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policy-detail-modal/rgw-account-policy-detail-modal.component.scss
@@ -1,0 +1,30 @@
+.policy-document-panel {
+  background: var(--cds-layer-01, #f4f4f4);
+  border: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  border-radius: 0;
+  max-height: 24rem;
+  overflow: auto;
+  padding: 1rem;
+}
+
+.version-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.tag-form__fields {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  margin-bottom: 1rem;
+}
+
+.selected-row {
+  background: var(--cds-layer-hover-01, #e8e8e8);
+}
+
+.version-form {
+  border: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  padding: 1rem;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policy-detail-modal/rgw-account-policy-detail-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policy-detail-modal/rgw-account-policy-detail-modal.component.ts
@@ -1,0 +1,209 @@
+import { Component, Inject, OnInit, Optional } from '@angular/core';
+import { Validators } from '@angular/forms';
+import { BaseModal } from 'carbon-components-angular';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
+import { CdValidators } from '~/app/shared/forms/cd-validators';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { RgwIamPolicyService } from '~/app/shared/api/rgw-iam-policy.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import {
+  DEFAULT_IAM_POLICY_DOCUMENT,
+  IamPolicy,
+  IamPolicyTag,
+  IamPolicyVersion
+} from '../models/rgw-iam-policy';
+
+@Component({
+  selector: 'cd-rgw-account-policy-detail-modal',
+  templateUrl: './rgw-account-policy-detail-modal.component.html',
+  styleUrls: ['./rgw-account-policy-detail-modal.component.scss'],
+  standalone: false
+})
+export class RgwAccountPolicyDetailModalComponent extends BaseModal implements OnInit {
+  policy: IamPolicy;
+  accountId: string;
+  policyDocument = '';
+  versions: IamPolicyVersion[] = [];
+  tags: IamPolicyTag[] = [];
+  selectedVersionId = '';
+  selectedVersionDocument = '';
+  loading = true;
+
+  versionForm: CdFormGroup;
+  tagForm: CdFormGroup;
+  showVersionForm = false;
+
+  constructor(
+    @Optional() @Inject('policy') policy: IamPolicy,
+    @Optional() @Inject('accountId') accountId: string,
+    private rgwIamPolicyService: RgwIamPolicyService,
+    private notificationService: NotificationService,
+    public actionLabels: ActionLabelsI18n,
+    private formBuilder: CdFormBuilder
+  ) {
+    super();
+    this.policy = policy;
+    this.accountId = accountId;
+  }
+
+  ngOnInit(): void {
+    this.versionForm = this.formBuilder.group({
+      policy_doc: [DEFAULT_IAM_POLICY_DOCUMENT, [Validators.required, CdValidators.json()]],
+      set_as_default: [true]
+    });
+    this.tagForm = this.formBuilder.group({
+      tag_key: ['', [Validators.required]],
+      tag_value: ['', [Validators.required]]
+    });
+    this.loadPolicyData();
+  }
+
+  loadPolicyData(): void {
+    this.loading = true;
+    forkJoin({
+      policy: this.rgwIamPolicyService
+        .get(this.accountId, this.policy.Arn)
+        .pipe(catchError(() => of(this.policy))),
+      versions: this.rgwIamPolicyService
+        .listVersions(this.accountId, this.policy.Arn)
+        .pipe(catchError(() => of([] as IamPolicyVersion[]))),
+      tags: this.rgwIamPolicyService
+        .listTags(this.accountId, this.policy.Arn)
+        .pipe(catchError(() => of([] as IamPolicyTag[])))
+    }).subscribe({
+      next: ({ policy, versions, tags }) => {
+        this.policy = { ...this.policy, ...policy };
+        this.policyDocument = this.formatDocument(policy.PolicyDocument);
+        this.versions = versions || [];
+        this.tags = tags || [];
+        if (this.versions.length > 0 && !this.selectedVersionId) {
+          const defaultVersion =
+            this.versions.find((version) => this.isDefaultVersion(version)) || this.versions[0];
+          this.selectVersion(defaultVersion.VersionId);
+        }
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      }
+    });
+  }
+
+  selectVersion(versionId: string): void {
+    this.selectedVersionId = versionId;
+    this.rgwIamPolicyService.getVersion(this.accountId, this.policy.Arn, versionId).subscribe({
+      next: (version) => {
+        this.selectedVersionDocument = this.formatDocument(version.Document || version);
+      },
+      error: () => {
+        this.selectedVersionDocument = '';
+      }
+    });
+  }
+
+  setDefaultVersion(versionId: string): void {
+    this.rgwIamPolicyService
+      .setDefaultVersion(this.accountId, this.policy.Arn, versionId)
+      .subscribe({
+        next: () => {
+          this.notificationService.show(
+            NotificationType.success,
+            $localize`Default policy version updated`
+          );
+          this.loadPolicyData();
+        }
+      });
+  }
+
+  deleteVersion(versionId: string): void {
+    this.rgwIamPolicyService.deleteVersion(this.accountId, this.policy.Arn, versionId).subscribe({
+      next: () => {
+        this.notificationService.show(NotificationType.success, $localize`Policy version deleted`);
+        this.selectedVersionId = '';
+        this.loadPolicyData();
+      }
+    });
+  }
+
+  toggleVersionForm(): void {
+    this.showVersionForm = !this.showVersionForm;
+  }
+
+  createVersion(): void {
+    if (this.versionForm.invalid) {
+      return;
+    }
+    const payload = this.versionForm.getRawValue();
+    this.rgwIamPolicyService
+      .createVersion(this.accountId, this.policy.Arn, payload.policy_doc, payload.set_as_default)
+      .subscribe({
+        next: () => {
+          this.notificationService.show(
+            NotificationType.success,
+            $localize`Policy version created`
+          );
+          this.showVersionForm = false;
+          this.versionForm.reset({
+            policy_doc: DEFAULT_IAM_POLICY_DOCUMENT,
+            set_as_default: true
+          });
+          this.loadPolicyData();
+        },
+        error: () => {
+          this.versionForm.setErrors({ cdSubmitButton: true });
+        }
+      });
+  }
+
+  addTag(): void {
+    if (this.tagForm.invalid) {
+      return;
+    }
+    const payload = this.tagForm.getRawValue();
+    this.rgwIamPolicyService
+      .addTags(this.accountId, this.policy.Arn, [
+        { Key: payload.tag_key, Value: payload.tag_value }
+      ])
+      .subscribe({
+        next: () => {
+          this.notificationService.show(NotificationType.success, $localize`Tag added`);
+          this.tagForm.reset();
+          this.loadPolicyData();
+        },
+        error: () => {
+          this.tagForm.setErrors({ cdSubmitButton: true });
+        }
+      });
+  }
+
+  removeTag(tagKey: string): void {
+    this.rgwIamPolicyService.removeTags(this.accountId, this.policy.Arn, [tagKey]).subscribe({
+      next: () => {
+        this.notificationService.show(NotificationType.success, $localize`Tag removed`);
+        this.loadPolicyData();
+      }
+    });
+  }
+
+  isDefaultVersion(version: IamPolicyVersion): boolean {
+    return version.IsDefaultVersion === true || version.IsDefaultVersion === 'true';
+  }
+
+  private formatDocument(document: unknown): string {
+    if (document === null || document === undefined || document === '') {
+      return '';
+    }
+    if (typeof document === 'string') {
+      try {
+        return JSON.stringify(JSON.parse(document), null, 2);
+      } catch {
+        return document;
+      }
+    }
+    return JSON.stringify(document, null, 2);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policy-form/rgw-account-policy-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policy-form/rgw-account-policy-form.component.html
@@ -1,0 +1,179 @@
+<cds-modal
+  size="md"
+  [open]="open"
+  [hasScrollingContent]="true"
+  (overlaySelected)="closeModal()"
+>
+  <cds-modal-header (closeSelect)="closeModal()">
+    <h4
+      cdsModalHeaderLabel
+      class="cds--type-label-01"
+      i18n
+    >
+      User account
+    </h4>
+    <h3
+      cdsModalHeaderHeading
+      i18n
+    >
+      Create IAM policy
+    </h3>
+    <p
+      class="cds--modal-header__description cds--type-body-01 cds-mt-3"
+      i18n
+    >
+      Customer-managed policies are reusable permission documents that can be attached to users,
+      groups, and roles.
+    </p>
+  </cds-modal-header>
+
+  <form
+    class="form"
+    #formDir="ngForm"
+    [formGroup]="form"
+  >
+    <div cdsModalContent>
+      <div class="form-item">
+        <legend
+          class="cds--label cds--type-label-01"
+          i18n
+        >
+          Account
+        </legend>
+        <p class="cds--type-body-01">{{ accountName }}</p>
+      </div>
+
+      <div class="form-item">
+        <cds-text-label
+          label="Policy name"
+          for="policy_name"
+          [invalid]="policyName.isInvalid"
+          [invalidText]="policyNameError"
+          helperText="Unique name for this policy within the account."
+          i18n-helperText
+        >
+          Policy name
+          <input
+            cdsText
+            cdValidate
+            #policyName="cdValidate"
+            type="text"
+            id="policy_name"
+            name="policy_name"
+            formControlName="policy_name"
+            placeholder="Enter a policy name (e.g. ReadOnlyS3Access)"
+            [invalid]="policyName.isInvalid"
+            [autofocus]="true"
+            modal-primary-focus
+          />
+        </cds-text-label>
+        <ng-template #policyNameError>
+          @if (form.showError('policy_name', formDir, 'required')) {
+            <span
+              class="invalid-feedback"
+              i18n
+              >This field is required.</span
+            >
+          }
+        </ng-template>
+      </div>
+
+      <div class="form-item">
+        <cds-text-label
+          label="Policy path"
+          for="policy_path"
+          [invalid]="policyPath.isInvalid"
+          [invalidText]="pathError"
+          helperText='Optional hierarchy for the policy. Use "/" for the root path.'
+          i18n-helperText
+        >
+          Policy path
+          <input
+            cdsText
+            cdValidate
+            #policyPath="cdValidate"
+            type="text"
+            id="policy_path"
+            name="path"
+            formControlName="path"
+            placeholder="/"
+            [invalid]="policyPath.isInvalid"
+          />
+        </cds-text-label>
+        <ng-template #pathError>
+          @if (form.showError('path', formDir, 'required')) {
+            <span
+              class="invalid-feedback"
+              i18n
+              >This field is required.</span
+            >
+          }
+        </ng-template>
+      </div>
+
+      <div class="form-item">
+        <cds-text-label
+          label="Description"
+          for="policy_description"
+        >
+          Description
+          <input
+            cdsText
+            type="text"
+            id="policy_description"
+            name="description"
+            formControlName="description"
+            placeholder="Optional description for this policy"
+          />
+        </cds-text-label>
+      </div>
+
+      <div class="form-item">
+        <cds-textarea-label
+          labelInputID="policy_doc"
+          [invalid]="policyDoc.isInvalid"
+          [invalidText]="policyDocError"
+          helperText="JSON policy document following the IAM policy grammar."
+          i18n-helperText
+        >
+          Policy document
+          <textarea
+            cdsTextArea
+            cdValidate
+            #policyDoc="cdValidate"
+            id="policy_doc"
+            name="policy_doc"
+            formControlName="policy_doc"
+            rows="10"
+            cols="200"
+            [invalid]="policyDoc.isInvalid"
+            cdRequiredField="Policy document"
+          ></textarea>
+        </cds-textarea-label>
+        <ng-template #policyDocError>
+          @if (form.showError('policy_doc', formDir, 'required')) {
+            <span
+              class="invalid-feedback"
+              i18n
+              >This field is required.</span
+            >
+          }
+          @if (form.showError('policy_doc', formDir, 'json')) {
+            <span
+              class="invalid-feedback"
+              i18n
+              >Must be valid JSON.</span
+            >
+          }
+        </ng-template>
+      </div>
+    </div>
+
+    <cd-form-button-panel
+      (submitActionEvent)="onSubmit()"
+      [form]="form"
+      submitText="Create"
+      [modalForm]="true"
+    ></cd-form-button-panel>
+  </form>
+</cds-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policy-form/rgw-account-policy-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-account-policy-form/rgw-account-policy-form.component.ts
@@ -1,0 +1,68 @@
+import { Component, Inject, OnInit, Optional } from '@angular/core';
+import { Validators } from '@angular/forms';
+import { BaseModal } from 'carbon-components-angular';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
+import { CdValidators } from '~/app/shared/forms/cd-validators';
+import { RgwIamPolicyService } from '~/app/shared/api/rgw-iam-policy.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { DEFAULT_IAM_POLICY_DOCUMENT } from '../models/rgw-iam-policy';
+
+@Component({
+  selector: 'cd-rgw-account-policy-form',
+  templateUrl: './rgw-account-policy-form.component.html',
+  styleUrls: ['./rgw-account-policy-form.component.scss'],
+  standalone: false
+})
+export class RgwAccountPolicyFormComponent extends BaseModal implements OnInit {
+  form: CdFormGroup;
+
+  constructor(
+    @Optional() @Inject('accountId') public accountId: string,
+    @Optional() @Inject('accountName') public accountName: string,
+    private formBuilder: CdFormBuilder,
+    public actionLabels: ActionLabelsI18n,
+    private rgwIamPolicyService: RgwIamPolicyService,
+    private notificationService: NotificationService
+  ) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.form = this.formBuilder.group({
+      policy_name: ['', [Validators.required]],
+      path: ['/', [Validators.required]],
+      description: [''],
+      policy_doc: [DEFAULT_IAM_POLICY_DOCUMENT, [Validators.required, CdValidators.json()]]
+    });
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      return;
+    }
+
+    const payload = this.form.getRawValue();
+    this.rgwIamPolicyService
+      .create(this.accountId, {
+        policy_name: payload.policy_name,
+        policy_doc: payload.policy_doc,
+        path: payload.path,
+        description: payload.description || undefined
+      })
+      .subscribe({
+        next: () => {
+          this.notificationService.show(
+            NotificationType.success,
+            $localize`Policy created successfully`
+          );
+          this.closeModal();
+        },
+        error: () => {
+          this.form.setErrors({ cdSubmitButton: true });
+        }
+      });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-page/rgw-user-accounts-resource-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-page/rgw-user-accounts-resource-page.component.html
@@ -51,6 +51,13 @@
       >
       </cd-rgw-account-roles-list>
     }
+    @case ('policies') {
+      <cd-rgw-account-policies-list
+        [accountId]="selection.id"
+        [accountName]="selection.name"
+      >
+      </cd-rgw-account-policies-list>
+    }
   }
 } @else if (notFound) {
   <cd-alert-panel

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-sidebar/rgw-user-accounts-resource-sidebar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-sidebar/rgw-user-accounts-resource-sidebar.component.ts
@@ -52,6 +52,11 @@ export class RgwUserAccountsResourceSidebarComponent implements OnInit, OnDestro
         label: $localize`Roles`,
         route: [this.basePath, this.accountNameRoute, 'roles'],
         routerLinkActiveOptions: { exact: true }
+      },
+      {
+        label: $localize`Policies`,
+        route: [this.basePath, this.accountNameRoute, 'policies'],
+        routerLinkActiveOptions: { exact: true }
       }
     ];
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -140,6 +140,9 @@ import { RgwNotificationFormComponent } from './rgw-notification-form/rgw-notifi
 import { ComponentsModule } from '~/app/shared/components/components.module';
 import { RgwAccountRolesListComponent } from './rgw-account-roles-list/rgw-account-roles-list.component';
 import { RgwAccountRoleFormComponent } from './rgw-account-role-form/rgw-account-role-form.component';
+import { RgwAccountPoliciesListComponent } from './rgw-account-policies-list/rgw-account-policies-list.component';
+import { RgwAccountPolicyFormComponent } from './rgw-account-policy-form/rgw-account-policy-form.component';
+import { RgwAccountPolicyDetailModalComponent } from './rgw-account-policy-detail-modal/rgw-account-policy-detail-modal.component';
 import { RgwBucketResourceSidebarComponent } from './rgw-bucket-resource-sidebar/rgw-bucket-resource-sidebar.component';
 import { RgwBucketResourcePageComponent } from './rgw-bucket-resource-page/rgw-bucket-resource-page.component';
 import { RgwBucketResourceBreadcrumbResolver } from './rgw-bucket-resource-page/rgw-bucket-resource-breadcrumb.resolver';
@@ -247,6 +250,9 @@ import { RgwBucketTagsTableComponent } from './rgw-bucket-tags-table/rgw-bucket-
     RgwUserAccountsFormComponent,
     RgwUserAccountsResourceSidebarComponent,
     RgwUserAccountsResourcePageComponent,
+    RgwAccountPoliciesListComponent,
+    RgwAccountPolicyFormComponent,
+    RgwAccountPolicyDetailModalComponent,
     RgwStorageClassListComponent,
     RgwStorageClassResourceSidebarComponent,
     RgwStorageClassResourcePageComponent,
@@ -388,6 +394,11 @@ const routes: Routes = [
             path: 'roles',
             component: RgwUserAccountsResourcePageComponent,
             data: { breadcrumbs: 'Roles', section: 'roles' }
+          },
+          {
+            path: 'policies',
+            component: RgwUserAccountsResourcePageComponent,
+            data: { breadcrumbs: 'Policies', section: 'policies' }
           }
         ]
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/context/context.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/context/context.component.ts
@@ -27,7 +27,8 @@ export class ContextComponent implements OnInit, OnDestroy {
   private rgwUserUrlPrefix = '/rgw/user';
   private rgwBuckerUrlPrefix = '/rgw/bucket';
   private rgwAccountsUrlPrefix = '/rgw/accounts';
-  private rgwAccountsResourcePagePattern = /^\/rgw\/accounts\/[^/]+\/(overview|roles)(?:$|[?#])/;
+  private rgwAccountsResourcePagePattern =
+    /^\/rgw\/accounts\/[^/]+\/(overview|roles|policies)(?:$|[?#])/;
   private rgwMultisiteSyncPolicyPrefix = '/rgw/multisite/sync-policy';
   permissions: Permissions;
   featureToggleMap$: FeatureTogglesMap$;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-iam-policy.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-iam-policy.service.ts
@@ -1,0 +1,93 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import {
+  IamPolicy,
+  IamPolicyCreatePayload,
+  IamPolicyTag,
+  IamPolicyVersion
+} from '~/app/ceph/rgw/models/rgw-iam-policy';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RgwIamPolicyService {
+  constructor(private http: HttpClient) {}
+
+  private getUrl(accountId: string): string {
+    return `api/rgw/accounts/${accountId}/policies`;
+  }
+
+  list(accountId: string): Observable<IamPolicy[]> {
+    return this.http.get<IamPolicy[]>(this.getUrl(accountId));
+  }
+
+  get(accountId: string, policyArn: string): Observable<IamPolicy> {
+    const params = new HttpParams().append('policy_arn', policyArn);
+    return this.http.get<IamPolicy>(`${this.getUrl(accountId)}/get`, { params });
+  }
+
+  create(accountId: string, payload: IamPolicyCreatePayload): Observable<IamPolicy> {
+    return this.http.post<IamPolicy>(this.getUrl(accountId), payload);
+  }
+
+  delete(accountId: string, policyName: string): Observable<void> {
+    return this.http.delete<void>(`${this.getUrl(accountId)}/${encodeURIComponent(policyName)}`);
+  }
+
+  listVersions(accountId: string, policyArn: string): Observable<IamPolicyVersion[]> {
+    const params = new HttpParams().append('policy_arn', policyArn);
+    return this.http.get<IamPolicyVersion[]>(`${this.getUrl(accountId)}/versions`, { params });
+  }
+
+  getVersion(
+    accountId: string,
+    policyArn: string,
+    versionId: string
+  ): Observable<IamPolicyVersion> {
+    const params = new HttpParams().append('policy_arn', policyArn).append('version_id', versionId);
+    return this.http.get<IamPolicyVersion>(`${this.getUrl(accountId)}/versions/get`, { params });
+  }
+
+  createVersion(
+    accountId: string,
+    policyArn: string,
+    policyDoc: string,
+    setAsDefault = false
+  ): Observable<IamPolicyVersion> {
+    return this.http.post<IamPolicyVersion>(`${this.getUrl(accountId)}/versions`, {
+      policy_arn: policyArn,
+      policy_doc: policyDoc,
+      set_as_default: setAsDefault
+    });
+  }
+
+  deleteVersion(accountId: string, policyArn: string, versionId: string): Observable<void> {
+    const params = new HttpParams().append('policy_arn', policyArn).append('version_id', versionId);
+    return this.http.delete<void>(`${this.getUrl(accountId)}/versions`, { params });
+  }
+
+  setDefaultVersion(accountId: string, policyArn: string, versionId: string): Observable<void> {
+    const params = new HttpParams().append('policy_arn', policyArn).append('version_id', versionId);
+    return this.http.put<void>(`${this.getUrl(accountId)}/versions/default`, null, { params });
+  }
+
+  listTags(accountId: string, policyArn: string): Observable<IamPolicyTag[]> {
+    const params = new HttpParams().append('policy_arn', policyArn);
+    return this.http.get<IamPolicyTag[]>(`${this.getUrl(accountId)}/tags`, { params });
+  }
+
+  addTags(accountId: string, policyArn: string, tags: IamPolicyTag[]): Observable<void> {
+    return this.http.post<void>(`${this.getUrl(accountId)}/tags`, {
+      policy_arn: policyArn,
+      tags
+    });
+  }
+
+  removeTags(accountId: string, policyArn: string, tagKeys: string[]): Observable<void> {
+    const params = new HttpParams()
+      .append('policy_arn', policyArn)
+      .append('tag_keys', tagKeys.join(','));
+    return this.http.delete<void>(`${this.getUrl(accountId)}/tags`, { params });
+  }
+}

--- a/src/pybind/mgr/dashboard/services/rgw_iam_policy.py
+++ b/src/pybind/mgr/dashboard/services/rgw_iam_policy.py
@@ -1,0 +1,247 @@
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from ..exceptions import DashboardException
+
+_POLICY_VERSION_LIMIT = 5
+
+
+class RgwIamPolicies:
+    """
+    Customer-managed IAM policies for RGW accounts.
+
+    RGW does not yet implement the IAM CreatePolicy/ListPolicies APIs. Until
+    that is available, policies are stored in the dashboard mgr module.
+    """
+
+    _policies: Dict[str, List[Dict[str, Any]]] = {}
+    _versions: Dict[str, List[Dict[str, Any]]] = {}
+    _tags: Dict[str, List[Dict[str, str]]] = {}
+
+    @staticmethod
+    def _utc_now() -> str:
+        return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    @classmethod
+    def _build_policy_arn(cls, account_id: str, path: str, policy_name: str) -> str:
+        policy_path = (path or '/').rstrip('/')
+        return f'arn:aws:iam::{account_id}:policy{policy_path}/{policy_name}'
+
+    @classmethod
+    def _find_policy(cls, policy_arn: str) -> Optional[Dict[str, Any]]:
+        for policies in cls._policies.values():
+            for policy in policies:
+                if policy.get('Arn') == policy_arn:
+                    return policy
+        return None
+
+    @classmethod
+    def _policy_versions(cls, policy_arn: str) -> List[Dict[str, Any]]:
+        if policy_arn not in cls._versions:
+            cls._versions[policy_arn] = []
+        return cls._versions[policy_arn]
+
+    @classmethod
+    def _policy_tags(cls, policy_arn: str) -> List[Dict[str, str]]:
+        if policy_arn not in cls._tags:
+            cls._tags[policy_arn] = []
+        return cls._tags[policy_arn]
+
+    @classmethod
+    def _init_default_version(cls, policy_arn: str, policy_doc: str,
+                              create_date: Optional[str] = None):
+        versions = cls._policy_versions(policy_arn)
+        if versions:
+            return
+        versions.append({
+            'VersionId': 'v1',
+            'IsDefaultVersion': True,
+            'CreateDate': create_date or cls._utc_now(),
+            'Document': policy_doc,
+        })
+
+    @classmethod
+    def _next_version_id(cls, policy_arn: str) -> str:
+        max_version = 0
+        for version in cls._policy_versions(policy_arn):
+            version_id = version.get('VersionId', '')
+            if version_id.startswith('v') and version_id[1:].isdigit():
+                max_version = max(max_version, int(version_id[1:]))
+        return f'v{max_version + 1}'
+
+    @classmethod
+    def _remove_policy(cls, policy_arn: str):
+        for account_id, policies in cls._policies.items():
+            cls._policies[account_id] = [
+                policy for policy in policies if policy.get('Arn') != policy_arn
+            ]
+        cls._versions.pop(policy_arn, None)
+        cls._tags.pop(policy_arn, None)
+
+    @classmethod
+    def _require_policy(cls, policy_arn: str) -> Dict[str, Any]:
+        policy = cls._find_policy(policy_arn)
+        if not policy:
+            raise DashboardException(msg='Policy not found',
+                                     http_status_code=404, component='rgw')
+        return policy
+
+    @classmethod
+    def list_policies(cls, account_id: str):
+        if not account_id:
+            return []
+        return list(cls._policies.get(account_id, []))
+
+    @classmethod
+    def get_policy(cls, policy_arn: str):
+        return cls._find_policy(policy_arn) or {}
+
+    @classmethod
+    def create_policy(cls, policy_name: str, policy_doc: str, account_id: str,
+                      path: str = '/', description: str = ''):
+        if not account_id:
+            raise DashboardException(msg='account_id is required',
+                                     http_status_code=400, component='rgw')
+
+        arn = cls._build_policy_arn(account_id, path, policy_name)
+        create_date = cls._utc_now()
+        policy = {
+            'PolicyName': policy_name,
+            'Arn': arn,
+            'Path': path or '/',
+            'DefaultVersionId': 'v1',
+            'CreateDate': create_date,
+            'Description': description or '',
+            'PolicyDocument': policy_doc,
+        }
+
+        account_policies = cls._policies.setdefault(account_id, [])
+        account_policies[:] = [item for item in account_policies if item.get('Arn') != arn]
+        account_policies.append(policy)
+        cls._init_default_version(arn, policy_doc, create_date)
+        return policy
+
+    @classmethod
+    def delete_policy(cls, policy_arn: str):
+        cls._remove_policy(policy_arn)
+        return {}
+
+    @classmethod
+    def delete_policy_by_name(cls, account_id: str, policy_name: str):
+        for policy in cls._policies.get(account_id, []):
+            if policy.get('PolicyName') == policy_name:
+                return cls.delete_policy(policy['Arn'])
+        raise DashboardException(msg='Policy not found',
+                                 http_status_code=404, component='rgw')
+
+    @classmethod
+    def list_policy_versions(cls, policy_arn: str):
+        policy = cls._find_policy(policy_arn)
+        if policy:
+            cls._init_default_version(
+                policy_arn,
+                policy.get('PolicyDocument', '{}'),
+                policy.get('CreateDate')
+            )
+        return list(cls._policy_versions(policy_arn))
+
+    @classmethod
+    def get_policy_version(cls, policy_arn: str, version_id: str):
+        for version in cls._policy_versions(policy_arn):
+            if version.get('VersionId') == version_id:
+                return dict(version)
+        return {}
+
+    @classmethod
+    def create_policy_version(cls, policy_arn: str, policy_doc: str,
+                              set_as_default: bool = False):
+        cls._require_policy(policy_arn)
+        versions = cls._policy_versions(policy_arn)
+        if not versions:
+            cls._init_default_version(policy_arn, policy_doc)
+            versions = cls._policy_versions(policy_arn)
+
+        if len(versions) >= _POLICY_VERSION_LIMIT:
+            raise DashboardException(
+                msg=f'A policy cannot have more than {_POLICY_VERSION_LIMIT} versions',
+                http_status_code=409,
+                component='rgw')
+
+        version_id = cls._next_version_id(policy_arn)
+        new_version = {
+            'VersionId': version_id,
+            'IsDefaultVersion': set_as_default,
+            'CreateDate': cls._utc_now(),
+            'Document': policy_doc,
+        }
+        if set_as_default:
+            for version in versions:
+                version['IsDefaultVersion'] = False
+            policy = cls._find_policy(policy_arn)
+            if policy:
+                policy['DefaultVersionId'] = version_id
+                policy['PolicyDocument'] = policy_doc
+        versions.append(new_version)
+        return new_version
+
+    @classmethod
+    def delete_policy_version(cls, policy_arn: str, version_id: str):
+        versions = cls._policy_versions(policy_arn)
+        version = next((item for item in versions if item.get('VersionId') == version_id), None)
+        if not version:
+            raise DashboardException(msg='Policy version not found',
+                                     http_status_code=404, component='rgw')
+        if version.get('IsDefaultVersion') in (True, 'true'):
+            raise DashboardException(msg='Cannot delete the default policy version',
+                                     http_status_code=409, component='rgw')
+
+        cls._versions[policy_arn] = [
+            item for item in versions if item.get('VersionId') != version_id
+        ]
+        return {}
+
+    @classmethod
+    def set_default_policy_version(cls, policy_arn: str, version_id: str):
+        versions = cls._policy_versions(policy_arn)
+        version = next((item for item in versions if item.get('VersionId') == version_id), None)
+        if not version:
+            raise DashboardException(msg='Policy version not found',
+                                     http_status_code=404, component='rgw')
+
+        for item in versions:
+            item['IsDefaultVersion'] = item.get('VersionId') == version_id
+        policy = cls._find_policy(policy_arn)
+        if policy:
+            policy['DefaultVersionId'] = version_id
+            policy['PolicyDocument'] = version.get('Document', '')
+        return {}
+
+    @classmethod
+    def list_policy_tags(cls, policy_arn: str):
+        return list(cls._policy_tags(policy_arn))
+
+    @classmethod
+    def tag_policy(cls, policy_arn: str, tags: List[Dict[str, str]]):
+        if not tags:
+            raise DashboardException(msg='At least one tag is required',
+                                     http_status_code=400, component='rgw')
+        cls._require_policy(policy_arn)
+
+        tag_list = cls._policy_tags(policy_arn)
+        for tag in tags:
+            tag_list[:] = [item for item in tag_list if item.get('Key') != tag['Key']]
+            tag_list.append({'Key': tag['Key'], 'Value': tag['Value']})
+        return {}
+
+    @classmethod
+    def untag_policy(cls, policy_arn: str, tag_keys: List[str]):
+        if not tag_keys:
+            raise DashboardException(msg='At least one tag key is required',
+                                     http_status_code=400, component='rgw')
+        cls._require_policy(policy_arn)
+
+        tag_list = cls._policy_tags(policy_arn)
+        cls._tags[policy_arn] = [
+            tag for tag in tag_list if tag.get('Key') not in tag_keys
+        ]
+        return {}


### PR DESCRIPTION
Add support for managing RGW customer-managed IAM policies within the dashboard under RGW User Accounts.

Key features added:
- Customer-managed IAM policy listing, creation, and deletion.
- Versioning support (create version, view version documents, set default, delete).
- Policy tag management (list, add, remove tags).
- UI integration with RGW Account Resource sidebar, overview page, and modal dialogs.
- Cypress E2E tests for IAM policy management.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
