### PR TITLE
install-deps: install cargo-1.91 on ubuntu jammy/noble

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -119,6 +119,17 @@ ENDOFKEY
     fi
 }
 
+function install_recent_cargo_on_ubuntu {
+    local new=$1
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y cargo-$new
+    $SUDO update-alternatives --remove-all cargo || true
+    # later on, Build-Depends: cargo in debian/control will install the cargo package
+    # for /usr/bin/cargo. use update-alternatives to create a symlink at /usr/local/bin/cargo
+    # so that it a) doesn't conflict and b) takes precedence over the default version
+    $SUDO update-alternatives --install /usr/local/bin/cargo cargo /usr/bin/cargo-$new 1
+    $SUDO update-alternatives --auto cargo
+}
+
 function ensure_python3_sphinx_on_ubuntu {
     ci_debug "Running ensure_python3_sphinx_on_ubuntu() in install-deps.sh"
     local sphinx_command=/usr/bin/sphinx-build
@@ -460,6 +471,11 @@ else
                 $SUDO apt-get install -y gcc
 		ensure_decent_gcc_on_ubuntu 12 jammy
                 [ ! $NO_BOOST_PKGS ] && install_boost_on_ubuntu jammy
+                install_recent_cargo_on_ubuntu 1.91
+                ;;
+            *Noble*)
+                $SUDO apt-get install -y gcc
+                install_recent_cargo_on_ubuntu 1.91
                 ;;
             *)
                 $SUDO apt-get install -y gcc


### PR DESCRIPTION
the 'cargo' package for these ubuntu versions isn't new enough to build lancedb for rgw, but a separate 'cargo-1.91' package is available

install-deps.sh now installs this (in addition to the 'cargo' pacakage requested by debian/control) and uses update-alternatives to make cargo-1.91 the preferred version. this is done with a symlink at /usr/local/bin/cargo so it doesn't conflict with /usr/bin/cargo from the cargo package

making /usr/bin/cargo-1.91 available under the name cargo allows CMakeLists.txt to choose the right version with find_program()

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
