### PR TITLE
mgr/cephadm: Dont update agent_timestamp upon http/ssh dep delivery

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -2116,13 +2116,14 @@ class AgentCache():
         return True
 
     def agent_config_successfully_delivered(self, daemon_spec: CephadmDaemonDeploySpec) -> None:
-        # agent successfully received new config (HTTP ACK or successful SSH
+        # Agent successfully received new config (HTTP ACK or successful SSH
         # deploy/reconfig). Only call this after confirmed delivery so
         # last_deps tracks what the agent actually has.
+        # Agent_timestamp get refreshed in handle_metadata(). This HTTP/SSH
+        # config delivery means the agent got new deps, not that it is reporting.
         assert daemon_spec.daemon_type == 'agent'
         self.update_agent_config_deps(
             daemon_spec.host, daemon_spec.deps, datetime_now())
-        self.agent_timestamp[daemon_spec.host] = datetime_now()
         self.agent_counter[daemon_spec.host] = 1
         self.save_agent(daemon_spec.host)
         self.mgr.log.debug(

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -171,16 +171,20 @@ class CephadmServe:
                 self.mgr.service_action('reconfig', svc)
 
     def _serve_sleep(self) -> None:
-        sleep_interval = max(
-            30,
-            min(
-                self.mgr.host_check_interval,
-                self.mgr.facts_cache_timeout,
-                self.mgr.daemon_cache_timeout,
-                self.mgr.device_cache_timeout,
-                self.mgr.stray_daemon_check_interval,
-            )
-        )
+        candidates = [
+            self.mgr.host_check_interval,
+            self.mgr.facts_cache_timeout,
+            self.mgr.daemon_cache_timeout,
+            self.mgr.device_cache_timeout,
+            self.mgr.stray_daemon_check_interval,
+        ]
+        if self.mgr.use_agent:
+            # _agent_down() only runs once per serve loop, so cap the sleep at
+            # the down-detection threshold. A future larger refactor is to run
+            # agent-down detection on its own thread.
+            down_mult = max(self.mgr.agent_down_multiplier, 1.5)
+            candidates.append(int(down_mult * self.mgr.agent_refresh_rate))
+        sleep_interval = max(30, min(candidates))
         self.log.debug('Sleeping for %d seconds', sleep_interval)
         self.mgr.event.wait(sleep_interval)
         self.mgr.event.clear()


### PR DESCRIPTION
Need not refresh agent_timestamp on a successful HTTP/SSH config delivery. That only means deps were written, not that the agent is reporting to mgr. No change in timestamp update by agent metadata POSTs so a silent agent hits CEPHADM_AGENT_DOWN and may get a subsequent SSH reconfig.

Another commit lets the agent failure detection to be triggered with agent_down tunable intervals, when agent mode is on.

Fixes: https://tracker.ceph.com/issues/79844


Unit test logs:

```
[root@ceph-node-1 ~]# systemctl stop ceph-7ee36a90-ad02-11f1-afd7-5254005eb93c@agent.ceph-node-1.service
[root@ceph-node-1 ~]#

[ceph: root@ceph-node-0 /]# date; ceph orch ps --daemon_type agent
Thu Sep 10 10:44:34 UTC 2026
NAME               HOST         PORTS   STATUS   REFRESHED   AGE  MEM USE  MEM LIM  VERSION    IMAGE ID   
agent.ceph-node-0  ceph-node-0  *:4721  running    12s ago   97s        -        -  <unknown>  <unknown>  
agent.ceph-node-1  ceph-node-1  *:4721  running    70s ago  104s        -        -  <unknown>  <unknown>  
agent.ceph-node-2  ceph-node-2  *:4721  running     8s ago  111s        -        -  <unknown>  <unknown>  
[ceph: root@ceph-node-0 /]# date; ceph orch ps --daemon_type agent
Thu Sep 10 10:44:42 UTC 2026
NAME               HOST         PORTS   STATUS   REFRESHED   AGE  MEM USE  MEM LIM  VERSION    IMAGE ID   
agent.ceph-node-0  ceph-node-0  *:4721  running     0s ago  105s        -        -  <unknown>  <unknown>  
agent.ceph-node-1  ceph-node-1  *:4721  error       2s ago  112s        -        -  <unknown>  <unknown>  
agent.ceph-node-2  ceph-node-2  *:4721  running    16s ago  118s        -        -  <unknown>  <unknown>  
[ceph: root@ceph-node-0 /]# ceph -s
  cluster:
    id:     7ee36a90-ad02-11f1-afd7-5254005eb93c
    health: HEALTH_WARN
            1 Cephadm Agent(s) are not reporting. Hosts may be offline
 
  services:
    mon: 3 daemons, quorum ceph-node-0,ceph-node-1,ceph-node-2 (age 4m) [leader: ceph-node-0]
    mgr: ceph-node-0.wwrwwr(active, since 12m), standbys: ceph-node-1.ehkyax
    osd: 12 osds: 12 up (since 4m), 12 in (since 5m)
 
  data:
    pools:   1 pools, 1 pgs
    objects: 2 objects, 449 KiB
    usage:   724 MiB used, 119 GiB / 120 GiB avail
    pgs:     1 active+clean
 
[ceph: root@ceph-node-0 /]#
```

```
[ceph: root@ceph-node-0 /]# ceph -w
  cluster:
    id:     7ee36a90-ad02-11f1-afd7-5254005eb93c
    health: HEALTH_WARN
            2 Cephadm Agent(s) are not reporting. Hosts may be offline
 
  services:
    mon: 3 daemons, quorum ceph-node-0,ceph-node-1,ceph-node-2 (age 9m) [leader: ceph-node-0]
    mgr: ceph-node-0.wwrwwr(active, since 17m), standbys: ceph-node-1.ehkyax
    osd: 12 osds: 12 up (since 9m), 12 in (since 10m)
 
  data:
    pools:   1 pools, 1 pgs
    objects: 2 objects, 449 KiB
    usage:   724 MiB used, 119 GiB / 120 GiB avail
    pgs:     1 active+clean
 

2026-09-10T10:50:00.000607+0000 mon.ceph-node-0 [WRN] Health detail: HEALTH_WARN 2 Cephadm Agent(s) are not reporting. Hosts may be offline
2026-09-10T10:50:00.000719+0000 mon.ceph-node-0 [WRN] [WRN] CEPHADM_AGENT_DOWN: 2 Cephadm Agent(s) are not reporting. Hosts may be offline
2026-09-10T10:50:00.000746+0000 mon.ceph-node-0 [WRN]     Cephadm agent on host ceph-node-1 has not reported in 60.0 seconds. Agent is assumed down and host may be offline.
2026-09-10T10:50:00.000772+0000 mon.ceph-node-0 [WRN]     Cephadm agent on host ceph-node-2 has not reported in 60.0 seconds. Agent is assumed down and host may be offline.

```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [X] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
