### PR TITLE
tentacle: mgr/dashboard: Add force parameter to NVMEoF CLI delete kmip server cmd

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -753,6 +753,13 @@ else:
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
                 "server_address": Param(str, "NVMeoF gateway address", True, None),
                 "traddr": Param(str, "NVMeoF gateway address", True, None),
+                "force": Param(
+                    bool,
+                    "Allow deleting the KMIP server's endpoint even if encrypted "
+                    "(or degraded) namespaces still use it",
+                    True,
+                    False
+                ),
             },
         )
         @convert_to_model(model.RequestStatus)
@@ -761,7 +768,8 @@ else:
                                      address: Optional[str] = None,
                                      port: Optional[int] = 5696, gw_group: Optional[str] = None,
                                      server_address: Optional[str] = None,
-                                     traddr: Optional[str] = None):
+                                     traddr: Optional[str] = None,
+                                     force: Optional[bool] = False):
             server_address = resolve_nvmeof_server_address(
                 server_address=server_address,
                 traddr=traddr
@@ -773,7 +781,8 @@ else:
             ).stub.del_kmip_server_endpoints(
                 NVMeoFClient.pb2.del_kmip_server_endpoints_req(
                     subsystem_nqn=nqn, server_name=server_name,
-                    endpoints=[ep]
+                    endpoints=[ep],
+                    force=str_to_bool(force)
                 )
             )
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79830

---

backport of https://github.com/ceph/ceph/pull/71287
parent tracker: https://tracker.ceph.com/issues/79800

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh