### PR TITLE
mds: account for where a rank's mds_lock time goes

### DIFF
--- a/doc/cephfs/index.rst
+++ b/doc/cephfs/index.rst
@@ -84,6 +84,7 @@ Administration
     MDS failover and standby configuration <standby>
     MDS Cache Configuration <cache-configuration>
     MDS Configuration Settings <mds-config-ref>
+    MDS Phase Times <mds-phase-times>
     MDS Quality of Service <mds-qos>
     Manual: ceph-mds <../../man/8/ceph-mds>
     Export over NFS <nfs>

--- a/doc/cephfs/mds-phase-times.rst
+++ b/doc/cephfs/mds-phase-times.rst
@@ -1,0 +1,271 @@
+.. _cephfs_mds_phase_times:
+
+================
+MDS Phase Times
+================
+
+An MDS rank does almost all of its work under a single lock, ``mds_lock``.
+Client requests dispatched by the messenger threads, journal completions run by
+the finisher, the periodic tick, cache trimming, client recall and log trimming
+all take it. That makes ``mds_lock`` -- rather than any one thread -- the
+resource a busy rank exhausts first, and it is why a rank rarely uses much more
+than one core no matter how many are available.
+
+Phase times answer the question that follows from this: of the wall clock a
+rank spends holding ``mds_lock``, how much goes to each kind of work? Knowing
+that is usually the difference between a useful scaling decision and a guess,
+because the remedies point in opposite directions -- more cache memory on the
+rank, more ranks, or a faster metadata pool.
+
+Tracking is off by default. Turn it on with
+:confval:`mds_enable_phase_tracker`, which may be changed at runtime:
+
+.. prompt:: bash #
+
+   ceph config set mds mds_enable_phase_tracker true
+
+Enabling it resets the counters, so everything reported afterwards describes
+only the period since it was turned on. See `Cost`_ for what it costs to leave
+on, and why it is not on by default.
+
+Reading the breakdown
+=====================
+
+For a one-shot view, ask a rank where its time went:
+
+.. prompt:: bash #
+
+   ceph tell mds.a dump phase times
+
+Abridged -- the real output lists every phase, busiest first:
+
+.. code-block:: json
+
+   {
+       "enabled": true,
+       "elapsed_sec": 3600.12,
+       "mds_lock": {
+           "acquisitions": 41203866,
+           "wait_sec": 8121.55,
+           "held_sec": 3216.44,
+           "utilization": 0.893
+       },
+       "accounted_sec": 3201.87,
+       "phases": [
+           {
+               "phase": "client_request",
+               "total_sec": 2402.11,
+               "count": 18442013,
+               "mean_ms": 0.130,
+               "pct_of_elapsed": 66.72,
+               "pct_of_accounted": 75.02
+           },
+           {
+               "phase": "client_caps",
+               "total_sec": 401.55,
+               "count": 9120441,
+               "mean_ms": 0.044,
+               "pct_of_elapsed": 11.15,
+               "pct_of_accounted": 12.54
+           },
+           {
+               "phase": "cache_trim",
+               "total_sec": 288.90,
+               "count": 3591,
+               "mean_ms": 80.45,
+               "pct_of_elapsed": 8.02,
+               "pct_of_accounted": 9.02
+           }
+       ]
+   }
+
+Everything is reported for the period since tracking was enabled. The numbers
+worth reading first:
+
+``mds_lock.utilization``
+  The share of the wall clock the rank spent holding ``mds_lock``. A rank
+  approaching ``1.0`` is saturated and cannot go faster without being split up,
+  whatever else is tuned. A rank well below it that still serves slow requests
+  is waiting on something else -- most often the metadata pool.
+
+``mds_lock.wait_sec``
+  Time other threads spent blocked on the lock. This is a sum over threads, so
+  it can exceed the elapsed time; what matters is its trend against
+  ``held_sec``.
+
+``phases[].pct_of_elapsed``
+  The share of the wall clock charged to each phase. Time is charged
+  *exclusively*: a phase is credited only with the time spent in it and not
+  with the time spent in phases it dispatched into, so the values are additive.
+
+``accounted_sec``
+  The sum of all phases. It should track ``mds_lock.held_sec`` closely -- a
+  little over it, since ``heap_release`` is counted here but runs without the
+  lock. A large *shortfall* means significant work is happening in a path that
+  is not yet instrumented.
+
+Phases
+======
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Phase
+     - Work charged to it
+   * - ``client_request``
+     - Handling ``CEPH_MSG_CLIENT_REQUEST``: path traversal, locking, journal
+       submission and replies.
+   * - ``client_caps``
+     - Capability and lease messages from clients, including cap flushes and
+       releases.
+   * - ``client_session``
+     - Session open/close, reconnect and reclaim.
+   * - ``peer_request``
+     - Requests from other ranks acting on behalf of a client request.
+   * - ``cache_message``
+     - Inter-MDS cache traffic: discover, resolve, dentry and inode updates.
+   * - ``migrator_message``
+     - Subtree import and export. A large share means the balancer is moving
+       metadata around, which is work not being spent on clients.
+   * - ``locker_message``
+     - Distributed lock traffic between ranks.
+   * - ``heartbeat_message``
+     - MDS load heartbeats consumed by the balancer.
+   * - ``table_message``, ``quiesce_message``, ``scrub_message``
+     - Anchor/snap table traffic, quiesce database replication, and scrub.
+   * - ``other_message``
+     - Anything else reaching ``MDSRank::handle_message()``. This should stay
+       near zero; a large share means a message class that deserves a phase of
+       its own is being dispatched in volume.
+   * - ``io_completion``
+     - Journal and object IO completions, run under ``mds_lock`` by the
+       objecter's finisher. This is the second half of a client request that
+       had to wait for the journal, so on a write-heavy rank it is charged
+       much of the work ``client_request`` appears to be missing.
+   * - ``finished_contexts``
+     - Queued contexts: waiters unblocked by an IO completion and drained on
+       the next pass through dispatch.
+   * - ``tick``
+     - The periodic tick, excluding ``locker_tick`` and ``balancer_tick``.
+   * - ``locker_tick``
+     - Periodic cap revocation and idle session detection.
+   * - ``balancer_tick``
+     - Periodic load balancing decisions.
+   * - ``cache_memory``
+     - Sampling the process memory footprint.
+   * - ``cache_trim``
+     - Trimming inodes and dentries out of the cache.
+   * - ``client_leases``
+     - Trimming client dentry leases.
+   * - ``client_recall``
+     - Asking clients to release capabilities so the cache can shrink.
+   * - ``heap_release``
+     - Returning free memory to the OS. Unlike the phases above this one runs
+       *without* ``mds_lock``, so it is excluded from the lock utilization, but
+       a slow release still stalls all cache trimming behind it.
+   * - ``log_trim``
+     - Trimming journal segments.
+
+Graphing it
+===========
+
+The same values are exported as perf counters, so they reach
+``mgr/prometheus`` and any other collector without further work:
+
+.. prompt:: bash #
+
+   ceph tell mds.a perf dump mds_phase
+
+Each phase is a time average: ``sum`` is the total time charged to the phase in
+nanoseconds and ``avgcount`` is the number of times it was entered, so the rate
+of ``sum`` is the fraction of a rank spent on that phase and
+``sum / avgcount`` is the mean cost of one entry. ``lock_held`` and
+``lock_wait`` are plain time counters; the rate of ``lock_held`` is the rank's
+utilization.
+
+Deciding what to do about it
+============================
+
+.. list-table::
+   :widths: 45 55
+   :header-rows: 1
+
+   * - What the breakdown shows
+     - What it usually means
+   * - ``utilization`` near 1, ``client_request``, ``io_completion`` and
+       ``client_caps`` dominating
+     - The rank is serialization-bound on real client work. Scale out: add
+       ranks, and pin subtrees to spread the load deliberately. More memory
+       will not help.
+   * - ``cache_trim`` plus ``client_recall`` a large share, ``mds_mem.rss``
+       near :confval:`mds_cache_memory_limit`, high ``mds.inodes_expired``
+     - The rank is thrashing its cache. Scale up:
+       raise :confval:`mds_cache_memory_limit` on that rank. See
+       :doc:`/cephfs/cache-configuration`.
+   * - ``utilization`` low but ``mds_server.req_*_latency`` and
+       ``mds_log.jlat`` high
+     - The rank is idle waiting for the metadata pool. Neither scaling
+       direction helps; the OSDs backing the metadata pool do.
+   * - ``migrator_message`` and ``balancer_tick`` a large share
+     - The balancer is thrashing subtrees. Pin the hot subtrees, or tune the
+       ephemeral pinning and ``mds_bal_*`` settings. See
+       :doc:`/cephfs/multimds`.
+   * - ``client_recall`` high with ``mds_server.*_recall_throttle`` climbing
+     - Clients are not releasing caps fast enough for recall to keep up.
+       Investigate the clients before adding MDS capacity.
+
+Cost
+====
+
+Accounting is not free, and because it happens under ``mds_lock`` its cost is
+serialized along with everything else. That is why it is off by default: a
+rank should not pay for instrumentation nobody is reading.
+
+Per instrumented scope the cost is two monotonic clock reads and the three
+atomic increments any Ceph time average already costs; per ``mds_lock``
+acquisition it is three more clock reads and three atomic increments. A client
+request typically passes through two acquisitions and two scopes -- once on
+dispatch, once when its journal completion runs -- so roughly ten clock reads
+and a dozen increments, a few hundred nanoseconds of added serialized work per
+request.
+
+Against a mean ``client_request`` cost in the hundreds of microseconds that is
+a fraction of a percent per request, and at 50,000 requests per second on a
+saturated rank it comes to one or two percent of the rank's capacity. It adds
+next to no cross-core cache line contention: every counter it touches except
+``heap_release`` is written under ``mds_lock`` and is therefore effectively
+single-writer.
+
+Those numbers assume ``clock_gettime`` is a vDSO read, which requires the host
+to be using the TSC clocksource:
+
+.. prompt:: bash #
+
+   cat /sys/devices/system/clocksource/clocksource0/current_clocksource
+
+On a host that has fallen back to ``hpet``, ``acpi_pm`` or an unaccelerated
+hypervisor clock, each read can cost hundreds of nanoseconds to microseconds
+instead of tens, and the overhead stops being negligible. Leave the tracker
+off on such hosts, or turn it on only for as long as it takes to answer a
+question. With it off the counters do not advance and the residual cost is one
+relaxed load of a boolean per lock acquisition.
+
+If you need to confirm the overhead on your own hardware rather than take
+these figures on trust, the honest measurement is a fixed metadata benchmark
+run twice against the same rank with the setting toggled between runs, since
+the tracker cannot measure its own cost.
+
+Limitations
+===========
+
+Phase times measure wall clock, not CPU time: a phase that blocks while
+holding ``mds_lock`` is charged for the time it blocks, which is the point --
+that time is denied to every other phase. But it does mean a large
+``client_request`` share is not by itself evidence that the rank is CPU-bound;
+confirm with ``mds_lock.utilization`` and, if a call-level breakdown is needed,
+with a profiler against ``ceph-mds``.
+
+Work that runs off ``mds_lock`` entirely -- the objecter, the purge queue,
+messenger threads -- is not covered here. Use ``perf dump`` sections
+``objecter``, ``purge_queue`` and ``finisher-*`` for those.

