### PR TITLE
rgw: Optional Yield Completion

### DIFF
--- a/src/rgw/driver/d4n/d4n_directory.cc
+++ b/src/rgw/driver/d4n/d4n_directory.cc
@@ -2,8 +2,10 @@
 #include <boost/asio/consign.hpp>
 #include <boost/algorithm/string.hpp>
 #include <memory>
-#include "common/async/blocked_completion.h"
-#include "common/dout.h" 
+#include "common/dout.h"
+
+#include "rgw/yield_completion.h"
+
 #include "d4n_directory.h"
 
 namespace rgw { namespace d4n {
@@ -36,19 +38,6 @@ auto async_exec(std::shared_ptr<connection> conn,
       initiate_exec{std::move(conn)}, token, req, resp);
 }
 
-template <typename... Types>
-void redis_exec(std::shared_ptr<connection> conn,
-                boost::system::error_code& ec,
-                const boost::redis::request& req,
-                boost::redis::response<Types...>& resp, optional_yield y)
-{
-  if (y) {
-    auto yield = y.get_yield_context();
-    async_exec(std::move(conn), req, resp, yield[ec]);
-  } else {
-    async_exec(std::move(conn), req, resp, ceph::async::use_blocked[ec]);
-  }
-}
 
 template <typename... Types>
 void redis_exec_cp(const DoutPrefixProvider* dpp,
@@ -62,12 +51,7 @@ void redis_exec_cp(const DoutPrefixProvider* dpp,
 	std::shared_ptr<connection> conn = pool->acquire(dpp);
 	try {
 
-  		if (y) {
-    		auto yield = y.get_yield_context();
-    		async_exec(conn, req, resp, yield[ec]);
-  		} else {
-    		async_exec(conn, req, resp, ceph::async::use_blocked[ec]);
-  		}
+    		async_exec(conn, req, resp, rgw::maybe_yield(dpp, y, ec));
 	} catch (const std::exception& e) {
 		//release the connection upon exception
     		pool->release(conn);
@@ -77,18 +61,6 @@ void redis_exec_cp(const DoutPrefixProvider* dpp,
 	pool->release(conn);
 }
 
-void redis_exec(std::shared_ptr<connection> conn,
-                boost::system::error_code& ec,
-                const boost::redis::request& req,
-    boost::redis::generic_response& resp, optional_yield y)
-{
-  if (y) {
-    auto yield = y.get_yield_context();
-    async_exec(std::move(conn), req, resp, yield[ec]);
-  } else {
-    async_exec(std::move(conn), req, resp, ceph::async::use_blocked[ec]);
-  }
-}
 
 void redis_exec_cp(const DoutPrefixProvider* dpp,
                 std::shared_ptr<rgw::d4n::RedisPool> pool,
@@ -100,12 +72,7 @@ void redis_exec_cp(const DoutPrefixProvider* dpp,
 	std::shared_ptr<connection> conn = pool->acquire(dpp);
 
 	try {
-  		if (y) {
-    			auto yield = y.get_yield_context();
-    			async_exec(conn, req, resp, yield[ec]);
-  		} else {
-    			async_exec(conn, req, resp, ceph::async::use_blocked[ec]);
-  		}	
+    		async_exec(conn, req, resp, rgw::maybe_yield(dpp, y, ec));
 	} catch (const std::exception& e) {
     			pool->release(conn);
     			throw;
@@ -134,7 +101,7 @@ void redis_exec_connection_pool(const DoutPrefixProvider* dpp,
 {
     if(!redis_pool)[[unlikely]]
     {
-	redis_exec(conn, ec, req, resp, y);
+        async_exec(conn, req, resp, rgw::maybe_yield(dpp, y, ec));
 	ldpp_dout(dpp, 0) << "Directory::" << __func__ << " not using connection-pool, it's using the shared connection " << dendl;
     }
     else[[likely]]
@@ -152,7 +119,7 @@ void redis_exec_connection_pool(const DoutPrefixProvider* dpp,
 {
     if(!redis_pool)[[unlikely]]
     {
-	redis_exec(conn, ec, req, resp, y);
+        async_exec(conn, req, resp, rgw::maybe_yield(dpp, y, ec));
 	ldpp_dout(dpp, 0) << "Directory::" << __func__ << " not using connection-pool, it's using the shared connection " << dendl;
     }
     else[[likely]]
@@ -1275,7 +1242,7 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, std::vector<CacheBlock>& 
 
   try {
     boost::system::error_code ec;
-    redis_exec(conn, ec, req, resp, y);
+    async_exec(conn, req, resp, rgw::maybe_yield(dpp, y, ec));
 
     if (ec) {
       ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;

--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -1,8 +1,9 @@
 #include "d4n_policy.h"
 
 #include "../../../common/async/yield_context.h"
-#include "common/async/blocked_completion.h"
 #include "common/split.h"
+
+#include "yield_completion.h"
 #include "rgw_perf_counters.h"
 
 namespace rgw { namespace d4n {
@@ -35,19 +36,6 @@ auto async_exec(std::shared_ptr<connection> conn,
       initiate_exec{std::move(conn)}, token, req, resp);
 }
 
-template <typename... Types>
-static inline void redis_exec(std::shared_ptr<connection> conn,
-                boost::system::error_code& ec,
-                const boost::redis::request& req,
-                boost::redis::response<Types...>& resp, optional_yield y)
-{
-  if (y) {
-    auto yield = y.get_yield_context();
-    async_exec(std::move(conn), req, resp, yield[ec]);
-  } else {
-    async_exec(std::move(conn), req, resp, ceph::async::use_blocked[ec]);
-  }
-}
 
 int LFUDAPolicy::init(CephContext* cct, const DoutPrefixProvider* dpp, asio::io_context& io_context, rgw::sal::Driver* _driver) {
   response<int, int, int, int> resp;
@@ -90,7 +78,7 @@ int LFUDAPolicy::init(CephContext* cct, const DoutPrefixProvider* dpp, asio::io_
     req.push("HSETNX", "lfuda", "age", age); /* Only set maximum age if it doesn't exist */
     req.push("EXEC");
   
-    redis_exec(conn, ec, req, resp, y);
+    async_exec(conn, req, resp, rgw::maybe_yield(dpp, y, ec));
 
     if (ec) {
       ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "() ERROR: " << ec.what() << dendl;
@@ -115,7 +103,7 @@ int LFUDAPolicy::age_sync(const DoutPrefixProvider* dpp, optional_yield y) {
     request req;
     req.push("HGET", "lfuda", "age");
       
-    redis_exec(conn, ec, req, resp, y);
+    async_exec(conn, req, resp, rgw::maybe_yield(dpp, y, ec));
 
     if (ec) {
       ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "() ERROR: " << ec.what() << dendl;
@@ -132,7 +120,7 @@ int LFUDAPolicy::age_sync(const DoutPrefixProvider* dpp, optional_yield y) {
       request req;
       req.push("HSET", "lfuda", "age", age);
 
-      redis_exec(conn, ec, req, ret, y);
+      async_exec(conn, req, ret, rgw::maybe_yield(dpp, y, ec));
 
       if (ec) {
 	ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "() ERROR: " << ec.what() << dendl;
@@ -157,7 +145,7 @@ int LFUDAPolicy::local_weight_sync(const DoutPrefixProvider* dpp, optional_yield
       request req;
       req.push("HMGET", "lfuda", "minLocalWeights_sum", "minLocalWeights_size");
 	
-      redis_exec(conn, ec, req, resp, y);
+      async_exec(conn, req, resp, rgw::maybe_yield(dpp, y, ec));
 
       if (ec) {
 	ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "() ERROR: " << ec.what() << dendl;
@@ -181,7 +169,7 @@ int LFUDAPolicy::local_weight_sync(const DoutPrefixProvider* dpp, optional_yield
                   "minLocalWeights_size", std::to_string(entries_map.size()), 
                   "minLocalWeights_address", dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
 
-	redis_exec(conn, ec, req, resp, y);
+	async_exec(conn, req, resp, rgw::maybe_yield(dpp, y, ec));
 
 	if (ec) {
 	  ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "() ERROR: " << ec.what() << dendl;
@@ -203,7 +191,7 @@ int LFUDAPolicy::local_weight_sync(const DoutPrefixProvider* dpp, optional_yield
     req.push("HSET", dpp->get_cct()->_conf->rgw_d4n_local_rgw_address, "avgLocalWeight_sum", std::to_string(weightSum), 
               "avgLocalWeight_size", std::to_string(entries_map.size()));
 
-    redis_exec(conn, ec, req, resp, y);
+    async_exec(conn, req, resp, rgw::maybe_yield(dpp, y, ec));
 
     if (ec) {
       ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "() ERROR: " << ec.what() << dendl;

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -67,6 +67,7 @@
 #include "rgw_zone.h"
 #include "rgw_restore.h"
 #include "rgw_multipart_meta_filter.h"
+#include "yield_completion.h"
 
 #include "services/svc_bilog_rados.h"
 #include "services/svc_bi_rados.h"
@@ -4724,12 +4725,7 @@ void MPRadosSerializer::stop_renewal()
 
   // wait for notification of completion
   boost::system::error_code ec_ignored;
-  if (y) {
-    cond.async_wait(lock, y.get_yield_context()[ec_ignored]);
-  } else {
-    maybe_warn_about_blocking(dpp);
-    cond.async_wait(lock, ceph::async::use_blocked[ec_ignored]);
-  }
+  cond.async_wait(lock, rgw::maybe_yield(dpp, y, ec_ignored));
 }
 
 int MPRadosSerializer::try_lock(const DoutPrefixProvider *dpp, ceph::timespan dur, optional_yield y)
@@ -4998,11 +4994,10 @@ int RadosRestore::initialize(const DoutPrefixProvider* dpp, optional_yield y,
   num_objs = n_objs;
   obj_names = o_names;
 
-  maybe_warn_about_blocking(dpp);
   for (auto i=0; i < num_objs; i++) {
     std::unique_ptr<fifo::FIFO> fifo_tmp;
     try {
-      fifo_tmp = fifo::FIFO::create(dpp, r, obj_names[i], neo_ioctx, ceph::async::use_blocked);
+      fifo_tmp = fifo::FIFO::create(dpp, r, obj_names[i], neo_ioctx, rgw::maybe_yield(dpp, y));
     } catch (const sys::system_error& e) {
       ldpp_dout(dpp, -1) << "creating fifo object for index=" << i
 	   << ", objname=" << obj_names[i] << " failed : " << e.what() << dendl;
@@ -5057,9 +5052,8 @@ int RadosRestore::push(const DoutPrefixProvider *dpp, optional_yield y,
 		int index, std::deque<ceph::buffer::list>&& items) {
   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
 		 << "Pushing entries to FIFO:" << obj_names[index] << dendl;
-  maybe_warn_about_blocking(dpp);
   try {
-    fifos[index]->push(dpp, items, ceph::async::use_blocked);
+    fifos[index]->push(dpp, items, rgw::maybe_yield(dpp, y));
   } catch (const sys::system_error& e) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 		 << ": unable to push to FIFO: " << obj_names[index]
@@ -5074,9 +5068,8 @@ int RadosRestore::push(const DoutPrefixProvider *dpp, optional_yield y,
   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
 		 << "Pushing entry to FIFO:" << obj_names[index] << dendl;
 
-  maybe_warn_about_blocking(dpp);
   try {
-    fifos[index]->push(dpp, std::move(bl), ceph::async::use_blocked);
+    fifos[index]->push(dpp, std::move(bl), rgw::maybe_yield(dpp, y));
   } catch (const sys::system_error& e) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 		 << ": unable to push to FIFO: " << obj_names[index]
@@ -5125,10 +5118,9 @@ int RadosRestore::list(const DoutPrefixProvider *dpp, optional_yield y,
   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
 		 << "Listing entries from FIFO:" << obj_names[index] << dendl;
 
-  maybe_warn_about_blocking(dpp);
   try {
     auto [lentries, lmark] = fifos[index]->list(dpp, marker,
-			  	 restore_entries, ceph::async::use_blocked);
+			  	 restore_entries, rgw::maybe_yield(dpp, y));
     entries.clear();
 
     for (const auto& entry : lentries) {
@@ -5186,9 +5178,8 @@ int RadosRestore::trim(const DoutPrefixProvider *dpp, optional_yield y,
   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__
 		 << "Trimming FIFO:" << obj_names[index] << " upto marker:" << marker << dendl;
 
-  maybe_warn_about_blocking(dpp);
   try {
-    fifos[index]->trim(dpp, std::string(marker), false, ceph::async::use_blocked);
+    fifos[index]->trim(dpp, std::string(marker), false, rgw::maybe_yield(dpp, y));
   } catch (const sys::system_error& e) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 		 << ": unable to trim FIFO: " << obj_names[index]

--- a/src/rgw/rgw_asio_thread.cc
+++ b/src/rgw/rgw_asio_thread.cc
@@ -23,6 +23,12 @@ thread_local bool is_asio_thread = false;
 
 void maybe_warn_about_blocking(const DoutPrefixProvider* dpp)
 {
+  // This is a logging function, by contract null pointers to logging
+  // functions are a no-op.
+  if (!dpp) {
+    return;
+  }
+
   // work on asio threads should be asynchronous, so warn when they block
   if (!is_asio_thread) {
     return;

--- a/src/rgw/yield_completion.h
+++ b/src/rgw/yield_completion.h
@@ -1,0 +1,129 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <boost/asio/async_result.hpp>
+
+#include "common/async/blocked_completion.h"
+#include "common/async/concepts.h"
+#include "common/async/redirect_error.h"
+#include "common/async/yield_context.h"
+
+#include "common/dout.h"
+
+#include "rgw_asio_thread.h"
+
+namespace rgw {
+namespace detail {
+/// CompletionToken wrapping an optional_yield and a DoutPrefixProvider*
+///
+/// \note I thought briefly of whether I could justify asserting on
+/// blocking in an asio thread. Unconditionally, since I didn't have a
+/// CephContext* either.
+///
+/// \note Obviously, I could not.
+///
+/// \note ;(
+struct maybe_completer {
+  const DoutPrefixProvider* dpp;
+  optional_yield y;
+};
+} // namespace detail
+
+/// Adapt `optional_yield` as a completion token for Asio operations
+///
+/// Rather than `use_blocked`, use this as a completion token when
+/// calling to neorados or similar functions expecting one.
+///
+/// \warning Errors from calls made using this adaptor will throw.
+///
+/// For example, with neorados:
+///
+/// \code{.cpp}
+/// try {
+///   rados.execute(o, ioc, std::move(op), maybe_yield(dpp, y));
+/// } catch (sys::system_error& e) {
+///   // …
+/// }
+///
+/// \endcode
+///
+/// \param[in] dpp Logging for `maybe_warn_about_blocking()`
+/// \param[in] y The yield_context, maybe. Maybe not.
+///
+/// \note I was originally going to write an `async_result`
+/// specialization for optional_yield.
+inline detail::maybe_completer
+maybe_yield(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  return {dpp, y};
+}
+
+/// Adapt `optional_yield` as a completion token for Asio operations,
+/// with error diversion
+///
+/// Rather than `use_blocked`, use this as a completion token when
+/// calling to neorados or similar functions expecting one.
+///
+/// \note This version diverts the error rather than throwing. The
+/// type of the error (the `disposition` in Asio parlance) depends on
+/// the operation. Basic neorados operations use
+/// `boost::system::error_code`. Coroutines use `std::exception_ptr`.
+///
+/// An example for neorados,
+/// \code{.cpp}
+///
+/// boost::system::error_code ec;
+/// rados.execute(o, ioc, std::move(op), maybe_yield(dpp, y, ec));
+///
+/// if (ec) {
+///   …
+/// }
+/// \endcode
+///
+/// \param[in] dpp Logging for `maybe_warn_about_blocking()`
+/// \param[in] y The yield_context, maybe. Maybe not.
+/// \param[in] disposition A disposition to redirect
+///
+/// \note I was going to add an overload to optional_yield for
+/// `operator []` to give ergonomic error redirection. Then I
+/// remembered to add maybe warn about blocking and discovered it
+/// required a DoutPrefixProvider*.
+template<ceph::async::disposition Disposition>
+inline auto
+maybe_yield(const DoutPrefixProvider* dpp, optional_yield y, Disposition& disposition)
+{
+  return ceph::async::redirect_error(maybe_yield(dpp, y), disposition);
+}
+} // namespace rgw
+
+namespace boost::asio {
+template <typename Signature>
+struct async_result<rgw::detail::maybe_completer, Signature> {
+  template <typename Initiation, typename RawCompletionToken, typename... Args>
+  static auto
+  initiate(Initiation&& initiation, RawCompletionToken&& token, Args&&... args)
+  {
+    if (token.y) {
+      return async_result<yield_context, Signature>::initiate(
+          std::forward<Initiation>(initiation), token.y.get_yield_context(),
+          std::forward<Args>(args)...);
+    } else {
+      maybe_warn_about_blocking(token.dpp);
+      return async_result<ceph::async::use_blocked_t, Signature>::initiate(
+          std::forward<Initiation>(initiation), ceph::async::use_blocked,
+          std::forward<Args>(args)...);
+    }
+  }
+};
+} // namespace boost::asio

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -523,10 +523,17 @@ add_ceph_unittest(unittest_rgw_http_client)
 target_link_libraries(unittest_rgw_http_client
   rgw_common ${rgw_libs} ${UNITTEST_LIBS})
 
+
 # unittest_rgw_rest_conn
 add_executable(unittest_rgw_rest_conn test_rgw_rest_conn.cc)
 add_ceph_unittest(unittest_rgw_rest_conn)
 target_link_libraries(unittest_rgw_rest_conn
+  rgw_common ${rgw_libs} ${UNITTEST_LIBS})
+
+# unittest_yield_completion
+add_executable(unittest_yield_completion test_yield_completion.cc)
+add_ceph_unittest(unittest_yield_completion)
+target_link_libraries(unittest_yield_completion
   rgw_common ${rgw_libs} ${UNITTEST_LIBS})
 
 if(WITH_RADOSGW_FDB)

--- a/src/test/rgw/test_yield_completion.cc
+++ b/src/test/rgw/test_yield_completion.cc
@@ -1,0 +1,75 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/spawn.hpp>
+
+#include <boost/system/system_error.hpp>
+
+#include <gtest/gtest.h>
+
+#include "common/async/context_pool.h"
+#include "common/async/yield_context.h"
+
+#include "common/dout.h"
+
+#include "rgw/rgw_asio_thread.h"
+#include "rgw/yield_completion.h"
+
+namespace asio = boost::asio;
+namespace sys = boost::system;
+
+static auto cct = std::make_unique<CephContext>(CEPH_ENTITY_TYPE_ANY);
+static NoDoutPrefix dp(cct.get(), ceph_subsys_rgw);
+
+static asio::awaitable<void>
+maybethrow(int code)
+{
+  if (code != 0) {
+    throw sys::system_error{code, sys::generic_category()};
+  }
+  co_return;
+}
+
+TEST(HybridToken, HybridToken)
+{
+  ceph::async::io_context_pool io_context{3, [] { is_asio_thread = true; }};
+  bool ran = false;
+  asio::spawn(
+      io_context,
+      [&](asio::yield_context yc) {
+        optional_yield y{yc};
+
+        ASSERT_NO_THROW(
+            asio::co_spawn(yc.get_executor(), maybethrow(0), rgw::maybe_yield(&dp, y)));
+        ASSERT_NO_THROW(co_spawn(
+            yc.get_executor(), maybethrow(0), rgw::maybe_yield(&dp, null_yield)));
+
+        ASSERT_THROW(
+            asio::co_spawn(yc.get_executor(), maybethrow(ENOENT), rgw::maybe_yield(&dp, y)),
+            sys::system_error);
+        ASSERT_THROW(
+            asio::co_spawn(
+                yc.get_executor(), maybethrow(ENOENT),
+                rgw::maybe_yield(&dp, null_yield)),
+            sys::system_error);
+
+        {
+          std::exception_ptr eptr;
+          ASSERT_NO_THROW(co_spawn(
+              yc.get_executor(), maybethrow(ENOENT), rgw::maybe_yield(&dp, y, eptr)));
+          ASSERT_EQ(-ENOENT, ceph::from_exception(eptr));
+        }
+        {
+          std::exception_ptr eptr;
+          ASSERT_NO_THROW(co_spawn(
+              yc.get_executor(), maybethrow(ENOENT), rgw::maybe_yield(&dp, null_yield, eptr)));
+          ASSERT_EQ(-ENOENT, ceph::from_exception(eptr));
+        }
+
+        ran = true;
+      },
+      rgw::maybe_yield(&dp, null_yield));
+  ASSERT_TRUE(ran);
+}


### PR DESCRIPTION
Introduce `rgw::maybe_yield`, a completion adapter that takes a `DoutPrefixProvider` and a `yield_context`, yields if non-null and blocks otherwise.

This is intended to replace use of `use_blocked` for calls that require a `CompletionToken` when we have a `yield_context` while not requiring a conditional at every call.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
