### PR TITLE
umbrella: rgw/auth: Fixed Content-Type always needing to be in the signature and don't require x-amz-content-sha256 in signed headers

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -807,6 +807,12 @@ get_v4_canonical_headers(CephContext* cct,
         boost::container::small_vector<char, 64> buf(env_key.size());
         lowercase_dash_transform(env_key, buf.begin(), true);
         std::string_view lower_key{buf.data(), buf.size()};
+        // S3 has an exception for x-amz-content-sha256 because it's already
+        // signed as part of the HashedPayload
+        // TODO: make this specific to CredentialScope:service == s3
+        if (lower_key == "x-amz-content-sha256") {
+          continue;
+        }
         if (!canonical_hdrs_map.contains(lower_key)) {
         dout(5) << "Signature rejected: '" << lower_key
         << "' supplied, but not in CanonicalHeaders." << dendl;

--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -106,7 +106,7 @@ get_canon_resource(const DoutPrefixProvider *dpp, const char* const request_uri,
     if (iter == std::end(sub_resources)) {
       continue;
     }
-    
+
     if (initial) {
       dest.append("?");
       initial = false;
@@ -147,7 +147,7 @@ void rgw_create_s3_canonical_header(
     dest = method;
   }
   dest.append("\n");
-  
+
   if (content_md5) {
     dest.append(content_md5);
   }
@@ -774,12 +774,28 @@ get_v4_canonical_headers(CephContext* cct,
         dout(5) << "Signature rejected: CanonicalHeaders must contain `host`." << dendl;
         return boost::none;
     }
-    // If `content-type` is present, it must be in CanonicalHeaders
-    if (info.env->exists("CONTENT_TYPE") &&
-        !canonical_hdrs_map.contains("content-type")) {
-        dout(5) << "Signature rejected: 'content-type' supplied but not in CanonicalHeaders." << dendl;
-        return boost::none;
-    }
+    // Content-type is deliberately NOT required here. That page has a bullet
+    // saying that a content-type present in the request "must" be added to
+    // CanonicalHeaders, but the same page contradicts it twice:
+    //
+    //   "You must include the host header (HTTP/1.1) or the :authority
+    //    header (HTTP/2), and any `x-amz-*` headers in the signature. You
+    //    can optionally include other standard headers in the signature,
+    //    such as content-type."
+    //
+    //   "For the purpose of calculating an authorization signature, only
+    //    the host and any `x-amz-*` headers are required[.]"
+    //
+    // Real S3 accepts requests where content-type wasnt signed, and SDKs rely
+    // on that. minio-go's streaming signer straight up drops content-type from
+    // SignedHeaders every time (see pkg/signer/request-signature-streaming.go,
+    // `ignoredStreamingHeaders`), and thats the path every minio-go PutObject
+    // over plain HTTP takes. Rejecting these requests broke Mimir, Loki,
+    // Thanos and basically everything else built on thanos-io/objstore.
+    //
+    // The privilege escalation that CVE-2026-54330 describes comes from
+    // unsigned `x-amz-*` headers, and those are still rejected below.
+
     // Any header starting with `x-amz-` must be in CanonicalHeaders
     const auto& emap = info.env->get_map();
     static const std::string xamz{"HTTP_X_AMZ_"};
@@ -1321,7 +1337,7 @@ AWSv4ComplMulti::ReceiveChunkResult AWSv4ComplMulti::recv_chunk(
   size_t to_extract = \
     std::min(chunk_meta.get_data_size(stream_pos_was), buf_max);
   dout(30) << "AWSv4ComplMulti: stream_pos_was=" << stream_pos_was << ", to_extract=" << to_extract << dendl;
-  
+
   /* It's quite probable we have a couple of real data bytes stored together
    * with meta-data in the parsing_buf. We need to extract them and move to
    * the final buffer. This is a trade-off between frontend's read overhead

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -489,6 +489,11 @@ add_executable(unittest_rgw_tag test_rgw_tag.cc)
 add_ceph_unittest(unittest_rgw_tag)
 target_link_libraries(unittest_rgw_tag ${rgw_libs} ${UNITTEST_LIBS})
 
+# unittest_rgw_auth_sigv4
+add_executable(unittest_rgw_auth_sigv4 test_rgw_auth_sigv4.cc)
+add_ceph_unittest(unittest_rgw_auth_sigv4)
+target_link_libraries(unittest_rgw_auth_sigv4 ${rgw_libs} ${UNITTEST_LIBS})
+
 # unittest_rgw_http_client
 add_executable(unittest_rgw_http_client test_rgw_http_client.cc)
 add_ceph_unittest(unittest_rgw_http_client)

--- a/src/test/rgw/s3-tests/s3tests/functional/test_headers.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_headers.py
@@ -46,7 +46,7 @@ def _add_header_create_object(headers, client=None):
 
 
 def _add_header_create_bad_object(headers, client=None):
-    """ Create a new bucket, add an object with a header. This should cause a failure 
+    """ Create a new bucket, add an object with a header. This should cause a failure
     """
     bucket_name = get_new_bucket()
     if client == None:
@@ -114,7 +114,7 @@ def _add_header_create_bucket(headers, client=None):
 
 
 def _add_header_create_bad_bucket(headers=None, client=None):
-    """ Create a new bucket, w/header customizations that should cause a failure 
+    """ Create a new bucket, w/header customizations that should cause a failure
     """
     bucket_name = get_new_bucket_name()
     if client == None:
@@ -679,7 +679,11 @@ def test_sigv4_contenttype_good():
     assert(resp.status_code == 200)
 
 @pytest.mark.auth_aws4
-def test_sigv4_contenttype_bad():
+def test_sigv4_contenttype_unsigned():
+    # An unsigned Content-Type must be ACCEPTED: AWS documents it as optional
+    # in the signature, and real S3 accepts it. See the rationale in
+    # get_v4_canonical_headers() (src/rgw/rgw_auth_s3.cc).
+    # test_sigv4_xamz_bad still pins the CVE-2026-54330 behaviour.
     signer = _get_s3sigv4_signer()
     req = AWSRequest(
         method="GET",
@@ -689,7 +693,7 @@ def test_sigv4_contenttype_bad():
     req.headers["content-type"] = "application/octet-stream"
     assert req.url is not None
     resp = requests.get(req.url, headers=dict(req.headers), verify=get_config_ssl_verify())
-    assert(resp.status_code == 403)
+    assert(resp.status_code == 200)
 
 @pytest.mark.auth_aws4
 def test_sigv4_missing_header():
@@ -726,6 +730,31 @@ def test_sigv4_presigned_xamz_bad():
     req = AWSRequest(method="GET", url=get_config_endpoint() + "/")
     signer.add_auth(req)
     resp = requests.get(req.url, headers={'x-amz-malevolent': 'evil-header'})
+    assert(resp.status_code == 403)
+
+@pytest.mark.auth_aws4
+def test_sigv4_presigned_contenttype_unsigned():
+    # A presigned URL only signs `host`, so any uploader that sends its own
+    # content-type sends it unsigned. Of course every browser does this, so
+    # thats the most common S3 upload shape in the wild and it has to work.
+    signer = _get_s3sigv4_query_signer()
+    req = AWSRequest(method="GET", url=get_config_endpoint() + "/")
+    signer.add_auth(req)
+    resp = requests.get(req.url, headers={'content-type': 'application/octet-stream'},
+                        verify=get_config_ssl_verify())
+    assert(resp.status_code == 200)
+
+@pytest.mark.auth_aws4
+def test_sigv4_presigned_contenttype_plus_xamz_bad():
+    # ...but an unsigned x-amz- header sitting alongside an unsigned
+    # content-type still has to be rejected. Thats the combination a careless
+    # relaxation of the header checks would let slip through.
+    signer = _get_s3sigv4_query_signer()
+    req = AWSRequest(method="GET", url=get_config_endpoint() + "/")
+    signer.add_auth(req)
+    resp = requests.get(req.url, headers={'content-type': 'application/octet-stream',
+                                          'x-amz-malevolent': 'evil-header'},
+                        verify=get_config_ssl_verify())
     assert(resp.status_code == 403)
 
 @pytest.mark.auth_aws4

--- a/src/test/rgw/s3-tests/s3tests/functional/test_headers.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_headers.py
@@ -712,6 +712,38 @@ def test_sigv4_missing_header():
     assert(resp.status_code == 403)
 
 @pytest.mark.auth_aws4
+def test_sigv4_with_signed_content_sha256():
+    signer = _get_s3sigv4_signer()
+    req = AWSRequest(method="GET", url=get_config_endpoint() + "/")
+    signer.add_auth(req)
+    assert req.url is not None
+    assert 'x-amz-content-sha256' in req.headers
+    resp = requests.get(req.url, headers=dict(req.headers), verify=get_config_ssl_verify())
+    assert(resp.status_code == 200)
+
+@pytest.mark.auth_aws4
+def test_sigv4_without_signed_content_sha256():
+    # custom signer that excludes x-amz-content-sha256 from signed-headers
+    class CustomAuth(S3SigV4Auth):
+        def headers_to_sign(self, request):
+            saved = request.headers['x-amz-content-sha256']
+            del request.headers['x-amz-content-sha256']
+            result = super().headers_to_sign(request)
+            request.headers['x-amz-content-sha256'] = saved
+            return result
+
+    creds = Credentials(access_key=get_main_aws_access_key(),
+                        secret_key=get_main_aws_secret_key())
+    signer = CustomAuth(credentials=creds, service_name="s3",
+                        region_name=get_main_api_name())
+    req = AWSRequest(method="GET", url=get_config_endpoint() + "/")
+    signer.add_auth(req)
+    assert req.url is not None
+    assert 'x-amz-content-sha256' in req.headers
+    resp = requests.get(req.url, headers=dict(req.headers), verify=get_config_ssl_verify())
+    assert(resp.status_code == 200)
+
+@pytest.mark.auth_aws4
 def test_sigv4_xgoog_signed():
     signer = _get_s3sigv4_signer()
     req = AWSRequest(

--- a/src/test/rgw/test_rgw_auth_sigv4.cc
+++ b/src/test/rgw/test_rgw_auth_sigv4.cc
@@ -201,10 +201,6 @@ TEST_F(SigV4CanonicalHeaders, PresignedUnsignedXAmzHeadersAreRejected)
         canonicalize_presigned({{"HTTP_X_AMZ_ACL", "public-read"}}, boto2));
     EXPECT_FALSE(canonicalize_presigned(
         {{"HTTP_X_AMZ_COPY_SOURCE", "/victim/secret"}}, boto2));
-    /* botocore's query signer doesnt sign x-amz-content-sha256, so a
-     * presigned URL is exactly where forging it would matter. */
-    EXPECT_FALSE(canonicalize_presigned(
-        {{"HTTP_X_AMZ_CONTENT_SHA256", "UNSIGNED-PAYLOAD"}}, boto2));
     EXPECT_FALSE(canonicalize_presigned(
         {{"HTTP_X_AMZ_SECURITY_TOKEN", "forged"}}, boto2));
   }

--- a/src/test/rgw/test_rgw_auth_sigv4.cc
+++ b/src/test/rgw/test_rgw_auth_sigv4.cc
@@ -1,0 +1,347 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Tests for the SigV4 CanonicalHeaders/SignedHeaders checks that got added
+ * to fix CVE-2026-54330.
+ *
+ * Theres basically two kinds of test in here, and its worth knowing which
+ * one youre reading:
+ *
+ *  - REGRESSION tests, marked [REGRESSION], fail without the "unsigned
+ *    content-type is legal" fix and pass with it.
+ *  - INVARIANT guards, marked [INVARIANT], pass either way. Theyre only
+ *    here so that a future refactor cant quietly reopen CVE-2026-54330.
+ *    Please dont "simplify" them away because they look redundant, thats
+ *    literally the whole point of them.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+
+#include <boost/optional.hpp>
+
+#include "common/ceph_argparse.h"
+#include "common/ceph_context.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+
+#include "rgw_auth_s3.h"
+#include "rgw_common.h"
+
+using rgw::auth::s3::get_v4_canonical_headers;
+
+namespace {
+
+/* The headers a conformant SigV4 client always signs. Per AWS, `host` plus
+ * every `x-amz-*` header actually sent are the only ones that MUST be
+ * signed. */
+const std::string BASE_SIGNED{"host;x-amz-content-sha256;x-amz-date"};
+
+class SigV4CanonicalHeaders : public ::testing::Test {
+protected:
+  /* rgw_auth_s3.cc logs through `dout_context g_ceph_context`, so the
+   * tests have to run against the global context that global_init() sets
+   * up in main(). */
+  CephContext* cct = g_ceph_context;
+
+  void
+  SetUp() override
+  {
+    set_insecure(false);
+  }
+
+  void
+  set_insecure(bool val)
+  {
+    cct->_conf.set_val("rgw_sigv4_insecure", val ? "true" : "false");
+    cct->_conf.apply_changes(nullptr);
+  }
+
+  /* Build an RGWEnv shaped the way rgw::asio::ClientIO::init_env() shapes
+   * it (see rgw_asio_client.cc), then run get_v4_canonical_headers() over
+   * it. `extra_env` gets merged on top of a minimal well-formed request. */
+  boost::optional<std::string>
+  canonicalize(
+      const std::map<std::string, std::string>& extra_env,
+      const std::string& signedheaders,
+      bool using_qs = false,
+      bool force_boto2_compat = false,
+      bool with_default_xamz = true)
+  {
+    RGWEnv env;
+    env.init(cct);
+    env.set("REQUEST_METHOD", "PUT");
+    env.set("REQUEST_URI", "/testbucket/testobj");
+    env.set("SCRIPT_URI", "/testbucket/testobj");
+    env.set("HTTP_HOST", "rgw.example.com");
+    /* init_env() always sets these, and the boto2-compat path reads them. */
+    env.set("SERVER_PORT", "80");
+    if (with_default_xamz) {
+      env.set("HTTP_X_AMZ_DATE", "20260819T000000Z");
+      env.set("HTTP_X_AMZ_CONTENT_SHA256", "UNSIGNED-PAYLOAD");
+    }
+    for (const auto& [key, val] : extra_env) {
+      env.set(key, val);
+    }
+    req_info info(cct, &env);
+    return get_v4_canonical_headers(
+        cct, info, signedheaders, using_qs, force_boto2_compat);
+  }
+
+  /* A presigned request: SignedHeaders is just `host` and the X-Amz-*
+   * parameters ride in the query string instead of as headers, so the
+   * environment has no x-amz-* request headers of its own. */
+  boost::optional<std::string>
+  canonicalize_presigned(
+      const std::map<std::string, std::string>& extra_env,
+      bool force_boto2_compat = false)
+  {
+    return canonicalize(
+        extra_env, "host", true /* using_qs */, force_boto2_compat,
+        false /* with_default_xamz */);
+  }
+};
+
+/* [INVARIANT] Sanity check: a fully-covered request gets accepted. */
+TEST_F(SigV4CanonicalHeaders, FullySignedRequestIsAccepted)
+{
+  const auto canon = canonicalize({}, BASE_SIGNED);
+  ASSERT_TRUE(canon);
+  EXPECT_NE(canon->find("host:rgw.example.com\n"), std::string::npos);
+}
+
+/* [INVARIANT] `host` has to be in SignedHeaders. */
+TEST_F(SigV4CanonicalHeaders, UnsignedHostIsRejected)
+{
+  EXPECT_FALSE(canonicalize({}, "x-amz-content-sha256;x-amz-date"));
+}
+
+/*
+ * [INVARIANT] CVE-2026-54330 regression guard. This is the most important
+ * test in this file.
+ *
+ * A presigned-URL holder must not be able to bolt on `x-amz-*` headers
+ * that the signature never covered. If any of these start passing, the
+ * privilege escalation is back.
+ *
+ * The list is deliberately weighted towards headers that grant authority
+ * or change how the request gets interpreted, not just ACLs.
+ */
+TEST_F(SigV4CanonicalHeaders, UnsignedXAmzHeadersAreRejected)
+{
+  static const char* const attack_headers[] = {
+      /* the original CVE vectors */
+      "HTTP_X_AMZ_ACL",
+      "HTTP_X_AMZ_COPY_SOURCE",
+      "HTTP_X_AMZ_GRANT_FULL_CONTROL",
+      "HTTP_X_AMZ_GRANT_READ",
+      "HTTP_X_AMZ_GRANT_WRITE",
+      "HTTP_X_AMZ_GRANT_READ_ACP",
+      "HTTP_X_AMZ_GRANT_WRITE_ACP",
+      "HTTP_X_AMZ_META_INJECTED",
+      "HTTP_X_AMZ_METADATA_DIRECTIVE",
+      /* credential inputs. x-amz-content-sha256 gets covered in the
+     * presigned test instead, because BASE_SIGNED already signs it here. */
+      "HTTP_X_AMZ_SECURITY_TOKEN",
+      /* object-lock: an unrecoverable storage DoS if you can forge it */
+      "HTTP_X_AMZ_BYPASS_GOVERNANCE_RETENTION",
+      "HTTP_X_AMZ_OBJECT_LOCK_MODE",
+      "HTTP_X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE",
+      "HTTP_X_AMZ_OBJECT_LOCK_LEGAL_HOLD",
+      /* attacker picks the key protecting the victims upload */
+      "HTTP_X_AMZ_SERVER_SIDE_ENCRYPTION",
+      "HTTP_X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID",
+      "HTTP_X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM",
+      "HTTP_X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY",
+      "HTTP_X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5",
+      /* body-framing switches */
+      "HTTP_X_AMZ_DECODED_CONTENT_LENGTH",
+      "HTTP_X_AMZ_TRAILER",
+      /* stored open redirect, tagging, tiering */
+      "HTTP_X_AMZ_WEBSITE_REDIRECT_LOCATION",
+      "HTTP_X_AMZ_TAGGING",
+      "HTTP_X_AMZ_TAGGING_DIRECTIVE",
+      "HTTP_X_AMZ_STORAGE_CLASS",
+      /* an unsigned checksum header isnt any more trustworthy than any other
+     * unsigned x-amz- header when it shows up as a *request header* */
+      "HTTP_X_AMZ_CHECKSUM_CRC32C",
+  };
+  for (const char* const hdr : attack_headers) {
+    EXPECT_FALSE(canonicalize({{hdr, "attacker-supplied"}}, BASE_SIGNED))
+        << "unsigned " << hdr << " was accepted, CVE-2026-54330 is back";
+  }
+}
+
+/*
+ * [INVARIANT] The presigned-URL shape specifically.
+ *
+ * A presigned URL signs just `host` and carries its SignedHeaders in the
+ * query string (using_qs=true). Thats the exact shape CVE-2026-54330 got
+ * reported against, and the fixtures default (using_qs=false) doesnt
+ * exercise that path. Also covers the boto2-compat abstractor, which
+ * passes force_boto2_compat=true.
+ */
+TEST_F(SigV4CanonicalHeaders, PresignedUnsignedXAmzHeadersAreRejected)
+{
+  for (const bool boto2 : {false, true}) {
+    EXPECT_TRUE(canonicalize_presigned({}, boto2))
+        << "a bare presigned request should still canonicalize";
+    EXPECT_FALSE(
+        canonicalize_presigned({{"HTTP_X_AMZ_ACL", "public-read"}}, boto2));
+    EXPECT_FALSE(canonicalize_presigned(
+        {{"HTTP_X_AMZ_COPY_SOURCE", "/victim/secret"}}, boto2));
+    /* botocore's query signer doesnt sign x-amz-content-sha256, so a
+     * presigned URL is exactly where forging it would matter. */
+    EXPECT_FALSE(canonicalize_presigned(
+        {{"HTTP_X_AMZ_CONTENT_SHA256", "UNSIGNED-PAYLOAD"}}, boto2));
+    EXPECT_FALSE(canonicalize_presigned(
+        {{"HTTP_X_AMZ_SECURITY_TOKEN", "forged"}}, boto2));
+  }
+}
+
+/*
+ * [INVARIANT] The combination case. This is the one this patch actually
+ * puts at risk. An unsigned `x-amz-*` header still has to be rejected
+ * when theres also an unsigned content-type in the same request. A future
+ * refactor that relaxed the header checks "because content-type is
+ * unsigned anyway" would reopen the CVE, and only this test would catch
+ * it.
+ */
+TEST_F(
+    SigV4CanonicalHeaders,
+    UnsignedXAmzStillRejectedAlongsideUnsignedContentType)
+{
+  EXPECT_FALSE(canonicalize(
+      {{"CONTENT_TYPE", "application/json"}, {"HTTP_X_AMZ_ACL", "public-read"}},
+      BASE_SIGNED));
+  EXPECT_FALSE(canonicalize(
+      {{"CONTENT_TYPE", "application/json"},
+       {"HTTP_X_AMZ_COPY_SOURCE", "/victim/secret"}},
+      BASE_SIGNED));
+  EXPECT_FALSE(canonicalize(
+      {{"CONTENT_TYPE", "application/json"}, {"HTTP_X_AMZ_ACL", "public-read"}},
+      "host", true, false, false));
+}
+
+/*
+ * [INVARIANT] The x-amz scan pairs emap.lower_bound(), which uses the
+ * maps case-INsensitive ltstr_nocase comparator, with a separate
+ * boost::istarts_with guard. Thats a subtle pairing thats easy to break,
+ * so pin it with a case-variant key.
+ */
+TEST_F(SigV4CanonicalHeaders, UnsignedXAmzRejectedRegardlessOfEnvKeyCase)
+{
+  EXPECT_FALSE(canonicalize({{"http_x_amz_acl", "public-read"}}, BASE_SIGNED));
+  EXPECT_FALSE(canonicalize({{"Http_X_Amz_Acl", "public-read"}}, BASE_SIGNED));
+}
+
+/* [INVARIANT] rgw_sigv4_insecure=true restores the pre-CVE behaviour, and
+ * has to keep doing so. Multisite upgrades depend on it. */
+TEST_F(SigV4CanonicalHeaders, InsecureOptionRestoresOldBehaviour)
+{
+  set_insecure(true);
+  EXPECT_TRUE(canonicalize({{"HTTP_X_AMZ_ACL", "public-read"}}, BASE_SIGNED));
+  EXPECT_TRUE(canonicalize({{"CONTENT_TYPE", "application/json"}}, BASE_SIGNED));
+}
+
+/*
+ * [REGRESSION] The real-world breakage.
+ *
+ * AWS documents content-type as OPTIONAL in the signature:
+ *   "You must include the host header (HTTP/1.1) [...] and any `x-amz-*`
+ *    headers in the signature. You can optionally include other standard
+ *    headers in the signature, such as content-type."
+ *   "For the purpose of calculating an authorization signature, only the
+ *    host and any `x-amz-*` headers are required[.]"
+ * (IAM UG, "Create a signed AWS API request")
+ *
+ * Real AWS S3 accepts these requests, and so does every SDK-generated
+ * presigned PUT URL that a browser uploads to (of course browsers always
+ * set a content-type). minio-go's streaming signer also drops content-type
+ * from SignedHeaders every time (see
+ * pkg/signer/request-signature-streaming.go, ignoredStreamingHeaders),
+ * which is the path every minio-go PutObject over plain HTTP takes.
+ */
+TEST_F(SigV4CanonicalHeaders, UnsignedContentTypeIsAccepted)
+{
+  EXPECT_TRUE(canonicalize({{"CONTENT_TYPE", "application/json"}}, BASE_SIGNED));
+  /* and in the presigned shape, which is the common case in the wild */
+  EXPECT_TRUE(canonicalize_presigned({{"CONTENT_TYPE", "application/json"}}));
+}
+
+/*
+ * [INVARIANT] A signed content-type still lands in CanonicalHeaders,
+ * carrying the value that was actually in the request. Thats what makes a
+ * tampered content-type fail: it changes the string-to-sign, so the
+ * signature comparison downstream doesnt match.
+ */
+TEST_F(SigV4CanonicalHeaders, SignedContentTypeIsCanonicalized)
+{
+  const auto canon = canonicalize(
+      {{"CONTENT_TYPE", "application/json"}}, "content-type;" + BASE_SIGNED);
+  ASSERT_TRUE(canon);
+  EXPECT_NE(canon->find("content-type:application/json\n"), std::string::npos);
+
+  /* tampering changes the canonical string, so different string-to-sign */
+  const auto tampered = canonicalize(
+      {{"CONTENT_TYPE", "text/html"}}, "content-type;" + BASE_SIGNED);
+  ASSERT_TRUE(tampered);
+  EXPECT_NE(*canon, *tampered);
+}
+
+/*
+ * [REGRESSION] The request shape minio-go emits for a small single-shot
+ * PutObject over plain HTTP with TrailingHeaders enabled. Every x-amz-
+ * header IS signed; only content-type isnt.
+ *
+ * Note this only covers the canonicalization step. The trailing checksum
+ * itself rides in the aws-chunked body and gets parsed much later by
+ * AWSv4ComplMulti::complete() (rgw_auth_s3.cc), which doesnt run here.
+ * Thats also precisely why a trailer can never be visible to this
+ * function.
+ */
+TEST_F(SigV4CanonicalHeaders, MinioGoStreamingTrailerPutObjectIsAccepted)
+{
+  const auto canon = canonicalize(
+      {
+          {"CONTENT_TYPE", "application/json"},
+          {"CONTENT_LENGTH", "1234"},
+          {"HTTP_CONTENT_ENCODING", "aws-chunked"},
+          {"HTTP_X_AMZ_CONTENT_SHA256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER"},
+          {"HTTP_X_AMZ_DECODED_CONTENT_LENGTH", "1024"},
+          {"HTTP_X_AMZ_TRAILER", "x-amz-checksum-crc32c"},
+          {"HTTP_X_AMZ_CHECKSUM_ALGORITHM", "CRC32C"},
+      },
+      "content-encoding;content-length;host;x-amz-checksum-algorithm;"
+      "x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length;"
+      "x-amz-trailer");
+  ASSERT_TRUE(canon);
+  EXPECT_NE(
+      canon->find("x-amz-trailer:x-amz-checksum-crc32c\n"), std::string::npos);
+}
+
+} // anonymous namespace
+
+int
+main(int argc, char** argv)
+{
+  auto args = argv_to_vec(argc, argv);
+  auto cct = global_init(
+      nullptr, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  (void)cct;
+  common_init_finish(g_ceph_context);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Original trackers: https://tracker.ceph.com/issues/79674 https://tracker.ceph.com/issues/79803
Original PRs: https://github.com/ceph/ceph/pull/71192 https://github.com/ceph/ceph/pull/71292
Backport trackers: https://tracker.ceph.com/issues/79724 https://tracker.ceph.com/issues/79872


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
