### PR TITLE
umbrella: mgr/dashboard: fix osd_removal status dict serialization 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -218,7 +218,7 @@ class Osd(RESTController):
     def get_removing_osds() -> Optional[List[int]]:
         orch = OrchClient.instance()
         if orch.available(features=[OrchFeature.OSD_GET_REMOVE_STATUS]):
-            return [osd.osd_id for osd in orch.osds.removing_status()]
+            return [osd['osd_id'] for osd in orch.osds.removing_status()]
         return None
 
     @staticmethod
@@ -340,7 +340,7 @@ class Osd(RESTController):
         while True:
             removal_osds = orch.osds.removing_status()
             logger.info('Current removing OSDs %s', removal_osds)
-            pending = [osd for osd in removal_osds if osd.osd_id == int(svc_id)]
+            pending = [osd for osd in removal_osds if osd['osd_id'] == int(svc_id)]
             if not pending:
                 break
             logger.info('Wait until osd.%s is removed...', svc_id)

--- a/src/pybind/mgr/dashboard/tests/test_osd.py
+++ b/src/pybind/mgr/dashboard/tests/test_osd.py
@@ -495,3 +495,38 @@ class OsdTest(ControllerTestCase):
         self.assertFalse(res['options'][OsdDeploymentOptions.COST_CAPACITY]['available'])
         self.assertFalse(res['options'][OsdDeploymentOptions.THROUGHPUT]['available'])
         self.assertTrue(res['options'][OsdDeploymentOptions.IOPS]['available'])
+
+    @mock.patch('dashboard.controllers.osd.time.sleep')
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_osd_delete_with_dict_status(self, instance, mock_sleep):
+        fake_client = mock.Mock()
+        instance.return_value = fake_client
+        fake_client.get_missing_features.return_value = []
+
+        fake_client.osds.removing_status.side_effect = [
+            [{'osd_id': 7, 'started': True, 'draining': False}],
+            []
+        ]
+
+        self._task_delete('/api/osd/7?force=true&preserve_id=true')
+        self.assertStatus(204)
+
+        fake_client.osds.remove.assert_called_once_with(['7'], True)
+        self.assertEqual(fake_client.osds.removing_status.call_count, 2)
+        mock_sleep.assert_called_once_with(60)
+
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_get_removing_osds_with_dict_status(self, instance):
+        fake_client = mock.Mock()
+        instance.return_value = fake_client
+        fake_client.get_missing_features.return_value = []
+
+        fake_client.osds.removing_status.return_value = [
+            {'osd_id': 7, 'started': True},
+            {'osd_id': 8, 'started': False}
+        ]
+
+        osd = Osd()
+        removing_osds = osd.get_removing_osds()
+
+        self.assertEqual(removing_osds, [7, 8])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79859

---

backport of https://github.com/ceph/ceph/pull/71286
parent tracker: https://tracker.ceph.com/issues/79802

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh