### PR TITLE
mgr/dashboard: Allow editing non-runtime configurations with force edit confirmation

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
+++ b/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
@@ -188,18 +188,10 @@ class ClusterConfiguration(RESTController):
         for name in config_option_names:
             config_option = self._get_config_option(name)
 
-            # making rgw configuration to be editable by bypassing 'can_update_at_runtime'
-            # as the same can be done via CLI.
-            if force_update and 'rgw' in name and not config_option['can_update_at_runtime']:
-                break
+            # Allow non-runtime configurations to be updated when force_update is enabled
+            if force_update and not config_option['can_update_at_runtime']:
+                continue
 
-            if force_update and 'rgw' not in name and not config_option['can_update_at_runtime']:
-                raise DashboardException(
-                    msg=f'Only the configuration containing "rgw" can be edited at runtime with'
-                        f' force_update flag, hence not able to update "{name}"',
-                    code='config_option_not_updatable_at_runtime',
-                    component='cluster_configuration'
-                )
             if not config_option['can_update_at_runtime']:
                 not_updateable.append(name)
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -30,7 +30,8 @@ import {
   LayerModule,
   AccordionModule,
   MenuButtonModule,
-  ContextMenuModule
+  ContextMenuModule,
+  NotificationModule
 } from 'carbon-components-angular';
 import Analytics from '@carbon/icons/es/analytics/16';
 import CloseFilled from '@carbon/icons/es/close--filled/16';
@@ -55,6 +56,7 @@ import { CephSharedModule } from '../shared/ceph-shared.module';
 import { ConfigurationResourcePageComponent } from './configuration/configuration-resource-page/configuration-resource-page.component';
 import { ConfigurationResourceSidebarComponent } from './configuration/configuration-resource-sidebar/configuration-resource-sidebar.component';
 import { ConfigurationFormComponent } from './configuration/configuration-form/configuration-form.component';
+import { ConfigOptionRestartModalComponent } from './configuration/configuration-form/config-option-restart-modal/config-option-restart-modal.component';
 import { ConfigurationComponent } from './configuration/configuration.component';
 import { CreateClusterReviewComponent } from './create-cluster/create-cluster-review.component';
 import { CreateClusterStep1Component } from './create-cluster/create-cluster-step-1/create-cluster-step-1.component';
@@ -156,7 +158,8 @@ import { TextLabelListComponent } from '~/app/shared/components/text-label-list/
     LayerModule,
     AccordionModule,
     MenuButtonModule,
-    ContextMenuModule
+    ContextMenuModule,
+    NotificationModule
   ],
   declarations: [
     MonitorComponent,
@@ -170,6 +173,7 @@ import { TextLabelListComponent } from '~/app/shared/components/text-label-list/
     ConfigurationResourcePageComponent,
     ConfigurationResourceSidebarComponent,
     ConfigurationFormComponent,
+    ConfigOptionRestartModalComponent,
     OsdReweightModalComponent,
     CrushmapComponent,
     LogsComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/config-option-restart-modal/config-option-restart-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/config-option-restart-modal/config-option-restart-modal.component.html
@@ -1,0 +1,107 @@
+<cds-modal
+  size="md"
+  [open]="open"
+  (overlaySelected)="closeModal()"
+>
+  <cds-modal-header (closeSelect)="closeModal()">
+    <h4
+      cdsModalHeaderLabel
+      class="cds--type-label-01"
+      i18n
+    >
+      Cluster Configuration
+    </h4>
+    <h3
+      cdsModalHeaderHeading
+      i18n
+    >
+      Restart Required Services
+    </h3>
+  </cds-modal-header>
+
+  <section cdsModalContent>
+    <div class="cds-mb-4">
+      <cd-alert-panel
+        type="warning"
+        spacingClass="cds-mb-3"
+      >
+        <span i18n>
+          Restarting services may cause temporary service disruption, potential downtime, or data
+          unavailability. Please make sure no I/O is happening before proceeding.
+        </span>
+      </cd-alert-panel>
+      <cd-alert-panel
+        type="info"
+        spacingClass="cds-mb-3"
+        *ngIf="hasMgrService"
+      >
+        <span i18n>
+          Note: Manager (MGR) hosts the active Dashboard session. Restarting MGR via UI will
+          temporarily drop connection. Use CLI (ceph orch restart mgr) or allow failover.
+        </span>
+      </cd-alert-panel>
+      <p
+        class="cds--type-body-01 cds-mb-3"
+        i18n
+      >
+        Configuration option <strong>{{ configName }}</strong> was updated successfully. The
+        following service(s) require a restart for changes to take effect:
+      </p>
+
+      <!-- Carbon Service Restart List -->
+      <div class="service-restart-list cds-mb-4">
+        <div
+          *ngFor="let item of serviceItems"
+          class="service-restart-row"
+        >
+          <div class="service-info">
+            <span class="service-name">{{ item.name | uppercase }}</span>
+            <cds-tag [type]="item.tagType">{{ item.statusText }}</cds-tag>
+          </div>
+          <button
+            type="button"
+            cdsButton="tertiary"
+            size="sm"
+            [disabled]="item.status === 'restarting' || item.status === 'restarted'"
+            (click)="restartSingleService(item)"
+          >
+            <ng-container *ngIf="item.status === 'restarting'">
+              <cds-inline-loading
+                status="active"
+                loadingText="Restarting..."
+              ></cds-inline-loading>
+            </ng-container>
+            <ng-container *ngIf="item.status !== 'restarting'">
+              {{ item.status === 'restarted' ? 'Restarted' : 'Restart' }}
+            </ng-container>
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <cds-modal-footer>
+    <button
+      type="button"
+      cdsButton="secondary"
+      (click)="skipRestart()"
+    >
+      <ng-container *ngIf="allRestarted">Close</ng-container>
+      <ng-container *ngIf="!allRestarted">Skip / Restart Later</ng-container>
+    </button>
+    <button
+      type="button"
+      cdsButton="primary"
+      [disabled]="allRestarted || restartingAll"
+      (click)="restartAllServices()"
+    >
+      <ng-container *ngIf="restartingAll">
+        <cds-inline-loading
+          status="active"
+          loadingText="Restarting All..."
+        ></cds-inline-loading>
+      </ng-container>
+      <ng-container *ngIf="!restartingAll"> Restart All Services </ng-container>
+    </button>
+  </cds-modal-footer>
+</cds-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/config-option-restart-modal/config-option-restart-modal.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/config-option-restart-modal/config-option-restart-modal.component.scss
@@ -1,0 +1,30 @@
+.service-restart-list {
+  background-color: var(--cds-layer-01, #f4f4f4);
+  border: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+  border-radius: 4px;
+  padding: 0.75rem 1rem;
+}
+
+.service-restart-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--cds-border-subtle-01, #e0e0e0);
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.service-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+
+  .service-name {
+    font-weight: 600;
+    font-size: 0.875rem;
+    color: var(--cds-text-01, #161616);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/config-option-restart-modal/config-option-restart-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/config-option-restart-modal/config-option-restart-modal.component.spec.ts
@@ -1,0 +1,33 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { ConfigOptionRestartModalComponent } from './config-option-restart-modal.component';
+
+describe('ConfigOptionRestartModalComponent', () => {
+  let component: ConfigOptionRestartModalComponent;
+  let fixture: ComponentFixture<ConfigOptionRestartModalComponent>;
+
+  configureTestBed({
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
+    declarations: [ConfigOptionRestartModalComponent]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfigOptionRestartModalComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize service items correctly', () => {
+    component.services = ['osd', 'mon'];
+    component.ngOnInit();
+    expect(component.serviceItems.length).toBe(2);
+    expect(component.serviceItems[0].name).toBe('osd');
+    expect(component.serviceItems[1].name).toBe('mon');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/config-option-restart-modal/config-option-restart-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/config-option-restart-modal/config-option-restart-modal.component.ts
@@ -1,0 +1,183 @@
+import { Component, Inject, OnInit, Optional } from '@angular/core';
+import { Router } from '@angular/router';
+import { BaseModal } from 'carbon-components-angular';
+import { of, forkJoin, timer } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
+import { DaemonService } from '~/app/shared/api/daemon.service';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { NotificationService } from '~/app/shared/services/notification.service';
+
+export interface ServiceRestartItem {
+  name: string;
+  status: 'pending' | 'restarting' | 'restarted' | 'failed';
+  tagType:
+    'gray' | 'cool-gray' | 'warm-gray' | 'magenta' | 'blue' | 'cyan' | 'teal' | 'green' | 'red';
+  statusText: string;
+}
+
+@Component({
+  selector: 'cd-config-option-restart-modal',
+  templateUrl: './config-option-restart-modal.component.html',
+  styleUrls: ['./config-option-restart-modal.component.scss'],
+  standalone: false
+})
+export class ConfigOptionRestartModalComponent extends BaseModal implements OnInit {
+  serviceItems: ServiceRestartItem[] = [];
+  restartingAll = false;
+
+  constructor(
+    @Optional() @Inject('configName') public configName = '',
+    @Optional() @Inject('services') public services: string[] = [],
+    private daemonService: DaemonService,
+    private notificationService: NotificationService,
+    private router: Router
+  ) {
+    super();
+  }
+
+  ngOnInit() {
+    const rawServices =
+      this.services && this.services.length > 0 ? this.services : ['affected service'];
+    this.serviceItems = rawServices.map((s) => ({
+      name: s,
+      status: 'pending',
+      tagType: 'blue',
+      statusText: 'Pending'
+    }));
+  }
+
+  get allRestarted(): boolean {
+    return this.serviceItems.every((item) => item.status === 'restarted');
+  }
+
+  get hasMgrService(): boolean {
+    return this.serviceItems.some((item) => item.name.toLowerCase().includes('mgr'));
+  }
+
+  restartSingleService(item: ServiceRestartItem) {
+    if (item.status === 'restarting' || item.status === 'restarted') {
+      return;
+    }
+    item.status = 'restarting';
+    item.tagType = 'magenta';
+    item.statusText = 'Restarting...';
+
+    const serviceName = item.name;
+    this.daemonService
+      .list([serviceName])
+      .pipe(
+        switchMap((daemons) => {
+          if (daemons && daemons.length > 0) {
+            const restartObservables = daemons
+              .map((d) => d.daemon_name || (d as any).name)
+              .filter(Boolean)
+              .map((daemonName) =>
+                this.daemonService
+                  .action(daemonName, 'restart', true)
+                  .pipe(catchError(() => of(null)))
+              );
+
+            if (restartObservables.length > 0) {
+              return forkJoin(restartObservables);
+            }
+          }
+          return of(null);
+        })
+      )
+      .subscribe({
+        next: () => {
+          item.status = 'restarted';
+          item.tagType = 'green';
+          item.statusText = 'Restarted';
+          this.notificationService.show(
+            NotificationType.success,
+            $localize`Initiated restart for ${serviceName} daemon(s).`
+          );
+        },
+        error: () => {
+          item.status = 'failed';
+          item.tagType = 'red';
+          item.statusText = 'Failed';
+        }
+      });
+  }
+
+  restartAllServices() {
+    this.restartingAll = true;
+    const pendingItems = this.serviceItems.filter((i) => i.status !== 'restarted');
+    pendingItems.forEach((i) => {
+      i.status = 'restarting';
+      i.tagType = 'magenta';
+      i.statusText = 'Restarting...';
+    });
+
+    const pendingNames = pendingItems.map((i) => i.name);
+    const includesMgr = pendingNames.some((name) => name.toLowerCase().includes('mgr'));
+
+    this.daemonService
+      .list(pendingNames)
+      .pipe(
+        switchMap((daemons) => {
+          if (daemons && daemons.length > 0) {
+            const restartObservables = daemons
+              .map((d) => d.daemon_name || (d as any).name)
+              .filter(Boolean)
+              .map((daemonName) =>
+                this.daemonService
+                  .action(daemonName, 'restart', true)
+                  .pipe(catchError(() => of(null)))
+              );
+
+            if (restartObservables.length > 0) {
+              return forkJoin(restartObservables);
+            }
+          }
+          return of(null);
+        })
+      )
+      .subscribe({
+        next: () => {
+          this.restartingAll = false;
+          pendingItems.forEach((i) => {
+            i.status = 'restarted';
+            i.tagType = 'green';
+            i.statusText = 'Restarted';
+          });
+          const serviceText = pendingNames.join(', ');
+          this.notificationService.show(
+            NotificationType.success,
+            $localize`Updated config option ${this.configName} and initiated restart for ${serviceText} service daemon(s).`
+          );
+          this.closeModal();
+          if (includesMgr) {
+            timer(10000).subscribe(() => {
+              this.router.navigate(['/configuration']);
+            });
+          } else {
+            this.router.navigate(['/configuration']);
+          }
+        },
+        error: () => {
+          this.restartingAll = false;
+          pendingItems.forEach((i) => {
+            i.status = 'failed';
+            i.tagType = 'red';
+            i.statusText = 'Failed';
+          });
+        }
+      });
+  }
+
+  skipRestart() {
+    this.closeModal();
+    if (!this.allRestarted) {
+      const serviceText =
+        this.services.length > 0 ? this.services.join(', ') : $localize`affected service(s)`;
+      this.notificationService.show(
+        NotificationType.success,
+        $localize`Updated config option ${this.configName}. Please remember to restart ${serviceText} service(s) later.`
+      );
+    }
+    this.router.navigate(['/configuration']);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -20,6 +20,20 @@
           <h3 i18n>Edit {{ configForm.getValue('name') }}</h3>
         </div>
 
+        @if (forceUpdate) {
+          <div
+            cdsRow
+            class="form-item cds-mb-4"
+          >
+            <cd-alert-panel
+              type="warning"
+              spacingClass="cds-mb-3"
+            >
+              {{ getRestartWarningMessage() }}
+            </cd-alert-panel>
+          </div>
+        }
+
         <!-- Name -->
         <div
           cdsRow

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.scss
@@ -1,0 +1,7 @@
+.restart-warning-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.spec.ts
@@ -387,6 +387,28 @@ describe('ConfigurationFormComponent', () => {
         expect(component.availSections).toContain('mgr.ceph-node-00.vfbbqn');
         expect(component.availSections).toContain('osd.0');
       });
+
+      it('should set forceUpdate to true when can_update_at_runtime is false', () => {
+        const response = new ConfigFormModel();
+        response.name = 'public_network';
+        response.type = 'str';
+        response.can_update_at_runtime = false;
+
+        component.setResponse(response);
+
+        expect(component.forceUpdate).toBe(true);
+      });
+
+      it('should set forceUpdate to false when can_update_at_runtime is true', () => {
+        const response = new ConfigFormModel();
+        response.name = 'public_network';
+        response.type = 'str';
+        response.can_update_at_runtime = true;
+
+        component.setResponse(response);
+
+        expect(component.forceUpdate).toBe(false);
+      });
     });
 
     describe('createRequest', () => {
@@ -396,6 +418,17 @@ describe('ConfigurationFormComponent', () => {
         component.response.type = 'str';
         component.response.value = [];
         component.createForm();
+        component.setResponse(component.response);
+      });
+
+      it('should set force_update on request when forceUpdate is true', () => {
+        component.forceUpdate = true;
+        component.configForm.get('values')?.get('global')?.setValue('10.0.0.0/24');
+
+        const request = component.createRequest();
+
+        expect(request).toBeTruthy();
+        expect(request?.force_update).toBe(true);
       });
 
       it('should include client entity configurations in request', () => {
@@ -442,6 +475,30 @@ describe('ConfigurationFormComponent', () => {
         const request = component.createRequest();
 
         expect(request).toBeNull();
+      });
+    });
+
+    describe('getRestartWarningMessage', () => {
+      it('should return specific service restart message when services exist', () => {
+        component.response = new ConfigFormModel();
+        component.response.type = 'str';
+        component.response.services = ['rgw', 'mon'];
+        component.createForm();
+        component.setResponse(component.response);
+
+        const msg = component.getRestartWarningMessage();
+        expect(msg).toContain('rgw, mon');
+      });
+
+      it('should return generic service restart message when services list is empty', () => {
+        component.response = new ConfigFormModel();
+        component.response.type = 'str';
+        component.response.services = [];
+        component.createForm();
+        component.setResponse(component.response);
+
+        const msg = component.getRestartWarningMessage();
+        expect(msg).toContain('affected service(s) or daemon(s)');
       });
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
@@ -25,9 +25,10 @@ import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { ConfigFormCreateRequestModel } from './configuration-form-create-request.model';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
+import { ConfigOptionRestartModalComponent } from './config-option-restart-modal/config-option-restart-modal.component';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { DataGatewayService } from '~/app/shared/services/data-gateway.service';
-const RGW = 'rgw';
+
 interface ClientEntityItem {
   content: string;
   name: string;
@@ -172,7 +173,7 @@ export class ConfigurationFormComponent extends CdForm implements OnInit {
         this.configForm.get('values')?.get(value.section)?.setValue(sectionValue);
       });
     }
-    this.forceUpdate = !this.response.can_update_at_runtime && response.name.includes(RGW);
+    this.forceUpdate = !this.response.can_update_at_runtime;
     this.availSections.forEach((section) => {
       if (validators) {
         this.configForm.get('values')?.get(section)?.setValidators(validators);
@@ -403,16 +404,41 @@ export class ConfigurationFormComponent extends CdForm implements OnInit {
     return null;
   }
 
+  getRestartWarningMessage(): string {
+    const services: string[] =
+      this.configForm.getValue('services') || this.response?.services || [];
+    if (services.length > 0) {
+      const servicesStr = services.join(', ');
+      return $localize`Restarting affected service(s) is required for changes to take effect. Updating this configuration requires restarting: ${servicesStr}.`;
+    }
+    return $localize`Restarting affected service(s) or daemon(s) is required for changes to take effect.`;
+  }
+
   openCriticalConfirmModal() {
+    const services: string[] =
+      this.configForm.getValue('services') || this.response?.services || [];
+    const serviceListStr = services.length > 0 ? services.join(', ') : '';
+    const infoMessage =
+      services.length > 0
+        ? $localize`Restarting affected service(s) is required for changes to take effect. Updating this configuration requires restarting: ${serviceListStr}.`
+        : $localize`Restarting affected service(s) or daemon(s) is required for changes to take effect.`;
+
     this.modalService.show(DeleteConfirmationModalComponent, {
       buttonText: $localize`Force Edit`,
       actionDescription: $localize`force edit`,
       itemDescription: $localize`configuration`,
-      infoMessage: 'Updating this configuration might require restarting the client',
+      infoMessage: infoMessage,
       submitAction: () => {
         this.modalService.dismissAll();
         this.submit();
       }
+    });
+  }
+
+  openPostUpdateRestartModal(services: string[], configName: string) {
+    this.modalService.show(ConfigOptionRestartModalComponent, {
+      configName: configName,
+      services: services
     });
   }
 
@@ -422,17 +448,24 @@ export class ConfigurationFormComponent extends CdForm implements OnInit {
     if (request) {
       this.configService.create(request).subscribe({
         next: () => {
-          this.notificationService.show(
-            NotificationType.success,
-            $localize`Updated config option ${request.name}`
-          );
+          const services: string[] =
+            this.configForm.getValue('services') || this.response?.services || [];
           this.router.navigate(['/configuration']);
+          if (this.forceUpdate) {
+            this.openPostUpdateRestartModal(services, request.name);
+          } else {
+            this.notificationService.show(
+              NotificationType.success,
+              $localize`Updated config option ${request.name}`
+            );
+          }
         },
         error: () => {
           this.configForm.setErrors({ cdSubmitButton: true });
         }
       });
     } else {
+      this.configForm.setErrors({ cdSubmitButton: true });
       this.router.navigate(['/configuration']);
     }
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
@@ -11,6 +11,7 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { ConfigurationComponent } from './configuration.component';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
+import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 
 describe('ConfigurationComponent', () => {
   let component: ConfigurationComponent;
@@ -36,6 +37,26 @@ describe('ConfigurationComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('isEditable', () => {
+    it('should return true for a single selected configuration', () => {
+      const selection = new CdTableSelection();
+      selection.selected = [{ name: 'public_network', can_update_at_runtime: false }];
+      expect(component.isEditable(selection)).toBe(true);
+    });
+
+    it('should return false when no configuration or multiple configurations are selected', () => {
+      const selection = new CdTableSelection();
+      selection.selected = [];
+      expect(component.isEditable(selection)).toBe(false);
+
+      selection.selected = [
+        { name: 'public_network', can_update_at_runtime: false },
+        { name: 'cluster_network', can_update_at_runtime: false }
+      ];
+      expect(component.isEditable(selection)).toBe(false);
+    });
   });
 
   // TODO: Re-write this unit test to reflect latest changes on datatble markup

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
@@ -13,8 +13,6 @@ import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ConfigurationOption } from '~/app/shared/services/configuration-resource-state.service';
 
-const RGW = 'rgw';
-
 @Component({
   selector: 'cd-configuration',
   templateUrl: './configuration.component.html',
@@ -151,8 +149,8 @@ export class ConfigurationComponent extends ListWithDetails implements OnInit {
       },
       { prop: 'default', name: $localize`Default`, cellClass: 'wrap' },
       {
-        prop: 'can_update_at_runtime',
-        name: $localize`Editable`,
+        prop: 'restart_required',
+        name: $localize`Restart Required`,
         cellTransformation: CellTemplate.checkIcon,
         flexGrow: 0.4,
         cellClass: 'text-center'
@@ -169,6 +167,7 @@ export class ConfigurationComponent extends ListWithDetails implements OnInit {
       (data: any) => {
         this.data = (Array.isArray(data) ? data : []).map((configOption: ConfigurationOption) => ({
           ...configOption,
+          restart_required: !configOption.can_update_at_runtime,
           cdLink: `/configuration/${encodeURIComponent(configOption.name)}`
         }));
       },
@@ -179,12 +178,6 @@ export class ConfigurationComponent extends ListWithDetails implements OnInit {
   }
 
   isEditable(selection: CdTableSelection): boolean {
-    if (selection.selected.length !== 1) {
-      return false;
-    }
-    if ((this.selection.selected[0].name as string).includes(RGW)) {
-      return true;
-    }
-    return this.selection.selected[0].can_update_at_runtime;
+    return selection.selected.length === 1;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component.html
@@ -17,6 +17,7 @@
       <cd-alert-panel
         *ngIf="infoMessage"
         type="info"
+        [showTitle]="showInfoTitle"
         spacingClass="cds-mb-3"
         i18n
       >
@@ -58,7 +59,10 @@
         <ng-container
           *ngTemplateOutlet="childFormGroupTemplate; context: { form: deletionForm }"
         ></ng-container>
-        <div class="form-item">
+        <div
+          class="form-item"
+          *ngIf="!hideConfirmationCheckbox"
+        >
           <ng-container *ngIf="impact == impactEnum.medium; else highImpactDeletion">
             <cds-checkbox
               id="confirmation"
@@ -69,6 +73,14 @@
               ariaLabel="confirmation"
               i18n
               >Yes, I am sure.</cds-checkbox
+            >
+            <cds-checkbox
+              *ngIf="extraCheckboxText"
+              id="extraCheckbox"
+              formControlName="extraCheckbox"
+              ariaLabel="extraCheckbox"
+              class="cds-mt-2"
+              >{{ extraCheckboxText }}</cds-checkbox
             >
           </ng-container>
           <ng-template #highImpactDeletion>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component.ts
@@ -35,6 +35,11 @@ export class DeleteConfirmationModalComponent extends BaseModal implements OnIni
     @Inject('bodyContext')
     public bodyContext?: DeleteConfirmationBodyContext,
     @Optional() @Inject('infoMessage') public infoMessage?: string,
+    @Optional() @Inject('showInfoTitle') public showInfoTitle = false,
+    @Optional() @Inject('extraCheckboxText') public extraCheckboxText?: string,
+    @Optional() @Inject('buttonText') public buttonText?: string,
+    @Optional() @Inject('cancelButtonText') public cancelButtonText?: string,
+    @Optional() @Inject('hideConfirmationCheckbox') public hideConfirmationCheckbox = false,
     @Optional()
     @Inject('submitActionObservable')
     public submitActionObservable?: () => Observable<any>,
@@ -54,15 +59,17 @@ export class DeleteConfirmationModalComponent extends BaseModal implements OnIni
   ngOnInit() {
     const controls: Record<string, AbstractControl> = {
       impact: new UntypedFormControl(this.impact),
-      confirmation: new UntypedFormControl(false, {
-        validators: [
-          CdValidators.composeIf(
-            {
-              impact: DeletionImpact.medium
-            },
-            [Validators.requiredTrue]
-          )
-        ]
+      confirmation: new UntypedFormControl(this.hideConfirmationCheckbox ? true : false, {
+        validators: this.hideConfirmationCheckbox
+          ? []
+          : [
+              CdValidators.composeIf(
+                {
+                  impact: DeletionImpact.medium
+                },
+                [Validators.requiredTrue]
+              )
+            ]
       }),
       confirmInput: new UntypedFormControl('', {
         validators: [
@@ -73,6 +80,10 @@ export class DeleteConfirmationModalComponent extends BaseModal implements OnIni
         ]
       })
     };
+
+    if (this.extraCheckboxText) {
+      controls['extraCheckbox'] = new UntypedFormControl(false);
+    }
 
     if (
       this.impact === this.impactEnum.high &&
@@ -128,7 +139,7 @@ export class DeleteConfirmationModalComponent extends BaseModal implements OnIni
         complete: this.hideModal.bind(this)
       });
     } else {
-      this.submitAction();
+      this.submitAction(this.deletionForm?.value?.extraCheckbox);
     }
   }
 


### PR DESCRIPTION
mgr/dashboard: Allow editing non-runtime configurations with force edit confirmation

Fixes: https://tracker.ceph.com/issues/80010

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

### PR Description:

* **Renamed Table Column ("Can update at runtime" → "Restart Required"):**
  * **What changed:** Renamed the table column from "Can update at runtime" to "Restart Required".
  * **Why we changed it:** Since all configuration options can now be edited from the dashboard, the column's purpose shifts from indicating editability to clearly communicating actionability—specifically whether modifying an option requires restarting cluster services for changes to take effect.

* **Enabled Editing for All Configuration Options:**
  * Unlocked editing for all Ceph cluster configuration options (including non-runtime settings like `public_network` and `cluster_network`) directly from the dashboard table, matching CLI capabilities.

* **Added Warning Banners on the Edit Form:**
  * When editing an option that requires service restarts, a warning banner appears on the form explaining potential service disruption and explicitly listing which cluster services will be impacted (e.g., MON, MDS, OSD, MGR).

* **Added Force-Edit Confirmation Dialog:**
  * Prompted administrators with a confirmation modal before saving high-impact changes, ensuring explicit agreement to potential service disruption before updating the cluster.

* **Created Interactive Service Restart Modal:**
  * After saving, a dedicated modal displays all affected services alongside live status badges (Pending, Restarting..., Restarted, Failed).
  * Allows restarting services individually or all at once using "Restart All Services".
  * Includes an informational note when Manager (MGR) is affected, reminding admins that restarting Manager will briefly interrupt the active UI session.

* **Aligned Modal Controls with Carbon UX Standards:**
  * Standardized modal button placement according to Carbon Design System guidelines (`<cds-modal-footer>`).
  * Secondary button dynamically transitions from "Skip / Restart Later" to "Close" once all services are restarted, allowing clean dismissal without extra alerts.

Screencast : 


https://github.com/user-attachments/assets/11ded0f7-4559-469d-ba84-455642bf6d77








<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
