### PR TITLE
rgw: add --show-storage-classes to radosgw-admin bucket stats

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -923,6 +923,12 @@ Options
 
    Shows restore stats in a bucket stat command. Here the bucket name need be provided.
 
+.. option:: --show-storage-classes
+
+   Show per-storage-class size and object counts in bucket stats output.
+   Triggers a full index scan (O(n) in object count); intended for billing
+   or quota reporting, not real-time queries. Requires ``--bucket``.
+
 Quota Options
 =============
 

--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -927,7 +927,9 @@ Options
 
    Show per-storage-class size and object counts in bucket stats output.
    Triggers a full index scan (O(n) in object count); intended for billing
-   or quota reporting, not real-time queries. Requires ``--bucket``.
+   or quota reporting, not real-time queries. The reported object and byte
+   totals reconcile with the ``rgw.main`` usage category; incomplete
+   multipart parts are excluded. Requires ``--bucket``.
 
 Quota Options
 =============

--- a/qa/suites/rgw/verify/tasks/multipart-category.yaml
+++ b/qa/suites/rgw/verify/tasks/multipart-category.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rgw/run-multipart-category.sh

--- a/qa/workunits/rgw/run-multipart-category.sh
+++ b/qa/workunits/rgw/run-multipart-category.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -ex
+
+# assume working ceph environment (radosgw-admin in path) and rgw on localhost:80
+
+mydir=`dirname $0`
+
+python3 -m venv $mydir
+source $mydir/bin/activate
+pip install pip --upgrade
+pip install boto3
+
+$mydir/bin/python3 $mydir/test_rgw_multipart_category.py
+
+deactivate
+echo OK.

--- a/qa/workunits/rgw/test_rgw_multipart_category.py
+++ b/qa/workunits/rgw/test_rgw_multipart_category.py
@@ -20,8 +20,9 @@ SECRET_KEY = 'mpartcat1testsecretkey000000001'
 PART_SIZE = 5 * 1024 * 1024  # 5 MiB (S3 minimum part size)
 
 
-def get_bucket_stats(bucket_name):
-    out = exec_cmd(f'radosgw-admin bucket stats --bucket {bucket_name}')
+def get_bucket_stats(bucket_name, show_storage_classes=False):
+    flag = ' --show-storage-classes' if show_storage_classes else ''
+    out = exec_cmd(f'radosgw-admin bucket stats --bucket {bucket_name}{flag}')
     return json.loads(out)
 
 
@@ -79,6 +80,16 @@ def test_category_tracking(connection):
     assert_category(stats, 'rgw.multipart', 2, 'after upload parts')
     assert_category(stats, 'rgw.multimeta', 1, 'after upload parts')
 
+    # The billable per-class view must reconcile with rgw.main and must not
+    # silently include incomplete multipart parts.
+    stats_with_classes = get_bucket_stats(bucket_name, show_storage_classes=True)
+    class_stats = stats_with_classes['rgw.storage_classes']
+    assert sum(v['num_objects'] for v in class_stats.values()) == 0, \
+        'incomplete multipart parts must not be reported as billable objects'
+    assert sum(v['size'] for v in class_stats.values()) == \
+        get_category(stats_with_classes, 'rgw.main').get('size', 0), \
+        'per-class size must reconcile with rgw.main.size'
+
     response = s3client.list_objects_v2(Bucket=bucket_name)
     assert response['KeyCount'] == 0, f'expected 0 listed objects, got {response["KeyCount"]}'
 
@@ -98,6 +109,14 @@ def test_category_tracking(connection):
     assert_category(stats, 'rgw.main', 1, 'after complete')
     assert_category(stats, 'rgw.multipart', 0, 'after complete')
     assert_category(stats, 'rgw.multimeta', 0, 'after complete')
+
+    stats_with_classes = get_bucket_stats(bucket_name, show_storage_classes=True)
+    class_stats = stats_with_classes['rgw.storage_classes']
+    assert sum(v['num_objects'] for v in class_stats.values()) == 1, \
+        'completed multipart object must be reported once'
+    assert sum(v['size'] for v in class_stats.values()) == \
+        get_category(stats_with_classes, 'rgw.main').get('size', 0), \
+        'completed multipart size must reconcile with rgw.main.size'
 
     # TESTCASE 'abort multipart cleans up rgw.multipart entries'
     log.debug('TEST: abort multipart cleans up rgw.multipart entries\n')

--- a/qa/workunits/rgw/test_rgw_versioning.py
+++ b/qa/workunits/rgw/test_rgw_versioning.py
@@ -50,6 +50,27 @@ def main():
     bucket = connection.create_bucket(Bucket=BUCKET_NAME)
     connection.BucketVersioning(BUCKET_NAME).enable()
 
