### PR TITLE
rgw: fix manifest end iterators before tail rule start

### DIFF
--- a/src/rgw/rgw_obj_manifest.cc
+++ b/src/rgw/rgw_obj_manifest.cc
@@ -115,6 +115,7 @@ void RGWObjManifest::obj_iterator::seek(uint64_t o)
     update_location();
     return;
   }
+
   if (o < manifest->get_head_size()) {
     rule_iter = manifest->rules.begin();
     stripe_ofs = 0;
@@ -139,6 +140,23 @@ void RGWObjManifest::obj_iterator::seek(uint64_t o)
   }
 
   const RGWObjManifestRule& rule = rule_iter->second;
+
+  /* A small head-only object can end before the first tail rule. For example,
+   * obj_end() for a 7-byte object (head_size==obj_size==7) with seek offset at 7, 
+   * while its tail manifest rule starts at 4 MiB. The head check above is ofs < head_size, 
+   * so that offset falls through to the tail rule calculation.
+   *
+   * Calculating (ofs - rule.start_ofs) below results in underflow for such small objects. 
+   * Comparing against obj_size or head_size instead would break multipart end iterators, 
+   * which need this calculation to determine the part after the last one. 
+   *
+   * start_ofs identifies whether the current ofs is covered by the manifest rule. */
+  if (ofs < rule.start_ofs) {
+    stripe_ofs = ofs;
+    stripe_size = 0;
+    update_location();
+    return;
+  }
 
   if (rule.part_size > 0) {
     cur_part_id = rule.start_part_num + (ofs - rule.start_ofs) / rule.part_size;

--- a/src/test/rgw/test_rgw_manifest.cc
+++ b/src/test/rgw/test_rgw_manifest.cc
@@ -384,6 +384,130 @@ TEST(TestRGWManifest, old_obj_manifest) {
 
 }
 
+/* Verify that obj_end() and its stripe offset stay within a non-multipart
+ * object. */
+static void check_end_iter(RGWObjManifest& manifest, uint64_t obj_size)
+{
+  auto end = manifest.obj_end(&dp);
+  ASSERT_EQ(end.get_ofs(), obj_size);
+  ASSERT_LE(end.get_stripe_ofs(), obj_size);
+}
+
+/* An empty object has identical begin and end iterators. */
+TEST(TestRGWManifest, end_iter_empty_obj) {
+  test_rgw_env env;
+  RGWObjManifest manifest;
+  rgw_bucket bucket;
+
+  test_rgw_init_bucket(&bucket, "buck");
+  rgw_obj head(bucket, "oid");
+
+  manifest.set_trivial_rule(512 * 1024, 4 * 1024 * 1024);
+  manifest.set_head(env.zonegroup.default_placement, head, 0);
+  manifest.set_obj_size(0);
+
+  check_end_iter(manifest, 0);
+  ASSERT_TRUE(manifest.obj_begin(&dp) == manifest.obj_end(&dp));
+}
+
+/* Test obj_end() for:
+ * - a tiny head-only object
+ * - an object smaller than the head limit
+ * - an object that exactly fills the head 
+ * - an object with tail stripes.
+ */
+struct end_iter_param {
+  const char *name;
+  uint64_t obj_size;
+  uint64_t head_max_size;
+  uint64_t stripe_size;
+  int expected_cur_stripe;
+};
+
+class EndIterTest : public ::testing::TestWithParam<end_iter_param> {};
+
+TEST_P(EndIterTest, obj_end_stays_in_object) {
+  const end_iter_param& p = GetParam();
+
+  test_rgw_env env;
+  RGWObjManifest manifest;
+  rgw_bucket bucket;
+  rgw_obj head;
+  RGWObjManifest::generator gen;
+  list<rgw_obj> objs;
+
+  ASSERT_NO_FATAL_FAILURE(gen_obj(env, p.obj_size, p.head_max_size, p.stripe_size, &manifest, env.zonegroup.default_placement, &bucket, &head, &gen, &objs));
+
+  ASSERT_NO_FATAL_FAILURE(check_end_iter(manifest, p.obj_size));
+  ASSERT_EQ(manifest.obj_end(&dp).get_cur_stripe(), p.expected_cur_stripe);
+
+  if (manifest.has_tail()) {
+    auto iter = manifest.obj_find(&dp, manifest.get_head_size());
+    ASSERT_FALSE(env.get_raw(iter.get_location()) == env.get_raw(head));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TestRGWManifest, EndIterTest,
+    ::testing::Values(
+        /*             name           obj_size    head_max_size stripe_size  cur_stripe */
+        end_iter_param{"tiny",                7,    512 * 1024, 4 * 1024 * 1024, 0},
+        end_iter_param{"under_head",  256 * 1024,   512 * 1024, 4 * 1024 * 1024, 0},
+        end_iter_param{"fills_head",  512 * 1024,   512 * 1024, 4 * 1024 * 1024, 1},
+        end_iter_param{"with_tail",  10 * 1024 * 1024, 512 * 1024, 4 * 1024 * 1024, 3}),
+    [](const testing::TestParamInfo<end_iter_param>& i) { return i.param.name; });
+
+/*  For a 16-part manifest, obj_end() must return part ID 17. Position 
+ * immediately after the final part. A part ID 0 would make obj_find_part()
+ * treat manifest as non-multipart
+ */
+TEST(TestRGWManifest, end_iter_multipart_part_id) {
+  test_rgw_env env;
+  const int num_parts = 16;
+  vector <RGWObjManifest> pm(num_parts);
+  rgw_bucket bucket;
+  uint64_t part_size = 10 * 1024 * 1024;
+  uint64_t stripe_size = 4 * 1024 * 1024;
+
+  for (int i = 0; i < num_parts; ++i) {
+    RGWObjManifest& manifest = pm[i];
+    RGWObjManifest::generator gen;
+    manifest.set_prefix("abc123");
+
+    manifest.set_multipart_part_rule(stripe_size, i + 1);
+
+    uint64_t ofs;
+    rgw_obj head;
+    for (ofs = 0; ofs < part_size; ofs += stripe_size) {
+      if (ofs == 0) {
+        rgw_placement_rule rule(env.zonegroup.default_placement.name, RGW_STORAGE_CLASS_STANDARD);
+        int r = gen.create_begin(g_ceph_context, &manifest, rule, nullptr, bucket, head);
+        ASSERT_EQ(r, 0);
+        continue;
+      }
+      gen.create_next(ofs);
+    }
+    if (ofs > part_size) {
+      gen.create_next(part_size);
+    }
+  }
+
+  RGWObjManifest m;
+
+  for (int i = 0; i < num_parts; i++) {
+    m.append(&dp, pm[i], env.zonegroup, env.zone_params);
+  }
+
+  auto end = m.obj_end(&dp);
+  ASSERT_EQ(end.get_ofs(), m.get_obj_size());
+  ASSERT_EQ(end.get_cur_part_id(), num_parts + 1);
+
+  /* A zero part ID marks a non-multipart manifest. Verify that the end
+   * iterator allows obj_find_part() to locate an existing multipart part. */
+  auto part = m.obj_find_part(&dp, 3);
+  ASSERT_NE(part, end);
+  ASSERT_EQ(part.get_cur_part_id(), 3);
+}
 
 int main(int argc, char **argv) {
   auto args = argv_to_vec(argc, argv);


### PR DESCRIPTION
### Problem: 

Fixes: https://tracker.ceph.com/issues/79851

For small S3 objects, where entire object can be stored in RADOS head object , `obj_end()` can select a tail rule that starts after the object end, which results in underflow error. 

An unconditional early return at `obj_size`  avoids the underflow, but prevents multipart end iterators from calculating the part ID immediately after the final part.

### Solution:

Use rule specific `start_ofs` to check the current offset instead of checking with `obj_size` or `head_size`. The iterator return empty stripe instead of performing invalid arthithemetic. Hence only small objects are guarded with this rule, while multipart end iterators can calculate the next partID normally. 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
