### PR TITLE
tentacle: mgr: fix OpHistory shutdown race condition

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -74,13 +74,17 @@ void* OpHistoryServiceThread::entry() {
 
 void OpHistory::on_shutdown()
 {
+  if (shutdown.exchange(true)) {   // idempotent; join is reached exactly once
+    return;
+  }
   opsvc.break_thread();
-  opsvc.join();
+  if (opsvc.is_started()) {
+    opsvc.join();
+  }
   std::lock_guard history_lock(ops_history_lock);
   arrived.clear();
   duration.clear();
   slow_op.clear();
-  shutdown = true;
 }
 
 void OpHistory::_insert_delayed(const utime_t& now, TrackedOpRef op)
@@ -175,6 +179,13 @@ OpTracker::OpTracker(CephContext *cct_, bool tracking, uint32_t num_shards):
 }
 
 OpTracker::~OpTracker() {
+  // NOTE: on_shutdown() must be called before OpTracker destruction.
+  // This ensures the OpHistory service thread is stopped and all tracked
+  // operations are properly cleared before the OpTracker is destroyed.
+  // See usages in OSD::shutdown(), Monitor::shutdown(), MDSRank::~MDSRank(),
+  // and DaemonServer::~DaemonServer() for examples. This addition is a failsafe
+  history.on_shutdown();
+
   while (!sharded_in_flight_list.empty()) {
     ShardedTrackingData* sdata = sharded_in_flight_list.back();
     ceph_assert(NULL != sdata);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -136,9 +136,22 @@ DaemonServer::DaemonServer(MonClient *monc_,
                                                     cct->_conf->mgr_op_history_slow_op_threshold);
 }
 
-DaemonServer::~DaemonServer() {
+void DaemonServer::shutdown()
+{
+  bool expected = false;
+  if (!shutting_down.compare_exchange_strong(expected, true)) {
+    return;
+  }
+
+  op_tracker.on_shutdown();
+
   delete msgr;
+  msgr = nullptr;
   g_conf().remove_observer(this);
+}
+
+DaemonServer::~DaemonServer() {
+  shutdown();
 }
 
 class DaemonServerHook : public AdminSocketHook {

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -248,6 +248,7 @@ private:
   void tick();
   void maybe_adjust_stats_period();
   void schedule_tick_locked(double delay_sec);
+  std::atomic<bool> shutting_down = false;
 
   class OSDPerfMetricCollectorListener : public MetricListener {
   public:
@@ -317,11 +318,12 @@ public:
 
   DaemonServer(MonClient *monc_,
                Finisher &finisher_,
-	       DaemonStateIndex &daemon_state_,
-	       ClusterState &cluster_state_,
-	       PyModuleRegistry &py_modules_,
-	       LogChannelRef cl,
-	       LogChannelRef auditcl);
+        DaemonStateIndex &daemon_state_,
+        ClusterState &cluster_state_,
+        PyModuleRegistry &py_modules_,
+        LogChannelRef cl,
+        LogChannelRef auditcl);
+  void shutdown();
   ~DaemonServer() override;
 
   Dispatcher::dispatch_result_t ms_dispatch2(const ceph::ref_t<Message>& m) override;

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -77,6 +77,18 @@ Mgr::Mgr(MonClient *monc_, const MgrMap& mgrmap,
 
 Mgr::~Mgr()
 {
+}
+
+void Mgr::shutdown()
+{
+  if (initialized) {
+    AdminSocket *admin_socket = g_ceph_context->get_admin_socket();
+    admin_socket->unregister_commands(this);
+  }
+
+  finisher.wait_for_empty();
+  finisher.stop();
+
   server.shutdown();
 }
 

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -77,6 +77,7 @@ Mgr::Mgr(MonClient *monc_, const MgrMap& mgrmap,
 
 Mgr::~Mgr()
 {
+  server.shutdown();
 }
 
 void MetadataUpdate::finish(int r)

--- a/src/mgr/Mgr.h
+++ b/src/mgr/Mgr.h
@@ -74,6 +74,7 @@ public:
       Messenger *clientm_, Objecter *objecter_,
       LogChannelRef clog_, LogChannelRef audit_clog_);
   ~Mgr();
+  void shutdown();
 
   bool is_initialized() const {return initialized;}
   bool exceeded_initialization_expiration();

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -89,6 +89,10 @@ MgrStandby::MgrStandby(int argc, const char **argv) :
 }
 
 MgrStandby::~MgrStandby() {
+  if (active_mgr) {
+    active_mgr->shutdown();
+    active_mgr.reset();
+  }
   if (asok_hook) {
     g_ceph_context->get_admin_socket()->unregister_commands(asok_hook.get());
     asok_hook.reset();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79862

---

backport of https://github.com/ceph/ceph/pull/68901
parent tracker: https://tracker.ceph.com/issues/76334

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh