### PR TITLE
mds: take waiting flock on unlock if owner itself is waiting

### DIFF
--- a/qa/workunits/fs/misc/filelock_unlock_upgrade.py
+++ b/qa/workunits/fs/misc/filelock_unlock_upgrade.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+#
+# An owner that has a blocked lock request (e.g. LOCK_SH to LOCK_EX
+# upgrade) may also be holding a second lock over the same range.  A
+# real unlock from that owner has to drop both.  The MDS used to only
+# cancel the pending request, stranding the held lock in held_locks
+# with nobody left to release it, which blocked every other owner
+# forever.
+#
+
+from contextlib import contextmanager
+import ctypes
+import fcntl
+import signal
+import threading
+import time
+
+FILENAME = "filelock_unlock_upgrade"
+
+libc = ctypes.CDLL(None, use_errno=True)
+
+
+def raw_flock(fd, operation):
+    """flock(2) without CPython's PEP 475 EINTR retry loop.
+
+    The MDS answers the cancelled upgrade with EINTR; fcntl.flock() would
+    silently reissue it and paper over what we are trying to observe.
+    """
+    if libc.flock(ctypes.c_int(fd), ctypes.c_int(operation)) == 0:
+        return 0
+    return ctypes.get_errno()
+
+
+@contextmanager
+def timeout(seconds):
+    def timeout_handler(signum, frame):
+        raise InterruptedError
+
+    orig_handler = signal.signal(signal.SIGALRM, timeout_handler)
+    try:
+        signal.alarm(seconds)
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, orig_handler)
+
+
+def main():
+    # two open file descriptions -> two distinct flock owners
+    f1 = open(FILENAME, 'w')
+    f2 = open(FILENAME, 'w')
+
+    fcntl.flock(f1, fcntl.LOCK_SH | fcntl.LOCK_NB)
+    fcntl.flock(f2, fcntl.LOCK_SH | fcntl.LOCK_NB)
+
+    # A thread shares f1's file description, so it upgrades as the
+    # same owner.  f2's shared lock makes it block, putting that owner
+    # on the MDS waiting list while it still holds a shared lock.
+    def upgrade():
+        raw_flock(f1.fileno(), fcntl.LOCK_EX)
+
+    t = threading.Thread(target=upgrade)
+    t.start()
+    time.sleep(2)
+
+    # An unlock from an owner that is also waiting.  This triggered
+    # the bug.  Manipulating f1 makes the flock() interrupts the
+    # LOCK_EX in the thread (which then fails with EINTR).
+    fcntl.flock(f1, fcntl.LOCK_UN)
+
+    t.join(60)
+    if t.is_alive():
+        raise RuntimeError("blocked upgrade never completed")
+
+    fcntl.flock(f2, fcntl.LOCK_UN)
+    f1.close()
+    f2.close()
+
+    # No owner holds anything now, so a fresh owner must be granted
+    # immediately.
+    f3 = open(FILENAME, 'w')
+    with timeout(60):
+        try:
+            fcntl.flock(f3, fcntl.LOCK_EX)
+        except InterruptedError:
+            raise RuntimeError("stale lock left behind by unlock-while-waiting")
+    fcntl.flock(f3, fcntl.LOCK_UN)
+    f3.close()
+
+    print('ok')
+
+
+main()

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5378,15 +5378,19 @@ void Server::handle_client_file_setlock(const MDRequestRef& mdr)
   if (CEPH_LOCK_UNLOCK == set_lock.type) {
     list<ceph_filelock> activated_locks;
     MDSContext::vec waiters;
+    bool changed = false;
     if (lock_state->is_waiting(set_lock)) {
       dout(10) << " unlock removing waiting lock " << set_lock << dendl;
       lock_state->remove_waiting(set_lock);
-      cur->take_waiting(CInode::WAIT_FLOCK, waiters);
-    } else if (!interrupt) {
+      changed = true;
+    }
+    if (!interrupt) {
       dout(10) << " unlock attempt on " << set_lock << dendl;
       lock_state->remove_lock(set_lock, activated_locks);
-      cur->take_waiting(CInode::WAIT_FLOCK, waiters);
+      changed = true;
     }
+    if (changed)
+      cur->take_waiting(CInode::WAIT_FLOCK, waiters);
     mds->queue_waiters(waiters);
 
     respond_to_request(mdr, 0);


### PR DESCRIPTION
handle_client_file_setlock() treated "owner has a request on the waiting list" and "owner holds a lock" as mutually exclusive: if is_waiting() matched, it cancelled the pending request and returned without ever calling remove_lock().

Yet an owner that is upgrading a shared lock to exclusive is both at the same time.  Another unlock in that state (e.g. on another thread) therefore left the lock behind in `held_locks` without anybody actuall holding a lock.  All following attempts to take an exclusive lock on that file will block forever in "failed to add lock, waiting", retrying whenever some unrelated unlock woke WAIT_FLOCK and getting nowhere.

Recovery is only possible by restarting the MDS process; anything else, including client eviction, will not remove bogus `held_locks` entries.

Solution: cancel the waiting entry if there is one, and, unless this is an interrupt (which cancels the pending request only), also remove the held lock.

Fixes: https://tracker.ceph.com/issues/79952



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [X] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