+    # TESTCASE 'per-storage-class stats reconcile versioned bucket accounting'
+    log.debug('TEST: per-storage-class stats reconcile versioned bucket accounting\n')
+    versioned_key = 'storage-class-versioned-object'
+    bucket.put_object(Key=versioned_key, Body=b'first version')
+    bucket.put_object(Key=versioned_key, Body=b'second version')
+    bucket.Object(versioned_key).delete()  # leave a delete marker behind
+    plain_stats = json.loads(exec_cmd(
+        f'radosgw-admin bucket stats --bucket {BUCKET_NAME}'))
+    class_stats = json.loads(exec_cmd(
+        f'radosgw-admin bucket stats --bucket {BUCKET_NAME} '
+        '--show-storage-classes'))
+    main_stats = plain_stats['usage'].get('rgw.main', {})
+    classes = class_stats['rgw.storage_classes']
+    assert sum(v['num_objects'] for v in classes.values()) == \
+        main_stats.get('num_objects', 0), \
+        'versioned per-class object count does not reconcile with rgw.main'
+    assert sum(v['size'] for v in classes.values()) == \
+        main_stats.get('size', 0), \
+        'versioned per-class size does not reconcile with rgw.main'
+    bucket.object_versions.filter(Prefix=versioned_key).delete()
+
     # reproducer for bug from https://tracker.ceph.com/issues/59663
     # TESTCASE 'verify that index entries and OLH objects are cleaned up after redundant deletes'
     log.debug('TEST: verify that index entries and OLH objects are cleaned up after redundant deletes\n')

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -356,6 +356,19 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
   formatter->close_section();
 }
 
+static void dump_storage_class_usage(
+    const std::map<std::string, RGWStorageClassStats>& sc_stats,
+    Formatter* formatter)
+{
+  formatter->open_object_section("rgw.storage_classes");
+  for (const auto& [name, s] : sc_stats) {
+    formatter->open_object_section(name);
+    s.dump(formatter);
+    formatter->close_section();
+  }
+  formatter->close_section();
+}
+
 #ifdef WITH_RADOSGW_RADOS
 static void dump_index_check(map<RGWObjCategory, RGWStorageStats> existing_stats,
         map<RGWObjCategory, RGWStorageStats> calculated_stats,
@@ -1632,9 +1645,75 @@ static int bucket_restore_stats(rgw::sal::Driver* driver,
   return 0;
 }
 
+// Scan the bucket index and aggregate sizes by storage class.
+// This is an O(objects) operation; only call when explicitly requested.
+// Works for all buckets including those created before this feature was added.
+#ifdef WITH_RADOSGW_RADOS
+static int read_storage_class_stats(
+    const DoutPrefixProvider* dpp, optional_yield y,
+    rgw::sal::RadosStore* rados_store,
+    rgw::sal::Bucket* bucket,
+    std::map<std::string, RGWStorageClassStats>& sc_stats)
+{
+  RGWRados* store = rados_store->getRados();
+  const RGWBucketInfo& bucket_info = bucket->get_info();
+  const auto& index = bucket_info.get_current_index();
+  const int num_shards = std::max(1, (int)rgw::num_shards(index.layout.normal));
+
+  for (int shard = 0; shard < num_shards; ++shard) {
+    RGWRados::BucketShard bs(store);
+    int ret = bs.init(dpp, bucket_info, index, shard, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, -1) << "ERROR read_storage_class_stats: bs.init shard=" << shard
+                         << " ret=" << cpp_strerror(-ret) << dendl;
+      return ret;
+    }
+
+    std::string marker;
+    bool is_truncated = true;
+    while (is_truncated) {
+      std::list<rgw_cls_bi_entry> entries;
+      ret = store->bi_list(bs, "", marker, -1, &entries, &is_truncated, false, y);
+      if (ret < 0) {
+        ldpp_dout(dpp, -1) << "ERROR read_storage_class_stats: bi_list shard=" << shard
+                           << " ret=" << cpp_strerror(-ret) << dendl;
+        return ret;
+      }
+      for (const auto& raw_entry : entries) {
+        marker = raw_entry.idx;
+        if (raw_entry.type != BIIndexType::Plain) {
+          continue;
+        }
+        rgw_bucket_dir_entry dir_entry;
+        auto iiter = raw_entry.data.cbegin();
+        try {
+          decode(dir_entry, iiter);
+        } catch (const buffer::error& err) {
+          ldpp_dout(dpp, 0) << "WARNING read_storage_class_stats: failed to decode entry idx="
+                            << raw_entry.idx << ", skipping" << dendl;
+          continue;
+        }
+        if (!dir_entry.exists) {
+          continue;
+        }
+        const std::string& sc =
+            rgw_placement_rule::get_canonical_storage_class(dir_entry.meta.storage_class);
+        RGWStorageClassStats& s = sc_stats[sc];
+        s.size += dir_entry.meta.accounted_size;
+        s.size_rounded += cls_rgw_get_rounded_size(dir_entry.meta.accounted_size);
+        s.size_utilized += dir_entry.meta.size;
+        s.num_objects++;
+      }
+    }
+  }
+  return 0;
+}
+#endif // WITH_RADOSGW_RADOS
+
 static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
                         const std::string& tenant_name, const std::string& bucket_name,
