### PR TITLE
qa/suites/crimson-rados: enable the workunit watchdog everywhere

### DIFF
--- a/qa/suites/crimson-rados/basic/tasks/cls.yaml
+++ b/qa/suites/crimson-rados/basic/tasks/cls.yaml
@@ -1,10 +1,13 @@
 overrides:
+  cephadm:
+    watchdog_setup: true
   ceph:
     conf:
       osd:
         debug objclass: 20 
 tasks:
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - cls/test_cls_cmpomap.sh 

--- a/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
@@ -1,4 +1,6 @@
 overrides:
+  cephadm:
+    watchdog_setup: true
   ceph:
     log-ignorelist:
     - but it is still running
@@ -14,6 +16,7 @@ overrides:
       - python3-pytest
 tasks:
 - workunit:
+    watchdog: true
     timeout: 1h
     clients:
       client.0:

--- a/qa/suites/crimson-rados/cephfs/tasks/test/cfuse_workunit_suites_blogbench.yaml
+++ b/qa/suites/crimson-rados/cephfs/tasks/test/cfuse_workunit_suites_blogbench.yaml
@@ -6,6 +6,7 @@ overrides:
         - \(POOL_APP_NOT_ENABLED\)
   - ceph-fuse:
   - workunit:
+      watchdog: true
       clients:
         all:
           - suites/blogbench.sh

--- a/qa/suites/crimson-rados/cephfs/tasks/test/cfuse_workunit_suites_fsstress.yaml
+++ b/qa/suites/crimson-rados/cephfs/tasks/test/cfuse_workunit_suites_fsstress.yaml
@@ -5,6 +5,7 @@ overrides:
         - \(POOL_APP_NOT_ENABLED\)
   - ceph-fuse:
   - workunit:
+      watchdog: true
       clients:
         all:
           - suites/fsstress.sh

--- a/qa/suites/crimson-rados/cephfs/tasks/test/cfuse_workunit_suites_iozone.yaml
+++ b/qa/suites/crimson-rados/cephfs/tasks/test/cfuse_workunit_suites_iozone.yaml
@@ -14,6 +14,7 @@ overrides:
 tasks:
 - ceph-fuse: [client.0]
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - suites/iozone.sh

--- a/qa/suites/crimson-rados/cephfs/tasks/test/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/crimson-rados/cephfs/tasks/test/cfuse_workunit_suites_pjd.yaml
@@ -14,6 +14,7 @@ overrides:
           fuse set user groups: true
   - ceph-fuse:
   - workunit:
+      watchdog: true
       clients:
         all:
           - suites/pjd.sh

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_api_tests.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_api_tests.yaml
@@ -13,6 +13,7 @@ overrides:
       - \(POOL_FULL\)
 tasks:
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - rbd/test_librbd.sh

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_api_tests_old_format.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_api_tests_old_format.yaml
@@ -8,6 +8,7 @@ overrides:
       - \(POOL_FULL\)
 tasks:
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - rbd/test_librbd.sh

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_cls_tests.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_cls_tests.yaml
@@ -1,5 +1,6 @@
 tasks:
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - cls/test_cls_rbd.sh

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_lock_and_fence.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_lock_and_fence.yaml
@@ -1,5 +1,6 @@
 tasks:
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - rbd/test_lock_fence.sh

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests.yaml
@@ -9,6 +9,7 @@ overrides:
       - python3-pytest
 tasks:
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - rbd/test_librbd_python.sh

--- a/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/crimson-rados/rbd/tasks/rbd_python_api_tests_old_format.yaml
@@ -9,6 +9,7 @@ overrides:
       - python3-pytest
 tasks:
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - rbd/test_librbd_python.sh

--- a/qa/suites/crimson-rados/singleton/all/osd-dump-metrics.yaml
+++ b/qa/suites/crimson-rados/singleton/all/osd-dump-metrics.yaml
@@ -25,6 +25,7 @@ tasks:
         crimson cpu num: 2
       global:
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - crimson/test_crimson_dump_metrics.sh

--- a/qa/suites/crimson-rados/singleton/all/osd-pg-merging.yaml
+++ b/qa/suites/crimson-rados/singleton/all/osd-pg-merging.yaml
@@ -25,6 +25,7 @@ tasks:
         osd min pg log entries: 5
         crimson cpu num: 2
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - rados/test_pg_merging.sh

--- a/qa/suites/crimson-rados/singleton/all/osd-pg-splitting.yaml
+++ b/qa/suites/crimson-rados/singleton/all/osd-pg-splitting.yaml
@@ -26,6 +26,7 @@ tasks:
         crimson cpu num: 2
       global:
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - rados/test_pg_splitting.sh

--- a/qa/suites/crimson-rados/singleton/all/pg-subcommands.yaml
+++ b/qa/suites/crimson-rados/singleton/all/pg-subcommands.yaml
@@ -26,6 +26,7 @@ tasks:
         crimson cpu num: 2
       global:
 - workunit:
+    watchdog: true
     clients:
       client.0:
         - crimson/test_pg_subcommands.sh


### PR DESCRIPTION
This PR enables the workunit's watchdog introduced in https://github.com/ceph/ceph/pull/71030 in all workunit tasks in crimson-raods suite. This will help these tasks fail fast in the event of a failure, instead of running for long hours, hogging resources.

Fixes: https://tracker.ceph.com/issues/79961

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
