### PR TITLE
mgr/dashboard: send every namespace update to the chosen gateway

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -2172,7 +2172,10 @@ else:
                     contains_failure = True
 
             if load_balancing_group:
-                resp = NVMeoFClient().stub.namespace_change_load_balancing_group(
+                resp = NVMeoFClient(
+                    gw_group=gw_group,
+                    server_address=server_address
+                ).stub.namespace_change_load_balancing_group(
                     NVMeoFClient.pb2.namespace_change_load_balancing_group_req(
                         subsystem_nqn=nqn, nsid=int(nsid), anagrpid=load_balancing_group
                     )
@@ -2182,7 +2185,10 @@ else:
 
             if rw_ios_per_second or rw_mbytes_per_second or r_mbytes_per_second \
                or w_mbytes_per_second:
-                resp = NVMeoFClient().stub.namespace_set_qos_limits(
+                resp = NVMeoFClient(
+                    gw_group=gw_group,
+                    server_address=server_address
+                ).stub.namespace_set_qos_limits(
                     NVMeoFClient.pb2.namespace_set_qos_req(
                         subsystem_nqn=nqn,
                         nsid=int(nsid),
@@ -2196,7 +2202,10 @@ else:
                     contains_failure = True
 
             if trash_image is not None:
-                resp = NVMeoFClient().stub.namespace_set_rbd_trash_image(
+                resp = NVMeoFClient(
+                    gw_group=gw_group,
+                    server_address=server_address
+                ).stub.namespace_set_rbd_trash_image(
                     NVMeoFClient.pb2.namespace_set_rbd_trash_image_req(
                         subsystem_nqn=nqn,
                         nsid=int(nsid),

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_controller.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_controller.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ..controllers import nvmeof as nvmeof_controller
+from ..services import nvmeof_client
+
+
+@pytest.fixture(name='nvmeof_client_mock')
+def fixture_nvmeof_client_mock(monkeypatch):
+    """Stand in for NVMeoFClient, answering every RPC with a success.
+
+    The keyword arguments each instance is built with decide the gateway
+    the request goes to, and the mock records them.
+    """
+    monkeypatch.setattr(nvmeof_client, 'MessageToDict',
+                        lambda msg, **kwargs: {'namespaces': [{}]})
+
+    class SucceedingStub:
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: MagicMock(status=0, error_message='')
+
+    with patch.object(nvmeof_controller, 'NVMeoFClient') as client:
+        client.return_value.stub = SucceedingStub()
+        yield client
+
+
+@pytest.mark.parametrize('update', [
+    {'rbd_image_size': 1024 ** 3},
+    {'load_balancing_group': 3},
+    {'rw_ios_per_second': 100},
+    {'trash_image': True},
+    {'location': 'dc1'},
+])
+def test_namespace_update_uses_requested_gateway(nvmeof_client_mock, update):
+    nvmeof_controller.NVMeoFNamespace().update(
+        nqn='nqn.2016-06.io.spdk:cnode1', nsid='1', gw_group='group-b', **update)
+
+    assert nvmeof_client_mock.call_args_list
+    for call in nvmeof_client_mock.call_args_list:
+        assert call.kwargs.get('gw_group') == 'group-b'


### PR DESCRIPTION
`PATCH /api/nvmeof/subsystem/{nqn}/namespace/{nsid}`, also reachable as "ceph nvmeof namespace update", takes a gw_group and makes one gRPC call per namespace attribute the caller supplied. Most of those calls build their client with the group that was asked for:
```py
    NVMeoFClient(gw_group=gw_group, server_address=server_address)
```
The load balancing group, the QoS limits and the trash image flag instead construct a bare `NVMeoFClient()`, which ends up in `_get_default_service()`. That function refuses to pick a gateway once a cluster has more than one group, and raises
```
    Multiple NVMe-oF gateway groups are configured.
    Please specify the 'gw_group' parameter in the request.
```
So changing any of those three fails with HTTP 400 asking for the parameter the request already carried. `handle_nvmeof_error` only catches grpc errors, so this one escapes the handler untouched.

A request that changes several attributes at once is left half applied. "Resize to 2G and move to load balancing group 3" commits the resize on the requested gateway, then aborts on the group change, leaving the namespace with its new size and its old group.

The three were missed when `gw_group` first reached this handler in 485cb051192a6142104756ed88a900a5ba455179, which wired it into the resize call and left the two below it alone, and again when `trash_image` was added later.

Pass `gw_group` and `server_address` to those three as well.

With a single gateway `group _get_default_service()` returns that group, so it takes two before any of this shows up.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
