### PR TITLE
osd: Fix bugs with EC sync reads coroutine lifecycle 

### DIFF
--- a/src/osd/Coroutines.h
+++ b/src/osd/Coroutines.h
@@ -18,10 +18,12 @@
  *
  * - yield_token_t (pull_type): Is used by a coroutine to suspend execution (yield)
  * while waiting for an I/O operation to complete.
- * - resume_token_t (push_type): Is used by the completion callback to
+ * - resume_token_t (push_type): Is used by the completion callback to resume execution
+ * once the I/O operations are complete.
  */
 
 #pragma once
+#include <memory>
 #include <boost/coroutine2/all.hpp>
 
 using yield_token_t = boost::coroutines2::coroutine<void>::pull_type;
@@ -29,5 +31,5 @@ using resume_token_t = boost::coroutines2::coroutine<void>::push_type;
 
 struct CoroHandles {
   yield_token_t& yield;
-  resume_token_t& resume;
+  std::weak_ptr<resume_token_t> resume;
 };

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1236,29 +1236,34 @@ int ECBackend::objects_read_sync(
   std::pair<ceph::buffer::list*, Context*>>> &to_read,
   CoroHandles coro)
 {
-  int result = 0;
-  bool done = false;
-  bool waiting = false;
+  struct ReadState {
+    int result = 0;
+    bool done = false;
+    bool waiting = false;
+  };
+  auto state = std::make_shared<ReadState>();
 
-  // Callback for the async read
-  Context *on_finish = new LambdaContext([&, coro](int r) {
-    result = r;
-    done = true;
+  std::weak_ptr<resume_token_t> weak_resume = coro.resume;
+  Context *on_finish = new LambdaContext([state, weak_resume](int r) {
+    state->result = r;
+    state->done = true;
 
-    if (waiting) {
-      coro.resume();
+    if (state->waiting) {
+      if (auto locked = weak_resume.lock(); locked) {
+        (*locked)();
+      }
     }
   });
 
   objects_read_async(hoid, object_size, to_read, on_finish, true);
 
   // If the async read is not yet complete, yield and wait for it to complete
-  if (!done) {
-    waiting = true;
+  if (!state->done) {
+    state->waiting = true;
     coro.yield();
   }
 
-  return result;
+  return state->result;
 }
 
 int ECBackend::objects_read_local(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2615,16 +2615,15 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     OpRequest* op_raw = op.get();
 
     // Spawn a coroutine to handle the message
-    auto resumer = std::make_unique<resume_token_t>(
+    auto resumer = std::make_shared<resume_token_t>(
       [this, op_raw](yield_token_t& yield) {
-        op_raw->coro_handles.emplace(CoroHandles{ yield, *coro_resumer });
+        op_raw->coro_handles.emplace(CoroHandles{ yield, coro_resumer });
         {
           const OpRequestRef op_ref(op_raw);
           do_op_impl(op_ref);
         }
 
         // Cleanup
-        coro_resumer = nullptr;
         on_coroutine_complete();
       });
 
@@ -2641,6 +2640,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
 void PrimaryLogPG::on_coroutine_complete()
 {
   ceph_assert(coro_op_in_flight);
+  coro_resumer = nullptr;
   coro_op_in_flight = false;
   active_coro_op = nullptr;
 
@@ -13343,6 +13343,9 @@ void PrimaryLogPG::on_change(ObjectStore::Transaction &t)
 
   if (coro_resumer != nullptr) {
     dout(20) << __func__ << ": Stopping active coroutine" << dendl;
+    coro_resumer = nullptr;
+    coro_op_in_flight = false;
+
     if (active_coro_ctx) {
       dout(20) << __func__ << ": Cleaning up orphaned OpContext from coroutine" << dendl;
       // Remove from in_progress_async_reads if present
@@ -13357,8 +13360,6 @@ void PrimaryLogPG::on_change(ObjectStore::Transaction &t)
       close_op_ctx(active_coro_ctx);
       active_coro_ctx = nullptr;
     }
-    coro_resumer = nullptr;
-    coro_op_in_flight = false;
   }
 
   if (hit_set && hit_set->insert_count() == 0) {

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -940,7 +940,7 @@ public:
 protected:
 
   OpRequestRef active_coro_op = nullptr;
-  std::unique_ptr<resume_token_t> coro_resumer = nullptr;
+  std::shared_ptr<resume_token_t> coro_resumer = nullptr;
   bool coro_op_in_flight = false;
   std::list<OpRequestRef> waiting_for_coro_op;
   OpContext* active_coro_ctx = nullptr;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/79515

Valgrind encountered some memory leaks related to the coroutine that is used for synchronous reads in EC pools.

Bug 1: The coroutine lambda called `coro_resumer = nullptr` from inside its own body.
Fix: Instead, reset coro_resumer from the caller's stack immediately after `(*coro_resumer)() returns. Or reset it lazily at the top of do_op() during the next op.

Bug 2: use-after-free of resume token in the on_finish callback.
Fix: Have a shared pointer to the resume token. The callback derives a weak pointer and attempts to lock the weak pointer before resuming the coroutine. If on_change() already reset the resume token, the lock fails and the resume is skipped. The token is freed when the last shared pointer is released.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
