### PR TITLE
mgr/cephadm:  Include hostname in all cephadm logs and tracebacks

### DIFF
--- a/src/cephadm/cephadmlib/logging.py
+++ b/src/cephadm/cephadmlib/logging.py
@@ -5,6 +5,7 @@ import logging
 import logging.config
 import logging.handlers
 import os
+import socket
 import sys
 
 from typing import List, Any, Dict, Optional, cast
@@ -21,6 +22,24 @@ class _ExcludeErrorsFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         """Only lets through log messages with log level below WARNING ."""
         return record.levelno < logging.WARNING
+
+
+class _HostnameFilter(logging.Filter):
+    """Stamp every LogRecord with the local hostname.
+
+    Enables ``%(hostname)s`` in the format string so that every log line –
+    and every traceback – clearly identifies which host cephadm is running on.
+    This is especially valuable when backtraces from many nodes are all
+    forwarded to the same MON cluster log.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._hostname: str = socket.gethostname()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.hostname = self._hostname  # type: ignore[attr-defined]
+        return True
 
 
 class _termcolors(str, enum.Enum):
@@ -65,18 +84,21 @@ class _Colorizer(logging.Formatter):
 
 _common_formatters = {
     'cephadm': {
-        'format': '%(asctime)s %(thread)x %(levelname)s %(message)s',
+        'format': '%(asctime)s %(thread)x %(hostname)s %(levelname)s %(message)s',
     },
     'colorized': {
         '()': _Colorizer,
     },
 }
 
+# Shared filter entry reused by both logging config dicts.
+_hostname_filter_entry: Dict[str, Any] = {'()': _HostnameFilter}
 
 _log_file_handler = {
     'level': 'DEBUG',
     'class': 'logging.handlers.WatchedFileHandler',
     'formatter': 'cephadm',
+    'filters': ['hostname'],
     'filename': '%s/cephadm.log' % LOG_DIR,
 }
 
@@ -84,6 +106,7 @@ _syslog_handler = {
     'level': 'DEBUG',
     'class': 'logging.handlers.SysLogHandler',
     'formatter': 'cephadm',
+    'filters': ['hostname'],
     'address': '/dev/log',
 }
 
@@ -94,11 +117,15 @@ _syslog_handler = {
 _logging_config = {
     'version': 1,
     'disable_existing_loggers': True,
+    'filters': {
+        'hostname': _hostname_filter_entry,
+    },
     'formatters': _common_formatters,
     'handlers': {
         'console': {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
+            'filters': ['hostname'],
         },
         'log_file': _log_file_handler,
         'syslog': _syslog_handler,
@@ -120,7 +147,8 @@ _interactive_logging_config = {
     'filters': {
         'exclude_errors': {
             '()': _ExcludeErrorsFilter,
-        }
+        },
+        'hostname': _hostname_filter_entry,
     },
     'disable_existing_loggers': True,
     'formatters': _common_formatters,
@@ -128,7 +156,7 @@ _interactive_logging_config = {
         'console_stdout': {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
-            'filters': ['exclude_errors'],
+            'filters': ['exclude_errors', 'hostname'],
             'stream': sys.stdout,
         },
         'console_stderr': {
@@ -136,6 +164,7 @@ _interactive_logging_config = {
             'class': 'logging.StreamHandler',
             'stream': sys.stderr,
             'formatter': 'colorized',
+            'filters': ['hostname'],
         },
         'log_file': _log_file_handler,
         'syslog': _syslog_handler,

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -2019,11 +2019,11 @@ class CephadmServe:
             assert False, 'unsupported mode'
 
         if log_output:
-            self.log.debug(f'code: {code}')
+            self.log.debug(f'[{host}] code: {code}')
             if out:
-                self.log.debug(f'out: {out}')
+                self.log.debug(f'[{host}] out: {out}')
             if err:
-                self.log.debug(f'err: {err}')
+                self.log.debug(f'[{host}] err: {err}')
         if code and not error_ok:
             raise OrchestratorError(
                 f'cephadm exited with an error code: {code}, stderr: {err}')

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -320,7 +320,7 @@ class SSHManager:
         except Exception:
             address = host
         if log_command:
-            logger.debug(f'Running command: {rcmd}')
+            logger.debug(f'[{host}] Running command: {rcmd}')
 
         # Retry logic for transient connection/channel errors
         for attempt in range(self.SSH_RETRY_COUNT):


### PR DESCRIPTION
[mgr/cephadm]: Currently, cephadm log messages and error tracebacks contain no hostname,
making it impossible to identify which node a message originated from
when multiple SSH threads run concurrently or when tracebacks are
forwarded to the MON cluster log.

## Changes

- **`cephadmlib/logging.py`** — add `_HostnameFilter` to stamp
  `socket.gethostname()` onto every `LogRecord`; add `%(hostname)s`
  to the format string; wire the filter into all handlers
- **`serve.py`** — prefix `_run_cephadm` code/out/err debug lines
  with `[{host}]`
- **`ssh.py`** — prefix the `Running command` trace line with `[{host}]`

## Before / After

Before
2026-08-21T05:40:09 7f8ab0546640 ERROR OSError: [Errno 28] No space left on device

After
2026-08-21T09:40:09 7f8ab0546640 node42.example.com ERROR OSError: [Errno 28] No space left on device

No behaviour change — purely additive to log output.

Fixes: https://tracker.ceph.com/issues/79891
Signed-off-by: Swati Thombe <swati.thombe@ibm.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
