### PR TITLE
rgw/auth: invalidate and retry admin token on 401 in EC2Engine

### DIFF
--- a/qa/workunits/rgw/keystone-fake-server-s3test.py
+++ b/qa/workunits/rgw/keystone-fake-server-s3test.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# Enhanced Keystone fake server for testing EC2Engine admin token retry.
+#
+# Simulates:
+#   - POST /v3/auth/tokens         (admin token issuance)
+#   - POST /v3/s3tokens            (EC2 signature validation)
+#   - GET  /v3/users/{id}/credentials/OS-EC2/{access_key_id} (secret fetch)
+#   - Fernet key rotation: invalidates the current admin token so that
+#     s3tokens returns 401, forcing RGW to invalidate its cache and retry.
+
+from datetime import datetime, timedelta
+import logging
+import json
+import base64
+import hashlib
+import hmac
+import threading
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+DEFAULT_DOMAIN = {
+    'id': 'default',
+    'name': 'Default',
+}
+
+PROJECTS = {
+    'admin': {
+        'domain': DEFAULT_DOMAIN,
+        'id': 'a6944d763bf64ee6a275f1263fae0352',
+        'name': 'admin',
+    },
+    'deadbeef': {
+        'domain': DEFAULT_DOMAIN,
+        'id': 'b4221c214dd64ee6a464g2153fae3813',
+        'name': 'deadbeef',
+    },
+}
+
+USERS = {
+    'admin': {
+        'domain': DEFAULT_DOMAIN,
+        'id': '51cc68287d524c759f47c811e6463340',
+        'name': 'admin',
+    },
+    'deadbeef': {
+        'domain': DEFAULT_DOMAIN,
+        'id': '99gg485738df758349jf8d848g774392',
+        'name': 'deadbeef',
+    },
+}
+
+USERROLES = {
+    'admin': [
+        {'id': '51cc68287d524c759f47c811e6463340', 'name': 'admin'},
+    ],
+    'deadbeef': [
+        {'id': '98bd32184f854f393a72b932g5334124', 'name': 'Member'},
+    ],
+}
+
+# EC2 credentials: access_key_id -> (user_id, secret)
+EC2_CREDS = {
+    '04daaeb0960f46b9a2c9abbb25f1ad4a': {
+        'user_id': '99gg485738df758349jf8d848g774392',
+        'username': 'deadbeef',
+        'project': 'deadbeef',
+        'secret': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    },
+}
+
+# Admin tokens: token_id -> valid (bool)
+# After "Fernet rotation", the old admin token becomes invalid.
+ADMIN_TOKENS = {
+    'admin-token-1': True,
+    'admin-token-2': True,
+}
+
+CURRENT_ADMIN_TOKEN = 'admin-token-1'
+LOCK = threading.Lock()
+
+# When True, s3tokens and credentials endpoints will return 401 for
+# the old admin token, simulating a Fernet key rotation.
+FERNET_ROTATED = False
+
+COUNTERS = {
+    'auth_post': 0,
+    's3tokens_post': 0,
+    'credentials_get': 0,
+    's3tokens_401': 0,
+    's3tokens_401_retry': 0,
+    's3tokens_200': 0,
+}
+
+
+def _generate_token_result(username, project, expired=False):
+    userdata = USERS[username]
+    projectdata = PROJECTS[project]
+    userroles = USERROLES[username]
+
+    if expired:
+        then = datetime.now() - timedelta(hours=2)
+        issued_at = then.strftime('%Y-%m-%dT%H:%M:%SZ')
+        expires_at = (then + timedelta(hours=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    else:
+        now = datetime.now()
+        issued_at = now.strftime('%Y-%m-%dT%H:%M:%SZ')
+        expires_at = (now + timedelta(hours=24)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    return {
+        'token': {
+            'audit_ids': ['3T2dc1CGQxyJsHdDu1xkcw'],
+            'catalog': [],
+            'expires_at': expires_at,
+            'is_domain': False,
+            'issued_at': issued_at,
+            'methods': ['password'],
+            'project': projectdata,
+            'roles': userroles,
+            'user': userdata,
+        }
+    }
+
+
+def _generate_s3token_result(access_key_id):
+    cred = EC2_CREDS.get(access_key_id)
+    if not cred:
+        return None
+    userdata = USERS[cred['username']]
+    projectdata = PROJECTS[cred['project']]
+    userroles = USERROLES[cred['username']]
+    now = datetime.now()
+    issued_at = now.strftime('%Y-%m-%dT%H:%M:%SZ')
+    expires_at = (now + timedelta(hours=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    return {
+        'token': {
+            'audit_ids': ['3T2dc1CGQxyJsHdDu1xkcw'],
+            'catalog': [],
+            'expires_at': expires_at,
+            'is_domain': False,
+            'issued_at': issued_at,
+            'methods': ['s3credentials'],
+            'project': projectdata,
+            'roles': userroles,
+            'user': userdata,
+        }
+    }
+
+
+class HTTPRequestHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        logging.info("%s - %s" % (self.address_string(), format % args))
+
+    def do_GET(self):
+        if self.path == '/stats':
+            self._handle_stats()
+            return
+        if self.path == '/rotate':
+            self._handle_rotate()
+            return
+        if self.path.startswith('/v3/auth/tokens'):
+            self._handle_get_auth()
+            return
+        if '/credentials/OS-EC2/' in self.path:
+            self._handle_get_credentials()
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        if self.path == '/v3/auth/tokens':
+            self._handle_post_auth()
+            return
+        if self.path == '/v3/s3tokens':
+            self._handle_s3tokens()
+            return
+        self.send_response(400)
+        self.end_headers()
+
+    def _get_data(self):
+        length = int(self.headers.get('content-length'))
+        data = self.rfile.read(length).decode('utf8')
+        return json.loads(data)
+
+    def _set_data(self, data):
+        jdata = json.dumps(data)
+        self.wfile.write(jdata.encode('utf8'))
+
+    def _handle_stats(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        with LOCK:
+            stats = dict(COUNTERS)
+            stats['fernet_rotated'] = FERNET_ROTATED
+            stats['current_admin_token'] = CURRENT_ADMIN_TOKEN
+        self._set_data(stats)
+
+    def _handle_rotate(self):
+        global FERNET_ROTATED, CURRENT_ADMIN_TOKEN
+        with LOCK:
+            FERNET_ROTATED = True
+            ADMIN_TOKENS['admin-token-1'] = False
+            CURRENT_ADMIN_TOKEN = 'admin-token-2'
+        logging.info("Fernet rotation simulated: admin-token-1 invalidated, admin-token-2 is now current")
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self._set_data({'status': 'rotated', 'new_token': 'admin-token-2'})
+
+    def _is_valid_admin_token(self, token):
+        with LOCK:
+            return ADMIN_TOKENS.get(token, False)
+
+    def _handle_get_auth(self):
+        auth_token = self.headers.get('X-Subject-Token', None)
+        if auth_token and auth_token in TOKENS:
+            tokendata = TOKENS[auth_token]
+            if tokendata['expired'] and 'allow_expired=1' not in self.path:
+                self.send_response(404)
+                self.end_headers()
+            else:
+                self.send_response(200)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                result = _generate_token_result(tokendata['username'],
+                                                tokendata['project'],
+                                                tokendata['expired'])
+                self._set_data(result)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _handle_post_auth(self):
+        global COUNTERS
+        with LOCK:
+            COUNTERS['auth_post'] += 1
+        data = self._get_data()
+        user = data['auth']['identity']['password']['user']
+        if user['name'] == 'admin' and user['password'] == 'ADMIN':
+            with LOCK:
+                token = CURRENT_ADMIN_TOKEN
+            self.send_response(201)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('X-Subject-Token', token)
+            self.end_headers()
+            tokendata = TOKENS.get(token, TOKENS['admin-token-1'])
+            result = _generate_token_result(tokendata['username'],
+                                            tokendata['project'],
+                                            tokendata['expired'])
+            self._set_data(result)
+        else:
+            self.send_response(401)
+            self.end_headers()
+
+    def _handle_s3tokens(self):
+        global COUNTERS
+        with LOCK:
+            COUNTERS['s3tokens_post'] += 1
+
+        admin_token = self.headers.get('X-Auth-Token', '')
+        logging.info("s3tokens: admin_token=%s, fernet_rotated=%s" % (admin_token, FERNET_ROTATED))
+
+        # Check if admin token is valid
+        if not self._is_valid_admin_token(admin_token):
+            with LOCK:
+                COUNTERS['s3tokens_401'] += 1
+                if FERNET_ROTATED:
+                    COUNTERS['s3tokens_401_retry'] += 1
+            logging.info("s3tokens: returning 401 (admin token invalid: %s)" % admin_token)
+            self.send_response(401)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self._set_data({'error': {'message': 'The request you have made requires authentication.',
+                                       'code': 401, 'title': 'Unauthorized'}})
+            return
+
+        # Admin token is valid, validate the EC2 credentials
+        data = self._get_data()
+        cred = data.get('credentials', {})
+        access_key_id = cred.get('access', '')
+        string_to_sign_b64 = cred.get('token', '')
+        signature = cred.get('signature', '')
+
+        if access_key_id not in EC2_CREDS:
+            self.send_response(404)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self._set_data({'error': {'message': 'Could not find access key.',
+                                       'code': 404, 'title': 'Not Found'}})
+            return
+
+        # We don't fully verify the signature in the fake server,
+        # we just return a valid token if the access key exists.
+        result = _generate_s3token_result(access_key_id)
+        if result:
+            with LOCK:
+                COUNTERS['s3tokens_200'] += 1
+            logging.info("s3tokens: returning 200 for access_key=%s" % access_key_id)
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self._set_data(result)
+        else:
+            self.send_response(404)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self._set_data({'error': {'message': 'Could not find access key.',
+                                       'code': 404, 'title': 'Not Found'}})
+
+    def _handle_get_credentials(self):
+        global COUNTERS
+        with LOCK:
+            COUNTERS['credentials_get'] += 1
+
+        admin_token = self.headers.get('X-Auth-Token', '')
+        logging.info("credentials: admin_token=%s, path=%s" % (admin_token, self.path))
+
+        if not self._is_valid_admin_token(admin_token):
+            logging.info("credentials: returning 401 (admin token invalid: %s)" % admin_token)
+            self.send_response(401)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self._set_data({'error': {'message': 'The request you have made requires authentication.',
+                                       'code': 401, 'title': 'Unauthorized'}})
+            return
+
+        # Extract access_key_id from path: /v3/users/{user_id}/credentials/OS-EC2/{access_key_id}
+        parts = self.path.split('/')
+        try:
+            idx = parts.index('OS-EC2')
+            access_key_id = parts[idx + 1]
+        except (ValueError, IndexError):
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        cred = EC2_CREDS.get(access_key_id)
+        if cred:
+            logging.info("credentials: returning 200 for access_key=%s" % access_key_id)
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self._set_data({'credential': {'secret': cred['secret'],
+                                            'user_id': cred['user_id'],
+                                            'access': access_key_id}})
+        else:
+            self.send_response(404)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self._set_data({'error': {'message': 'Could not find credential.',
+                                       'code': 404, 'title': 'Not Found'}})
+
+
+# Keep the old TOKENS dict for compatibility
+TOKENS = {
+    'admin-token-1': {
+        'username': 'admin',
+        'project': 'admin',
+        'expired': False,
+    },
+    'admin-token-2': {
+        'username': 'admin',
+        'project': 'admin',
+        'expired': False,
+    },
+    'user-token-1': {
+        'username': 'deadbeef',
+        'project': 'deadbeef',
+        'expired': False,
+    },
+    'user-token-2': {
+        'username': 'deadbeef',
+        'project': 'deadbeef',
+        'expired': True,
+    },
+}
+
+
+def main():
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s %(levelname)s %(message)s')
+    port = int(os.environ.get('KEYSTONE_PORT', '5000'))
+    logging.info('Starting keystone-fake-server-s3test on port %d' % port)
+    logging.info('Endpoints:')
+    logging.info('  POST /v3/auth/tokens          - admin token issuance')
+    logging.info('  POST /v3/s3tokens              - EC2 signature validation')
+    logging.info('  GET  /v3/users/{id}/credentials/OS-EC2/{key} - secret fetch')
+    logging.info('  GET  /rotate                   - simulate Fernet key rotation')
+    logging.info('  GET  /stats                     - show counters')
+    server = HTTPServer(('0.0.0.0', port), HTTPRequestHandler)
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/qa/workunits/rgw/test-ec2-admin-token-retry.sh
+++ b/qa/workunits/rgw/test-ec2-admin-token-retry.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Regression test: EC2Engine must invalidate and retry the cached Keystone
+# admin token when Keystone returns 401 (e.g. after a Fernet key rotation).
+#
+# Scenario:
+#   1. Start a Keystone fake server + a vstart RGW cluster configured with
+#      Keystone S3 auth (rgw keystone token cache ttl = 5 to keep the test fast).
+#   2. Make an S3 request: RGW fetches admin-token-1, s3tokens succeeds.
+#   3. Simulate a Fernet key rotation: the fake server invalidates
+#      admin-token-1 and starts issuing admin-token-2.
+#   4. Wait for the secret cache to expire, then make another S3 request.
+#      RGW still has admin-token-1 cached and sends it to s3tokens.
+#
+# Expected:
+#   - WITHOUT the fix: s3tokens returns 401, EC2Engine misreports it as
+#     ERR_SIGNATURE_NO_MATCH and the request fails with SignatureDoesNotMatch.
+#     The stale admin token is never refreshed (auth_post stays at 1).
+#   - WITH the fix: EC2Engine detects the 401, invalidates the admin token
+#     cache, fetches admin-token-2 (auth_post becomes 2) and retries;
+#     the request succeeds.
+#
+# Usage (inside the ceph-build container, see ContainerBuild.md):
+#   python3 src/script/build-with-container.py -d rocky10 --no-prereqs -e custom -- \
+#       bash /ceph/qa/workunits/rgw/test-ec2-admin-token-retry.sh
+
+set -x
+
+# The build container lacks iproute, required by vstart.sh
+dnf install -y iproute 2>/dev/null || true
+
+CEPH_DIR=/ceph
+BUILD_DIR=$CEPH_DIR/build
+FAKE_SERVER=$CEPH_DIR/qa/workunits/rgw/keystone-fake-server-s3test.py
+RGW_PORT=8000
+KEYSTONE_PORT=5000
+
+# EC2 credentials served by the fake Keystone server
+ACCESS_KEY=04daaeb0960f46b9a2c9abbb25f1ad4a
+SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+cleanup() {
+    $CEPH_DIR/src/stop.sh 2>/dev/null || true
+    kill $KEYSTONE_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
+pip3 install boto3 2>/dev/null || true
+
+s3_list_buckets() {
+    python3 -c "
+import boto3
+s3 = boto3.client('s3',
+    endpoint_url='http://localhost:$RGW_PORT',
+    aws_access_key_id='$ACCESS_KEY',
+    aws_secret_access_key='$SECRET_KEY',
+    region_name='us-east-1')
+try:
+    resp = s3.list_buckets()
+    print('SUCCESS: list_buckets returned', len(resp.get('Buckets', [])), 'buckets')
+except Exception as e:
+    print('FAILED:', e)
+    exit(1)
+"
+}
+
+# Start fake Keystone server
+python3 $FAKE_SERVER > /tmp/keystone.log 2>&1 &
+KEYSTONE_PID=$!
+sleep 2
+curl -s http://localhost:$KEYSTONE_PORT/stats && echo " <- Keystone fake server up"
+
+# Start vstart cluster. Do NOT use CEPH_ARGS: it is injected into every
+# Ceph binary, including ceph-authtool, which chokes on rgw_* options.
+# Use vstart's -o option to inject the Keystone configuration instead.
+cd $BUILD_DIR
+rm -f keyring ceph.conf
+rm -rf dev out
+
+echo "Starting vstart cluster..."
+RGW=1 OSD=1 MON=1 MGR=0 MDS=0 $CEPH_DIR/src/vstart.sh -n -l --bluestore --without-dashboard \
+    -o "rgw s3 auth use keystone = true" \
+    -o "rgw keystone url = http://localhost:$KEYSTONE_PORT" \
+    -o "rgw keystone admin user = admin" \
+    -o "rgw keystone admin password = ADMIN" \
+    -o "rgw keystone admin project = admin" \
+    -o "rgw keystone admin domain = default" \
+    -o "rgw keystone api version = 3" \
+    -o "rgw keystone accepted roles = admin, Member" \
+    -o "rgw keystone token cache ttl = 5" \
+    -o "rgw keystone verify ssl = false" \
+    -o "debug rgw = 20" \
+    2>&1 || true
+
+echo "Waiting for RGW on port $RGW_PORT..."
+for i in $(seq 1 30); do
+    if curl -s http://localhost:$RGW_PORT/ >/dev/null 2>&1; then
+        echo "RGW is listening"
+        break
+    fi
+    sleep 2
+done
+
+echo "=== Keystone stats before any request ==="
+curl -s http://localhost:$KEYSTONE_PORT/stats | python3 -m json.tool
+
+# Request 1: admin token cache is cold, RGW fetches admin-token-1
+echo "=== Request 1 (admin token valid, must succeed) ==="
+s3_list_buckets
+R1=$?
+
+echo "=== Keystone stats after request 1 ==="
+curl -s http://localhost:$KEYSTONE_PORT/stats | python3 -m json.tool
+
+# Simulate Fernet key rotation: admin-token-1 is no longer accepted
+echo "=== Simulating Fernet key rotation ==="
+curl -s http://localhost:$KEYSTONE_PORT/rotate | python3 -m json.tool
+
+# Wait for the secret cache (rgw_keystone_token_cache_ttl = 5s) to expire so
+# that request 2 goes back to Keystone with the stale admin token
+echo "Waiting 6s for the secret cache to expire..."
+sleep 6
+
+# Request 2: RGW sends the stale admin-token-1 to s3tokens and gets a 401.
+# With the fix, EC2Engine invalidates the cache, fetches admin-token-2
+# and retries; without the fix the request fails with SignatureDoesNotMatch.
+echo "=== Request 2 (after rotation, must succeed with the fix) ==="
+s3_list_buckets
+R2=$?
+
+echo "=== Keystone stats after request 2 ==="
+curl -s http://localhost:$KEYSTONE_PORT/stats | python3 -m json.tool
+
+echo "=== RGW log: admin token retry messages ==="
+grep -i 'invalidating admin_token\|retrying with uncached' \
+    $BUILD_DIR/out/radosgw.*.log 2>/dev/null | tail -20 || echo "(no retry messages found)"
+
+echo ""
+if [ $R1 -eq 0 ] && [ $R2 -eq 0 ]; then
+    echo "PASS: request 1 and request 2 both succeeded"
+    exit 0
+else
+    echo "FAIL: request 1 (rc=$R1), request 2 (rc=$R2)"
+    echo "Without the fix, request 2 is expected to fail with SignatureDoesNotMatch."
+    exit 1
+fi

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -426,6 +426,10 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
 
   keystone_url.append("v3/s3tokens");
 
+  bool admin_token_retried = false;
+
+admin_token_retry:
+
   /* get authentication token for Keystone. */
   std::string admin_token;
   bool admin_token_cached = false;
@@ -469,6 +473,24 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
 
   /* send request */
   ret = validate.process(dpp, y);
+
+  /* If the admin token is invalid (e.g. after a Fernet key rotation on
+   * the Keystone side), Keystone will return 401. In that case, we
+   * invalidate the cached admin token and retry once with a fresh one,
+   * mirroring the behavior of TokenEngine::get_from_keystone. */
+  bool admin_token_unauthorized = (validate.get_http_status() ==
+    decltype(validate)::HTTP_STATUS_UNAUTHORIZED);
+
+  if (admin_token_unauthorized && admin_token_cached) {
+    ldpp_dout(dpp, 20) << "s3 keystone: invalidating admin_token cache due to 401" << dendl;
+    token_cache.invalidate_admin(dpp);
+
+    if (!admin_token_retried) {
+      ldpp_dout(dpp, 20) << "s3 keystone: retrying with uncached admin_token" << dendl;
+      admin_token_retried = true;
+      goto admin_token_retry;
+    }
+  }
 
   /* if the supplied signature is wrong, we will get 401 from Keystone */
   if (validate.get_http_status() ==
@@ -518,6 +540,10 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
   keystone_url.append("/credentials/OS-EC2/");
   keystone_url.append(std::string(access_key_id));
 
+  bool admin_token_retried = false;
+
+admin_token_retry:
+
   /* get authentication token for Keystone. */
   std::string admin_token;
   bool admin_token_cached = false;
@@ -544,6 +570,22 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
 
   /* send request */
   ret = secret.process(dpp, y);
+
+  /* If the admin token is invalid, Keystone will return 401. Invalidate
+   * the cached admin token and retry once with a fresh one. */
+  bool admin_token_unauthorized = (secret.get_http_status() ==
+    decltype(secret)::HTTP_STATUS_UNAUTHORIZED);
+
+  if (admin_token_unauthorized && admin_token_cached) {
+    ldpp_dout(dpp, 20) << "s3 keystone: invalidating admin_token cache due to 401" << dendl;
+    token_cache.invalidate_admin(dpp);
+
+    if (!admin_token_retried) {
+      ldpp_dout(dpp, 20) << "s3 keystone: retrying with uncached admin_token" << dendl;
+      admin_token_retried = true;
+      goto admin_token_retry;
+    }
+  }
 
   /* if the supplied access key isn't found, we will get 404 from Keystone */
   if (secret.get_http_status() ==


### PR DESCRIPTION
## Problem

`EC2Engine::get_from_keystone` and `EC2Engine::get_secret_from_keystone` do not invalidate the cached Keystone admin token when Keystone returns 401. If the admin token becomes invalid (e.g. after a Fernet key rotation on the Keystone side), every subsequent S3 request going through the EC2 auth path fails with `ERR_SIGNATURE_NO_MATCH` (-2027) because the stale admin token is never refreshed — until RGW is restarted.

This was observed in production: a scheduled Fernet key rotation at midnight UTC caused an immediate flood of HTTP 403 responses for all S3 EC2-authenticated requests (rclone clients). The RGW admin token was still cached and valid from RGW's perspective, but Keystone could no longer validate it with the rotated Fernet keys. The issue persisted for ~4.5 hours until RGW was restarted (clearing in-memory caches).

`TokenEngine::get_from_keystone` (the Swift/Keystone token auth path) already handles this correctly: on 401 with a cached admin token, it invalidates the cache, fetches a fresh admin token, and retries once.

## Solution

Apply the same admin token retry/invalidation logic to:
- `EC2Engine::get_from_keystone` — `POST /v3/s3tokens`
- `EC2Engine::get_secret_from_keystone` — `GET /v3/users/{id}/credentials/OS-EC2/{access_key_id}`

On 401 with a cached admin token: invalidate (`token_cache.invalidate_admin`), refetch via `get_admin_token`, retry once. The retry is bounded by `admin_token_retried` — no loop risk.

## Impact

- **Normal case** (admin token valid): zero overhead — no 401, no retry
- **401 case**: one additional Keystone admin token fetch (~100ms), only during token rotation events
- **Client bad signature**: the retry fetches a fresh admin token, Keystone returns 401 again, `ERR_SIGNATURE_NO_MATCH` is returned as before

## Test results

The bug was reproduced and the fix validated with an A/B test on Rocky Linux 10 (`build-with-container.py -d rocky10`), using the reproducer added in this PR (`qa/workunits/rgw/test-ec2-admin-token-retry.sh` + extended fake Keystone server `qa/workunits/rgw/keystone-fake-server-s3test.py`).

Scenario: S3 request → admin token cached → Fernet key rotation simulated (old admin token rejected) → secret cache expiry → second S3 request.

| Keystone fake server stats | build WITHOUT fix (`main`) | build WITH fix (this PR) |
|---|---|---|
| Request 1 (before rotation) | SUCCESS | SUCCESS |
| Request 2 (after rotation) | **FAILED: SignatureDoesNotMatch** | **SUCCESS** |
| `auth_post` (admin token fetches) | **1** — never refreshed after the 401 | **2** — cache invalidated, fresh token fetched |
| `s3tokens_post` | 2 | 3 (includes the retry) |
| `s3tokens_401` | 1 | 1 |
| `s3tokens_200` | 1 | **2** |
| RGW log | (silent — 401 misreported as bad client signature) | `s3 keystone: invalidating admin_token cache due to 401` + `s3 keystone: retrying with uncached admin_token` |

Without the fix, the second request fails exactly like the production incident: RGW keeps sending the stale admin token (no re-fetch) and interprets Keystone's 401 as a client signature error, so every S3 EC2-authenticated request returns 403 until RGW is restarted.

Code has been patched with Euria Code AI

Fixes: https://tracker.ceph.com/issues/79931

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes bug reproducer
  - [ ] No tests