### PR TITLE
mds/*: use the erase() return value

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -717,7 +717,7 @@ void Locker::request_drop_remote_locks(const MDRequestRef& mdr)
       dout(10) << "request_drop_remote_locks forgetting lock " << *lock
 	       << " on " << lock->get_parent() << dendl;
       lock->put_xlock();
-      mdr->locks.erase(it++);
+      it = mdr->locks.erase(it);
     } else if (it->is_remote_wrlock()) {
       dout(10) << "request_drop_remote_locks forgetting remote_wrlock " << *lock
 	       << " on mds." << it->wrlock_target << " on " << *lock->get_parent() << dendl;
@@ -725,7 +725,7 @@ void Locker::request_drop_remote_locks(const MDRequestRef& mdr)
 	it->clear_remote_wrlock();
 	++it;
       } else {
-	mdr->locks.erase(it++);
+	it = mdr->locks.erase(it);
       }
     } else {
       ++it;
@@ -810,7 +810,7 @@ void Locker::_drop_locks(MutationImpl *mut, set<CInode*> *pneed_issue,
 	ceph_assert(lock->get_sm()->can_remote_xlock);
 	peers.insert(obj->authority().first);
 	lock->put_xlock();
-	mut->locks.erase(it++);
+	it = mut->locks.erase(it);
       }
     } else if (it->is_wrlock() || it->is_remote_wrlock()) {
       if (it->is_remote_wrlock()) {
@@ -823,7 +823,7 @@ void Locker::_drop_locks(MutationImpl *mut, set<CInode*> *pneed_issue,
 	if (ni)
 	  pneed_issue->insert(static_cast<CInode*>(obj));
       } else {
-	mut->locks.erase(it++);
+	it = mut->locks.erase(it);
       }
     } else if (drop_rdlocks && it->is_rdlock()) {
       bool ni = false;
@@ -1229,7 +1229,7 @@ void Locker::create_lock_cache(const MDRequestRef& mdr, CInode *diri, file_layou
     }
     if (lock_flag) {
       lock_cache->emplace_lock(it->lock, lock_flag);
-      mdr->locks.erase(it++);
+      it = mdr->locks.erase(it);
     } else {
       ++it;
     }
@@ -4380,7 +4380,7 @@ std::set<client_t> Locker::get_late_revoking_clients(double timeout)
     for (auto it = revoking_caps_by_client.begin();
 	 it != revoking_caps_by_client.end(); ) {
       if (it->second.empty()) {
-	revoking_caps_by_client.erase(it++);
+	it = revoking_caps_by_client.erase(it);
 	continue;
       }
       if (any_late_revoking(it->second))

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -1097,7 +1097,7 @@ void MDBalancer::try_rebalance(balance_state_t& state)
 		<< " to mds." << target << dendl;
 	have += pop;
 	mds->mdcache->migrator->export_dir_nicely(dir, target);
-	import_pop_map.erase(p++);
+	p = import_pop_map.erase(p);
       } else {
 	++p;
       }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -626,7 +626,7 @@ void MDSRank::update_targets()
     double val = counter.get();
     if (val <= 0.01) {
       dout(15) << "export target mds." << rank << " is no longer an export target" << dendl;
-      export_targets.erase(it++);
+      it = export_targets.erase(it);
       send = true;
       continue;
     }
@@ -2588,7 +2588,7 @@ void MDSRankDispatcher::handle_mds_map(
     while (p != waiting_for_mdsmap.end() && p->first <= mdsmap->get_epoch()) {
       MDSContext::vec ls;
       ls.swap(p->second);
-      waiting_for_mdsmap.erase(p++);
+      p = waiting_for_mdsmap.erase(p);
       queue_waiters(ls);
     }
   }

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -3129,7 +3129,7 @@ void Migrator::import_notify_abort(CDir *dir, set<CDir*>& bounds)
     if (mds->is_cluster_degraded() &&
 	!mds->mdsmap->is_clientreplay_or_active_or_stopping(*p)) {
       // this can happen if both exporter and bystander fail in the same mdsmap epoch
-      stat.bystanders.erase(p++);
+      p = stat.bystanders.erase(p);
       continue;
     }
     auto notify = make_message<MExportDirNotify>(dir->dirfrag(), stat.tid, true,

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -1250,6 +1250,6 @@ void OpenFileTable::trim_destroyed_inos(uint64_t seq)
   while (p != logseg_destroyed_inos.end()) {
     if (p->first >= seq)
       break;
-    logseg_destroyed_inos.erase(p++);
+    p = logseg_destroyed_inos.erase(p);
   }
 }

--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -736,7 +736,7 @@ void PurgeQueue::_execute_item_complete(
 	  if (*p >= n->first)
 	    break;
 	  pos = *p;
-	  pending_expire.erase(p++);
+	  p = pending_expire.erase(p);
 	} while (p != pending_expire.end());
       }
     }

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -1210,7 +1210,7 @@ void ScrubStack::handle_scrub_stats(const cref_t<MMDSScrubStats> &m)
 				header->get_uninline_skipped()
 	};
 	counters[header->get_tag()] = c;
-	scrubbing_map.erase(it++);
+	it = scrubbing_map.erase(it);
       } else {
 	++it;
       }
@@ -1349,7 +1349,7 @@ void ScrubStack::advance_scrub_status()
       sc.uninline_failed = header->get_uninline_failed();
       sc.uninline_skipped = header->get_uninline_skipped();
 
-      scrubbing_map.erase(it++);
+      it = scrubbing_map.erase(it);
     } else {
       ++it;
     }
@@ -1383,7 +1383,7 @@ void ScrubStack::handle_mds_failure(mds_rank_t mds)
     if (it->second.gather_set.erase(mds) &&
 	it->second.gather_set.empty()) {
       CInode *in = it->first;
-      remote_scrubs.erase(it++);
+      it = remote_scrubs.erase(it);
       remove_from_waiting(in, false);
       kick = true;
     } else {

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1071,7 +1071,7 @@ version_t Server::prepare_force_open_sessions(map<client_t,entity_inst_t>& cm,
 	    dout(10) << " ignoring blocklisted client." << p->first
 		     << " (" <<  p->second.addr << ")" << dendl;
 	    cmm.erase(p->first);
-	    cm.erase(p++);
+	    p = cm.erase(p);
 	  } else {
 	    ++p;
 	  }

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -218,7 +218,7 @@ public:
       want -= (int)it.get_len();
       inos.insert(it.get_start(), it.get_len());
       delegated_inos.insert(it.get_start(), it.get_len());
-      free_prealloc_inos.erase(it++);
+      it = free_prealloc_inos.erase(it);
       if (want <= 0)
 	break;
     }

--- a/src/mds/SnapClient.cc
+++ b/src/mds/SnapClient.cc
@@ -93,7 +93,7 @@ void SnapClient::handle_query_result(const cref_t<MMDSTableRequest> &m)
 	++p;
       } else {
 	// pending update/destroy have been committed.
-	committing_tids.erase(p++);
+	p = committing_tids.erase(p);
       }
     }
   }

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -381,7 +381,7 @@ void SnapRealm::split_at(SnapRealm *child)
       dout(20) << " child gets child realm " << *realm << " on " << *realm->inode << dendl;
       realm->parent = child;
       child->open_children.insert(realm);
-      open_children.erase(p++);
+      p = open_children.erase(p);
     } else {
       dout(20) << "    keeping child realm " << *realm << " on " << *realm->inode << dendl;
       ++p;
@@ -518,7 +518,7 @@ void SnapRealm::prune_past_parent_snaps()
     auto q = cached_snaps.find(*p);
     if (q == cached_snaps.end()) {
       dout(10) << __func__ << " pruning " << *p << dendl;
-      srnode.past_parent_snaps.erase(p++);
+      p = srnode.past_parent_snaps.erase(p);
     } else {
       dout(10) << __func__ << " keeping " << *p << dendl;
       ++p;

--- a/src/mds/flock.cc
+++ b/src/mds/flock.cc
@@ -362,7 +362,7 @@ bool ceph_lock_state_t::remove_all_from (client_t client)
     multimap<uint64_t, ceph_filelock>::iterator iter = held_locks.begin();
     while (iter != held_locks.end()) {
       if ((client_t)iter->second.client == client) {
-	held_locks.erase(iter++);
+	iter = held_locks.erase(iter);
       } else
 	++iter;
     }
@@ -380,7 +380,7 @@ bool ceph_lock_state_t::remove_all_from (client_t client)
       if (type == CEPH_LOCK_FCNTL) {
 	remove_global_waiting(iter->second, this);
       }
-      waiting_locks.erase(iter++);
+      iter = waiting_locks.erase(iter);
     }
     client_waiting_lock_counts.erase(client);
   }


### PR DESCRIPTION
.. instead of incrementing the iterator manually.  This is the canonical way to do it and comes with less overhead.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