--- a/doc/cephfs/mds-phase-times.rst
+++ b/doc/cephfs/mds-phase-times.rst
@@ -25,8 +25,10 @@ Tracking is off by default. Turn it on with
    ceph config set mds mds_enable_phase_tracker true
 
 Enabling it resets the counters, so everything reported afterwards describes
-only the period since it was turned on. See `Cost`_ for what it costs to leave
-on, and why it is not on by default.
+only the period since it was turned on; work that was already in progress when
+it was turned on is not charged to any phase, since only part of it happened in
+the period being reported. See `Cost`_ for what it costs to leave on, and why
+it is not on by default.
 
 Reading the breakdown
 =====================
@@ -222,9 +224,10 @@ Accounting is not free, and because it happens under ``mds_lock`` its cost is
 serialized along with everything else. That is why it is off by default: a
 rank should not pay for instrumentation nobody is reading.
 
-Per instrumented scope the cost is two monotonic clock reads and the three
-atomic increments any Ceph time average already costs; per ``mds_lock``
-acquisition it is three more clock reads and three atomic increments. A client
+Per instrumented scope the cost is two monotonic clock reads, two loads of a
+generation counter, and the three atomic increments any Ceph time average
+already costs; per ``mds_lock`` acquisition it is three more clock reads and
+three atomic increments. A client
 request typically passes through two acquisitions and two scopes -- once on
 dispatch, once when its journal completion runs -- so roughly ten clock reads
 and a dozen increments, a few hundred nanoseconds of added serialized work per

--- a/doc/cephfs/multimds.rst
+++ b/doc/cephfs/multimds.rst
@@ -14,7 +14,9 @@ When should I use multiple active MDS daemons?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You should configure multiple active MDS daemons when your metadata performance
-is bottlenecked on the single MDS that runs by default.
+is bottlenecked on the single MDS that runs by default. To tell whether that is
+in fact the bottleneck, see :doc:`/cephfs/mds-phase-times`, which reports how
+much of the wall clock a rank spends holding ``mds_lock`` and on what.
 
 Adding more daemons may not increase performance on all workloads.  Typically,
 a single application running on a single client will not benefit from an

--- a/qa/cephfs/overrides/mds_phase_tracker/no.yaml
+++ b/qa/cephfs/overrides/mds_phase_tracker/no.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    cluster-conf:
+      mds:
+        mds_enable_phase_tracker: false

--- a/qa/cephfs/overrides/mds_phase_tracker/yes.yaml
+++ b/qa/cephfs/overrides/mds_phase_tracker/yes.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    cluster-conf:
+      mds:
+        mds_enable_phase_tracker: true

--- a/qa/suites/fs/functional/tasks/phase-times.yaml
+++ b/qa/suites/fs/functional/tasks/phase-times.yaml
@@ -1,0 +1,4 @@
+tasks:
+- cephfs_test_runner:
+    modules:
+      - tasks.cephfs.test_phase_times

--- a/qa/suites/fs/thrash/workloads/overrides/mds_phase_tracker
+++ b/qa/suites/fs/thrash/workloads/overrides/mds_phase_tracker
@@ -1,0 +1,1 @@
+.qa/cephfs/overrides/mds_phase_tracker

--- a/qa/tasks/cephfs/test_phase_times.py
+++ b/qa/tasks/cephfs/test_phase_times.py
@@ -1,0 +1,202 @@
+"""
+Exercise the MDS phase tracker, and above all its runtime toggle.
+
+Setting mds_enable_phase_tracker resets the counters and the mds_lock
+baselines from a config thread, without mds_lock, while phase timers are in
+flight on the messenger, finisher and upkeep threads.  These tests flip the
+setting under a metadata workload and check that what comes back out of
+`dump phase times` and the mds_phase perf counters stays sane: a phase or a
+lock delta accounted across a reset shows up as an absurd total, and an
+unsigned delta computed against a newer baseline shows up as a near-2^64
+one.
+"""
+
+import logging
+import time
+
+from teuthology.exceptions import CommandFailedError
+
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
+
+log = logging.getLogger(__name__)
+
+
+class TestPhaseTimes(CephFSTestCase):
+    CLIENTS_REQUIRED = 1
+    MDSS_REQUIRED = 1
+
+    # Enough metadata churn to keep every instrumented path busy: client
+    # requests, cap traffic, journal completions, and the upkeep threads.
+    WORKLOAD = """
+        mkdir -p load
+        while true; do
+          for i in $(seq 200); do
+            echo x > load/f$i
+            cat load/f$i > /dev/null
+          done
+          rm -f load/f*
+        done
+    """
+
+    # Nothing legitimate comes anywhere near this; a wrapped unsigned delta
+    # is ~1.8e10 seconds and a total accounted across a reset is at least as
+    # large as the rank's uptime.
+    ABSURD_SEC = 1e6
+
+    def setUp(self):
+        super().setUp()
+        # config_reset() in tearDown() puts this back
+        self._set_enabled(False)
+        self.workload = self.mount_a.run_shell_payload(self.WORKLOAD,
+                                                       wait=False,
+                                                       timeout=None,
+                                                       check_status=False)
+
+    def tearDown(self):
+        # stdin-killer stops the workload when its stdin goes away
+        self.workload.stdin.close()
+        try:
+            self.workload.wait()
+        except CommandFailedError:
+            pass
+        super().tearDown()
+
+    def _dump(self):
+        return self.fs.rank_asok(["dump", "phase", "times"])
+
+    def _perf(self):
+        return self.fs.rank_asok(["perf", "dump", "mds_phase"])["mds_phase"]
+
+    def _set_enabled(self, enable):
+        self.config_set('mds', 'mds_enable_phase_tracker',
+                        'true' if enable else 'false')
+        # the config change reaches the MDS asynchronously; poll tightly so
+        # that a toggle takes about as long as it takes to propagate, which
+        # test_reset_on_enable() relies on
+        self.wait_until_true(lambda: self._dump()["enabled"] == enable,
+                             timeout=60, period=1)
+
+    def _assert_sane(self, dump):
+        """The invariants a botched reset breaks."""
+        self.assertGreaterEqual(dump["elapsed_sec"], 0)
+        self.assertLess(dump["elapsed_sec"], self.ABSURD_SEC)
+
+        lock = dump["mds_lock"]
+        for k in ("wait_sec", "held_sec"):
+            self.assertGreaterEqual(lock[k], 0)
+            self.assertLess(lock[k], self.ABSURD_SEC, f"mds_lock.{k}")
+        # the lock cannot have been held for longer than the rank has been
+        # tracking, give or take the resolution of elapsed_sec
+        self.assertLess(lock["held_sec"], dump["elapsed_sec"] + 1)
+        self.assertGreaterEqual(lock["utilization"], 0)
+
+        self.assertLess(dump["accounted_sec"], self.ABSURD_SEC)
+        for phase in dump["phases"]:
+            self.assertGreaterEqual(phase["total_sec"], 0, phase["phase"])
+            self.assertLess(phase["total_sec"], dump["elapsed_sec"] + 1,
+                            phase["phase"])
+
+    def _phase(self, dump, name):
+        for phase in dump["phases"]:
+            if phase["phase"] == name:
+                return phase
+        self.fail(f"no {name} phase in {dump}")
+
+    def _wait_for_requests(self, count):
+        """Wait until the tracker has seen `count` client requests."""
+        self.wait_until_true(
+            lambda: self._phase(self._dump(), "client_request")["count"] > count,
+            timeout=120, period=1)
+
+    def test_dump_disabled(self):
+        """Disabled, the dump says so and reports nothing else."""
+        dump = self._dump()
+        self.assertFalse(dump["enabled"])
+        self.assertIn("note", dump)
+        self.assertNotIn("phases", dump)
+
+    def test_enabled_under_load(self):
+        """Enabled under load, every reported total advances and stays sane."""
+        self._set_enabled(True)
+        self._wait_for_requests(100)
+
+        dump = self._dump()
+        log.info(f"dump phase times: {dump}")
+        self._assert_sane(dump)
+
+        self.assertGreater(dump["elapsed_sec"], 0)
+        self.assertGreater(dump["accounted_sec"], 0)
+        self.assertGreater(dump["mds_lock"]["acquisitions"], 0)
+        self.assertGreater(dump["mds_lock"]["held_sec"], 0)
+        self.assertGreater(dump["mds_lock"]["utilization"], 0)
+
+        requests = self._phase(dump, "client_request")
+        self.assertGreater(requests["count"], 0)
+        self.assertGreater(requests["total_sec"], 0)
+
+        # the same numbers, by way of the perf counters
+        perf = self._perf()
+        log.info(f"perf dump mds_phase: {perf}")
+        self.assertGreater(perf["lock_acquisitions"], 0)
+        self.assertGreater(float(perf["lock_held"]), 0)
+        self.assertLess(float(perf["lock_held"]), self.ABSURD_SEC)
+        self.assertLess(float(perf["lock_wait"]), self.ABSURD_SEC)
+        self.assertGreater(perf["client_request"]["avgcount"], 0)
+        self.assertGreater(float(perf["client_request"]["sum"]), 0)
+        for name, phase in perf.items():
+            if isinstance(phase, dict):
+                self.assertLess(float(phase["sum"]), self.ABSURD_SEC, name)
+
+    def test_reset_on_enable(self):
+        """Re-enabling starts a fresh window rather than continuing the old."""
+        self._set_enabled(True)
+        self._wait_for_requests(1000)
+        # Let the first window run long enough that it is unambiguously
+        # longer, and busier, than the second: the assertions below compare
+        # the totals of a ~30s window against those of the window opened by
+        # the toggle a couple of seconds ago.
+        time.sleep(30)
+
+        before = self._dump()
+        self._assert_sane(before)
+        requests_before = self._phase(before, "client_request")["count"]
+        acquisitions_before = before["mds_lock"]["acquisitions"]
+
+        self._set_enabled(False)
+        self._set_enabled(True)
+
+        # the workload is still running, so these are not zero for long; what
+        # matters is that they restarted from zero and not from `before`
+        after = self._dump()
+        self._assert_sane(after)
+        self.assertLess(after["elapsed_sec"], before["elapsed_sec"])
+        self.assertLess(self._phase(after, "client_request")["count"],
+                        requests_before)
+        self.assertLess(after["mds_lock"]["acquisitions"], acquisitions_before)
+
+        perf = self._perf()
+        self.assertLess(perf["client_request"]["avgcount"], requests_before)
+        self.assertLess(perf["lock_acquisitions"], acquisitions_before)
+
+    def test_toggle_repeatedly_under_load(self):
+        """Flip the setting under load; in-flight timers must not corrupt it.
+
+        Each transition races the reset against timers already in flight on
+        every thread that takes mds_lock, which is the code path the tracker
+        has no other coverage for.
+        """
+        for i in range(10):
+            self._set_enabled(True)
+            self._assert_sane(self._dump())
+            time.sleep(0.5)
+            self._assert_sane(self._dump())
+            self._set_enabled(False)
+            log.info(f"toggle {i} done")
+
+        # and the rank is still serving, and still accounting correctly
+        self._set_enabled(True)
+        self._wait_for_requests(100)
+        dump = self._dump()
+        self._assert_sane(dump)
+        self.assertGreater(dump["accounted_sec"], 0)
+        self.mount_a.run_shell(["ls", "load"])

--- a/src/common/fair_mutex.h
+++ b/src/common/fair_mutex.h
@@ -3,17 +3,29 @@
 #pragma once
 
 #include "common/ceph_mutex.h"
+#include "common/ceph_time.h"
 
 #ifdef CEPH_DEBUG_MUTEX
 #include <thread> // for std::this_thread::get_id()
 #endif
 
+#include <atomic>
+#include <cstdint>
 #include <string>
 
 namespace ceph {
 /// a FIFO mutex
 class fair_mutex {
 public:
+  /// cumulative wait/hold accounting; only advances while tracking is enabled
+  struct stats {
+    uint64_t acquisitions = 0;
+    /// total time spent blocked in lock(), in nanoseconds
+    uint64_t wait_ns = 0;
+    /// total time the mutex was held, in nanoseconds
+    uint64_t held_ns = 0;
+  };
+
   fair_mutex(const std::string& name)
     : mutex{ceph::make_mutex(name)}
   {}
@@ -23,28 +35,39 @@ public:
 
   void lock()
   {
+    const bool track = track_stats.load(std::memory_order_relaxed);
+    const auto start = track ? mono_clock::now() : mono_clock::zero();
     std::unique_lock lock(mutex);
     const unsigned my_id = next_id++;
     cond.wait(lock, [&] {
       return my_id == unblock_id;
     });
     _set_locked_by();
+    _account_acquired(track, start);
   }
 
   bool try_lock()
   {
+    const bool track = track_stats.load(std::memory_order_relaxed);
     std::lock_guard lock(mutex);
     if (is_locked()) {
       return false;
     }
     ++next_id;
     _set_locked_by();
+    /* an uncontended acquisition, so there is no wait to account for */
+    _account_acquired(track, mono_clock::zero());
     return true;
   }
 
   void unlock()
   {
     std::lock_guard lock(mutex);
+    if (!mono_clock::is_zero(locked_at)) {
+      held_ns.fetch_add((mono_clock::now() - locked_at).count(),
+                        std::memory_order_relaxed);
+      locked_at = mono_clock::zero();
+    }
     ++unblock_id;
     _reset_locked_by();
     cond.notify_all();
@@ -53,6 +76,31 @@ public:
   bool is_locked() const
   {
     return next_id != unblock_id;
+  }
+
+  /**
+   * Enable or disable wait/hold time accounting.
+   *
+   * Disabled by default: when disabled lock() does not read the clock at
+   * all, so the only cost is a relaxed load of a bool. Enabling it costs
+   * three clock reads and three relaxed increments per acquisition, which is
+   * why it is opt-in -- see mds_enable_phase_tracker, the one caller that
+   * turns it on.
+   */
+  void set_track_stats(bool b) {
+    track_stats.store(b, std::memory_order_relaxed);
+  }
+  bool get_track_stats() const {
+    return track_stats.load(std::memory_order_relaxed);
+  }
+
+  /// a snapshot of the counters; safe to call without holding the mutex
+  stats get_stats() const {
+    stats s;
+    s.acquisitions = acquisitions.load(std::memory_order_relaxed);
+    s.wait_ns = wait_ns.load(std::memory_order_relaxed);
+    s.held_ns = held_ns.load(std::memory_order_relaxed);
+    return s;
   }
 
 #ifdef CEPH_DEBUG_MUTEX
@@ -72,10 +120,32 @@ private:
 #endif
 
 private:
+  /* called with `mutex` held, right after the mutex was acquired. `start` is
+   * when the caller began waiting, or zero if it never did. */
+  void _account_acquired(bool track, const mono_time& start) {
+    if (!track) {
+      return;
+    }
+    const auto now = mono_clock::now();
+    if (!mono_clock::is_zero(start)) {
+      wait_ns.fetch_add((now - start).count(), std::memory_order_relaxed);
+    }
+    acquisitions.fetch_add(1, std::memory_order_relaxed);
+    locked_at = now;
+  }
+
   unsigned next_id = 0;
   unsigned unblock_id = 0;
   ceph::condition_variable cond;
   ceph::mutex mutex;
+  std::atomic<bool> track_stats = false;
+  /* `locked_at` is only ever read or written with `mutex` held; it is left at
+   * zero when tracking is off, which is also how unlock() knows whether the
+   * current acquisition was accounted for. */
+  mono_time locked_at = mono_clock::zero();
+  std::atomic<uint64_t> acquisitions = 0;
+  std::atomic<uint64_t> wait_ns = 0;
+  std::atomic<uint64_t> held_ns = 0;
 #ifdef CEPH_DEBUG_MUTEX
   std::thread::id locked_by = {};
 #endif

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1320,6 +1320,26 @@ options:
   services:
   - mds
   with_legacy: true
+- name: mds_enable_phase_tracker
+  type: bool
+  level: advanced
+  desc: account for the time mds_lock is held by each kind of upkeep work
+  long_desc: Charge wall time to a phase (client requests, cache trim, client
+    recall, subtree export, log trim, ...) so that "ceph tell mds.X perf dump
+    mds_phase" and "ceph tell mds.X dump phase times" show where a rank spends
+    its time, and how much of the wall clock it spends holding mds_lock. Off by
+    default because the accounting is not free -- two monotonic clock reads per
+    instrumented scope and three per mds_lock acquisition. A client request
+    passes through two of each, so a few hundred nanoseconds of serialized work
+    per request where clock_gettime is a vDSO read, or one to two percent of a
+    rank serving 50k requests per second. It costs considerably more on a host
+    without a usable TSC clocksource. Enable it at runtime when investigating
+    where a rank spends its time.
+  default: false
+  services:
+  - mds
+  flags:
+  - runtime
 # Max number of completed ops to track
 - name: mds_op_history_size
   type: uint

--- a/src/mds/CMakeLists.txt
+++ b/src/mds/CMakeLists.txt
@@ -39,6 +39,7 @@ set(mds_srcs
   Mantle.cc
   Anchor.cc
   OpenFileTable.cc
+  MDSPhaseTracker.cc
   MDSPinger.cc
   MetricAggregator.cc
   MetricsHandler.cc

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -14577,17 +14577,23 @@ void MDCache::upkeep_main(void)
       lock.lock();
       if (upkeep_trim_shutdown.load())
         return;
-      check_memory_usage();
+      {
+        MDSPhaseTracker::Timer phase_timer(&mds->phase_tracker, l_mdsp_cache_memory);
+        check_memory_usage();
+      }
       if (mds->is_cache_trimmable()) {
         dout(20) << "upkeep thread trimming cache; last trim " << since << " ago" << dendl;
         bool active_with_clients = mds->is_active() || mds->is_clientreplay() || mds->is_stopping();
         if (active_with_clients) {
+          MDSPhaseTracker::Timer phase_timer(&mds->phase_tracker, l_mdsp_client_leases);
           trim_client_leases();
         }
         if (is_ready_to_trim_cache() || mds->is_standby_replay()) {
+          MDSPhaseTracker::Timer phase_timer(&mds->phase_tracker, l_mdsp_cache_trim);
           trim();
         }
         if (active_with_clients) {
+          MDSPhaseTracker::Timer phase_timer(&mds->phase_tracker, l_mdsp_client_recall);
           auto recall_flags = Server::RecallFlags::ENFORCE_MAX|Server::RecallFlags::ENFORCE_LIVENESS;
           if (cache_toofull()) {
             recall_flags = recall_flags|Server::RecallFlags::TRIM;
@@ -14606,7 +14612,13 @@ void MDCache::upkeep_main(void)
     if (since >= release_interval*.90) {
       /* XXX not necessary once MDCache uses PriorityCache */
       dout(10) << "releasing free memory" << dendl;
-      ceph_heap_release_free_memory();
+      /* NB: unlike the phases above this one runs without mds_lock, so it is
+       * excluded from the lock utilization but still worth accounting for --
+       * a slow tcmalloc release stalls all cache trimming behind it. */
+      {
+        MDSPhaseTracker::Timer phase_timer(&mds->phase_tracker, l_mdsp_heap_release);
+        ceph_heap_release_free_memory();
+      }
       upkeep_last_release = clock::now();
     } else {
       release_interval -= since;

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -712,6 +712,7 @@ void MDLog::log_trim_upkeep(void) {
   std::unique_lock mds_lock(mds->mds_lock);
   while (!upkeep_log_trim_shutdown.load()) {
     if (mds->is_active() || mds->is_stopping()) {
+      MDSPhaseTracker::Timer phase_timer(&mds->phase_tracker, l_mdsp_log_trim);
       trim();
     }
 

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -102,6 +102,11 @@ void MDSIOContextBase::complete(int r) {
   // already acquired.
   std::lock_guard l(mds->mds_lock);
 
+  /* Journal and object IO completions are the one large consumer of mds_lock
+   * that message dispatch does not account for; without this the phase totals
+   * fall well short of the time the lock is held on a write-heavy rank. */
+  MDSPhaseTracker::Timer phase_timer(&mds->phase_tracker, l_mdsp_io_completion);
+
   if (mds->is_daemon_stopping()) {
     dout(4) << "MDSIOContextBase::complete: dropping for stopping "
             << typeid(*this).name() << dendl;

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -439,6 +439,11 @@ void MDSDaemon::set_up_admin_socket()
                                      asok_hook,
                                      "dump metadata loads");
   ceph_assert(r == 0);
+  r = admin_socket->register_command("dump phase times",
+                                     asok_hook,
+                                     "dump time spent in each upkeep phase, "
+                                     "and mds_lock utilization");
+  ceph_assert(r == 0);
   r = admin_socket->register_command("dump snaps name=server,type=CephChoices,strings=--server,req=false",
                                      asok_hook,
                                      "dump snapshots");

--- a/src/mds/MDSPhaseTracker.cc
+++ b/src/mds/MDSPhaseTracker.cc
@@ -173,8 +173,9 @@ void MDSPhaseTracker::set_enabled(bool enable)
   if (enable) {
     reset();
   }
-  /* Enable the mutex accounting first and disable it last, so that the
-   * published lock stats never cover a period the phase counters do not. */
+  /* Enable the mutex accounting before the phases and disable it after, so
+   * that the lock stats always cover at least the period the phase counters
+   * do -- utilization is then never under-reported against them. */
   if (enable) {
     mds_lock.set_track_stats(true);
     enabled.store(true, std::memory_order_relaxed);
@@ -186,18 +187,24 @@ void MDSPhaseTracker::set_enabled(bool enable)
 
 void MDSPhaseTracker::reset()
 {
-  /* Only ever called with tracking disabled, so no Timer is concurrently
-   * incrementing the counters we are about to zero -- except an in-flight
-   * l_mdsp_heap_release, the one phase that does not run under mds_lock.
-   * The counters are atomic, so the worst case is one lost sample. */
-  logger->reset();
+  /* Called from handle_conf_change() without mds_lock, so Timers on other
+   * threads may be in flight over this reset: a message being dispatched, an
+   * IO completion, the tick, a cache or log trim.  Zero the counters and take
+   * the mds_lock baselines first and only then publish a new generation.  A
+   * Timer that started before the bump is dropped by its destructor, and one
+   * that starts after it necessarily started after the counters were zeroed,
+   * so nothing charges time from before the reset into counters that are
+   * supposed to describe only the period since it. */
+  {
+    std::lock_guard l(stats_mutex);
+    logger->reset();
+    const auto stats = mds_lock.get_stats();
+    baseline_lock_stats = stats;
+    last_lock_stats = stats;
+    since_ns = now_ns();
+  }
 
-  const auto stats = mds_lock.get_stats();
-  last_lock_stats = stats;
-  baseline_acquisitions.store(stats.acquisitions, std::memory_order_relaxed);
-  baseline_wait_ns.store(stats.wait_ns, std::memory_order_relaxed);
-  baseline_held_ns.store(stats.held_ns, std::memory_order_relaxed);
-  since_ns.store(now_ns(), std::memory_order_relaxed);
+  generation.fetch_add(1, std::memory_order_release);
 }
 
 int MDSPhaseTracker::phase_for_message(int message_type)
@@ -262,6 +269,7 @@ void MDSPhaseTracker::update_lock_stats()
 
   /* fair_mutex keeps running totals; publish the delta since the last call so
    * that the perf counters behave like every other Ceph counter. */
+  std::lock_guard l(stats_mutex);
   const auto now = mds_lock.get_stats();
   logger->tinc(l_mdsp_lock_wait, std::chrono::nanoseconds(
                  static_cast<int64_t>(now.wait_ns - last_lock_stats.wait_ns)));
@@ -284,21 +292,32 @@ void MDSPhaseTracker::dump(ceph::Formatter *f) const
   }
 
   /* Everything below is reported for the period since tracking was enabled,
-   * which is also the period the perf counters cover. */
-  const uint64_t elapsed_ns =
-    now_ns() - since_ns.load(std::memory_order_relaxed);
+   * which is also the period the perf counters cover.  It is all read under
+   * stats_mutex, which reset() also holds while zeroing: a reset landing
+   * mid-dump would otherwise report a baseline newer than the mds_lock
+   * snapshot it is subtracted from -- an unsigned wrap -- or zeroed phase
+   * totals against the elapsed time of the window before it. */
+  uint64_t elapsed_ns, lock_held_ns, lock_wait_ns, lock_acquisitions;
+  std::vector<std::tuple<uint64_t, uint64_t, int>> by_time;
+  by_time.reserve(num_phases);
+  {
+    std::lock_guard l(stats_mutex);
+    const auto stats = mds_lock.get_stats();
+    elapsed_ns = now_ns() - since_ns;
+    lock_acquisitions = stats.acquisitions - baseline_lock_stats.acquisitions;
+    lock_wait_ns = stats.wait_ns - baseline_lock_stats.wait_ns;
+    lock_held_ns = stats.held_ns - baseline_lock_stats.held_ns;
+    for (int i = 0; i < num_phases; ++i) {
+      const auto [ns, count] = logger->get_tavg_ns(l_mdsp_phase_first + i);
+      by_time.emplace_back(ns, count, i);
+    }
+  }
   const double elapsed = to_seconds(elapsed_ns);
   f->dump_float("elapsed_sec", elapsed);
 
-  const auto stats = mds_lock.get_stats();
-  const uint64_t lock_held_ns =
-    stats.held_ns - baseline_held_ns.load(std::memory_order_relaxed);
   f->open_object_section("mds_lock");
-  f->dump_unsigned("acquisitions", stats.acquisitions -
-                   baseline_acquisitions.load(std::memory_order_relaxed));
-  f->dump_float("wait_sec", to_seconds(
-                  stats.wait_ns -
-                  baseline_wait_ns.load(std::memory_order_relaxed)));
+  f->dump_unsigned("acquisitions", lock_acquisitions);
+  f->dump_float("wait_sec", to_seconds(lock_wait_ns));
   f->dump_float("held_sec", to_seconds(lock_held_ns));
   /* The single most actionable number here: a rank whose lock is busy for
    * most of the wall clock cannot go any faster without being split up. */
@@ -308,13 +327,9 @@ void MDSPhaseTracker::dump(ceph::Formatter *f) const
 
   /* Report the busiest phase first: the answer to "what is this rank doing?"
    * should be the first line of the output. */
-  std::vector<std::tuple<uint64_t, uint64_t, int>> by_time;
-  by_time.reserve(num_phases);
   uint64_t total_ns = 0;
-  for (int i = 0; i < num_phases; ++i) {
-    const auto [ns, count] = logger->get_tavg_ns(l_mdsp_phase_first + i);
-    total_ns += ns;
-    by_time.emplace_back(ns, count, i);
+  for (const auto& phase : by_time) {
+    total_ns += std::get<0>(phase);
   }
   std::sort(by_time.begin(), by_time.end(), std::greater<>());
 

--- a/src/mds/MDSPhaseTracker.cc
+++ b/src/mds/MDSPhaseTracker.cc
@@ -1,0 +1,336 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Clyso Technologies Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "MDSPhaseTracker.h"
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <iterator>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "common/Formatter.h"
+#include "common/ceph_context.h"
+#include "common/debug.h"
+#include "common/perf_counters.h"
+#include "common/perf_counters_collection.h"
+#include "include/ceph_assert.h"
+#include "include/ceph_fs.h" // for CEPH_MSG_CLIENT_*
+#include "mdstypes.h"        // for MDS_PORT_*
+#include "msg/Message.h"     // for MSG_MDS_*
+
+#define dout_context cct
+#define dout_subsys ceph_subsys_mds
+#undef dout_prefix
+#define dout_prefix *_dout << "mds.phase_tracker "
+
+thread_local MDSPhaseTracker::Timer *MDSPhaseTracker::Timer::tl_current = nullptr;
+
+namespace {
+
+/* Indexed by (counter id - l_mdsp_phase_first); kept in the same order as the
+ * enum so that dump() can name a phase without a second switch. */
+const char *phase_names[] = {
+  "client_request",
+  "client_caps",
+  "client_session",
+  "peer_request",
+  "cache_message",
+  "migrator_message",
+  "locker_message",
+  "heartbeat_message",
+  "table_message",
+  "quiesce_message",
+  "scrub_message",
+  "other_message",
+  "io_completion",
+  "finished_contexts",
+  "tick",
+  "locker_tick",
+  "balancer_tick",
+  "cache_memory",
+  "cache_trim",
+  "client_leases",
+  "client_recall",
+  "heap_release",
+  "log_trim",
+};
+static_assert(static_cast<int>(std::size(phase_names)) ==
+                MDSPhaseTracker::num_phases,
+              "phase_names must cover every l_mdsp_* phase counter");
+
+double to_seconds(uint64_t ns)
+{
+  return static_cast<double>(ns) / 1e9;
+}
+
+uint64_t now_ns()
+{
+  return static_cast<uint64_t>(
+    ceph::mono_clock::now().time_since_epoch().count());
+}
+
+} // anonymous namespace
+
+MDSPhaseTracker::MDSPhaseTracker(CephContext *cct, ceph::fair_mutex& mds_lock)
+  : cct(cct), mds_lock(mds_lock)
+{
+  PerfCountersBuilder plb(cct, "mds_phase", l_mdsp_first, l_mdsp_last);
+
+  plb.set_prio_default(PerfCountersBuilder::PRIO_USEFUL);
+  plb.add_time(l_mdsp_lock_wait, "lock_wait",
+               "Time spent waiting to acquire mds_lock");
+  plb.add_time(l_mdsp_lock_held, "lock_held",
+               "Time mds_lock was held; over wall time, rank utilization");
+  plb.add_u64_counter(l_mdsp_lock_acquisitions, "lock_acquisitions",
+                      "mds_lock acquisitions");
+
+  /* Every phase is a time_avg, so that "sum" is the total time charged to the
+   * phase and "avgcount" is the number of times it was entered. */
+  plb.add_time_avg(l_mdsp_client_request, "client_request",
+                   "Time handling client requests");
+  plb.add_time_avg(l_mdsp_client_caps, "client_caps",
+                   "Time handling client cap messages");
+  plb.add_time_avg(l_mdsp_client_session, "client_session",
+                   "Time handling client session messages");
+  plb.add_time_avg(l_mdsp_peer_request, "peer_request",
+                   "Time handling peer (slave) requests");
+  plb.add_time_avg(l_mdsp_cache_message, "cache_message",
+                   "Time handling MDS cache messages (discover, resolve, ...)");
+  plb.add_time_avg(l_mdsp_migrator_message, "migrator_message",
+                   "Time handling subtree import/export messages");
+  plb.add_time_avg(l_mdsp_locker_message, "locker_message",
+                   "Time handling inter-MDS lock messages");
+  plb.add_time_avg(l_mdsp_heartbeat_message, "heartbeat_message",
+                   "Time handling MDS load heartbeats");
+  plb.add_time_avg(l_mdsp_table_message, "table_message",
+                   "Time handling MDS table messages");
+  plb.add_time_avg(l_mdsp_quiesce_message, "quiesce_message",
+                   "Time handling quiesce db messages");
+  plb.add_time_avg(l_mdsp_scrub_message, "scrub_message",
+                   "Time handling scrub messages");
+  plb.add_time_avg(l_mdsp_other_message, "other_message",
+                   "Time handling other messages");
+  plb.add_time_avg(l_mdsp_io_completion, "io_completion",
+                   "Time completing journal and object IO under mds_lock");
+  plb.add_time_avg(l_mdsp_finished_contexts, "finished_contexts",
+                   "Time completing queued contexts (waiters unblocked by an "
+                   "IO completion)");
+  plb.add_time_avg(l_mdsp_tick, "tick",
+                   "Time in the periodic tick, excluding the phases below");
+  plb.add_time_avg(l_mdsp_locker_tick, "locker_tick",
+                   "Time in periodic locker upkeep (cap revocation, idle "
+                   "sessions)");
+  plb.add_time_avg(l_mdsp_balancer_tick, "balancer_tick",
+                   "Time in periodic balancer upkeep");
+  plb.add_time_avg(l_mdsp_cache_memory, "cache_memory",
+                   "Time sampling memory usage");
+  plb.add_time_avg(l_mdsp_cache_trim, "cache_trim",
+                   "Time trimming the metadata cache");
+  plb.add_time_avg(l_mdsp_client_leases, "client_leases",
+                   "Time trimming client leases");
+  plb.add_time_avg(l_mdsp_client_recall, "client_recall",
+                   "Time asking clients to release caps");
+  plb.add_time_avg(l_mdsp_heap_release, "heap_release",
+                   "Time releasing free heap memory (not under mds_lock)");
+  plb.add_time_avg(l_mdsp_log_trim, "log_trim",
+                   "Time trimming the MDS log");
+
+  logger = plb.create_perf_counters();
+  cct->get_perfcounters_collection()->add(logger);
+}
+
+MDSPhaseTracker::~MDSPhaseTracker()
+{
+  if (logger) {
+    cct->get_perfcounters_collection()->remove(logger);
+    delete logger;
+    logger = nullptr;
+  }
+}
+
+void MDSPhaseTracker::set_enabled(bool enable)
+{
+  if (enable == is_enabled()) {
+    return;
+  }
+  dout(5) << (enable ? "enabling" : "disabling") << " mds phase tracking"
+          << dendl;
+  if (enable) {
+    reset();
+  }
+  /* Enable the mutex accounting first and disable it last, so that the
+   * published lock stats never cover a period the phase counters do not. */
+  if (enable) {
+    mds_lock.set_track_stats(true);
+    enabled.store(true, std::memory_order_relaxed);
+  } else {
+    enabled.store(false, std::memory_order_relaxed);
+    mds_lock.set_track_stats(false);
+  }
+}
+
+void MDSPhaseTracker::reset()
+{
+  /* Only ever called with tracking disabled, so no Timer is concurrently
+   * incrementing the counters we are about to zero -- except an in-flight
+   * l_mdsp_heap_release, the one phase that does not run under mds_lock.
+   * The counters are atomic, so the worst case is one lost sample. */
+  logger->reset();
+
+  const auto stats = mds_lock.get_stats();
+  last_lock_stats = stats;
+  baseline_acquisitions.store(stats.acquisitions, std::memory_order_relaxed);
+  baseline_wait_ns.store(stats.wait_ns, std::memory_order_relaxed);
+  baseline_held_ns.store(stats.held_ns, std::memory_order_relaxed);
+  since_ns.store(now_ns(), std::memory_order_relaxed);
+}
+
+int MDSPhaseTracker::phase_for_message(int message_type)
+{
+  switch (message_type & 0xff00) {
+  case MDS_PORT_CACHE:
+    return l_mdsp_cache_message;
+  case MDS_PORT_MIGRATOR:
+    return l_mdsp_migrator_message;
+  default:
+    break;
+  }
+
+  switch (message_type) {
+  case CEPH_MSG_CLIENT_REQUEST:
+  case CEPH_MSG_CLIENT_REPLY:
+    return l_mdsp_client_request;
+  case CEPH_MSG_CLIENT_CAPS:
+  case CEPH_MSG_CLIENT_CAPRELEASE:
+  case CEPH_MSG_CLIENT_LEASE:
+    return l_mdsp_client_caps;
+  case CEPH_MSG_CLIENT_SESSION:
+  case CEPH_MSG_CLIENT_RECONNECT:
+  case CEPH_MSG_CLIENT_RECLAIM:
+    return l_mdsp_client_session;
+  case MSG_MDS_PEER_REQUEST:
+    return l_mdsp_peer_request;
+  case MSG_MDS_LOCK:
+  case MSG_MDS_INODEFILECAPS:
+    return l_mdsp_locker_message;
+  case MSG_MDS_HEARTBEAT:
+    return l_mdsp_heartbeat_message;
+  case MSG_MDS_TABLE_REQUEST:
+    return l_mdsp_table_message;
+  case MSG_MDS_QUIESCE_DB_LISTING:
+  case MSG_MDS_QUIESCE_DB_ACK:
+    return l_mdsp_quiesce_message;
+  case MSG_MDS_SCRUB:
+  case MSG_MDS_SCRUB_STATS:
+    return l_mdsp_scrub_message;
+  default:
+    return l_mdsp_other_message;
+  }
+}
+
+void MDSPhaseTracker::account(int phase, ceph::timespan exclusive)
+{
+  ceph_assert(phase >= l_mdsp_phase_first && phase < l_mdsp_phase_last);
+
+  /* The counter is the only bookkeeping: a time_avg accumulates both the sum
+   * and the entry count, and get_tavg_ns() reads them back for dump().  This
+   * is the hottest path in the tracker -- it runs once per dispatched message
+   * -- so it does no work the perf counter does not already do. */
+  logger->tinc(phase, exclusive);
+}
+
+void MDSPhaseTracker::update_lock_stats()
+{
+  if (!is_enabled()) {
+    return;
+  }
+
+  /* fair_mutex keeps running totals; publish the delta since the last call so
+   * that the perf counters behave like every other Ceph counter. */
+  const auto now = mds_lock.get_stats();
+  logger->tinc(l_mdsp_lock_wait, std::chrono::nanoseconds(
+                 static_cast<int64_t>(now.wait_ns - last_lock_stats.wait_ns)));
+  logger->tinc(l_mdsp_lock_held, std::chrono::nanoseconds(
+                 static_cast<int64_t>(now.held_ns - last_lock_stats.held_ns)));
+  logger->inc(l_mdsp_lock_acquisitions,
+              now.acquisitions - last_lock_stats.acquisitions);
+  last_lock_stats = now;
+}
+
+void MDSPhaseTracker::dump(ceph::Formatter *f) const
+{
+  f->open_object_section("phase_times");
+  f->dump_bool("enabled", is_enabled());
+
+  if (!is_enabled()) {
+    f->dump_string("note", "set mds_enable_phase_tracker=true to enable");
+    f->close_section();
+    return;
+  }
+
+  /* Everything below is reported for the period since tracking was enabled,
+   * which is also the period the perf counters cover. */
+  const uint64_t elapsed_ns =
+    now_ns() - since_ns.load(std::memory_order_relaxed);
+  const double elapsed = to_seconds(elapsed_ns);
+  f->dump_float("elapsed_sec", elapsed);
+
+  const auto stats = mds_lock.get_stats();
+  const uint64_t lock_held_ns =
+    stats.held_ns - baseline_held_ns.load(std::memory_order_relaxed);
+  f->open_object_section("mds_lock");
+  f->dump_unsigned("acquisitions", stats.acquisitions -
+                   baseline_acquisitions.load(std::memory_order_relaxed));
+  f->dump_float("wait_sec", to_seconds(
+                  stats.wait_ns -
+                  baseline_wait_ns.load(std::memory_order_relaxed)));
+  f->dump_float("held_sec", to_seconds(lock_held_ns));
+  /* The single most actionable number here: a rank whose lock is busy for
+   * most of the wall clock cannot go any faster without being split up. */
+  f->dump_float("utilization",
+                elapsed_ns ? double(lock_held_ns) / elapsed_ns : 0);
+  f->close_section();
+
+  /* Report the busiest phase first: the answer to "what is this rank doing?"
+   * should be the first line of the output. */
+  std::vector<std::tuple<uint64_t, uint64_t, int>> by_time;
+  by_time.reserve(num_phases);
+  uint64_t total_ns = 0;
+  for (int i = 0; i < num_phases; ++i) {
+    const auto [ns, count] = logger->get_tavg_ns(l_mdsp_phase_first + i);
+    total_ns += ns;
+    by_time.emplace_back(ns, count, i);
+  }
+  std::sort(by_time.begin(), by_time.end(), std::greater<>());
+
+  f->dump_float("accounted_sec", to_seconds(total_ns));
+  f->open_array_section("phases");
+  for (const auto& [ns, count, i] : by_time) {
+    f->open_object_section("phase");
+    f->dump_string("phase", phase_names[i]);
+    f->dump_float("total_sec", to_seconds(ns));
+    f->dump_unsigned("count", count);
+    f->dump_float("mean_ms", count ? to_seconds(ns) * 1000 / count : 0);
+    f->dump_float("pct_of_elapsed", elapsed_ns ? 100.0 * ns / elapsed_ns : 0);
+    f->dump_float("pct_of_accounted", total_ns ? 100.0 * ns / total_ns : 0);
+    f->close_section();
+  }
+  f->close_section();
+
+  f->close_section();
+}

--- a/src/mds/MDSPhaseTracker.cc
+++ b/src/mds/MDSPhaseTracker.cc
@@ -239,9 +239,6 @@ int MDSPhaseTracker::phase_for_message(int message_type)
     return l_mdsp_heartbeat_message;
   case MSG_MDS_TABLE_REQUEST:
     return l_mdsp_table_message;
-  case MSG_MDS_QUIESCE_DB_LISTING:
-  case MSG_MDS_QUIESCE_DB_ACK:
-    return l_mdsp_quiesce_message;
   case MSG_MDS_SCRUB:
   case MSG_MDS_SCRUB_STATS:
     return l_mdsp_scrub_message;

--- a/src/mds/MDSPhaseTracker.h
+++ b/src/mds/MDSPhaseTracker.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 
 #include "common/ceph_time.h"
 #include "common/fair_mutex.h"
@@ -129,6 +130,12 @@ public:
    * An RAII scope charging exclusive wall time to `phase`.  Nesting is
    * tracked per thread, so a Timer may be used from any thread; every
    * instrumented scope but l_mdsp_heap_release holds mds_lock.
+   *
+   * A scope may straddle a set_enabled() cycle, which resets the counters
+   * from another thread; each Timer therefore remembers the generation it
+   * started in and its destructor drops the sample if a reset intervened,
+   * rather than charging time from before the reset into counters that are
+   * supposed to cover only the period since it.
    */
   class Timer {
   public:
@@ -139,6 +146,11 @@ public:
       if (!this->tracker) {
         return;
       }
+      /* Read the generation before the clock, so that a reset() racing with
+       * this constructor either has already published the generation we
+       * observe -- and therefore zeroed the counters before we started
+       * timing -- or publishes a newer one, and the destructor drops us. */
+      generation = this->tracker->generation.load(std::memory_order_acquire);
       parent = tl_current;
       tl_current = this;
       start = ceph::mono_clock::now();
@@ -149,12 +161,17 @@ public:
         return;
       }
       const auto total = ceph::mono_clock::now() - start;
-      tracker->account(phase, total > children ? total - children
-                                               : ceph::timespan::zero());
+      /* Unconditionally, and before the generation check: a parent that does
+       * survive must not be charged for a child that was dropped. */
       if (parent) {
         parent->children += total;
       }
       tl_current = parent;
+      if (generation != tracker->generation.load(std::memory_order_acquire)) {
+        return;
+      }
+      tracker->account(phase, total > children ? total - children
+                                               : ceph::timespan::zero());
     }
 
     Timer(const Timer&) = delete;
@@ -165,6 +182,7 @@ public:
 
     MDSPhaseTracker *tracker;
     int phase;
+    uint64_t generation = 0;
     Timer *parent = nullptr;
     ceph::mono_time start;
     ceph::timespan children = ceph::timespan::zero();
@@ -180,18 +198,23 @@ private:
 
   std::atomic<bool> enabled = false;
 
-  /* When tracking started; dump() reports everything relative to it.  Both
-   * this and the baselines below are written only by reset() but read by
-   * dump(), which runs without mds_lock, hence the atomics. */
-  std::atomic<uint64_t> since_ns = 0;
+  /* Bumped by every reset(); see MDSPhaseTracker::Timer. */
+  std::atomic<uint64_t> generation = 0;
 
-  /* mds_lock totals as of the last reset() */
-  std::atomic<uint64_t> baseline_acquisitions = 0;
-  std::atomic<uint64_t> baseline_wait_ns = 0;
-  std::atomic<uint64_t> baseline_held_ns = 0;
+  /* Everything below is written by reset(), which runs from
+   * handle_conf_change() without mds_lock, and read by update_lock_stats()
+   * on the tick thread and by dump() on an asok thread.  Both readers
+   * subtract one of these from a fresh mds_lock snapshot, so the snapshot
+   * has to be taken under the same mutex: taken outside it, a reset()
+   * landing in between would leave a newer baseline being subtracted from
+   * an older total and the wrapped difference being reported. */
+  mutable std::mutex stats_mutex;
 
-  /* the last mds_lock totals published, so that deltas can be tinc()'d;
-   * only touched by update_lock_stats(), which runs under mds_lock */
+  /// when tracking started; dump() reports everything relative to it
+  uint64_t since_ns = 0;
+  /// mds_lock totals as of the last reset(), subtracted by dump()
+  ceph::fair_mutex::stats baseline_lock_stats;
+  /// the last mds_lock totals published, so that deltas can be tinc()'d
   ceph::fair_mutex::stats last_lock_stats;
 };
 

--- a/src/mds/MDSPhaseTracker.h
+++ b/src/mds/MDSPhaseTracker.h
@@ -1,0 +1,198 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2026 Clyso Technologies Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MDS_PHASE_TRACKER_H
+#define CEPH_MDS_PHASE_TRACKER_H
+
+#include <atomic>
+#include <cstdint>
+
+#include "common/ceph_time.h"
+#include "common/fair_mutex.h"
+
+#include "include/common_fwd.h"
+
+namespace ceph { class Formatter; }
+
+/*
+ * Where does an MDS rank's time go?
+ *
+ * Nearly everything a rank does is serialized by mds_lock: messages
+ * dispatched by the messenger threads, contexts completed by the finisher,
+ * the periodic MDSRankDispatcher::tick(), MDCache's cache-trim thread and
+ * MDLog's log-trim thread all take it.  The lock, rather than any one
+ * thread, is therefore the resource that saturates first, and "where did
+ * mds_lock time go?" is the question that has to be answered before
+ * deciding whether to scale a rank up (more cache memory) or out (more
+ * ranks).
+ *
+ * MDSPhaseTracker answers it by charging *exclusive* wall time to a phase.
+ * Each Timer is an RAII scope; timers nest, and time spent in a nested
+ * timer is subtracted from its parent.  So mds_phase.cache_trim is the time
+ * actually spent trimming and not the time spent trimming plus everything
+ * the trim happened to dispatch into.
+ *
+ * Divided by wall time, the phase totals give the share of a rank spent on
+ * each kind of work; summed and divided by wall time they approximate
+ * mds_lock utilization, which is also reported directly (lock_held) from
+ * the mutex itself.
+ */
+
+enum {
+  l_mdsp_first = 2700,
+
+  /* mds_lock itself; see ceph::fair_mutex::stats */
+  l_mdsp_lock_wait,
+  l_mdsp_lock_held,
+  l_mdsp_lock_acquisitions,
+
+  /* message dispatch, by message class */
+  l_mdsp_phase_first,
+  l_mdsp_client_request = l_mdsp_phase_first,
+  l_mdsp_client_caps,
+  l_mdsp_client_session,
+  l_mdsp_peer_request,
+  l_mdsp_cache_message,
+  l_mdsp_migrator_message,
+  l_mdsp_locker_message,
+  l_mdsp_heartbeat_message,
+  l_mdsp_table_message,
+  l_mdsp_quiesce_message,
+  l_mdsp_scrub_message,
+  l_mdsp_other_message,
+
+  /* completions run under mds_lock outside message dispatch */
+  l_mdsp_io_completion,
+  l_mdsp_finished_contexts,
+
+  /* the periodic tick, and the more expensive things it calls */
+  l_mdsp_tick,
+  l_mdsp_locker_tick,
+  l_mdsp_balancer_tick,
+
+  /* the cache-trim upkeep thread */
+  l_mdsp_cache_memory,
+  l_mdsp_cache_trim,
+  l_mdsp_client_leases,
+  l_mdsp_client_recall,
+  l_mdsp_heap_release,
+
+  /* the log-trim upkeep thread */
+  l_mdsp_log_trim,
+
+  l_mdsp_phase_last,
+  l_mdsp_last = l_mdsp_phase_last,
+};
+
+class MDSPhaseTracker {
+public:
+  static constexpr int num_phases = l_mdsp_phase_last - l_mdsp_phase_first;
+
+  MDSPhaseTracker(CephContext *cct, ceph::fair_mutex& mds_lock);
+  ~MDSPhaseTracker();
+
+  MDSPhaseTracker(const MDSPhaseTracker&) = delete;
+  MDSPhaseTracker& operator=(const MDSPhaseTracker&) = delete;
+
+  /**
+   * Start or stop accounting.  Enabling resets the counters and the wall
+   * clock they are measured against, so that a dump taken afterwards
+   * describes only the period since it was enabled.
+   */
+  void set_enabled(bool enable);
+  bool is_enabled() const {
+    return enabled.load(std::memory_order_relaxed);
+  }
+
+  /// map a message type to the phase its handling should be charged to
+  static int phase_for_message(int message_type);
+
+  /// publish mds_lock wait/hold time; called periodically from tick()
+  void update_lock_stats();
+
+  /// human readable breakdown, for the `dump phase times` asok command
+  void dump(ceph::Formatter *f) const;
+
+  /*
+   * An RAII scope charging exclusive wall time to `phase`.  Nesting is
+   * tracked per thread, so a Timer may be used from any thread; every
+   * instrumented scope but l_mdsp_heap_release holds mds_lock.
+   */
+  class Timer {
+  public:
+    Timer(MDSPhaseTracker *tracker, int phase)
+      : tracker(tracker && tracker->is_enabled() ? tracker : nullptr),
+        phase(phase)
+    {
+      if (!this->tracker) {
+        return;
+      }
+      parent = tl_current;
+      tl_current = this;
+      start = ceph::mono_clock::now();
+    }
+
+    ~Timer() {
+      if (!tracker) {
+        return;
+      }
+      const auto total = ceph::mono_clock::now() - start;
+      tracker->account(phase, total > children ? total - children
+                                               : ceph::timespan::zero());
+      if (parent) {
+        parent->children += total;
+      }
+      tl_current = parent;
+    }
+
+    Timer(const Timer&) = delete;
+    Timer& operator=(const Timer&) = delete;
+
+  private:
+    static thread_local Timer *tl_current;
+
+    MDSPhaseTracker *tracker;
+    int phase;
+    Timer *parent = nullptr;
+    ceph::mono_time start;
+    ceph::timespan children = ceph::timespan::zero();
+  };
+
+private:
+  void account(int phase, ceph::timespan exclusive);
+  void reset();
+
+  CephContext *cct;
+  ceph::fair_mutex& mds_lock;
+  PerfCounters *logger = nullptr;
+
+  std::atomic<bool> enabled = false;
+
+  /* When tracking started; dump() reports everything relative to it.  Both
+   * this and the baselines below are written only by reset() but read by
+   * dump(), which runs without mds_lock, hence the atomics. */
+  std::atomic<uint64_t> since_ns = 0;
+
+  /* mds_lock totals as of the last reset() */
+  std::atomic<uint64_t> baseline_acquisitions = 0;
+  std::atomic<uint64_t> baseline_wait_ns = 0;
+  std::atomic<uint64_t> baseline_held_ns = 0;
+
+  /* the last mds_lock totals published, so that deltas can be tinc()'d;
+   * only touched by update_lock_stats(), which runs under mds_lock */
+  ceph::fair_mutex::stats last_lock_stats;
+};
+
+#endif // CEPH_MDS_PHASE_TRACKER_H

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -482,6 +482,7 @@ MDSRank::MDSRank(
     damage_table(whoami_), sessionmap(this),
     op_tracker(g_ceph_context, g_conf()->mds_enable_op_tracker,
                g_conf()->osd_num_op_tracker_shard),
+    phase_tracker(msgr->cct, mds_lock_),
     progress_thread(this), whoami(whoami_),
     purge_queue(g_ceph_context, whoami_,
       mdsmap_->get_metadata_pool(), objecter,
@@ -539,6 +540,8 @@ MDSRank::MDSRank(
                                            cct->_conf->mds_op_history_duration);
   op_tracker.set_history_slow_op_size_and_threshold(cct->_conf->mds_op_history_slow_op_size,
                                                     cct->_conf->mds_op_history_slow_op_threshold);
+
+  phase_tracker.set_enabled(cct->_conf.get_val<bool>("mds_enable_phase_tracker"));
 
   schedule_update_timer_task();
 }
@@ -708,7 +711,13 @@ void MDSRank::set_mdsmap_multimds_snaps_allowed()
 
 void MDSRankDispatcher::tick()
 {
+  MDSPhaseTracker::Timer phase_timer(&phase_tracker, l_mdsp_tick);
+
   heartbeat_reset();
+
+  /* mds_lock accounting is cumulative in the mutex itself; fold it into the
+   * perf counters here rather than on every acquisition. */
+  phase_tracker.update_lock_stats();
 
   if (beacon.is_laggy()) {
     dout(1) << "skipping upkeep work because connection to Monitors appears laggy" << dendl;
@@ -729,6 +738,7 @@ void MDSRankDispatcher::tick()
 
   // ...
   if (is_clientreplay() || is_active() || is_stopping()) {
+    MDSPhaseTracker::Timer locker_timer(&phase_tracker, l_mdsp_locker_tick);
     server->clear_laggy_clients();
     server->find_idle_sessions();
     server->evict_cap_revoke_non_responders();
@@ -745,7 +755,10 @@ void MDSRankDispatcher::tick()
     server->reconnect_tick();
 
   if (is_active()) {
-    balancer->tick();
+    {
+      MDSPhaseTracker::Timer balancer_timer(&phase_tracker, l_mdsp_balancer_tick);
+      balancer->tick();
+    }
     mdcache->find_stale_fragment_freeze();
     mdcache->migrator->find_stale_export_freeze();
 
@@ -1229,6 +1242,9 @@ bool MDSRank::is_valid_message(const cref_t<Message> &m) {
 
 void MDSRank::handle_message(const cref_t<Message> &m)
 {
+  MDSPhaseTracker::Timer phase_timer(
+    &phase_tracker, MDSPhaseTracker::phase_for_message(m->get_type()));
+
   int port = m->get_type() & 0xff00;
 
   switch (port) {
@@ -1321,6 +1337,7 @@ void MDSRank::_advance_queues()
   ceph_assert(ceph_mutex_is_locked_by_me(mds_lock));
 
   if (!finished_queue.empty()) {
+    MDSPhaseTracker::Timer phase_timer(&phase_tracker, l_mdsp_finished_contexts);
     dout(7) << "mds has " << finished_queue.size() << " queued contexts" << dendl;
     while (!finished_queue.empty()) {
       auto fin = finished_queue.front();
@@ -3120,6 +3137,11 @@ void MDSRankDispatcher::handle_asok_command(
     std::lock_guard l(mds_lock);
     mdcache->stray_status(ctx);
     return;
+  } else if (command == "dump phase times") {
+    /* deliberately without mds_lock: the whole point is to report how busy
+     * the lock is, and taking it here would both perturb that and block on
+     * whatever phase we are trying to measure */
+    phase_tracker.dump(f);
   } else if (command == "dump qos") {
     std::lock_guard l(mds_lock);
     mds_dmclock_scheduler->dump(f);
@@ -4165,6 +4187,7 @@ std::vector<std::string> MDSRankDispatcher::get_tracked_keys()
     "mds_dump_cache_threshold_file",
     "mds_dump_cache_threshold_formatter",
     "mds_enable_op_tracker",
+    "mds_enable_phase_tracker",
     "mds_export_ephemeral_distributed",
     "mds_export_ephemeral_random",
     "mds_export_ephemeral_random_max",
@@ -4238,6 +4261,9 @@ void MDSRankDispatcher::handle_conf_change(const ConfigProxy& conf, const std::s
   }
   if (changed.count("mds_enable_op_tracker")) {
     op_tracker.set_tracking(conf->mds_enable_op_tracker);
+  }
+  if (changed.count("mds_enable_phase_tracker")) {
+    phase_tracker.set_enabled(conf.get_val<bool>("mds_enable_phase_tracker"));
   }
   if (changed.count("mds_extraordinary_events_dump_interval")) {
     reset_event_flags();

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -28,6 +28,7 @@
 
 #include "DamageTable.h"
 #include "MDSMap.h"
+#include "MDSPhaseTracker.h"
 #include "SessionMap.h"
 #include "PurgeQueue.h"
 #include "MetricsHandler.h"
@@ -438,6 +439,9 @@ class MDSRank {
 
     PerfCounters *logger = nullptr, *mlogger = nullptr;
     OpTracker op_tracker;
+    /* Time accounting for mds_lock, shared with the subsystems (MDCache,
+     * MDLog, ...) that do their upkeep under it. */
+    MDSPhaseTracker phase_tracker;
 
     std::map<ceph_tid_t, std::unique_ptr<MDSMetaRequest>> internal_client_requests;
 

--- a/src/mds/MDSRankQuiesce.cc
+++ b/src/mds/MDSRankQuiesce.cc
@@ -370,8 +370,18 @@ void MDSRank::quiesce_cluster_update() {
 }
 
 bool MDSRank::quiesce_dispatch(const cref_t<Message> &m) {
+  const int type = m->get_type();
+  if (type != MSG_MDS_QUIESCE_DB_LISTING && type != MSG_MDS_QUIESCE_DB_ACK) {
+    return false;
+  }
+
+  /* Quiesce db messages are consumed here, from the top of _dispatch(), and
+   * so never reach MDSRank::handle_message() where the other message phases
+   * are charged; the timer has to live here to see them at all. */
+  MDSPhaseTracker::Timer phase_timer(&phase_tracker, l_mdsp_quiesce_message);
+
   try {
-    switch(m->get_type()) {
+    switch(type) {
       case MSG_MDS_QUIESCE_DB_LISTING:
       {
         const auto& req = ref_cast<MMDSQuiesceDbListing>(m);

--- a/src/test/common/test_fair_mutex.cc
+++ b/src/test/common/test_fair_mutex.cc
@@ -66,3 +66,62 @@ TEST(FairMutex, fair)
     completed[team] = std::async(std::launch::async, play, team);
   }
 }
+
+TEST(FairMutex, stats_disabled_by_default)
+{
+  ceph::fair_mutex mutex{"fair::stats_off"};
+  ASSERT_FALSE(mutex.get_track_stats());
+  {
+    std::unique_lock lock{mutex};
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+  auto stats = mutex.get_stats();
+  ASSERT_EQ(0u, stats.acquisitions);
+  ASSERT_EQ(0u, stats.wait_ns);
+  ASSERT_EQ(0u, stats.held_ns);
+}
+
+TEST(FairMutex, stats)
+{
+  ceph::fair_mutex mutex{"fair::stats"};
+  mutex.set_track_stats(true);
+  ASSERT_TRUE(mutex.get_track_stats());
+
+  const auto held = std::chrono::milliseconds(10);
+  {
+    std::unique_lock lock{mutex};
+    std::this_thread::sleep_for(held);
+  }
+  auto stats = mutex.get_stats();
+  ASSERT_EQ(1u, stats.acquisitions);
+  ASSERT_GE(stats.held_ns,
+            std::chrono::nanoseconds(held).count());
+
+  // a contended acquisition accrues wait time
+  {
+    std::unique_lock lock{mutex};
+    std::promise<void> blocking;
+    auto waiter = std::async(std::launch::async, [&] {
+      blocking.set_value();
+      std::unique_lock lock{mutex};
+    });
+    blocking.get_future().wait();
+    std::this_thread::sleep_for(held);
+    lock.unlock();
+    waiter.get();
+  }
+  stats = mutex.get_stats();
+  ASSERT_EQ(3u, stats.acquisitions);
+  ASSERT_GT(stats.wait_ns, 0u);
+
+  // and turning tracking off freezes the counters
+  mutex.set_track_stats(false);
+  {
+    std::unique_lock lock{mutex};
+    std::this_thread::sleep_for(held);
+  }
+  auto after = mutex.get_stats();
+  ASSERT_EQ(stats.acquisitions, after.acquisitions);
+  ASSERT_EQ(stats.wait_ns, after.wait_ns);
+  ASSERT_EQ(stats.held_ns, after.held_ns);
+}


### PR DESCRIPTION
  Nearly everything an MDS rank does is serialized by mds_lock, which makes
  the lock -- rather than any one thread -- the resource a busy rank
  exhausts first. There is currently no way to ask how much of the wall
  clock a rank spends holding it, or on what, so an operator cannot tell a
  rank that is serialization-bound on client work (scale out) from one
  thrashing its cache (scale up) from one merely waiting on the metadata
  pool (neither helps).

  This adds MDSPhaseTracker, which charges exclusive wall time to a phase --
  client requests, cap handling, IO completions, subtree import/export,
  cache trim, client recall, log trim, ... -- via an RAII timer at the choke
  points each kind of work already passes through. Timers nest and nested
  time is subtracted from the parent, so cache_trim is the time actually
  spent trimming rather than trimming plus whatever it dispatched into.
  fair_mutex gains opt-in wait/hold accounting so mds_lock utilization is
  reported directly alongside the phases.

  Totals land in a new "mds_phase" perf counters section, and therefore in
  mgr/prometheus. `ceph tell mds.X dump phase times` gives the one-shot
  human view: phases sorted by time spent, each with its share of the wall
  clock, plus mds_lock utilization.

  Off by default (mds_enable_phase_tracker, runtime adjustable). Enabled it
  costs two clock reads per instrumented scope and three per mds_lock
  acquisition, a few hundred nanoseconds of serialized work per client
  request; disabled, a relaxed load of a bool per lock acquisition.

  Fixes: https://tracker.ceph.com/issues/79953
  

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
