### PR TITLE
rgw/dedup: skip split-head on EC pools without allow_ec_overwrites

### DIFF
--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -96,6 +96,9 @@ The dedup estimate process skips the following RGW objects:
 - Objects with different placement rules.
 - Objects in different RADOS pools.
 - Objects with different RGW storage classes.
+- On EC pools without ``allow_ec_overwrites``: non-multipart objects smaller
+  than ``rgw_max_chunk_size`` in the default storage class (these require
+  split-head which is unavailable on such pools).
 
 The full dedup process skips all of the above and additionally skips
 **compressed** and **user-encrypted** objects.
@@ -176,6 +179,16 @@ be deduplicated.
 this option to ``false`` disables split-head entirely.
 
 .. confval:: rgw_dedup_split_obj_head
+
+.. note::
+   Split-head is automatically disabled on erasure-coded (EC) data pools
+   that do not have ``allow_ec_overwrites`` enabled. EC pools are
+   append-only and reject the truncate operation required by split-head.
+   On such pools, non-multipart default-storage-class objects smaller
+   than ``rgw_max_chunk_size`` are skipped during the bucket-index scan
+   since they cannot be deduped without split-head.
+   Non-default storage-class objects and multipart objects have an empty
+   head and remain dedupable without split-head.
 
 
 Memory Usage

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -394,6 +394,56 @@ namespace rgw::dedup {
 
     rados = store->getRados();
     rados_handle = rados->get_rados_handle();
+
+    // Detect whether the data pool supports truncate (needed for split-head).
+    // EC pools without allow_ec_overwrites reject TRUNCATE with -EOPNOTSUPP.
+    // We only check the default placement pool because the BI filter applies
+    // exclusively to RGW_STORAGE_CLASS_STANDARD objects, which always reside
+    // in the default placement's data pool. Non-default storage classes have
+    // an empty head and skip the filter entirely.
+    d_pool_supports_truncate = true;
+    const auto& zone_params = store->svc()->zone->get_zone_params();
+    const auto& zonegroup = store->svc()->zone->get_zonegroup();
+    const std::string& default_placement_name = zonegroup.default_placement.name;
+    auto it = zone_params.placement_pools.find(default_placement_name);
+    if (it != zone_params.placement_pools.end()) {
+      const rgw_pool& data_pool = it->second.get_standard_data_pool();
+      if (!data_pool.name.empty()) {
+        librados::IoCtx data_ioctx;
+        int ret = rgw_init_ioctx(dpp, rados_handle, data_pool, data_ioctx);
+        if (ret < 0) {
+          ldpp_dout(dpp, 5) << __func__ << "::failed to open default data pool "
+                            << data_pool.name << ": " << cpp_strerror(-ret) << dendl;
+          return ret;
+        }
+
+        bool requires_alignment = false;
+        ret = data_ioctx.pool_requires_alignment2(&requires_alignment);
+        if (ret < 0) {
+          ldpp_dout(dpp, 1) << __func__ << "::ERR: pool_requires_alignment2() failed on "
+                            << data_pool.name << ": " << cpp_strerror(-ret) << dendl;
+          return ret;
+        }
+
+        if (requires_alignment) {
+          d_pool_supports_truncate = false;
+          ldpp_dout(dpp, 5) << __func__ << "::default data pool " << data_pool.name
+                            << " is EC without allow_ec_overwrites, "
+                            << "disabling split-head" << dendl;
+        }
+      }
+      else {
+        ldpp_dout(dpp, 1) << __func__ << "::ERR: empty data-pool name for default-placement("
+                          << default_placement_name << ")" << dendl;
+        return -ENOENT;
+      }
+    }
+    else {
+      ldpp_dout(dpp, 1) << __func__ << "::ERR: default_placement("
+                        << default_placement_name << ") has no valid pool" << dendl;
+      return -ENOENT;
+    }
+
     if (init_pool) {
       int ret = init_dedup_pool_ioctx(store, dpp, d_dedup_cluster_ioctx);
       display_ioctx_state(dpp, d_dedup_cluster_ioctx, __func__);
@@ -620,8 +670,15 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  inline bool Background::should_split_head(const RGWObjManifest& manifest)
+  inline bool Background::should_split_head(const RGWObjManifest& manifest,
+                                            md5_stats_t *p_stats)
   {
+    if (!d_pool_supports_truncate) {
+      // we can't split-head without atomic truncate
+      p_stats->split_head_skip_no_truncate++;
+      return false;
+    }
+
     // Split-head is only applicable for single-part objects with a non-empty head.
     // To avoid issues with manifests created via append (specifically for Alibaba Cloud OSS),
     //    we should disable split-head whenever the manifest contains an override_prefix in the rules.
@@ -1242,7 +1299,7 @@ namespace rgw::dedup {
         return -ENOTSUP;
       }
 
-      need_to_split_head = should_split_head(manifest);
+      need_to_split_head = should_split_head(manifest, p_stats);
 
       // force explicit tail_placement as the dedup could be on another bucket
       const rgw_bucket_placement& tail_placement = manifest.get_tail_placement();
@@ -1830,7 +1887,7 @@ namespace rgw::dedup {
     // we might still need to split-head here when hash is valid
     // can happen if we failed compare before (md5-collison) and stored the src hash
     // in the obj-attributes
-    if (should_split_head(src_manifest)) {
+    if (should_split_head(src_manifest, p_stats)) {
       ret = split_head_object(p_src_rec, src_manifest, p_tgt_rec, p_stats);
       // compare_strong_hash() is called internally by split_head_object()
       return (ret == 0);
@@ -2311,8 +2368,21 @@ namespace rgw::dedup {
       p_worker_stats->non_default_storage_class_objs_bytes += ondisk_byte_size;
     }
 
+    const bool multipart_object = (parsed_etag.num_parts > 0);
+    if (entry.meta.size <= d_head_object_size       &&
+        !d_pool_supports_truncate                   &&
+        storage_class == RGW_STORAGE_CLASS_STANDARD &&
+        !multipart_object) {
+      // small objects dedup uses split-head which is dependent on truncate support
+      ldpp_dout(dpp, 20) << __func__ << "::ingress_skip_no_truncate_support::"
+                         << entry.meta.size << dendl;
+      p_worker_stats->ingress_skip_no_truncate_support++;
+      p_worker_stats->ingress_skip_no_truncate_support_bytes += ondisk_byte_size;
+      return 0;
+    }
+
     if (ondisk_byte_size < d_min_obj_size_for_dedup) {
-      if (parsed_etag.num_parts == 0) {
+      if (!multipart_object) {
         // dedup is only applied to objects larger than the configured minimum size
         // `rgw_dedup_min_obj_size_for_dedup`
         p_worker_stats->ingress_skip_too_small++;
@@ -2326,7 +2396,7 @@ namespace rgw::dedup {
       }
     }
     // multipart/single_part counters are for objects being fully processed
-    if (parsed_etag.num_parts > 0) {
+    if (multipart_object) {
       p_worker_stats->multipart_objs++;
     }
     else {

--- a/src/rgw/driver/rados/rgw_dedup.h
+++ b/src/rgw/driver/rados/rgw_dedup.h
@@ -99,7 +99,7 @@ namespace rgw::dedup {
     };
 
     inline uint64_t __calc_deduped_bytes(uint16_t num_parts, uint64_t size_bytes);
-    inline bool should_split_head(const RGWObjManifest &manifest);
+    inline bool should_split_head(const RGWObjManifest &manifest, md5_stats_t *p_stats);
     void remove_created_tail_object(const disk_record_t *p_rec,
                                     const RGWObjManifest &manifest,
                                     md5_stats_t *p_stats /*IN-OUT*/);
@@ -258,6 +258,7 @@ namespace rgw::dedup {
 
     uint32_t d_min_obj_size_for_dedup = (64ULL * 1024);
     bool     d_split_head             = true;
+    bool     d_pool_supports_truncate = true;
     uint32_t d_head_object_size       = (4ULL * 1024 * 1024);
     control_t d_ctl;
     dedup_filter_t d_filter;

--- a/src/rgw/driver/rados/rgw_dedup_utils.cc
+++ b/src/rgw/driver/rados/rgw_dedup_utils.cc
@@ -384,6 +384,8 @@ namespace rgw::dedup {
     this->ingress_skip_too_small += other.ingress_skip_too_small;
     this->ingress_skip_filtered_bucket += other.ingress_skip_filtered_bucket;
     this->ingress_skip_filtered_storage_class += other.ingress_skip_filtered_storage_class;
+    this->ingress_skip_no_truncate_support += other.ingress_skip_no_truncate_support;
+    this->ingress_skip_no_truncate_support_bytes += other.ingress_skip_no_truncate_support_bytes;
 
     return *this;
   }
@@ -456,6 +458,12 @@ namespace rgw::dedup {
         f->dump_unsigned("Ingress skipped filtered storage class, num objects skipped",
                          this->ingress_skip_filtered_storage_class);
       }
+      if (this->ingress_skip_no_truncate_support) {
+        f->dump_unsigned("Ingress skip: EC no truncate support",
+                         this->ingress_skip_no_truncate_support);
+        f->dump_unsigned("Ingress skip: EC no truncate support bytes",
+                         this->ingress_skip_no_truncate_support_bytes);
+      }
     }
 
     {
@@ -503,11 +511,12 @@ namespace rgw::dedup {
     encode(w.non_default_storage_class_objs_bytes, bl);
 
     encode(w.ingress_corrupted_etag, bl);
-
-    encode(w.ingress_skip_too_small_bytes, bl);
     encode(w.ingress_skip_too_small, bl);
+    encode(w.ingress_skip_too_small_bytes, bl);
     encode(w.ingress_skip_filtered_bucket, bl);
     encode(w.ingress_skip_filtered_storage_class, bl);
+    encode(w.ingress_skip_no_truncate_support, bl);
+    encode(w.ingress_skip_no_truncate_support_bytes, bl);
 
     encode(w.duration, bl);
     ENCODE_FINISH(bl);
@@ -533,10 +542,12 @@ namespace rgw::dedup {
     decode(w.non_default_storage_class_objs, bl);
     decode(w.non_default_storage_class_objs_bytes, bl);
     decode(w.ingress_corrupted_etag, bl);
-    decode(w.ingress_skip_too_small_bytes, bl);
     decode(w.ingress_skip_too_small, bl);
+    decode(w.ingress_skip_too_small_bytes, bl);
     decode(w.ingress_skip_filtered_bucket, bl);
     decode(w.ingress_skip_filtered_storage_class, bl);
+    decode(w.ingress_skip_no_truncate_support, bl);
+    decode(w.ingress_skip_no_truncate_support_bytes, bl);
 
     decode(w.duration, bl);
     DECODE_FINISH(bl);
@@ -580,6 +591,7 @@ namespace rgw::dedup {
     this->singleton_after_purge         += other.singleton_after_purge;
     this->shared_manifest_after_purge   += other.shared_manifest_after_purge;
     this->split_head_no_tail_placement  += other.split_head_no_tail_placement;
+    this->split_head_skip_no_truncate   += other.split_head_skip_no_truncate;
     this->illegal_rec_id                += other.illegal_rec_id;
     this->missing_last_block_marker     += other.missing_last_block_marker;
 
@@ -802,6 +814,10 @@ namespace rgw::dedup {
         f->dump_unsigned("No Tail Placement during Split-Head processing",
                          this->split_head_no_tail_placement);
       }
+      if (this->split_head_skip_no_truncate) {
+        f->dump_unsigned("Split-Head skipped: EC no truncate support",
+                         this->split_head_skip_no_truncate);
+      }
     }
   }
 
@@ -845,6 +861,7 @@ namespace rgw::dedup {
     encode(m.singleton_after_purge, bl);
     encode(m.shared_manifest_after_purge, bl);
     encode(m.split_head_no_tail_placement, bl);
+    encode(m.split_head_skip_no_truncate, bl);
     encode(m.illegal_rec_id, bl);
     encode(m.missing_last_block_marker, bl);
 
@@ -915,6 +932,7 @@ namespace rgw::dedup {
     decode(m.singleton_after_purge, bl);
     decode(m.shared_manifest_after_purge, bl);
     decode(m.split_head_no_tail_placement, bl);
+    decode(m.split_head_skip_no_truncate, bl);
     decode(m.illegal_rec_id, bl);
     decode(m.missing_last_block_marker, bl);
 

--- a/src/rgw/driver/rados/rgw_dedup_utils.h
+++ b/src/rgw/driver/rados/rgw_dedup_utils.h
@@ -200,6 +200,8 @@ namespace rgw::dedup {
 
     uint64_t ingress_skip_filtered_bucket = 0;
     uint64_t ingress_skip_filtered_storage_class = 0;
+    uint64_t ingress_skip_no_truncate_support = 0;
+    uint64_t ingress_skip_no_truncate_support_bytes = 0;
 
     utime_t  duration = {0, 0};
   };
@@ -247,6 +249,7 @@ namespace rgw::dedup {
     uint64_t singleton_after_purge = 0;
     uint64_t shared_manifest_after_purge = 0;
     uint64_t split_head_no_tail_placement = 0;
+    uint64_t split_head_skip_no_truncate = 0;
     uint64_t illegal_rec_id = 0;
     uint64_t missing_last_block_marker = 0;
 


### PR DESCRIPTION
EC data pools are append-only and reject TRUNCATE with -EOPNOTSUPP.

Split-head requires atomic truncate, so disable it on such pools.

On such pools, non-multipart default-storage-class objects smaller
than ``rgw_max_chunk_size`` are skipped during the bucket-index scan
since they cannot be deduped without split-head.
Non-default storage-class objects and multipart objects have an empty
head and remain dedupable without split-head.

Resolves: https://ibm-ceph.atlassian.net/browse/IBMCEPH-17907





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
