### PR TITLE
umbrella: mgr/smb: fix sqlite3.InternalError crash on lost RADOS lock

### DIFF
--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -4,7 +4,13 @@ overrides:
       osd:
         osd max markdown count: 1000
         osd blocked scrub grace period: 3600
+      mgr:
+        cephsqlite inject stat error probability: 0.005
     log-ignorelist:
+      - "Caught fatal database error: disk I/O error"
+      - "Unhandled exception from module .*: disk I/O error"
+      - "Module .* has failed: disk I/O error"
+      - db not ready
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6977,6 +6977,14 @@ options:
   default: true
   tags:
   - client
+- name: cephsqlite_inject_stat_error_probability
+  type: float
+  level: dev
+  desc: Probability that the libcephsqlite VFS fails a stat() with a fake I/O
+    error, for testing
+  default: 0
+  tags:
+  - client
 - name: bdev_type
   type: str
   level: advanced

--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -438,6 +438,12 @@ static int Sync(sqlite3_file *file, int flags)
 }
 
 
+static bool should_inject_stat_error(CephContext* cct)
+{
+  auto p = cct->_conf.get_val<double>("cephsqlite_inject_stat_error_probability");
+  return p && rand() % 10000 < p * 10000.0;
+}
+
 static int FileSize(sqlite3_file *file, sqlite_int64 *osize)
 {
   auto f = (cephsqlite_file*)file;
@@ -445,12 +451,14 @@ static int FileSize(sqlite3_file *file, sqlite_int64 *osize)
   df(5) << dendl;
 
   uint64_t size = 0;
-  if (int rc = f->io.rs->stat(&size); rc < 0) {
+  int rc = should_inject_stat_error(f->io.cct.get()) ? -EIO : f->io.rs->stat(&size);
+  if (rc < 0) {
     df(5) << "stat failed: " << cpp_strerror(rc) << dendl;
     if (rc == -EBLOCKLISTED) {
       getdata(f->vfs).maybe_reconnect(f->io.cluster);
+      return SQLITE_IOERR_LOCK;
     }
-    return SQLITE_NOTFOUND;
+    return SQLITE_IOERR_FSTAT;
   }
 
   *osize = (sqlite_int64)size;
@@ -727,9 +735,15 @@ static int Access(sqlite3_vfs* vfs, const char* path, int flags, int* result)
   }
 
   uint64_t size = 0;
-  if (int rc = io.rs->stat(&size); rc < 0) {
+  int access_rc = SQLITE_OK;
+  if (int rc = should_inject_stat_error(cct.get()) ? -EIO : io.rs->stat(&size); rc < 0) {
     dv(5) << "= " << rc << " (" << cpp_strerror(rc) << ")" << dendl;
-    *result = 0;
+    if (rc == -EBLOCKLISTED) {
+      getdata(vfs).maybe_reconnect(cluster);
+      access_rc = SQLITE_IOERR_LOCK;
+    } else {
+      access_rc = SQLITE_IOERR_FSTAT;
+    }
   } else {
     dv(5) << "= 0" << dendl;
     *result = 1;
@@ -737,7 +751,7 @@ static int Access(sqlite3_vfs* vfs, const char* path, int flags, int* result)
 
   auto end = ceph::coarse_mono_clock::now();
   getdata(vfs).logger->tinc(P_OP_ACCESS, end-start);
-  return SQLITE_OK;
+  return access_rc;
 }
 
 /* This method is only called once for each database. It provides a chance to

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -608,7 +608,7 @@ MAX_DBCLEANUP_RETRIES = 3
 
 def MgrModuleRecoverDB(func: Callable) -> Callable:
     @functools.wraps(func)
-    def check(self: MgrModule, *args: Any, **kwargs: Any) -> Any:
+    def check(self: 'MgrModule', *args: Any, **kwargs: Any) -> Any:
         retries = 0
         while True:
             try:
@@ -1270,6 +1270,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
 
         db.execute(SQL, (version,))
 
+    @MgrModuleRecoverDB
     def set_kv(self, key: str, value: Any) -> None:
         SQL = "INSERT OR REPLACE INTO MgrModuleKV (key, value) VALUES (?, ?);"
 
@@ -1281,6 +1282,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             self.db.execute(SQL, (key, value))
 
     @API.expose
+    @MgrModuleRecoverDB
     def get_kv(self, key: str) -> Any:
         SQL = "SELECT value FROM MgrModuleKV WHERE key = ?;"
 
@@ -1380,6 +1382,9 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             try:
                 return self.db is not None
             except MgrDBNotReady:
+                return False
+            except sqlite3.DatabaseError as e:
+                self.log.warning(f"db not ready: {e}")
                 return False
 
     @property

--- a/src/test/libcephsqlite/main.cc
+++ b/src/test/libcephsqlite/main.cc
@@ -1080,6 +1080,21 @@ out:
   ASSERT_EQ(0, rc);
 }
 
+TEST_F(CephSQLiteTest, FileSizeStatError) {
+  EXPECT_EQ(0, cct->_conf.set_val("cephsqlite_inject_stat_error_probability", "1.0"));
+  cct->_conf.apply_changes(nullptr);
+
+  sqlite3_extended_result_codes(db, 1);
+  int rc = sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS stat_error (a INT);", NULL, NULL, NULL);
+  std::string errmsg = sqlite3_errmsg(db);
+
+  cct->_conf.set_val("cephsqlite_inject_stat_error_probability", "0");
+  cct->_conf.apply_changes(nullptr);
+
+  ASSERT_EQ(SQLITE_IOERR, rc & 0xff)
+    << "sqlite3 error: " << rc << " `" << sqlite3_errstr(rc) << "': " << errmsg;
+}
+
 
 int main(int argc, char **argv) {
   auto args = argv_to_vec(argc, argv);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79840

---

backport of https://github.com/ceph/ceph/pull/71094
parent tracker: https://tracker.ceph.com/issues/79526

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh