### PR TITLE
ceph-exporter: add flag to disable process collecting

### DIFF
--- a/src/common/options/ceph-exporter.yaml.in
+++ b/src/common/options/ceph-exporter.yaml.in
@@ -66,3 +66,12 @@ options:
   - ceph-exporter
   flags:
   - runtime
+- name: exporter_enable_process_metrics
+  type: bool
+  level: advanced
+  desc: if true enable the collection of process metrics
+  default: true
+  services:
+  - ceph-exporter
+  flags:
+  - runtime

--- a/src/exporter/DaemonMetricCollector.cc
+++ b/src/exporter/DaemonMetricCollector.cc
@@ -251,6 +251,7 @@ void DaemonMetricCollector::dump_asok_metrics(bool sort_metrics, int64_t counter
         std::unique_ptr<UnorderedMetricsBuilder>(new UnorderedMetricsBuilder());
   }
   auto prio_limit = counter_prio;
+  const bool enable_process_metrics = g_conf().get_val<bool>("exporter_enable_process_metrics");
   for (auto &[daemon_name, sock_client] : clients) {
     if (sockClientsPing) {
       bool ok;
@@ -283,23 +284,24 @@ void DaemonMetricCollector::dump_asok_metrics(bool sort_metrics, int64_t counter
     try {
       parse_asok_metrics(counter_dump_response, counter_schema_response,
                          prio_limit, daemon_name);
-
-      std::string config_show = !config_show_response ? "" :
-        asok_request(sock_client, "config show", daemon_name);
-      if (config_show.size() == 0) {
-        failures++;
-        continue;
-      }
-      json_object pid_file_json = boost::json::parse(config_show).as_object();
-      std::string pid_path =
-          boost_string_to_std(pid_file_json["pid_file"].as_string());
-      std::string pid_str = read_file_to_string(pid_path);
-      if (!pid_path.size()) {
-        dout(1) << "pid path is empty; process metrics won't be fetched for: "
-                << daemon_name << dendl;
-      }
-      if (!pid_str.empty()) {
-        daemon_pids.push_back({daemon_name, std::stoi(pid_str)});
+      if (enable_process_metrics) {
+        std::string config_show = !config_show_response ? "" :
+          asok_request(sock_client, "config show", daemon_name);
+        if (config_show.size() == 0) {
+          failures++;
+          continue;
+        }
+        json_object pid_file_json = boost::json::parse(config_show).as_object();
+        std::string pid_path =
+            boost_string_to_std(pid_file_json["pid_file"].as_string());
+        std::string pid_str = read_file_to_string(pid_path);
+        if (!pid_path.size()) {
+          dout(1) << "pid path is empty; process metrics won't be fetched for: "
+                  << daemon_name << dendl;
+        }
+        if (!pid_str.empty()) {
+          daemon_pids.push_back({daemon_name, std::stoi(pid_str)});
+        }
       }
     } catch (const std::invalid_argument &e) {
       failures++;

--- a/src/exporter/ceph_exporter.cc
+++ b/src/exporter/ceph_exporter.cc
@@ -36,7 +36,9 @@ static void usage() {
                "  --cert-file:    Path to the certificate file when using HTTPS\n"
                "  --key-file:     Path to the certificate key file when using HTTPS\n"
                "  --prio-limit:   Only perf counters greater than or equal to prio-limit are fetched. Default: 5\n"
-               "  --stats-period: Interval between daemon scrapes (seconds). Default: 5s"
+               "  --stats-period: Interval between daemon scrapes (seconds). Default: 5s\n"
+               "  --enable-process-metrics: enable or disable the collection of process metrics of a ceph daemon. Default: true"
+
             << std::endl;
   generic_server_usage();
 }
@@ -72,6 +74,8 @@ int main(int argc, char **argv) {
       cct->_conf.set_val("exporter_prio_limit", val);
     } else if (ceph_argparse_witharg(args, i, &val, "--stats-period", (char *)NULL)) {
       cct->_conf.set_val("exporter_stats_period", val);
+    } else if (ceph_argparse_witharg(args, i, &val, "--enable-process-metrics", (char*)nullptr)) {
+      cct->_conf.set_val("exporter_enable_process_metrics", val);
     } else {
       ++i;
     }


### PR DESCRIPTION
reopen of: https://github.com/ceph/ceph/pull/64534

For the collection of process metrics the ceph-exporter querys the ceph config for the config option: "pid_file", but in our case the option is empty, after looking in the [docs](https://docs.ceph.com/en/latest/rados/configuration/general-config-ref/#confval-pid_file) :
`If the process is not daemonized (i.e. runs with the -f or -d option), the pid file is not created.`

If using the official ceph packages the -f option is the default option when starting daemons: https://github.com/ceph/ceph/blob/main/systemd/ceph-osd%40.service.in#L11

This means the exporter logs the error: `pid path is empty; process metrics won't be fetched for `every 5 seconds

Tracker: https://tracker.ceph.com/issues/71991

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
