### PR TITLE
mgr/rook: relist resources after an expired watch

### DIFF
--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -308,7 +308,10 @@ class KubernetesResource(Generic[T]):
         if self.exception:
             e = self.exception
             self.exception = None
-            raise e  # Propagate the exception to the user.
+            if isinstance(e, ApiException) and e.status == 410:
+                self.thread = None
+            else:
+                raise e  # Propagate the exception to the user.
         if not self.thread or not self.thread.is_alive():
             resource_version = self._fetch()
             if _urllib3_supports_read_chunked:

--- a/src/pybind/mgr/rook/tests/test_rook.py
+++ b/src/pybind/mgr/rook/tests/test_rook.py
@@ -1,10 +1,10 @@
 import orchestrator
 from .fixtures import wait
 import pytest
-from unittest.mock import patch, PropertyMock
+from unittest.mock import Mock, patch, PropertyMock
 
 from rook.module import RookOrchestrator
-from rook.rook_cluster import RookCluster
+from rook.rook_cluster import ApiException, KubernetesResource, RookCluster
 
 
 # we use this intermediate class as .rook_cluster property
@@ -12,6 +12,46 @@ from rook.rook_cluster import RookCluster
 class FakeRookCluster(RookCluster):
     def __init__(self):
         pass
+
+
+class TestKubernetesResource(object):
+
+    def test_items_refetch_after_watch_expires(self):
+        expired = ApiException()
+        expired.status = 410
+
+        stale_item = Mock()
+        stale_item.metadata.name = 'stale'
+        fresh_item = Mock()
+        fresh_item.metadata.name = 'fresh'
+        response = Mock()
+        response.items = [fresh_item]
+        response.metadata.resource_version = 'new-version'
+        api_func = Mock(return_value=response)
+
+        resource = KubernetesResource(api_func)
+        resource._items = {'stale': stale_item}
+        resource.exception = expired
+        resource.thread = Mock()
+        resource.thread.is_alive.return_value = True
+
+        with patch('rook.rook_cluster._urllib3_supports_read_chunked', True):
+            with patch.object(resource, '_watch') as watch:
+                assert list(resource.items) == [fresh_item]
+
+        api_func.assert_called_once_with()
+        watch.assert_called_once_with('new-version')
+
+    def test_items_propagate_other_watch_errors(self):
+        error = ApiException()
+        error.status = 500
+        resource = KubernetesResource(Mock())
+        resource.exception = error
+
+        with pytest.raises(ApiException) as raised:
+            list(resource.items)
+
+        assert raised.value is error
 
 
 class TestRook(object):


### PR DESCRIPTION
## Summary

Kubernetes returns HTTP 410 when a watched resource version is no longer available. `KubernetesResource` currently caches that exception and propagates it to the next caller, so an orchestrator command can fail before the following command refreshes the resource list.

This was observed as `ceph nfs export ls` returning EINVAL while an immediate retry refreshed the resource list and succeeded.

Treat only HTTP 410 as an expired watch. Reset the watcher so the existing full-fetch path replaces stale items and starts a new watch from the current resource version. Other API errors continue to propagate unchanged.

Tracker: https://tracker.ceph.com/issues/79879

## Testing

- `pytest -q src/pybind/mgr/rook/tests/test_rook.py`: 3 passed
- `mypy --config-file=../../mypy.ini -m rook`: passed

## Checklist

- Tracker
  - [x] References tracker ticket
- Component impact
  - [x] Affects Orchestrator, opened tracker ticket
- Documentation
  - [x] No doc update is appropriate
- Tests
  - [x] Includes unit tests
  - [x] Includes bug reproducer