### PR TITLE
mgr/selftest: add QA tests for labeled and unlabeled perf schema

### DIFF
--- a/qa/suites/rados/mgr/tasks/4-units/perf_schema.yaml
+++ b/qa/suites/rados/mgr/tasks/4-units/perf_schema.yaml
@@ -1,0 +1,4 @@
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.mgr.test_perf_schema

--- a/qa/tasks/mgr/test_perf_schema.py
+++ b/qa/tasks/mgr/test_perf_schema.py
@@ -1,0 +1,116 @@
+import json
+
+from .mgr_test_case import MgrTestCase
+
+
+class TestPerfSchema(MgrTestCase):
+    MGRS_REQUIRED = 1
+
+    def setUp(self):
+        super().setUp()
+        self.setup_mgrs()
+        self._load_module("selftest")
+
+    def _get_schema_data(self):
+        """Call the selftest command and return the parsed JSON payload."""
+        raw = self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            "mgr", "self-test", "perf-schema-test")
+        return json.loads(raw)
+
+    def test_unlabeled_schema_structure(self):
+        """Test that get_unlabeled_perf_schema('osd', '0') returns a non-empty dict keyed by 'osd.0'."""
+        unlabeled = self._get_schema_data()["unlabeled"]
+
+        self.assertIsInstance(unlabeled, dict)
+        self.assertIn("osd.0", unlabeled)
+        svc_schema = unlabeled["osd.0"]
+        self.assertIsInstance(svc_schema, dict)
+        self.assertGreater(len(svc_schema), 0)
+
+        for counter_name, counter_info in svc_schema.items():
+            self.assertIsInstance(counter_info, dict,
+                                  "counter info for '{}' must be a dict".format(counter_name))
+
+    def test_labeled_schema_structure(self):
+        """Test that get_perf_schema('mon', '<id>') returns lists of {labels, counters} entries for every live mon."""
+        labeled = self._get_schema_data()["labeled"]
+
+        self.assertIsInstance(labeled, dict)
+        self.assertGreater(len(labeled), 0)
+
+        for full_name, daemon_schema in labeled.items():
+            self.assertTrue(full_name.startswith("mon."),
+                            "labeled schema key '{}' must start with 'mon.'".format(full_name))
+            self.assertIsInstance(daemon_schema, dict)
+
+            for group_name, entries in daemon_schema.items():
+                self.assertIsInstance(entries, list,
+                                      "group '{}' in '{}' must be a list".format(group_name, full_name))
+                self.assertGreater(len(entries), 0)
+
+                for entry in entries:
+                    self.assertIsInstance(entry, dict)
+                    self.assertIn("labels", entry)
+                    self.assertIn("counters", entry)
+                    self.assertIsInstance(entry["labels"], dict)
+                    self.assertIsInstance(entry["counters"], dict)
+
+                    for cname, cinfo in entry["counters"].items():
+                        self.assertIsInstance(cinfo, dict)
+
+    def test_unlabeled_wildcard(self):
+        """Test that get_unlabeled_perf_schema('', '') returns schema for every registered daemon including osd.0."""
+        wildcard = self._get_schema_data()["unlabeled_wildcard"]
+
+        self.assertIsInstance(wildcard, dict)
+        self.assertGreater(len(wildcard), 0)
+        self.assertIn("osd.0", wildcard)
+        for svc_key, svc_schema in wildcard.items():
+            self.assertIsInstance(svc_schema, dict,
+                                  "schema for '{}' must be a dict".format(svc_key))
+
+    def test_unlabeled_by_service(self):
+        """Test that get_unlabeled_perf_schema('osd', '') returns schema for all OSDs and nothing else."""
+        by_svc = self._get_schema_data()["unlabeled_by_service"]
+
+        self.assertIsInstance(by_svc, dict)
+        self.assertGreater(len(by_svc), 0)
+        for svc_key, svc_schema in by_svc.items():
+            self.assertTrue(svc_key.startswith("osd."),
+                            "by-service key '{}' must start with 'osd.'".format(svc_key))
+            self.assertIsInstance(svc_schema, dict)
+
+    def test_labeled_wildcard(self):
+        """Test that get_perf_schema('', '') returns a non-empty dict covering all daemons."""
+        wildcard = self._get_schema_data()["labeled_wildcard"]
+
+        self.assertIsInstance(wildcard, dict)
+        self.assertGreater(len(wildcard), 0)
+
+    def test_labeled_by_service(self):
+        """Test that get_perf_schema('mon', '') returns schema only for mon daemons."""
+        by_svc = self._get_schema_data()["labeled_by_service"]
+
+        self.assertIsInstance(by_svc, dict)
+        self.assertGreater(len(by_svc), 0)
+        for svc_key in by_svc:
+            self.assertTrue(svc_key.startswith("mon."),
+                            "by-service labeled key '{}' must start with 'mon.'".format(svc_key))
+
+    def test_empty_daemon_state(self):
+        """Test that both schema functions return an empty dict for a non-existent service type."""
+        empty_unlabeled = json.loads(
+            self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                "mgr", "self-test", "dump-unlabeled-perf-schema",
+                "__noexist__", ""))
+        self.assertIsInstance(empty_unlabeled, dict)
+        self.assertEqual(len(empty_unlabeled), 0,
+                         "get_unlabeled_perf_schema for unknown type must return empty dict")
+
+        empty_labeled = json.loads(
+            self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                "mgr", "self-test", "dump-perf-schema",
+                "__noexist__", ""))
+        self.assertIsInstance(empty_labeled, dict)
+        self.assertEqual(len(empty_labeled), 0,
+                         "get_perf_schema for unknown type must return empty dict")

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -86,6 +86,24 @@ class Module(MgrModule):
         self._self_test()
         return 0, '', 'Self-test succeeded'
 
+    @SelftestCLICommand('mgr self-test perf-schema-test', perm='r')
+    def perf_schema_test(self) -> Tuple[int, str, str]:
+        result = self._collect_perf_schema()
+        return 0, json.dumps(result, indent=2), ''
+
+    @SelftestCLICommand('mgr self-test dump-unlabeled-perf-schema', perm='r')
+    def dump_unlabeled_perf_schema(self,
+                                   svc_type: str,
+                                   svc_id: str) -> Tuple[int, str, str]:
+        '''Return get_unlabeled_perf_schema(svc_type, svc_id) as JSON.'''
+        return 0, json.dumps(self.get_unlabeled_perf_schema(svc_type, svc_id)), ''
+
+    @SelftestCLICommand('mgr self-test dump-perf-schema', perm='r')
+    def dump_perf_schema(self,
+                         svc_type: str,
+                         svc_id: str) -> Tuple[int, str, str]:
+        return 0, json.dumps(self.get_perf_schema(svc_type, svc_id)), ''
+
     @SelftestCLICommand('mgr self-test background start')
     def backgroun_start(self, workload: Workload) -> Tuple[int, str, str]:
         '''
@@ -364,11 +382,33 @@ class Module(MgrModule):
         assert (set(self.get_store_prefix("test").keys())
                 == {"testkey"} | existing_keys)
 
+    def _collect_perf_schema(self) -> Dict[str, Any]:
+        servers = self.list_servers()
+        mon_services = [
+            svc
+            for srv in servers
+            for svc in srv.get("services", [])
+            if svc["type"] == "mon"
+        ]
+
+        labeled: Dict[str, Any] = {}
+        for mon_svc in mon_services:
+            schema = self.get_perf_schema(mon_svc["type"], mon_svc["id"])
+            labeled.update(schema)
+
+        return {
+            "unlabeled":            self.get_unlabeled_perf_schema("osd", "0"),
+            "unlabeled_wildcard":   self.get_unlabeled_perf_schema("", ""),
+            "unlabeled_by_service": self.get_unlabeled_perf_schema("osd", ""),
+            "labeled":              labeled,
+            "labeled_wildcard":     self.get_perf_schema("", ""),
+            "labeled_by_service":   self.get_perf_schema("mon", ""),
+        }
+
     def _self_test_perf_counters(self) -> None:
         self.get_unlabeled_perf_schema("osd", "0")
+        self.get_perf_schema("osd", "0")
         self.get_unlabeled_counter("osd", "0", "osd.op")
-        # get_counter
-        # get_all_perf_coutners
 
     def _self_test_misc(self) -> None:
         self.set_uri("http://this.is.a.test.com")


### PR DESCRIPTION
PR #69181 (tracker #74693) refactored get_unlabeled_perf_schema_python() and get_perf_schema_python() in ActivePyModules.cc to use RAII Formatter::ObjectSection guards, but left test coverage gaps.

Add _collect_perf_schema() to selftest/module.py as a pure collector that calls all six query variants (exact, wildcard, by-service for both labeled and unlabeled APIs) and returns the raw results. Expose it via three CLI commands:

  ceph mgr self-test perf-schema-test
  ceph mgr self-test dump-unlabeled-perf-schema <svc_type> <svc_id>
  ceph mgr self-test dump-perf-schema <svc_type> <svc_id>

Add qa/tasks/mgr/test_perf_schema.py with seven test methods that assert the structural shape of each query variant: exact lookup keyed by 'osd.0', wildcard covering all daemons, by-service filtering, labeled schema list-of-entries structure (labels + counters dicts), and empty-result behaviour for a non-existent service type.

Add qa/suites/rados/mgr/tasks/4-units/perf_schema.yaml to slot the new test into the existing pick-one teuthology task suite.

Also call both get_unlabeled_perf_schema() and get_perf_schema() in _self_test_perf_counters() so that 'mgr self-test run' smoke-tests both APIs.

Fixes: https://tracker.ceph.com/issues/79553





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