-                        bool dump_restore_stats, Formatter* formatter,
+                        bool dump_restore_stats, bool show_storage_classes,
+                        Formatter* formatter,
                         const DoutPrefixProvider* dpp, optional_yield y) {
   std::unique_ptr<rgw::sal::Bucket> bucket;
   map<RGWObjCategory, RGWStorageStats> stats;
@@ -1663,6 +1742,20 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
     if (ret < 0) {
       cerr << "error getting bucket stats bucket=" << bucket->get_name() << " ret=" << ret << std::endl;
       return ret;
+    }
+  }
+
+  std::map<std::string, RGWStorageClassStats> sc_stats;
+  if (show_storage_classes && has_index) {
+    auto* rados_store = dynamic_cast<rgw::sal::RadosStore*>(driver);
+    if (rados_store) {
+      ret = read_storage_class_stats(dpp, y, rados_store, bucket.get(), sc_stats);
+      if (ret < 0) {
+        cerr << "warning: could not read storage class stats for bucket="
+             << bucket->get_name() << " ret=" << ret << std::endl;
+        // non-fatal: continue and omit the section
+        sc_stats.clear();
+      }
     }
   }
 
@@ -1697,6 +1790,9 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
     formatter->dump_string("master_ver", master_ver);
     formatter->dump_string("max_marker", max_marker);
     dump_bucket_usage(stats, formatter);
+    if (!sc_stats.empty()) {
+      dump_storage_class_usage(sc_stats, formatter);
+    }
   }
   ut.gmtime(formatter->dump_stream("mtime"));
   ctime_ut.gmtime(formatter->dump_stream("creation_time"));
@@ -1898,7 +1994,7 @@ static int list_owner_bucket_info(const DoutPrefixProvider* dpp,
 
     for (const auto& ent : listing.buckets) {
       if (show_stats) {
-        bucket_stats(driver, site, tenant, ent.bucket.name, false, formatter, dpp, y);
+        bucket_stats(driver, site, tenant, ent.bucket.name, false, false, formatter, dpp, y);
       } else {
         formatter->dump_string("bucket", ent.bucket.name);
       }
@@ -1954,7 +2050,7 @@ int RGWBucketAdminOp::info(rgw::sal::Driver* driver,
   const bool show_stats = op_state.will_fetch_stats();
   const rgw_user& user_id = op_state.get_user_id();
   if (!bucket_name.empty()) {
-    ret = bucket_stats(driver, site, user_id.tenant, bucket_name, op_state.restore_stats, formatter, dpp, y);
+    ret = bucket_stats(driver, site, user_id.tenant, bucket_name, op_state.restore_stats, op_state.show_storage_classes, formatter, dpp, y);
     if (ret < 0) {
       return ret;
     }
@@ -2018,7 +2114,7 @@ int RGWBucketAdminOp::info(rgw::sal::Driver* driver,
       for (const auto& bucket_name : buckets) {
         if (show_stats) {
           bucket_stats(driver, site, user_id.tenant, bucket_name,
-                       op_state.restore_stats, formatter, dpp, y);
+                       op_state.restore_stats, op_state.show_storage_classes, formatter, dpp, y);
 	} else {
           formatter->dump_string("bucket", bucket_name);
 	}

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1651,18 +1651,16 @@ static int bucket_restore_stats(rgw::sal::Driver* driver,
 // O(objects); only call when explicitly requested.
 //
 // Index entry semantics:
-// - BIIndexType::Plain covers all data entries. Only Main entries are included
-//   here: this is the same accounting category exposed by bucket stats and is
-//   the billable object population. Multipart metadata/parts are deliberately
-//   excluded; they must not silently change the meaning of the billable total.
-// - BIIndexType::Instance is a secondary lookup index for versioned objects and
-//   must NOT be scanned here to avoid double-counting.
+// - Unversioned objects are Plain entries with flags == 0. A versioned key also
+//   has a Plain version-marker entry, which must not be counted.
+// - Each versioned object version is stored as an Instance entry. Existing
+//   Instance entries must be counted, including non-current versions.
 // - BIIndexType::OLH entries are version-pointer records with no data size.
 //
-// Accounting: num_objects counts every Main entry with exists=true, including
-// historical versions. It is not equivalent to the number of user-visible S3
-// objects. size/size_actual/size_utilized follow the same semantics as
-// RGWStorageStats.
+// These inclusion rules intentionally mirror cls_rgw check_index() so the scan
+// accounts the same entries as the bucket index header. Only Main-category
+// entries are included: multipart metadata/parts are reported under different
+// bucket-stats categories and must not silently change the billable total.
 //
 // Resharding: uses the current index generation. Objects being migrated may be
 // temporarily undercounted. Consistent with read_stats() behavior.
@@ -1700,7 +1698,8 @@ static int read_storage_class_stats(
       }
       for (const auto& raw_entry : entries) {
         marker = raw_entry.idx;
-        if (raw_entry.type != BIIndexType::Plain) {
+        if (raw_entry.type != BIIndexType::Plain &&
+            raw_entry.type != BIIndexType::Instance) {
           continue;
         }
         rgw_bucket_dir_entry dir_entry;
@@ -1713,7 +1712,10 @@ static int read_storage_class_stats(
                              << ": " << err.what() << dendl;
           return -EIO;
         }
-        if (!dir_entry.exists || dir_entry.meta.category != RGWObjCategory::Main) {
+        const bool accounted_entry = dir_entry.exists &&
+            (raw_entry.type == BIIndexType::Instance || dir_entry.flags == 0);
+        if (!accounted_entry ||
+            dir_entry.meta.category != RGWObjCategory::Main) {
           continue;
         }
         const std::string& sc =

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1651,18 +1651,18 @@ static int bucket_restore_stats(rgw::sal::Driver* driver,
 // O(objects); only call when explicitly requested.
 //
 // Index entry semantics:
-// - BIIndexType::Plain covers all data entries: regular objects (all versions),
-//   delete markers (category=None, exists=false, skipped below), and in-progress
-//   multipart metadata/parts (category=MultiMeta/MultiPart). Completed multipart
-//   objects appear as regular Main entries.
+// - BIIndexType::Plain covers all data entries. Only Main entries are included
+//   here: this is the same accounting category exposed by bucket stats and is
+//   the billable object population. Multipart metadata/parts are deliberately
+//   excluded; they must not silently change the meaning of the billable total.
 // - BIIndexType::Instance is a secondary lookup index for versioned objects and
 //   must NOT be scanned here to avoid double-counting.
 // - BIIndexType::OLH entries are version-pointer records with no data size.
 //
-// Accounting: num_objects counts every Plain entry with exists=true, including
-// historical versions and multipart parts. It is not equivalent to the number of
-// user-visible S3 objects. size/size_actual/size_utilized follow the same
-// semantics as RGWStorageStats.
+// Accounting: num_objects counts every Main entry with exists=true, including
+// historical versions. It is not equivalent to the number of user-visible S3
+// objects. size/size_actual/size_utilized follow the same semantics as
+// RGWStorageStats.
 //
 // Resharding: uses the current index generation. Objects being migrated may be
 // temporarily undercounted. Consistent with read_stats() behavior.
@@ -1713,7 +1713,7 @@ static int read_storage_class_stats(
                              << ": " << err.what() << dendl;
           return -EIO;
         }
-        if (!dir_entry.exists) {
+        if (!dir_entry.exists || dir_entry.meta.category != RGWObjCategory::Main) {
           continue;
         }
         const std::string& sc =
@@ -1725,6 +1725,38 @@ static int read_storage_class_stats(
         s.num_objects++;
       }
     } while (is_truncated);
+  }
+  return 0;
+}
+
+static int reconcile_storage_class_stats(
+    const std::map<std::string, RGWStorageClassStats>& sc_stats,
+    const std::map<RGWObjCategory, RGWStorageStats>& stats,
+    const DoutPrefixProvider* dpp, const std::string& bucket_name)
+{
+  RGWStorageClassStats total;
+  for (const auto& entry : sc_stats) {
+    total += entry.second;
+  }
+
+  const auto iter = stats.find(RGWObjCategory::Main);
+  const RGWStorageStats empty;
+  const auto& expected = iter == stats.end() ? empty : iter->second;
+  if (total.size != expected.size ||
+      total.size_rounded != expected.size_rounded ||
+      total.size_utilized != expected.size_utilized ||
+      total.num_objects != expected.num_objects) {
+    ldpp_dout(dpp, -1)
+      << "ERROR: storage class stats reconciliation failed for bucket="
+      << bucket_name << " (class size=" << total.size
+      << ", bucket size=" << expected.size
+      << "; class size_actual=" << total.size_rounded
+      << ", bucket size_actual=" << expected.size_rounded
+      << "; class size_utilized=" << total.size_utilized
+      << ", bucket size_utilized=" << expected.size_utilized
+      << "; class objects=" << total.num_objects
+      << ", bucket objects=" << expected.num_objects << ")" << dendl;
+    return -EUCLEAN;
   }
   return 0;
 }
@@ -1766,15 +1798,25 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
   }
 
   std::map<std::string, RGWStorageClassStats> sc_stats;
-  if (show_storage_classes && has_index) {
+  if (show_storage_classes) {
+    if (!has_index) {
+      return -EOPNOTSUPP;
+    }
     auto* rados_store = dynamic_cast<rgw::sal::RadosStore*>(driver);
-    if (rados_store) {
-      ret = read_storage_class_stats(dpp, y, rados_store, bucket.get(), sc_stats);
-      if (ret < 0) {
-        ldpp_dout(dpp, -1) << "ERROR: storage class stats scan failed for bucket="
-                           << bucket->get_name() << " ret=" << ret << dendl;
-        return ret;
-      }
+    if (!rados_store) {
+      ldpp_dout(dpp, -1) << "ERROR: storage class stats require the RADOS driver"
+                         << " for bucket=" << bucket->get_name() << dendl;
+      return -EOPNOTSUPP;
+    }
+    ret = read_storage_class_stats(dpp, y, rados_store, bucket.get(), sc_stats);
+    if (ret < 0) {
+      ldpp_dout(dpp, -1) << "ERROR: storage class stats scan failed for bucket="
+                         << bucket->get_name() << " ret=" << ret << dendl;
+      return ret;
+    }
+    ret = reconcile_storage_class_stats(sc_stats, stats, dpp, bucket->get_name());
+    if (ret < 0) {
+      return ret;
     }
   }
 
@@ -1809,7 +1851,7 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
     formatter->dump_string("master_ver", master_ver);
     formatter->dump_string("max_marker", max_marker);
     dump_bucket_usage(stats, formatter);
-    if (!sc_stats.empty()) {
+    if (show_storage_classes) {
       dump_storage_class_usage(sc_stats, formatter);
     }
   }
@@ -3994,4 +4036,3 @@ void RGWBucketEntryPoint::decode_json(JSONObj *obj) {
     JSONDecoder::decode_json("old_bucket_info", old_bucket_info, obj);
   }
 }
-

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -356,6 +356,7 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
   formatter->close_section();
 }
 
+#ifdef WITH_RADOSGW_RADOS
 static void dump_storage_class_usage(
     const std::map<std::string, RGWStorageClassStats>& sc_stats,
     Formatter* formatter)
@@ -369,7 +370,6 @@ static void dump_storage_class_usage(
   formatter->close_section();
 }
 
-#ifdef WITH_RADOSGW_RADOS
 static void dump_index_check(map<RGWObjCategory, RGWStorageStats> existing_stats,
         map<RGWObjCategory, RGWStorageStats> calculated_stats,
         Formatter *formatter)
@@ -1645,10 +1645,11 @@ static int bucket_restore_stats(rgw::sal::Driver* driver,
   return 0;
 }
 
-// Scan the bucket index and aggregate sizes by storage class.
-// This is an O(objects) operation; only call when explicitly requested.
-// Works for all buckets including those created before this feature was added.
 #ifdef WITH_RADOSGW_RADOS
+// Scan the bucket index and aggregate sizes by storage class.
+// O(objects); only call when explicitly requested.
+// Uses the current index generation; during resharding, objects being
+// migrated may be temporarily undercounted. Consistent with read_stats behavior.
 static int read_storage_class_stats(
     const DoutPrefixProvider* dpp, optional_yield y,
     rgw::sal::RadosStore* rados_store,
@@ -1658,24 +1659,26 @@ static int read_storage_class_stats(
   RGWRados* store = rados_store->getRados();
   const RGWBucketInfo& bucket_info = bucket->get_info();
   const auto& index = bucket_info.get_current_index();
-  const int num_shards = std::max(1, (int)rgw::num_shards(index.layout.normal));
+  const uint32_t num_shards = std::max(1u, rgw::num_shards(index.layout.normal));
 
-  for (int shard = 0; shard < num_shards; ++shard) {
+  for (uint32_t shard = 0; shard < num_shards; ++shard) {
     RGWRados::BucketShard bs(store);
-    int ret = bs.init(dpp, bucket_info, index, shard, y);
+    int ret = bs.init(dpp, bucket_info, index, static_cast<int>(shard), y);
     if (ret < 0) {
-      ldpp_dout(dpp, -1) << "ERROR read_storage_class_stats: bs.init shard=" << shard
+      ldpp_dout(dpp, -1) << "ERROR: bs.init failed for shard=" << shard
                          << " ret=" << cpp_strerror(-ret) << dendl;
       return ret;
     }
 
     std::string marker;
-    bool is_truncated = true;
-    while (is_truncated) {
+    bool is_truncated = false;
+    do {
       std::list<rgw_cls_bi_entry> entries;
-      ret = store->bi_list(bs, "", marker, -1, &entries, &is_truncated, false, y);
+      // UINT32_MAX: cls_rgw caps the page size internally
+      ret = store->bi_list(bs, "", marker, std::numeric_limits<uint32_t>::max(),
+                           &entries, &is_truncated, false, y);
       if (ret < 0) {
-        ldpp_dout(dpp, -1) << "ERROR read_storage_class_stats: bi_list shard=" << shard
+        ldpp_dout(dpp, -1) << "ERROR: bi_list() failed for shard=" << shard
                            << " ret=" << cpp_strerror(-ret) << dendl;
         return ret;
       }
@@ -1689,7 +1692,7 @@ static int read_storage_class_stats(
         try {
           decode(dir_entry, iiter);
         } catch (const buffer::error& err) {
-          ldpp_dout(dpp, 0) << "WARNING read_storage_class_stats: failed to decode entry idx="
+          ldpp_dout(dpp, 0) << "WARNING: failed to decode bi entry idx="
                             << raw_entry.idx << ", skipping" << dendl;
           continue;
         }
@@ -1704,7 +1707,7 @@ static int read_storage_class_stats(
         s.size_utilized += dir_entry.meta.size;
         s.num_objects++;
       }
-    }
+    } while (is_truncated);
   }
   return 0;
 }

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -5,6 +5,7 @@
 #include "common/JSONFormatter.h"
 #include "common/errno.h"
 #include "include/function2.hpp"
+#include <limits>
 #include "rgw_acl_s3.h"
 #include "rgw_tag_s3.h"
 
@@ -1646,10 +1647,25 @@ static int bucket_restore_stats(rgw::sal::Driver* driver,
 }
 
 #ifdef WITH_RADOSGW_RADOS
-// Scan the bucket index and aggregate sizes by storage class.
+// Scan the bucket index Plain namespace and aggregate sizes by storage class.
 // O(objects); only call when explicitly requested.
-// Uses the current index generation; during resharding, objects being
-// migrated may be temporarily undercounted. Consistent with read_stats behavior.
+//
+// Index entry semantics:
+// - BIIndexType::Plain covers all data entries: regular objects (all versions),
+//   delete markers (category=None, exists=false, skipped below), and in-progress
+//   multipart metadata/parts (category=MultiMeta/MultiPart). Completed multipart
+//   objects appear as regular Main entries.
+// - BIIndexType::Instance is a secondary lookup index for versioned objects and
+//   must NOT be scanned here to avoid double-counting.
+// - BIIndexType::OLH entries are version-pointer records with no data size.
+//
+// Accounting: num_objects counts every Plain entry with exists=true, including
+// historical versions and multipart parts. It is not equivalent to the number of
+// user-visible S3 objects. size/size_actual/size_utilized follow the same
+// semantics as RGWStorageStats.
+//
+// Resharding: uses the current index generation. Objects being migrated may be
+// temporarily undercounted. Consistent with read_stats() behavior.
 static int read_storage_class_stats(
     const DoutPrefixProvider* dpp, optional_yield y,
     rgw::sal::RadosStore* rados_store,
@@ -1692,9 +1708,10 @@ static int read_storage_class_stats(
         try {
           decode(dir_entry, iiter);
         } catch (const buffer::error& err) {
-          ldpp_dout(dpp, 0) << "WARNING: failed to decode bi entry idx="
-                            << raw_entry.idx << ", skipping" << dendl;
-          continue;
+          ldpp_dout(dpp, -1) << "ERROR: failed to decode bi entry idx="
+                             << raw_entry.idx << " in shard=" << shard
+                             << ": " << err.what() << dendl;
+          return -EIO;
         }
         if (!dir_entry.exists) {
           continue;
@@ -1754,10 +1771,9 @@ static int bucket_stats(rgw::sal::Driver* driver, const rgw::SiteConfig& site,
     if (rados_store) {
       ret = read_storage_class_stats(dpp, y, rados_store, bucket.get(), sc_stats);
       if (ret < 0) {
-        cerr << "warning: could not read storage class stats for bucket="
-             << bucket->get_name() << " ret=" << ret << std::endl;
-        // non-fatal: continue and omit the section
-        sc_stats.clear();
+        ldpp_dout(dpp, -1) << "ERROR: storage class stats scan failed for bucket="
+                           << bucket->get_name() << " ret=" << ret << dendl;
+        return ret;
       }
     }
   }

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -240,6 +240,7 @@ struct RGWBucketAdminOpState {
   bool dump_keys;
   bool hide_progress;
   bool restore_stats;
+  bool show_storage_classes{false};
   int max_aio = 0;
   ceph::timespan min_age = std::chrono::hours::zero();
 
@@ -250,6 +251,7 @@ struct RGWBucketAdminOpState {
 
   void set_fetch_stats(bool value) { stat_buckets = value; }
   void set_restore_stats(bool value) { restore_stats = value; }
+  void set_show_storage_classes(bool value) { show_storage_classes = value; }
   void set_check_objects(bool value) { check_objects = value; }
   void set_fix_index(bool value) { fix_index = value; }
   void set_delete_children(bool value) { delete_child_objects = value; }

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -585,6 +585,7 @@ void usage()
   cout << "                                 use together with --marker to paginate through versioned buckets\n";
   cout << "                                 example: --marker=obj1 --object-version=abc123def456\n";
   cout << "   --show-restore-stats          if the flag is in present it will show restores stats in the bucket stats command\n";
+  cout << "   --show-storage-classes        show per-storage-class size and object counts in bucket stats (requires index scan)\n";
   cout << "\n";
   generic_client_usage();
 }
@@ -4052,6 +4053,7 @@ int main(int argc, const char **argv)
   std::optional<std::string> rgw_obj_fs; // radoslist field separator
   std::optional<std::string> restore_status_filter;
   int show_restore_stats = false;
+  int show_storage_classes = false;
 
   // global CORS settings
   std::optional<std::string> gcors_allow_origins;
@@ -4686,6 +4688,8 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--restore-status", (char*)NULL)) {
       restore_status_filter = val;
     } else if (ceph_argparse_binary_flag(args, i, &show_restore_stats, NULL, "--show-restore-stats", (char*)NULL)){
+      // do nothing
+    } else if (ceph_argparse_binary_flag(args, i, &show_storage_classes, NULL, "--show-storage-classes", (char*)NULL)){
       // do nothing
     } else if (ceph_argparse_witharg(args, i, &val, "--allow-origin", (char*)NULL)) {
       gcors_allow_origins = val;
@@ -8020,6 +8024,7 @@ int main(int argc, const char **argv)
     else
       bucket_op.max_entries = 0; /* for backward compatibility */
     bucket_op.set_restore_stats(bool(show_restore_stats));
+    bucket_op.set_show_storage_classes(bool(show_storage_classes));
 
     int r = RGWBucketAdminOp::info(driver, *site, bucket_op, stream_flusher, null_yield, dpp());
     if (r < 0) {

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -585,7 +585,7 @@ void usage()
   cout << "                                 use together with --marker to paginate through versioned buckets\n";
   cout << "                                 example: --marker=obj1 --object-version=abc123def456\n";
   cout << "   --show-restore-stats          if the flag is in present it will show restores stats in the bucket stats command\n";
-  cout << "   --show-storage-classes        show per-storage-class size and object counts in bucket stats (requires index scan)\n";
+  cout << "   --show-storage-classes        show per-storage-class stats; scans entire bucket index (O(objects))\n";
   cout << "\n";
   generic_client_usage();
 }

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -3153,6 +3153,17 @@ void RGWStorageStats::dump(Formatter *f) const
   encode_json("num_objects", num_objects, f);
 }
 
+void RGWStorageClassStats::dump(Formatter *f) const
+{
+  encode_json("size", size, f);
+  encode_json("size_actual", size_rounded, f);
+  encode_json("size_utilized", size_utilized, f);
+  encode_json("size_kb", rgw_rounded_kb(size), f);
+  encode_json("size_kb_actual", rgw_rounded_kb(size_rounded), f);
+  encode_json("size_kb_utilized", rgw_rounded_kb(size_utilized), f);
+  encode_json("num_objects", num_objects, f);
+}
+
 void rgw_obj_key::dump(Formatter *f) const
 {
   encode_json("name", name, f);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1261,6 +1261,24 @@ struct RGWStorageStats
   void dump(Formatter *f) const;
 }; // RGWStorageStats
 
+// Per-storage-class aggregate stats for billing and quota reporting.
+// Computed on demand by scanning the bucket index; never persisted.
+struct RGWStorageClassStats {
+  uint64_t size{0};
+  uint64_t size_rounded{0};
+  uint64_t size_utilized{0};
+  uint64_t num_objects{0};
+
+  void dump(Formatter *f) const;
+  RGWStorageClassStats& operator+=(const RGWStorageClassStats& o) {
+    size += o.size;
+    size_rounded += o.size_rounded;
+    size_utilized += o.size_utilized;
+    num_objects += o.num_objects;
+    return *this;
+  }
+}; // RGWStorageClassStats
+
 class RGWEnv;
 
 /* Namespaced forward declarations. */

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -441,6 +441,7 @@
                                    use together with --marker to paginate through versioned buckets
                                    example: --marker=obj1 --object-version=abc123def456
      --show-restore-stats          if the flag is in present it will show restores stats in the bucket stats command
+     --show-storage-classes        show per-storage-class stats; scans entire bucket index (O(objects))
   
     --conf/-c FILE    read configuration from the given configuration file
     --id ID           set ID portion of my name


### PR DESCRIPTION
## Problem

Operators running multi-tier RGW deployments (e.g. STANDARD + GLACIER +
COLD storage classes backed by different RADOS pools) have no way to answer
the question **"how much data does tenant X store in storage class Y?"**
without reading every object's metadata individually.

This is a blocker for two real workflows:

1. **Billing** — cloud providers need to charge different rates per storage
   class. Without per-class byte counts there is no input to the billing
   system.
2. **Quota enforcement** — quotas that should apply only to specific tiers
   (e.g. "GLACIER usage ≤ 10 TiB per tenant") cannot be evaluated.

The existing `radosgw-admin bucket stats` output only reports aggregate
totals across all storage classes combined.

An earlier attempt at this (PR #66501) solves the problem by adding a new
persistent counter inside the OSD-side `cls_rgw` bucket index entry. That
design is correct long-term but carries significant risk:

- 38 files changed, touching the OSD class, SAL layer, multiple drivers,
  and the RGW data path
- New `std::optional` fields in the hot-path `rgw_bucket_dir_entry` struct
  introduced OSD crash bugs (`.value()` called without `has_value()` guard)
  and negative-counter bugs in the `unaccount_entry` path
- Rolling upgrade correctness requires the OSD to handle both old and new
  on-disk layouts simultaneously
- The PR has not yet been merged and the upgrade story needs more work

## Approach taken here

This PR implements the **minimal viable version** needed for billing and
quota use cases: an on-demand index scan triggered by an explicit
`--show-storage-classes` flag.

### Why a scan is acceptable here

- The flag is **opt-in and off by default**. Normal `bucket stats` is
  unchanged in behavior and performance.
- Billing and quota jobs run periodically (hourly/daily), not on every
  request. A one-time O(objects) scan per billing cycle is acceptable.
- The approach works on **all existing buckets** with no migration, no OSD
  restart, no schema change.
- It produces correct results even for buckets created before this feature
  existed.

### What changes

| File | Change |
|------|--------|
| `src/rgw/rgw_common.h` | Add `RGWStorageClassStats` struct (transient, never persisted) |
| `src/rgw/rgw_common.cc` | Add `RGWStorageClassStats::dump()` |
| `src/rgw/driver/rados/rgw_bucket.cc` | Add `read_storage_class_stats()` and `dump_storage_class_usage()`; thread `show_storage_classes` through `bucket_stats()` |
| `src/rgw/driver/rados/rgw_bucket.h` | Add `show_storage_classes` flag to `RGWBucketAdminOpState` |
| `src/rgw/radosgw-admin/radosgw-admin.cc` | Parse `--show-storage-classes` and pass it through |

**Total: 5 files, ~136 lines net.**

### Output example

\`\`\`json
{
  "bucket": "mybucket",
  "rgw.storage_classes": {
    "STANDARD": {
      "size": 1073741824,
      "size_actual": 1074790400,
      "size_utilized": 1073741824,
      "size_kb": 1048576,
      "size_kb_actual": 1049600,
      "size_kb_utilized": 1048576,
      "num_objects": 42
    },
    "GLACIER": {
      "size": 214748364800,
      "size_actual": 214749413376,
      "size_utilized": 214748364800,
      "size_kb": 209715200,
      "size_kb_actual": 209716224,
      "size_kb_utilized": 209715200,
      "num_objects": 1500
    }
  }
}
\`\`\`

### Implementation notes

- Iterates every shard via `BucketShard::init` + `RGWRados::bi_list`, filtering to `BIIndexType::Plain` entries only (skips OLH/multipart manifests)
- Storage class normalized through `rgw_placement_rule::get_canonical_storage_class()` so objects without explicit class appear under "STANDARD"
- `size_rounded` uses `cls_rgw_get_rounded_size()` for 4 KiB alignment, consistent with `RGWStorageStats`
- Scan failure is non-fatal: warning to stderr, rest of output returned normally
- Guarded with `#ifdef WITH_RADOSGW_RADOS` per convention in this file

## Relationship to PR #66501

This is **not a replacement** for #66501. The persistent counter approach there is the right long-term design. This PR provides the billing/quota use case immediately with zero data-path risk while #66501 is reviewed.

Once #66501 lands, `--show-storage-classes` can be kept as a re-scan/verify option or reimplemented to read from the persistent counters.

## Honest limitations

- **O(objects) per call**: not for real-time use. Use periodic billing jobs.
- **Not cached**: back-to-back calls scan twice.
- **Rados-only**: silently returns no `rgw.storage_classes` section on non-Rados drivers (dbstore, posix) — those have no bucket index to scan.