### PR TITLE
mgr: count first_default off the handler's argument list

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -3,6 +3,15 @@
   ``$GETOPT`` environment override so GNU getopt can be selected
   (``brew install bash gnu-getopt``).
 
+* MGR: Several commands described a required argument to the monitor as optional.
+  They now describe it as required, so the monitor rejects a call that omits it
+  instead of handing the call to the manager module to fail on. The affected
+  commands include most of ``ceph nvmeof``, the ``ceph dashboard ac-role-*`` and
+  ``ceph dashboard ac-user-*`` families, ``ceph dashboard set-rgw-hostname``,
+  ``ceph dashboard set-cross-origin-url``, ``ceph dashboard iscsi-gateway-rm``,
+  the ``ceph fs snapshot mirror`` subcommands and ``ceph insights prune-health``.
+  Omitting these arguments has never worked, so no working command line changes.
+
 * CephFS: The ``client_force_lazyio`` configuration option is now correctly marked
   as not supporting runtime updates. Previously, the configuration schema indicated
   this option could be changed at runtime, but changes had no effect on opened file

--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -495,11 +495,9 @@ class NvmeofCLICommand(DBCLICommand):
             return None
 
     def _check_required_params(self, cmd_dict: Dict[str, Any]) -> Optional[str]:
-        for index, name in enumerate(self.arg_spec):
-            if name in self.KNOWN_ARGS:
+        for name in self.arg_spec:
+            if name in self.KNOWN_ARGS or name in self.defaulted_args:
                 continue
-            if index >= self.first_default:
-                break
             if cmd_dict.get(name) is None:
                 return f"missing required parameter: --{name}"
         return None

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -425,18 +425,26 @@ class CLICommandBase(object):
         self.func = None  # type: Optional[Callable]
         self.arg_spec = {}    # type: Dict[str, Any]
         self.first_default = -1
+        self.defaulted_args = set()  # type: Set[str]
 
     KNOWN_ARGS = '_', 'self', 'mgr', 'inbuf', 'return'
 
     @classmethod
-    def _load_func_metadata(cls: Any, f: HandlerFuncType) -> Tuple[str, Dict[str, Any], int, str]:
+    def _load_func_metadata(
+        cls: Any, f: HandlerFuncType
+    ) -> Tuple[str, Dict[str, Any], int, str, Set[str]]:
         f, extra_args = _extract_target_func(f)
         desc = (inspect.getdoc(f) or '').replace('\n', ' ')
         full_argspec = inspect.getfullargspec(f)
         arg_spec = full_argspec.annotations
-        first_default = len(arg_spec)
-        if full_argspec.defaults:
-            first_default -= len(full_argspec.defaults)
+        # first_default indexes into full_argspec.args, so it has to be
+        # counted there: len(arg_spec) only lines up when exactly one of
+        # the self/mgr argument and the return type is annotated, and a
+        # fully annotated handler taking mgr positionally has both.
+        first_default = len(full_argspec.args) - len(full_argspec.defaults or ())
+        # arg_spec is keyed by name and skips the unannotated self/mgr, so
+        # it does not share that indexing; ask for the names instead
+        defaulted_args = set(full_argspec.args[first_default:])
         args = []
         positional = True
         for index, arg in enumerate(full_argspec.args):
@@ -459,7 +467,7 @@ class CLICommandBase(object):
                 positional = False
             assert arg in arg_spec, \
                 f"'{arg}' is not annotated for {f}: {full_argspec}"
-            has_default = index >= first_default
+            has_default = arg in defaulted_args
             args.append(CephArgtype.to_argdesc(arg_spec[arg],
                                                dict(name=arg),
                                                has_default,
@@ -469,14 +477,15 @@ class CLICommandBase(object):
             if argname in arg_spec:
                 continue
             arg_spec[argname] = argtype
+            defaulted_args.add(argname)
             args.append(CephArgtype.to_argdesc(
                 argtype, dict(name=argname), has_default=True, positional=False
             ))
-        return desc, arg_spec, first_default, ' '.join(args)
+        return desc, arg_spec, first_default, ' '.join(args), defaulted_args
 
     def store_func_metadata(self, f: HandlerFuncType) -> None:
-        self.desc, self.arg_spec, self.first_default, self.args = \
-            self._load_func_metadata(f)
+        (self.desc, self.arg_spec, self.first_default, self.args,
+         self.defaulted_args) = self._load_func_metadata(f)
 
     def _register_handler(self, func: HandlerFuncType) -> HandlerFuncType:
         self.store_func_metadata(func)
@@ -508,15 +517,14 @@ class CLICommandBase(object):
         kwargs = {}
         special_args = set()
         kwargs_switch = False
-        for index, (name, tp) in enumerate(self.arg_spec.items()):
+        for name, tp in self.arg_spec.items():
             if name in self.KNOWN_ARGS:
                 special_args.add(name)
                 continue
             assert self.first_default >= 0
             raw_v = cmd_dict.get(name)
-            if index >= self.first_default:
-                if raw_v is None:
-                    continue
+            if raw_v is None and name in self.defaulted_args:
+                continue
             kwargs_switch, k, v = self._get_arg_value(kwargs_switch,
                                                       name, raw_v)
             kwargs[k] = CephArgtype.cast_to(tp, v)


### PR DESCRIPTION
## Where this PR came from

This came out of preparing the NVMe-oF control plane for its move from the dashboard into the always-on nvmeof mgr module. `src/mypy.ini` exempts `dashboard.* from disallow_untyped_defs but not nvmeof.*, so the handlers have to be fully annotated once they move. Annotating them broke seven command lines that work today:
```
ceph nvmeof namespace add           --rbd_pool became required (defaults to "rbd")
ceph nvmeof gateway refresh_network --nqn became required (defaults to "")
ceph nvmeof listener del            --adrfam became required (defaults to 0)
ceph nvmeof top cpu                 --server_address became required (defaults to "")
ceph nvmeof top io                  --nqn became required (defaults to "")
```
plus the `ceph nvmeof ns add` and `ceph nvmeof gw refresh_network` aliases.

The annotations were not at fault. `CLICommandBase` derives `first_default` from the size of the annotations dict and then uses it as an index into `full_argspec.args`. The two only agree when exactly one of the handler's `self`/`mgr` argument and its return type is annotated. A fully typed module-level handler taking mgr annotates both, so its count comes out one too high and arguments that do have defaults are described as required.

## So, what this means for main today?

Plenty of handlers annotate neither the self argument nor the return type. For those the count comes out one too low, and the last argument that really is required gets described as optional. 121 of the 419 command handlers in
the tree are in that state. The other 298 annotate their return type, which makes the two counts match.

"ceph dashboard set-rgw-hostname" is one of the 121:
```py
    def set_rgw_hostname(self, daemon_name: str, hostname: str):
```
Neither argument has a default. The descriptor the monitor gets marks the
second one optional anyway:
```
    name=daemon_name,type=CephString name=hostname,req=false,type=CephString
```
So the monitor accepts "ceph dashboard set-rgw-hostname rgw.foo" and hands it
to the manager, where the handler raises TypeError over the missing hostname.

Nobody has reported this because on main the mistake only goes one way: it can call a required argument optional, never the reverse. Reaching it means omitting an argument that was never optional, so the only way to see it is to
type the command wrong. The reply still names the argument, arriving as a Python traceback from the manager that ends in "missing 1 required positionalargument" instead of an argument error from the monitor. Worth tidying up, but not something anyone files a bug about.

Annotating a handler reverses the direction. An argument that does have a default starts being advertised as required, and command lines that are correct today get rejected. That is what the nvmeof work ran into, and it is
why the series cannot simply leave this alone.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
