### PR TITLE
mds/flock: remove buggy unused methods

### DIFF
--- a/src/mds/flock.cc
+++ b/src/mds/flock.cc
@@ -515,22 +515,6 @@ void ceph_lock_state_t::adjust_locks(list<multimap<uint64_t, ceph_filelock>::ite
 }
 
 multimap<uint64_t, ceph_filelock>::iterator
-ceph_lock_state_t::get_lower_bound(uint64_t start,
-                                   multimap<uint64_t, ceph_filelock>& lock_map)
-{
-   multimap<uint64_t, ceph_filelock>::iterator lower_bound =
-     lock_map.lower_bound(start);
-   if ((lower_bound->first != start)
-       && (start != 0)
-       && (lower_bound != lock_map.begin())) --lower_bound;
-   if (lock_map.end() == lower_bound)
-     ldout(cct,15) << "get_lower_dout(15)eturning end()" << dendl;
-   else ldout(cct,15) << "get_lower_bound returning iterator pointing to "
-                << lower_bound->second << dendl;
-   return lower_bound;
- }
-
-multimap<uint64_t, ceph_filelock>::iterator
 ceph_lock_state_t::get_last_before(uint64_t end,
                                    multimap<uint64_t, ceph_filelock>& lock_map)
 {
@@ -598,23 +582,6 @@ bool ceph_lock_state_t::get_overlapping_locks(const ceph_filelock& lock,
       cont = false;
     } else if (held_locks.begin() == iter) cont = false;
     else --iter;
-  }
-  return !overlaps.empty();
-}
-
-bool ceph_lock_state_t::get_waiting_overlaps(const ceph_filelock& lock,
-                                             list<multimap<uint64_t,
-                                               ceph_filelock>::iterator>&
-                                               overlaps)
-{
-  ldout(cct,15) << "get_waiting_overlaps" << dendl;
-  multimap<uint64_t, ceph_filelock>::iterator iter =
-    get_last_before(lock.start + lock.length - 1, waiting_locks);
-  bool cont = iter != waiting_locks.end();
-  while(cont) {
-    if (share_space(iter, lock)) overlaps.push_front(iter);
-    if (waiting_locks.begin() == iter) cont = false;
-    --iter;
   }
   return !overlaps.empty();
 }

--- a/src/mds/flock.h
+++ b/src/mds/flock.h
@@ -184,10 +184,6 @@ private:
                     std::list<std::multimap<uint64_t, ceph_filelock>::iterator>
                       neighbor_locks);
 
-  //get last lock prior to start position
-  std::multimap<uint64_t, ceph_filelock>::iterator
-  get_lower_bound(uint64_t start,
-                  std::multimap<uint64_t, ceph_filelock>& lock_map);
   //get latest-starting lock that goes over the byte "end"
   std::multimap<uint64_t, ceph_filelock>::iterator
   get_last_before(uint64_t end,
@@ -230,15 +226,6 @@ private:
     return get_overlapping_locks(lock, overlaps, NULL);
   }
 
-  /**
-   * Get a list of all waiting locks that overlap with the given lock's range.
-   * lock: specifies the range to compare with
-   * overlaps: an empty list, to be filled
-   * Returns: true if at least one waiting_lock overlaps
-   */
-  bool get_waiting_overlaps(const ceph_filelock& lock,
-                            std::list<std::multimap<uint64_t,
-                                ceph_filelock>::iterator>& overlaps);
   /*
    * split a list of locks up by whether they're owned by same
    * process as given lock


### PR DESCRIPTION
get_lower_bound() and get_waiting_overlaps() both dereference an iterator before comparing it against end(), which is undefined behavior.  Fortunately, both methods are unused, so the trivial solution is to remove the buggy code.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
