### PR TITLE
mgr/dashboard: add RBD image diff (changed-blocks) API endpoint

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -40,6 +40,22 @@ RBD_TRASH_SCHEMA = [{
     "pool_name": (str, 'pool name')
 }]
 
+RBD_DIFF_SCHEMA = {
+    "image_size": (int, 'Image size in bytes'),
+    "offset": (int, 'Start offset of the diffed region in bytes'),
+    "length": (int, 'Length of the diffed region in bytes'),
+    "from_snapshot": (str, 'Source snapshot name (null means full allocation)'),
+    "snapshot_name": (str, 'Target snapshot name (null means the live image)'),
+    "whole_object": (bool, 'Whether the diff was computed at object granularity'),
+    "count": (int, 'Number of returned extents'),
+    "diffs": ([{
+        "offset": (int, 'Extent start offset in bytes'),
+        "length": (int, 'Extent length in bytes'),
+        "exists": (bool, 'true if the extent holds data (changed/allocated), '
+                         'false if it was deallocated (discarded/zeroed)')
+    }], 'Changed extents, in ascending offset order')
+}
+
 RBD_GROUP_LIST_SCHEMA = [{
     "group": (str, 'group name'),
     "num_images": (int, '')
@@ -224,6 +240,36 @@ class Rbd(RESTController):
         can be moved to the trash and deleted at a later time.
         """
         return RbdService.move_image_to_trash(image_spec, delay)
+
+    @handle_rbd_error()
+    @handle_rados_error('pool')
+    @EndpointDoc("List the changed extents (diff) between two states of an RBD image",
+                 parameters={
+                     'image_spec': (str, 'URL-encoded "pool/namespace/image", e.g. "rbd%2Ffoo"'),
+                     'from_snapshot': (str, 'Report extents that changed since this snapshot. '
+                                            'Omit to report every allocated extent.'),
+                     'snapshot_name': (str, 'Diff up to this snapshot. '
+                                            'Omit to diff up to the live image.'),
+                     'offset': (int, 'Start offset in bytes (default: 0).'),
+                     'length': (int, 'Length in bytes (default: up to the image size).'),
+                     'whole_object': (bool, 'Diff whole objects using object-map/fast-diff: '
+                                            'faster and coarser. Default: false (byte-exact).'),
+                 },
+                 responses={200: RBD_DIFF_SCHEMA})
+    @RESTController.Resource('GET')
+    @ReadPermission
+    def diff(self, image_spec, from_snapshot=None, snapshot_name=None,
+             offset=0, length=None, whole_object=False):
+        """List the extents that differ between two states of an image.
+
+        Mirrors ``rbd diff [--from-snap <from_snapshot>] <image>[@<snapshot_name>]``:
+        it walks the image via ``diff_iterate2`` and returns the changed extents,
+        which is the primitive backup tools need for changed-block tracking (CBT).
+        """
+        return RbdService.image_diff(
+            image_spec, from_snapshot, snapshot_name, int(offset),
+            int(length) if length is not None else None,
+            str_to_bool(whole_object))
 
 
 @UIRouter('/block/rbd')

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -266,10 +266,33 @@ class Rbd(RESTController):
         it walks the image via ``diff_iterate2`` and returns the changed extents,
         which is the primitive backup tools need for changed-block tracking (CBT).
         """
+        if from_snapshot == '':
+            from_snapshot = None
+        if snapshot_name == '':
+            snapshot_name = None
+        if length == '':
+            length = None
+        try:
+            offset_i = int(offset)
+        except (TypeError, ValueError) as e:
+            raise DashboardException(
+                msg="invalid offset '{}'".format(offset),
+                code='invalid_offset', component='rbd') from e
+        try:
+            length_i = int(length) if length is not None else None
+        except (TypeError, ValueError) as e:
+            raise DashboardException(
+                msg="invalid length '{}'".format(length),
+                code='invalid_length', component='rbd') from e
+        try:
+            whole_object_b = str_to_bool(whole_object)
+        except ValueError as e:
+            raise DashboardException(
+                msg="invalid whole_object '{}'".format(whole_object),
+                code='invalid_whole_object', component='rbd') from e
         return RbdService.image_diff(
-            image_spec, from_snapshot, snapshot_name, int(offset),
-            int(length) if length is not None else None,
-            str_to_bool(whole_object))
+            image_spec, from_snapshot, snapshot_name, offset_i, length_i,
+            whole_object_b)
 
 
 @UIRouter('/block/rbd')

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -936,6 +936,167 @@ paths:
       - jwt: []
       tags:
       - Rbd
+  /api/block/image/{image_spec}/diff:
+    get:
+      description: "List the extents that differ between two states of an image.\n\
+        \n        Mirrors ``rbd diff [--from-snap <from_snapshot>] <image>[@<snapshot_name>]``:\n\
+        \        it walks the image via ``diff_iterate2`` and returns the changed\
+        \ extents,\n        which is the primitive backup tools need for changed-block\
+        \ tracking (CBT).\n        "
+      parameters:
+      - description: URL-encoded "pool/namespace/image", e.g. "rbd%2Ffoo"
+        in: path
+        name: image_spec
+        required: true
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: Report extents that changed since this snapshot. Omit to report
+          every allocated extent.
+        in: query
+        name: from_snapshot
+        schema:
+          type: string
+      - allowEmptyValue: true
+        description: Diff up to this snapshot. Omit to diff up to the live image.
+        in: query
+        name: snapshot_name
+        schema:
+          type: string
+      - default: 0
+        description: 'Start offset in bytes (default: 0).'
+        in: query
+        name: offset
+        schema:
+          type: integer
+      - allowEmptyValue: true
+        description: 'Length in bytes (default: up to the image size).'
+        in: query
+        name: length
+        schema:
+          type: integer
+      - default: false
+        description: 'Diff whole objects using object-map/fast-diff: faster and coarser.
+          Default: false (byte-exact).'
+        in: query
+        name: whole_object
+        schema:
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  count:
+                    description: Number of returned extents
+                    type: integer
+                  diffs:
+                    description: Changed extents, in ascending offset order
+                    items:
+                      properties:
+                        exists:
+                          description: true if the extent holds data (changed/allocated),
+                            false if it was deallocated (discarded/zeroed)
+                          type: boolean
+                        length:
+                          description: Extent length in bytes
+                          type: integer
+                        offset:
+                          description: Extent start offset in bytes
+                          type: integer
+                      required: &id008
+                      - offset
+                      - length
+                      - exists
+                      type: object
+                    type: array
+                  from_snapshot:
+                    description: Source snapshot name (null means full allocation)
+                    type: string
+                  image_size:
+                    description: Image size in bytes
+                    type: integer
+                  length:
+                    description: Length of the diffed region in bytes
+                    type: integer
+                  offset:
+                    description: Start offset of the diffed region in bytes
+                    type: integer
+                  snapshot_name:
+                    description: Target snapshot name (null means the live image)
+                    type: string
+                  whole_object:
+                    description: Whether the diff was computed at object granularity
+                    type: boolean
+                required: &id009
+                - image_size
+                - offset
+                - length
+                - from_snapshot
+                - snapshot_name
+                - whole_object
+                - count
+                - diffs
+                type: object
+            application/vnd.ceph.api.v1.0+json:
+              schema:
+                properties:
+                  count:
+                    description: Number of returned extents
+                    type: integer
+                  diffs:
+                    description: Changed extents, in ascending offset order
+                    items:
+                      properties:
+                        exists:
+                          description: true if the extent holds data (changed/allocated),
+                            false if it was deallocated (discarded/zeroed)
+                          type: boolean
+                        length:
+                          description: Extent length in bytes
+                          type: integer
+                        offset:
+                          description: Extent start offset in bytes
+                          type: integer
+                      required: *id008
+                      type: object
+                    type: array
+                  from_snapshot:
+                    description: Source snapshot name (null means full allocation)
+                    type: string
+                  image_size:
+                    description: Image size in bytes
+                    type: integer
+                  length:
+                    description: Length of the diffed region in bytes
+                    type: integer
+                  offset:
+                    description: Start offset of the diffed region in bytes
+                    type: integer
+                  snapshot_name:
+                    description: Target snapshot name (null means the live image)
+                    type: string
+                  whole_object:
+                    description: Whether the diff was computed at object granularity
+                    type: boolean
+                required: *id009
+                type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: List the changed extents (diff) between two states of an RBD image
+      tags:
+      - Rbd
   /api/block/image/{image_spec}/flatten:
     post:
       parameters:
@@ -1321,7 +1482,7 @@ paths:
                   mirror_mode:
                     description: Mirror Mode
                     type: string
-                required: &id008
+                required: &id010
                 - mirror_mode
                 type: object
             application/vnd.ceph.api.v1.0+json:
@@ -1330,7 +1491,7 @@ paths:
                   mirror_mode:
                     description: Mirror Mode
                     type: string
-                required: *id008
+                required: *id010
                 type: object
           description: OK
         '400':
@@ -1724,7 +1885,7 @@ paths:
                   site_name:
                     description: Site Name
                     type: string
-                required: &id009
+                required: &id011
                 - site_name
                 type: object
             application/vnd.ceph.api.v1.0+json:
@@ -1733,7 +1894,7 @@ paths:
                   site_name:
                     description: Site Name
                     type: string
-                required: *id009
+                required: *id011
                 type: object
           description: OK
         '400':
@@ -1847,7 +2008,7 @@ paths:
                               items:
                                 type: string
                               type: array
-                          required: &id010
+                          required: &id012
                           - name
                           - health_color
                           - health
@@ -1855,7 +2016,7 @@ paths:
                           - peer_uuids
                           type: object
                         type: array
-                    required: &id011
+                    required: &id013
                     - daemons
                     - pools
                     - image_error
@@ -1868,7 +2029,7 @@ paths:
                   status:
                     description: ''
                     type: integer
-                required: &id012
+                required: &id014
                 - site_name
                 - status
                 - content_data
@@ -1920,10 +2081,10 @@ paths:
                               items:
                                 type: string
                               type: array
-                          required: *id010
+                          required: *id012
                           type: object
                         type: array
-                    required: *id011
+                    required: *id013
                     type: object
                   site_name:
                     description: site name
@@ -1931,7 +2092,7 @@ paths:
                   status:
                     description: ''
                     type: integer
-                required: *id012
+                required: *id014
                 type: object
           description: OK
         '400':
@@ -2015,7 +2176,7 @@ paths:
                       description: ''
                       type: integer
                   type: object
-                required: &id013
+                required: &id015
                 - group
                 - num_images
                 type: array
@@ -2030,7 +2191,7 @@ paths:
                       description: ''
                       type: integer
                   type: object
-                required: *id013
+                required: *id015
                 type: array
           description: OK
         '400':
@@ -2194,7 +2355,7 @@ paths:
                     items:
                       type: object
                     type: array
-                required: &id014
+                required: &id016
                 - images
                 type: object
             application/vnd.ceph.api.v1.0+json:
@@ -2206,7 +2367,7 @@ paths:
                     items:
                       type: object
                     type: array
-                required: *id014
+                required: *id016
                 type: object
           description: OK
         '400':
@@ -2457,7 +2618,7 @@ paths:
                       description: snapshot state
                       type: integer
                   type: object
-                required: &id015
+                required: &id017
                 - id
                 - name
                 - state
@@ -2480,7 +2641,7 @@ paths:
                       description: snapshot state
                       type: integer
                   type: object
-                required: *id015
+                required: *id017
                 type: array
           description: OK
         '400':
@@ -2681,7 +2842,7 @@ paths:
                   state:
                     description: snapshot state
                     type: integer
-                required: &id016
+                required: &id018
                 - id
                 - name
                 - state
@@ -2712,7 +2873,7 @@ paths:
                   state:
                     description: snapshot state
                     type: integer
-                required: *id016
+                required: *id018
                 type: object
           description: OK
         '400':
@@ -3219,7 +3380,7 @@ paths:
                                     fs_name:
                                       description: Remote filesystem name
                                       type: string
-                                  required: &id017
+                                  required: &id019
                                   - client_name
                                   - cluster_name
                                   - fs_name
@@ -3233,20 +3394,20 @@ paths:
                                     recovery_count:
                                       description: Number of peer recoveries
                                       type: integer
-                                  required: &id018
+                                  required: &id020
                                   - failure_count
                                   - recovery_count
                                   type: object
                                 uuid:
                                   description: Peer UUID
                                   type: string
-                              required: &id019
+                              required: &id021
                               - uuid
                               - remote
                               - stats
                               type: object
                             type: array
-                        required: &id020
+                        required: &id022
                         - filesystem_id
                         - name
                         - directory_count
@@ -3254,7 +3415,7 @@ paths:
                         type: object
                       type: array
                   type: object
-                required: &id021
+                required: &id023
                 - daemon_id
                 - filesystems
                 type: array
@@ -3294,7 +3455,7 @@ paths:
                                     fs_name:
                                       description: Remote filesystem name
                                       type: string
-                                  required: *id017
+                                  required: *id019
                                   type: object
                                 stats:
                                   description: Peer statistics
@@ -3305,19 +3466,19 @@ paths:
                                     recovery_count:
                                       description: Number of peer recoveries
                                       type: integer
-                                  required: *id018
+                                  required: *id020
                                   type: object
                                 uuid:
                                   description: Peer UUID
                                   type: string
-                              required: *id019
+                              required: *id021
                               type: object
                             type: array
-                        required: *id020
+                        required: *id022
                         type: object
                       type: array
                   type: object
-                required: *id021
+                required: *id023
                 type: array
           description: OK
         '400':
@@ -3644,13 +3805,13 @@ paths:
                         site_name:
                           description: Remote site name
                           type: string
-                      required: &id022
+                      required: &id024
                       - client_name
                       - site_name
                       - fs_name
                       type: object
                   type: object
-                required: &id023
+                required: &id025
                 - uuid
                 type: array
             application/vnd.ceph.api.v1.0+json:
@@ -3669,10 +3830,10 @@ paths:
                         site_name:
                           description: Remote site name
                           type: string
-                      required: *id022
+                      required: *id024
                       type: object
                   type: object
-                required: *id023
+                required: *id025
                 type: array
           description: OK
         '400':
@@ -3785,7 +3946,7 @@ paths:
                         updated_at:
                           description: Checkpoint last update time
                           type: string
-                      required: &id024
+                      required: &id026
                       - snap_id
                       - snap_name
                       - status
@@ -3797,7 +3958,7 @@ paths:
                   dir_root:
                     description: Mirrored directory path
                     type: string
-                required: &id025
+                required: &id027
                 - dir_root
                 - checkpoints
                 type: object
@@ -3826,13 +3987,13 @@ paths:
                         updated_at:
                           description: Checkpoint last update time
                           type: string
-                      required: *id024
+                      required: *id026
                       type: object
                     type: array
                   dir_root:
                     description: Mirrored directory path
                     type: string
-                required: *id025
+                required: *id027
                 type: object
           description: OK
         '400':
@@ -4019,7 +4180,7 @@ paths:
                                           total_bytes:
                                             description: Total bytes to sync
                                             type: string
-                                        required: &id026
+                                        required: &id028
                                         - sync_bytes
                                         - total_bytes
                                         - sync_percent
@@ -4034,7 +4195,7 @@ paths:
                                             description: Phase state, e.g. completed,
                                               in-progress, or waiting
                                             type: string
-                                        required: &id027
+                                        required: &id029
                                         - state
                                         - duration
                                         type: object
@@ -4048,7 +4209,7 @@ paths:
                                             description: Phase state, e.g. completed,
                                               in-progress, or waiting
                                             type: string
-                                        required: &id028
+                                        required: &id030
                                         - state
                                         - duration
                                         type: object
@@ -4068,7 +4229,7 @@ paths:
                                           total_files:
                                             description: Total files to sync
                                             type: string
-                                        required: &id029
+                                        required: &id031
                                         - sync_files
                                         - total_files
                                         - sync_percent
@@ -4083,7 +4244,7 @@ paths:
                                         description: 'Snapshot sync mode: full or
                                           delta'
                                         type: string
-                                    required: &id030
+                                    required: &id032
                                     - id
                                     - name
                                     - sync-mode
@@ -4128,7 +4289,7 @@ paths:
                                         description: Wall-clock time when the snapshot
                                           sync finished
                                         type: string
-                                    required: &id031
+                                    required: &id033
                                     - id
                                     - name
                                     - crawl_duration
@@ -4157,7 +4318,7 @@ paths:
                                     description: 'Mirror sync state: idle, syncing,
                                       stale, or failed'
                                     type: string
-                                required: &id032
+                                required: &id034
                                 - state
                                 - failure_reason
                                 - current_syncing_snap
@@ -4167,16 +4328,16 @@ paths:
                                 - snaps_renamed
                                 - metrics_updated_at
                                 type: object
-                            required: &id033
+                            required: &id035
                             - peer_uuid
                             type: object
-                        required: &id034
+                        required: &id036
                         - peer
                         type: object
-                    required: &id035
+                    required: &id037
                     - /dir_path
                     type: object
-                required: &id036
+                required: &id038
                 - metrics
                 type: object
             application/vnd.ceph.api.v1.0+json:
@@ -4216,7 +4377,7 @@ paths:
                                           total_bytes:
                                             description: Total bytes to sync
                                             type: string
-                                        required: *id026
+                                        required: *id028
                                         type: object
                                       crawl:
                                         description: Directory crawl progress
@@ -4228,7 +4389,7 @@ paths:
                                             description: Phase state, e.g. completed,
                                               in-progress, or waiting
                                             type: string
-                                        required: *id027
+                                        required: *id029
                                         type: object
                                       datasync_queue_wait:
                                         description: Data sync queue wait progress
@@ -4240,7 +4401,7 @@ paths:
                                             description: Phase state, e.g. completed,
                                               in-progress, or waiting
                                             type: string
-                                        required: *id028
+                                        required: *id030
                                         type: object
                                       eta:
                                         description: Estimated time remaining for
@@ -4258,7 +4419,7 @@ paths:
                                           total_files:
                                             description: Total files to sync
                                             type: string
-                                        required: *id029
+                                        required: *id031
                                         type: object
                                       id:
                                         description: Snapshot ID
@@ -4270,7 +4431,7 @@ paths:
                                         description: 'Snapshot sync mode: full or
                                           delta'
                                         type: string
-                                    required: *id030
+                                    required: *id032
                                     type: object
                                   failure_reason:
                                     description: Last sync failure reason when state
@@ -4305,7 +4466,7 @@ paths:
                                         description: Wall-clock time when the snapshot
                                           sync finished
                                         type: string
-                                    required: *id031
+                                    required: *id033
                                     type: object
                                   metrics_updated_at:
                                     description: Wall-clock time when metrics were
@@ -4326,15 +4487,15 @@ paths:
                                     description: 'Mirror sync state: idle, syncing,
                                       stale, or failed'
                                     type: string
-                                required: *id032
+                                required: *id034
                                 type: object
-                            required: *id033
+                            required: *id035
                             type: object
-                        required: *id034
+                        required: *id036
                         type: object
-                    required: *id035
+                    required: *id037
                     type: object
-                required: *id036
+                required: *id038
                 type: object
           description: OK
         '400':
@@ -5955,7 +6116,7 @@ paths:
                   max_files:
                     description: ''
                     type: integer
-                required: &id037
+                required: &id039
                 - max_bytes
                 - max_files
                 type: object
@@ -5968,7 +6129,7 @@ paths:
                   max_files:
                     description: ''
                     type: integer
-                required: *id037
+                required: *id039
                 type: object
           description: OK
         '400':
@@ -6242,7 +6403,7 @@ paths:
                   subdirs:
                     description: ''
                     type: integer
-                required: &id038
+                required: &id040
                 - bytes
                 - files
                 - subdirs
@@ -6259,7 +6420,7 @@ paths:
                   subdirs:
                     description: ''
                     type: integer
-                required: *id038
+                required: *id040
                 type: object
           description: OK
         '400':
@@ -7242,7 +7403,7 @@ paths:
                       description: Config option type
                       type: string
                   type: object
-                required: &id039
+                required: &id041
                 - name
                 - type
                 - level
@@ -7319,7 +7480,7 @@ paths:
                       description: Config option type
                       type: string
                   type: object
-                required: *id039
+                required: *id041
                 type: array
           description: OK
         '400':
@@ -7443,7 +7604,7 @@ paths:
                   type:
                     description: Type of Rule
                     type: integer
-                required: &id040
+                required: &id042
                 - rule_id
                 - rule_name
                 - ruleset
@@ -7478,7 +7639,7 @@ paths:
                   type:
                     description: Type of Rule
                     type: integer
-                required: *id040
+                required: *id042
                 type: object
           description: OK
         '400':
@@ -7741,7 +7902,7 @@ paths:
                       description: ''
                       type: string
                   type: object
-                required: &id041
+                required: &id043
                 - crush-failure-domain
                 - k
                 - m
@@ -7772,7 +7933,7 @@ paths:
                       description: ''
                       type: string
                   type: object
-                required: *id041
+                required: *id043
                 type: array
           description: OK
         '400':
@@ -7930,7 +8091,7 @@ paths:
                   rgw:
                     description: ''
                     type: boolean
-                required: &id042
+                required: &id044
                 - rbd
                 - mirroring
                 - iscsi
@@ -7959,7 +8120,7 @@ paths:
                   rgw:
                     description: ''
                     type: boolean
-                required: *id042
+                required: *id044
                 type: object
           description: OK
         '400':
@@ -8217,7 +8378,7 @@ paths:
                   instance:
                     description: grafana instance
                     type: string
-                required: &id043
+                required: &id045
                 - instance
                 type: object
             application/vnd.ceph.api.v1.0+json:
@@ -8226,7 +8387,7 @@ paths:
                   instance:
                     description: grafana instance
                     type: string
-                required: *id043
+                required: *id045
                 type: object
           description: OK
         '400':
@@ -8447,7 +8608,7 @@ paths:
                       write_op_per_sec:
                         description: ''
                         type: integer
-                    required: &id044
+                    required: &id046
                     - read_bytes_sec
                     - read_op_per_sec
                     - recovering_bytes_per_sec
@@ -8469,12 +8630,12 @@ paths:
                           total_used_raw_bytes:
                             description: ''
                             type: integer
-                        required: &id045
+                        required: &id047
                         - total_avail_bytes
                         - total_bytes
                         - total_used_raw_bytes
                         type: object
-                    required: &id046
+                    required: &id048
                     - stats
                     type: object
                   fs_map:
@@ -8505,7 +8666,7 @@ paths:
                                     ro_compat:
                                       description: ''
                                       type: string
-                                  required: &id047
+                                  required: &id049
                                   - compat
                                   - ro_compat
                                   - incompat
@@ -8598,7 +8759,7 @@ paths:
                                 up:
                                   description: ''
                                   type: string
-                              required: &id048
+                              required: &id050
                               - session_autoclose
                               - balancer
                               - up
@@ -8632,12 +8793,12 @@ paths:
                             standbys:
                               description: ''
                               type: string
-                          required: &id049
+                          required: &id051
                           - mdsmap
                           - standbys
                           type: object
                         type: array
-                    required: &id050
+                    required: &id052
                     - filesystems
                     type: object
                   health:
@@ -8652,7 +8813,7 @@ paths:
                       status:
                         description: ''
                         type: string
-                    required: &id051
+                    required: &id053
                     - checks
                     - mutes
                     - status
@@ -8669,7 +8830,7 @@ paths:
                       up:
                         description: ''
                         type: integer
-                    required: &id052
+                    required: &id054
                     - up
                     - down
                     type: object
@@ -8682,7 +8843,7 @@ paths:
                       standbys:
                         description: ''
                         type: string
-                    required: &id053
+                    required: &id055
                     - active_name
                     - standbys
                     type: object
@@ -8695,7 +8856,7 @@ paths:
                           mons:
                             description: ''
                             type: string
-                        required: &id054
+                        required: &id056
                         - mons
                         type: object
                       quorum:
@@ -8703,7 +8864,7 @@ paths:
                         items:
                           type: integer
                         type: array
-                    required: &id055
+                    required: &id057
                     - monmap
                     - quorum
                     type: object
@@ -8720,12 +8881,12 @@ paths:
                             up:
                               description: ''
                               type: integer
-                          required: &id056
+                          required: &id058
                           - in
                           - up
                           type: object
                         type: array
-                    required: &id057
+                    required: &id059
                     - osds
                     type: object
                   pg_info:
@@ -8749,7 +8910,7 @@ paths:
                           num_objects_unfound:
                             description: ''
                             type: integer
-                        required: &id058
+                        required: &id060
                         - num_objects
                         - num_object_copies
                         - num_objects_degraded
@@ -8762,7 +8923,7 @@ paths:
                       statuses:
                         description: ''
                         type: string
-                    required: &id059
+                    required: &id061
                     - object_stats
                     - pgs_per_osd
                     - statuses
@@ -8776,7 +8937,7 @@ paths:
                   scrub_status:
                     description: ''
                     type: string
-                required: &id060
+                required: &id062
                 - client_perf
                 - df
                 - fs_map
@@ -8812,7 +8973,7 @@ paths:
                       write_op_per_sec:
                         description: ''
                         type: integer
-                    required: *id044
+                    required: *id046
                     type: object
                   df:
                     description: ''
@@ -8829,9 +8990,9 @@ paths:
                           total_used_raw_bytes:
                             description: ''
                             type: integer
-                        required: *id045
+                        required: *id047
                         type: object
-                    required: *id046
+                    required: *id048
                     type: object
                   fs_map:
                     description: ''
@@ -8861,7 +9022,7 @@ paths:
                                     ro_compat:
                                       description: ''
                                       type: string
-                                  required: *id047
+                                  required: *id049
                                   type: object
                                 created:
                                   description: ''
@@ -8951,15 +9112,15 @@ paths:
                                 up:
                                   description: ''
                                   type: string
-                              required: *id048
+                              required: *id050
                               type: object
                             standbys:
                               description: ''
                               type: string
-                          required: *id049
+                          required: *id051
                           type: object
                         type: array
-                    required: *id050
+                    required: *id052
                     type: object
                   health:
                     description: ''
@@ -8973,7 +9134,7 @@ paths:
                       status:
                         description: ''
                         type: string
-                    required: *id051
+                    required: *id053
                     type: object
                   hosts:
                     description: ''
@@ -8987,7 +9148,7 @@ paths:
                       up:
                         description: ''
                         type: integer
-                    required: *id052
+                    required: *id054
                     type: object
                   mgr_map:
                     description: ''
@@ -8998,7 +9159,7 @@ paths:
                       standbys:
                         description: ''
                         type: string
-                    required: *id053
+                    required: *id055
                     type: object
                   mon_status:
                     description: ''
@@ -9009,14 +9170,14 @@ paths:
                           mons:
                             description: ''
                             type: string
-                        required: *id054
+                        required: *id056
                         type: object
                       quorum:
                         description: ''
                         items:
                           type: integer
                         type: array
-                    required: *id055
+                    required: *id057
                     type: object
                   osd_map:
                     description: ''
@@ -9031,10 +9192,10 @@ paths:
                             up:
                               description: ''
                               type: integer
-                          required: *id056
+                          required: *id058
                           type: object
                         type: array
-                    required: *id057
+                    required: *id059
                     type: object
                   pg_info:
                     description: ''
@@ -9057,7 +9218,7 @@ paths:
                           num_objects_unfound:
                             description: ''
                             type: integer
-                        required: *id058
+                        required: *id060
                         type: object
                       pgs_per_osd:
                         description: ''
@@ -9065,7 +9226,7 @@ paths:
                       statuses:
                         description: ''
                         type: string
-                    required: *id059
+                    required: *id061
                     type: object
                   pools:
                     description: ''
@@ -9076,7 +9237,7 @@ paths:
                   scrub_status:
                     description: ''
                     type: string
-                required: *id060
+                required: *id062
                 type: object
           description: OK
         '400':
@@ -9114,7 +9275,7 @@ paths:
                       num_standbys:
                         description: Standby MDS count
                         type: integer
-                    required: &id061
+                    required: &id063
                     - num_active
                     - num_standbys
                     type: object
@@ -9142,16 +9303,16 @@ paths:
                                   message:
                                     description: Human-readable summary
                                     type: string
-                                required: &id062
+                                required: &id064
                                 - message
                                 - count
                                 type: object
-                            required: &id063
+                            required: &id065
                             - severity
                             - summary
                             - muted
                             type: object
-                        required: &id064
+                        required: &id066
                         - <check_name>
                         type: object
                       mutes:
@@ -9162,7 +9323,7 @@ paths:
                       status:
                         description: Overall health status
                         type: string
-                    required: &id065
+                    required: &id067
                     - status
                     - checks
                     - mutes
@@ -9176,7 +9337,7 @@ paths:
                       num_standbys:
                         description: Standby manager count
                         type: integer
-                    required: &id066
+                    required: &id068
                     - num_active
                     - num_standbys
                     type: object
@@ -9191,7 +9352,7 @@ paths:
                         items:
                           type: integer
                         type: array
-                    required: &id067
+                    required: &id069
                     - num_mons
                     - quorum
                     type: object
@@ -9210,7 +9371,7 @@ paths:
                       up:
                         description: Count of iSCSI gateways running
                         type: integer
-                    required: &id068
+                    required: &id070
                     - up
                     - down
                     type: object
@@ -9229,7 +9390,7 @@ paths:
                       up:
                         description: Number of OSDs up
                         type: integer
-                    required: &id069
+                    required: &id071
                     - in
                     - up
                     - num_osds
@@ -9259,7 +9420,7 @@ paths:
                             state_name:
                               description: Placement group state
                               type: string
-                          required: &id070
+                          required: &id072
                           - state_name
                           - count
                           type: object
@@ -9267,7 +9428,7 @@ paths:
                       recovering_bytes_per_sec:
                         description: Total recovery in bytes
                         type: integer
-                    required: &id071
+                    required: &id073
                     - pgs_by_state
                     - num_pools
                     - num_pgs
@@ -9275,7 +9436,7 @@ paths:
                     - bytes_total
                     - recovering_bytes_per_sec
                     type: object
-                required: &id072
+                required: &id074
                 - fsid
                 - health
                 - monmap
@@ -9303,7 +9464,7 @@ paths:
                       num_standbys:
                         description: Standby MDS count
                         type: integer
-                    required: *id061
+                    required: *id063
                     type: object
                   health:
                     description: Cluster health overview
@@ -9329,11 +9490,11 @@ paths:
                                   message:
                                     description: Human-readable summary
                                     type: string
-                                required: *id062
+                                required: *id064
                                 type: object
-                            required: *id063
+                            required: *id065
                             type: object
-                        required: *id064
+                        required: *id066
                         type: object
                       mutes:
                         description: List of muted check names
@@ -9343,7 +9504,7 @@ paths:
                       status:
                         description: Overall health status
                         type: string
-                    required: *id065
+                    required: *id067
                     type: object
                   mgrmap:
                     description: Manager map details
@@ -9354,7 +9515,7 @@ paths:
                       num_standbys:
                         description: Standby manager count
                         type: integer
-                    required: *id066
+                    required: *id068
                     type: object
                   monmap:
                     description: Monitor map details
@@ -9367,7 +9528,7 @@ paths:
                         items:
                           type: integer
                         type: array
-                    required: *id067
+                    required: *id069
                     type: object
                   num_hosts:
                     description: Count of hosts
@@ -9384,7 +9545,7 @@ paths:
                       up:
                         description: Count of iSCSI gateways running
                         type: integer
-                    required: *id068
+                    required: *id070
                     type: object
                   num_rgw_gateways:
                     description: Count of RGW gateway daemons running
@@ -9401,7 +9562,7 @@ paths:
                       up:
                         description: Number of OSDs up
                         type: integer
-                    required: *id069
+                    required: *id071
                     type: object
                   pgmap:
                     description: Placement group map details
@@ -9428,15 +9589,15 @@ paths:
                             state_name:
                               description: Placement group state
                               type: string
-                          required: *id070
+                          required: *id072
                           type: object
                         type: array
                       recovering_bytes_per_sec:
                         description: Total recovery in bytes
                         type: integer
-                    required: *id071
+                    required: *id073
                     type: object
-                required: *id072
+                required: *id074
                 type: object
           description: OK
         '400':
@@ -9525,7 +9686,7 @@ paths:
                         type:
                           description: type of service
                           type: string
-                      required: &id073
+                      required: &id075
                       - type
                       - count
                       type: object
@@ -9543,7 +9704,7 @@ paths:
                         type:
                           description: type of service
                           type: string
-                      required: &id074
+                      required: &id076
                       - type
                       - id
                       type: object
@@ -9557,14 +9718,14 @@ paths:
                       orchestrator:
                         description: ''
                         type: boolean
-                    required: &id075
+                    required: &id077
                     - ceph
                     - orchestrator
                     type: object
                   status:
                     description: ''
                     type: string
-                required: &id076
+                required: &id078
                 - hostname
                 - services
                 - service_instances
@@ -9602,7 +9763,7 @@ paths:
                         type:
                           description: type of service
                           type: string
-                      required: *id073
+                      required: *id075
                       type: object
                     type: array
                   service_type:
@@ -9618,7 +9779,7 @@ paths:
                         type:
                           description: type of service
                           type: string
-                      required: *id074
+                      required: *id076
                       type: object
                     type: array
                   sources:
@@ -9630,12 +9791,12 @@ paths:
                       orchestrator:
                         description: ''
                         type: boolean
-                    required: *id075
+                    required: *id077
                     type: object
                   status:
                     description: ''
                     type: string
-                required: *id076
+                required: *id078
                 type: object
           description: OK
         '400':
@@ -10038,7 +10199,7 @@ paths:
                                 IDENTsupport:
                                   description: ''
                                   type: string
-                              required: &id077
+                              required: &id079
                               - IDENTsupport
                               - IDENTstatus
                               - FAILsupport
@@ -10059,7 +10220,7 @@ paths:
                             transport:
                               description: ''
                               type: string
-                          required: &id078
+                          required: &id080
                           - serialNum
                           - transport
                           - mediaType
@@ -10097,7 +10258,7 @@ paths:
                               type:
                                 description: ''
                                 type: string
-                            required: &id079
+                            required: &id081
                             - name
                             - osd_id
                             - cluster_name
@@ -10162,7 +10323,7 @@ paths:
                                     start:
                                       description: ''
                                       type: string
-                                  required: &id080
+                                  required: &id082
                                   - start
                                   - sectors
                                   - sectorsize
@@ -10170,7 +10331,7 @@ paths:
                                   - human_readable_size
                                   - holders
                                   type: object
-                              required: &id081
+                              required: &id083
                               - partition_name
                               type: object
                             path:
@@ -10212,7 +10373,7 @@ paths:
                             vendor:
                               description: ''
                               type: string
-                          required: &id082
+                          required: &id084
                           - removable
                           - ro
                           - vendor
@@ -10232,7 +10393,7 @@ paths:
                           - path
                           - locked
                           type: object
-                      required: &id083
+                      required: &id085
                       - rejected_reasons
                       - available
                       - path
@@ -10252,7 +10413,7 @@ paths:
                   name:
                     description: Hostname
                     type: string
-                required: &id084
+                required: &id086
                 - name
                 - addr
                 - devices
@@ -10303,7 +10464,7 @@ paths:
                                 IDENTsupport:
                                   description: ''
                                   type: string
-                              required: *id077
+                              required: *id079
                               type: object
                             linkSpeed:
                               description: ''
@@ -10320,7 +10481,7 @@ paths:
                             transport:
                               description: ''
                               type: string
-                          required: *id078
+                          required: *id080
                           type: object
                         lvs:
                           description: ''
@@ -10350,7 +10511,7 @@ paths:
                               type:
                                 description: ''
                                 type: string
-                            required: *id079
+                            required: *id081
                             type: object
                           type: array
                         osd_ids:
@@ -10407,9 +10568,9 @@ paths:
                                     start:
                                       description: ''
                                       type: string
-                                  required: *id080
+                                  required: *id082
                                   type: object
-                              required: *id081
+                              required: *id083
                               type: object
                             path:
                               description: ''
@@ -10450,9 +10611,9 @@ paths:
                             vendor:
                               description: ''
                               type: string
-                          required: *id082
+                          required: *id084
                           type: object
-                      required: *id083
+                      required: *id085
                       type: object
                     type: array
                   labels:
@@ -10463,7 +10624,7 @@ paths:
                   name:
                     description: Hostname
                     type: string
-                required: *id084
+                required: *id086
                 type: object
           description: OK
         '400':
@@ -10534,7 +10695,7 @@ paths:
                       description: username
                       type: string
                   type: object
-                required: &id085
+                required: &id087
                 - user
                 - password
                 - mutual_user
@@ -10557,7 +10718,7 @@ paths:
                       description: username
                       type: string
                   type: object
-                required: *id085
+                required: *id087
                 type: array
           description: OK
         '400':
@@ -10898,13 +11059,13 @@ paths:
                                   type:
                                     description: ''
                                     type: string
-                                required: &id086
+                                required: &id088
                                 - type
                                 - addr
                                 - nonce
                                 type: object
                               type: array
-                          required: &id087
+                          required: &id089
                           - addrvec
                           type: object
                         channel:
@@ -10928,7 +11089,7 @@ paths:
                         stamp:
                           description: ''
                           type: string
-                      required: &id088
+                      required: &id090
                       - name
                       - rank
                       - addrs
@@ -10944,7 +11105,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: &id089
+                required: &id091
                 - clog
                 - audit_log
                 type: object
@@ -10971,10 +11132,10 @@ paths:
                                   type:
                                     description: ''
                                     type: string
-                                required: *id086
+                                required: *id088
                                 type: object
                               type: array
-                          required: *id087
+                          required: *id089
                           type: object
                         channel:
                           description: ''
@@ -10997,7 +11158,7 @@ paths:
                         stamp:
                           description: ''
                           type: string
-                      required: *id088
+                      required: *id090
                       type: object
                     type: array
                   clog:
@@ -11005,7 +11166,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: *id089
+                required: *id091
                 type: object
           description: OK
         '400':
@@ -11092,7 +11253,7 @@ paths:
                             type:
                               description: Type of the option
                               type: string
-                          required: &id090
+                          required: &id092
                           - name
                           - type
                           - level
@@ -11106,11 +11267,11 @@ paths:
                           - tags
                           - see_also
                           type: object
-                      required: &id091
+                      required: &id093
                       - Option_name
                       type: object
                   type: object
-                required: &id092
+                required: &id094
                 - name
                 - enabled
                 - always_on
@@ -11177,12 +11338,12 @@ paths:
                             type:
                               description: Type of the option
                               type: string
-                          required: *id090
+                          required: *id092
                           type: object
-                      required: *id091
+                      required: *id093
                       type: object
                   type: object
-                required: *id092
+                required: *id094
                 type: array
           description: OK
         '400':
@@ -11462,13 +11623,13 @@ paths:
                                   type:
                                     description: ''
                                     type: string
-                                required: &id093
+                                required: &id095
                                 - type
                                 - addr
                                 - nonce
                                 type: object
                               type: array
-                          required: &id094
+                          required: &id096
                           - addrvec
                           type: object
                         rank:
@@ -11482,13 +11643,13 @@ paths:
                               items:
                                 type: integer
                               type: array
-                          required: &id095
+                          required: &id097
                           - num_sessions
                           type: object
                         weight:
                           description: ''
                           type: integer
-                      required: &id096
+                      required: &id098
                       - rank
                       - name
                       - public_addrs
@@ -11526,7 +11687,7 @@ paths:
                                 release:
                                   description: ''
                                   type: string
-                              required: &id097
+                              required: &id099
                               - features
                               - release
                               - num
@@ -11545,7 +11706,7 @@ paths:
                                 release:
                                   description: ''
                                   type: string
-                              required: &id098
+                              required: &id100
                               - features
                               - release
                               - num
@@ -11564,7 +11725,7 @@ paths:
                                 release:
                                   description: ''
                                   type: string
-                              required: &id099
+                              required: &id101
                               - features
                               - release
                               - num
@@ -11583,13 +11744,13 @@ paths:
                                 release:
                                   description: ''
                                   type: string
-                              required: &id100
+                              required: &id102
                               - features
                               - release
                               - num
                               type: object
                             type: array
-                        required: &id101
+                        required: &id103
                         - mon
                         - mds
                         - client
@@ -11614,7 +11775,7 @@ paths:
                             items:
                               type: integer
                             type: array
-                        required: &id102
+                        required: &id104
                         - required_con
                         - required_mon
                         - quorum_con
@@ -11642,7 +11803,7 @@ paths:
                                 items:
                                   type: string
                                 type: array
-                            required: &id103
+                            required: &id105
                             - persistent
                             - optional
                             type: object
@@ -11690,13 +11851,13 @@ paths:
                                           type:
                                             description: ''
                                             type: string
-                                        required: &id104
+                                        required: &id106
                                         - type
                                         - addr
                                         - nonce
                                         type: object
                                       type: array
-                                  required: &id105
+                                  required: &id107
                                   - addrvec
                                   type: object
                                 rank:
@@ -11710,13 +11871,13 @@ paths:
                                       items:
                                         type: integer
                                       type: array
-                                  required: &id106
+                                  required: &id108
                                   - num_sessions
                                   type: object
                                 weight:
                                   description: ''
                                   type: integer
-                              required: &id107
+                              required: &id109
                               - rank
                               - name
                               - public_addrs
@@ -11727,7 +11888,7 @@ paths:
                               - stats
                               type: object
                             type: array
-                        required: &id108
+                        required: &id110
                         - epoch
                         - fsid
                         - modified
@@ -11764,7 +11925,7 @@ paths:
                         items:
                           type: string
                         type: array
-                    required: &id109
+                    required: &id111
                     - name
                     - rank
                     - state
@@ -11783,7 +11944,7 @@ paths:
                     items:
                       type: integer
                     type: array
-                required: &id110
+                required: &id112
                 - mon_status
                 - in_quorum
                 - out_quorum
@@ -11823,10 +11984,10 @@ paths:
                                   type:
                                     description: ''
                                     type: string
-                                required: *id093
+                                required: *id095
                                 type: object
                               type: array
-                          required: *id094
+                          required: *id096
                           type: object
                         rank:
                           description: ''
@@ -11839,12 +12000,12 @@ paths:
                               items:
                                 type: integer
                               type: array
-                          required: *id095
+                          required: *id097
                           type: object
                         weight:
                           description: ''
                           type: integer
-                      required: *id096
+                      required: *id098
                       type: object
                     type: array
                   mon_status:
@@ -11874,7 +12035,7 @@ paths:
                                 release:
                                   description: ''
                                   type: string
-                              required: *id097
+                              required: *id099
                               type: object
                             type: array
                           mds:
@@ -11890,7 +12051,7 @@ paths:
                                 release:
                                   description: ''
                                   type: string
-                              required: *id098
+                              required: *id100
                               type: object
                             type: array
                           mgr:
@@ -11906,7 +12067,7 @@ paths:
                                 release:
                                   description: ''
                                   type: string
-                              required: *id099
+                              required: *id101
                               type: object
                             type: array
                           mon:
@@ -11922,10 +12083,10 @@ paths:
                                 release:
                                   description: ''
                                   type: string
-                              required: *id100
+                              required: *id102
                               type: object
                             type: array
-                        required: *id101
+                        required: *id103
                         type: object
                       features:
                         description: ''
@@ -11946,7 +12107,7 @@ paths:
                             items:
                               type: integer
                             type: array
-                        required: *id102
+                        required: *id104
                         type: object
                       monmap:
                         description: ''
@@ -11970,7 +12131,7 @@ paths:
                                 items:
                                   type: string
                                 type: array
-                            required: *id103
+                            required: *id105
                             type: object
                           fsid:
                             description: ''
@@ -12016,10 +12177,10 @@ paths:
                                           type:
                                             description: ''
                                             type: string
-                                        required: *id104
+                                        required: *id106
                                         type: object
                                       type: array
-                                  required: *id105
+                                  required: *id107
                                   type: object
                                 rank:
                                   description: ''
@@ -12032,15 +12193,15 @@ paths:
                                       items:
                                         type: integer
                                       type: array
-                                  required: *id106
+                                  required: *id108
                                   type: object
                                 weight:
                                   description: ''
                                   type: integer
-                              required: *id107
+                              required: *id109
                               type: object
                             type: array
-                        required: *id108
+                        required: *id110
                         type: object
                       name:
                         description: ''
@@ -12069,14 +12230,14 @@ paths:
                         items:
                           type: string
                         type: array
-                    required: *id109
+                    required: *id111
                     type: object
                   out_quorum:
                     description: ''
                     items:
                       type: integer
                     type: array
-                required: *id110
+                required: *id112
                 type: object
           description: OK
         '400':
@@ -12617,7 +12778,7 @@ paths:
                           squash:
                             description: Client squash policy
                             type: string
-                        required: &id111
+                        required: &id113
                         - addresses
                         - access_type
                         - squash
@@ -12644,7 +12805,7 @@ paths:
                         user_id:
                           description: User id
                           type: string
-                      required: &id112
+                      required: &id114
                       - name
                       type: object
                     path:
@@ -12670,7 +12831,7 @@ paths:
                         type: string
                       type: array
                   type: object
-                required: &id113
+                required: &id115
                 - export_id
                 - path
                 - cluster_id
@@ -12705,7 +12866,7 @@ paths:
                           squash:
                             description: Client squash policy
                             type: string
-                        required: *id111
+                        required: *id113
                         type: object
                       type: array
                     cluster_id:
@@ -12729,7 +12890,7 @@ paths:
                         user_id:
                           description: User id
                           type: string
-                      required: *id112
+                      required: *id114
                       type: object
                     path:
                       description: Export path
@@ -12754,7 +12915,7 @@ paths:
                         type: string
                       type: array
                   type: object
-                required: *id113
+                required: *id115
                 type: array
           description: OK
         '400':
@@ -12878,7 +13039,7 @@ paths:
                         squash:
                           description: Client squash policy
                           type: string
-                      required: &id114
+                      required: &id116
                       - addresses
                       - access_type
                       - squash
@@ -12905,7 +13066,7 @@ paths:
                       user_id:
                         description: User id
                         type: string
-                    required: &id115
+                    required: &id117
                     - name
                     type: object
                   path:
@@ -12930,7 +13091,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: &id116
+                required: &id118
                 - export_id
                 - path
                 - cluster_id
@@ -12964,7 +13125,7 @@ paths:
                         squash:
                           description: Client squash policy
                           type: string
-                      required: *id114
+                      required: *id116
                       type: object
                     type: array
                   cluster_id:
@@ -12988,7 +13149,7 @@ paths:
                       user_id:
                         description: User id
                         type: string
-                    required: *id115
+                    required: *id117
                     type: object
                   path:
                     description: Export path
@@ -13012,7 +13173,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: *id116
+                required: *id118
                 type: object
           description: Resource created.
         '202':
@@ -13124,7 +13285,7 @@ paths:
                         squash:
                           description: Client squash policy
                           type: string
-                      required: &id117
+                      required: &id119
                       - addresses
                       - access_type
                       - squash
@@ -13151,7 +13312,7 @@ paths:
                       user_id:
                         description: User id
                         type: string
-                    required: &id118
+                    required: &id120
                     - name
                     type: object
                   path:
@@ -13176,7 +13337,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: &id119
+                required: &id121
                 - export_id
                 - path
                 - cluster_id
@@ -13210,7 +13371,7 @@ paths:
                         squash:
                           description: Client squash policy
                           type: string
-                      required: *id117
+                      required: *id119
                       type: object
                     type: array
                   cluster_id:
@@ -13234,7 +13395,7 @@ paths:
                       user_id:
                         description: User id
                         type: string
-                    required: *id118
+                    required: *id120
                     type: object
                   path:
                     description: Export path
@@ -13258,7 +13419,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: *id119
+                required: *id121
                 type: object
           description: OK
         '400':
@@ -13390,7 +13551,7 @@ paths:
                         squash:
                           description: Client squash policy
                           type: string
-                      required: &id120
+                      required: &id122
                       - addresses
                       - access_type
                       - squash
@@ -13417,7 +13578,7 @@ paths:
                       user_id:
                         description: User id
                         type: string
-                    required: &id121
+                    required: &id123
                     - name
                     type: object
                   path:
@@ -13442,7 +13603,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: &id122
+                required: &id124
                 - export_id
                 - path
                 - cluster_id
@@ -13476,7 +13637,7 @@ paths:
                         squash:
                           description: Client squash policy
                           type: string
-                      required: *id120
+                      required: *id122
                       type: object
                     type: array
                   cluster_id:
@@ -13500,7 +13661,7 @@ paths:
                       user_id:
                         description: User id
                         type: string
-                    required: *id121
+                    required: *id123
                     type: object
                   path:
                     description: Export path
@@ -13524,7 +13685,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: *id122
+                required: *id124
                 type: object
           description: Resource updated.
         '202':
@@ -16684,7 +16845,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: &id123
+                required: &id125
                 - list_of_flags
                 type: object
             application/vnd.ceph.api.v1.0+json:
@@ -16695,7 +16856,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: *id123
+                required: *id125
                 type: object
           description: OK
         '400':
@@ -16744,7 +16905,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: &id124
+                required: &id126
                 - list_of_flags
                 type: object
             application/vnd.ceph.api.v1.0+json:
@@ -16755,7 +16916,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: *id124
+                required: *id126
                 type: object
           description: Resource updated.
         '202':
@@ -16798,7 +16959,7 @@ paths:
                   osd:
                     description: OSD ID
                     type: integer
-                required: &id125
+                required: &id127
                 - osd
                 - flags
                 type: object
@@ -16813,7 +16974,7 @@ paths:
                   osd:
                     description: OSD ID
                     type: integer
-                required: *id125
+                required: *id127
                 type: object
           description: OK
         '400':
@@ -16886,7 +17047,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: &id126
+                required: &id128
                 - added
                 - removed
                 - ids
@@ -16909,7 +17070,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: *id126
+                required: *id128
                 type: object
           description: Resource updated.
         '202':
@@ -17006,7 +17167,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: &id127
+                required: &id129
                 - safe_to_destroy
                 - active
                 - missing_stats
@@ -17039,7 +17200,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: *id127
+                required: *id129
                 type: object
           description: OK
         '400':
@@ -17592,7 +17753,7 @@ paths:
                           value:
                             description: ''
                             type: integer
-                        required: &id128
+                        required: &id130
                         - description
                         - nick
                         - type
@@ -17600,10 +17761,10 @@ paths:
                         - units
                         - value
                         type: object
-                    required: &id129
+                    required: &id131
                     - .cache_bytes
                     type: object
-                required: &id130
+                required: &id132
                 - mon.a
                 type: object
             application/vnd.ceph.api.v1.0+json:
@@ -17633,11 +17794,11 @@ paths:
                           value:
                             description: ''
                             type: integer
-                        required: *id128
+                        required: *id130
                         type: object
-                    required: *id129
+                    required: *id131
                     type: object
-                required: *id130
+                required: *id132
                 type: object
           description: OK
         '400':
@@ -17957,7 +18118,7 @@ paths:
                         type:
                           description: ''
                           type: string
-                      required: &id131
+                      required: &id133
                       - type
                       type: object
                     hit_set_period:
@@ -17999,7 +18160,7 @@ paths:
                         target_version:
                           description: ''
                           type: string
-                      required: &id132
+                      required: &id134
                       - ready_epoch
                       - last_epoch_started
                       - last_epoch_clean
@@ -18028,7 +18189,7 @@ paths:
                         pg_num_min:
                           description: ''
                           type: integer
-                      required: &id133
+                      required: &id135
                       - pg_num_min
                       - pg_num_max
                       type: object
@@ -18114,7 +18275,7 @@ paths:
                       description: ''
                       type: integer
                   type: object
-                required: &id134
+                required: &id136
                 - pool
                 - pool_name
                 - flags
@@ -18240,7 +18401,7 @@ paths:
                         type:
                           description: ''
                           type: string
-                      required: *id131
+                      required: *id133
                       type: object
                     hit_set_period:
                       description: ''
@@ -18281,7 +18442,7 @@ paths:
                         target_version:
                           description: ''
                           type: string
-                      required: *id132
+                      required: *id134
                       type: object
                     min_read_recency_for_promote:
                       description: ''
@@ -18304,7 +18465,7 @@ paths:
                         pg_num_min:
                           description: ''
                           type: integer
-                      required: *id133
+                      required: *id135
                       type: object
                     pg_autoscale_mode:
                       description: ''
@@ -18388,7 +18549,7 @@ paths:
                       description: ''
                       type: integer
                   type: object
-                required: *id134
+                required: *id136
                 type: array
           description: OK
         '400':
@@ -20500,7 +20661,7 @@ paths:
                       description: Zone Group
                       type: string
                   type: object
-                required: &id135
+                required: &id137
                 - id
                 - version
                 - server_hostname
@@ -20531,7 +20692,7 @@ paths:
                       description: Zone Group
                       type: string
                   type: object
-                required: *id135
+                required: *id137
                 type: array
           description: OK
         '400':
@@ -21758,7 +21919,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: &id136
+                required: &id138
                 - list_of_users
                 type: object
             application/vnd.ceph.api.v1.0+json:
@@ -21769,7 +21930,7 @@ paths:
                     items:
                       type: string
                     type: array
-                required: *id136
+                required: *id138
                 type: object
           description: OK
         '400':
@@ -23594,14 +23755,14 @@ paths:
                           items:
                             type: string
                           type: array
-                      required: &id137
+                      required: &id139
                       - cephfs
                       type: object
                     system:
                       description: ''
                       type: boolean
                   type: object
-                required: &id138
+                required: &id140
                 - name
                 - description
                 - scopes_permissions
@@ -23625,13 +23786,13 @@ paths:
                           items:
                             type: string
                           type: array
-                      required: *id137
+                      required: *id139
                       type: object
                     system:
                       description: ''
                       type: boolean
                   type: object
-                required: *id138
+                required: *id140
                 type: array
           description: OK
         '400':
@@ -24038,7 +24199,7 @@ paths:
                       description: Certificate target (service name or hostname)
                       type: string
                   type: object
-                required: &id139
+                required: &id141
                 - cert_name
                 - scope
                 - signed_by
@@ -24081,7 +24242,7 @@ paths:
                       description: Certificate target (service name or hostname)
                       type: string
                   type: object
-                required: *id139
+                required: *id141
                 type: array
           description: OK
         '400':
@@ -24115,7 +24276,7 @@ paths:
                   certificate:
                     description: Root CA certificate in PEM format
                     type: string
-                required: &id140
+                required: &id142
                 - certificate
                 type: object
             application/vnd.ceph.api.v1.0+json:
@@ -24124,7 +24285,7 @@ paths:
                   certificate:
                     description: Root CA certificate in PEM format
                     type: string
-                required: *id140
+                required: *id142
                 type: object
           description: OK
         '400':
@@ -24392,7 +24553,7 @@ paths:
                       description: Settings Value
                       type: boolean
                   type: object
-                required: &id141
+                required: &id143
                 - name
                 - default
                 - type
@@ -24415,7 +24576,7 @@ paths:
                       description: Settings Value
                       type: boolean
                   type: object
-                required: *id141
+                required: *id143
                 type: array
           description: OK
         '400':
@@ -24626,7 +24787,7 @@ paths:
                               source_type:
                                 description: resource
                                 type: string
-                            required: &id142
+                            required: &id144
                             - source_type
                             - ref
                             type: object
@@ -24634,7 +24795,7 @@ paths:
                         realm:
                           description: Domain realm, e.g., 'DOMAIN1.SINK.TEST'
                           type: string
-                      required: &id143
+                      required: &id145
                       - realm
                       - join_sources
                       type: object
@@ -24648,7 +24809,7 @@ paths:
                         count:
                           description: Number of instances to place
                           type: integer
-                      required: &id144
+                      required: &id146
                       - count
                       type: object
                     public_addrs:
@@ -24663,7 +24824,7 @@ paths:
                             description: Defines where the system will assign the
                               managed IPs.
                             type: string
-                        required: &id145
+                        required: &id147
                         - address
                         - destination
                         type: object
@@ -24681,13 +24842,13 @@ paths:
                           source_type:
                             description: resource
                             type: string
-                        required: &id146
+                        required: &id148
                         - source_type
                         - ref
                         type: object
                       type: array
                   type: object
-                required: &id147
+                required: &id149
                 - resource_type
                 - cluster_id
                 - auth_mode
@@ -24728,13 +24889,13 @@ paths:
                               source_type:
                                 description: resource
                                 type: string
-                            required: *id142
+                            required: *id144
                             type: object
                           type: array
                         realm:
                           description: Domain realm, e.g., 'DOMAIN1.SINK.TEST'
                           type: string
-                      required: *id143
+                      required: *id145
                       type: object
                     intent:
                       description: Desired state of the resource, e.g., 'present'
@@ -24746,7 +24907,7 @@ paths:
                         count:
                           description: Number of instances to place
                           type: integer
-                      required: *id144
+                      required: *id146
                       type: object
                     public_addrs:
                       description: Public Address
@@ -24760,7 +24921,7 @@ paths:
                             description: Defines where the system will assign the
                               managed IPs.
                             type: string
-                        required: *id145
+                        required: *id147
                         type: object
                       type: array
                     resource_type:
@@ -24776,11 +24937,11 @@ paths:
                           source_type:
                             description: resource
                             type: string
-                        required: *id146
+                        required: *id148
                         type: object
                       type: array
                   type: object
-                required: *id147
+                required: *id149
                 type: array
           description: OK
         '400':
@@ -24853,7 +25014,7 @@ paths:
                                       source_type:
                                         description: resource
                                         type: string
-                                    required: &id148
+                                    required: &id150
                                     - source_type
                                     - ref
                                     type: object
@@ -24861,7 +25022,7 @@ paths:
                                 realm:
                                   description: Domain realm, e.g., 'DOMAIN1.SINK.TEST'
                                   type: string
-                              required: &id149
+                              required: &id151
                               - realm
                               - join_sources
                               type: object
@@ -24875,7 +25036,7 @@ paths:
                                 count:
                                   description: Number of instances to place
                                   type: integer
-                              required: &id150
+                              required: &id152
                               - count
                               type: object
                             public_addrs:
@@ -24890,7 +25051,7 @@ paths:
                                     description: Defines where the system will assign
                                       the managed IPs.
                                     type: string
-                                required: &id151
+                                required: &id153
                                 - address
                                 - destination
                                 type: object
@@ -24909,12 +25070,12 @@ paths:
                                   source_type:
                                     description: resource
                                     type: string
-                                required: &id152
+                                required: &id154
                                 - source_type
                                 - ref
                                 type: object
                               type: array
-                          required: &id153
+                          required: &id155
                           - resource_type
                           - cluster_id
                           - auth_mode
@@ -24932,7 +25093,7 @@ paths:
                         success:
                           description: Indicates if the operation was successful
                           type: boolean
-                      required: &id154
+                      required: &id156
                       - resource
                       - state
                       - success
@@ -24941,7 +25102,7 @@ paths:
                   success:
                     description: Indicates if the overall operation was successful
                     type: boolean
-                required: &id155
+                required: &id157
                 - results
                 - success
                 type: object
@@ -24982,13 +25143,13 @@ paths:
                                       source_type:
                                         description: resource
                                         type: string
-                                    required: *id148
+                                    required: *id150
                                     type: object
                                   type: array
                                 realm:
                                   description: Domain realm, e.g., 'DOMAIN1.SINK.TEST'
                                   type: string
-                              required: *id149
+                              required: *id151
                               type: object
                             intent:
                               description: Desired state of the resource, e.g., 'present'
@@ -25000,7 +25161,7 @@ paths:
                                 count:
                                   description: Number of instances to place
                                   type: integer
-                              required: *id150
+                              required: *id152
                               type: object
                             public_addrs:
                               description: Public Address
@@ -25014,7 +25175,7 @@ paths:
                                     description: Defines where the system will assign
                                       the managed IPs.
                                     type: string
-                                required: *id151
+                                required: *id153
                                 type: object
                               type: array
                             resource_type:
@@ -25031,10 +25192,10 @@ paths:
                                   source_type:
                                     description: resource
                                     type: string
-                                required: *id152
+                                required: *id154
                                 type: object
                               type: array
-                          required: *id153
+                          required: *id155
                           type: object
                         state:
                           description: The current state of the resource,                        e.g.,
@@ -25043,13 +25204,13 @@ paths:
                         success:
                           description: Indicates if the operation was successful
                           type: boolean
-                      required: *id154
+                      required: *id156
                       type: object
                     type: array
                   success:
                     description: Indicates if the overall operation was successful
                     type: boolean
-                required: *id155
+                required: *id157
                 type: object
           description: Resource created.
         '202':
@@ -25162,7 +25323,7 @@ paths:
                             source_type:
                               description: resource
                               type: string
-                          required: &id156
+                          required: &id158
                           - source_type
                           - ref
                           type: object
@@ -25170,7 +25331,7 @@ paths:
                       realm:
                         description: Domain realm, e.g., 'DOMAIN1.SINK.TEST'
                         type: string
-                    required: &id157
+                    required: &id159
                     - realm
                     - join_sources
                     type: object
@@ -25184,7 +25345,7 @@ paths:
                       count:
                         description: Number of instances to place
                         type: integer
-                    required: &id158
+                    required: &id160
                     - count
                     type: object
                   public_addrs:
@@ -25199,7 +25360,7 @@ paths:
                           description: Defines where the system will assign the managed
                             IPs.
                           type: string
-                      required: &id159
+                      required: &id161
                       - address
                       - destination
                       type: object
@@ -25217,12 +25378,12 @@ paths:
                         source_type:
                           description: resource
                           type: string
-                      required: &id160
+                      required: &id162
                       - source_type
                       - ref
                       type: object
                     type: array
-                required: &id161
+                required: &id163
                 - resource_type
                 - cluster_id
                 - auth_mode
@@ -25262,13 +25423,13 @@ paths:
                             source_type:
                               description: resource
                               type: string
-                          required: *id156
+                          required: *id158
                           type: object
                         type: array
                       realm:
                         description: Domain realm, e.g., 'DOMAIN1.SINK.TEST'
                         type: string
-                    required: *id157
+                    required: *id159
                     type: object
                   intent:
                     description: Desired state of the resource, e.g., 'present' or
@@ -25280,7 +25441,7 @@ paths:
                       count:
                         description: Number of instances to place
                         type: integer
-                    required: *id158
+                    required: *id160
                     type: object
                   public_addrs:
                     description: Public Address
@@ -25294,7 +25455,7 @@ paths:
                           description: Defines where the system will assign the managed
                             IPs.
                           type: string
-                      required: *id159
+                      required: *id161
                       type: object
                     type: array
                   resource_type:
@@ -25310,10 +25471,10 @@ paths:
                         source_type:
                           description: resource
                           type: string
-                      required: *id160
+                      required: *id162
                       type: object
                     type: array
-                required: *id161
+                required: *id163
                 type: object
           description: OK
         '400':
@@ -25351,7 +25512,7 @@ paths:
                         username:
                           description: Username for authentication
                           type: string
-                      required: &id162
+                      required: &id164
                       - username
                       - password
                       type: object
@@ -25371,7 +25532,7 @@ paths:
                       description: ceph.smb.join.auth
                       type: string
                   type: object
-                required: &id163
+                required: &id165
                 - resource_type
                 - auth_id
                 - intent
@@ -25391,7 +25552,7 @@ paths:
                         username:
                           description: Username for authentication
                           type: string
-                      required: *id162
+                      required: *id164
                       type: object
                     auth_id:
                       description: Unique identifier for the join auth resource
@@ -25409,7 +25570,7 @@ paths:
                       description: ceph.smb.join.auth
                       type: string
                   type: object
-                required: *id163
+                required: *id165
                 type: array
           description: OK
         '400':
@@ -25462,7 +25623,7 @@ paths:
                                 username:
                                   description: Username for authentication
                                   type: string
-                              required: &id164
+                              required: &id166
                               - username
                               - password
                               type: object
@@ -25481,7 +25642,7 @@ paths:
                             resource_type:
                               description: ceph.smb.join.auth
                               type: string
-                          required: &id165
+                          required: &id167
                           - resource_type
                           - auth_id
                           - intent
@@ -25495,7 +25656,7 @@ paths:
                         success:
                           description: Indicates if the operation was successful
                           type: boolean
-                      required: &id166
+                      required: &id168
                       - resource
                       - state
                       - success
@@ -25504,7 +25665,7 @@ paths:
                   success:
                     description: Indicates if the overall operation was successful
                     type: boolean
-                required: &id167
+                required: &id169
                 - results
                 - success
                 type: object
@@ -25527,7 +25688,7 @@ paths:
                                 username:
                                   description: Username for authentication
                                   type: string
-                              required: *id164
+                              required: *id166
                               type: object
                             auth_id:
                               description: Unique identifier for the join auth resource
@@ -25544,7 +25705,7 @@ paths:
                             resource_type:
                               description: ceph.smb.join.auth
                               type: string
-                          required: *id165
+                          required: *id167
                           type: object
                         state:
                           description: The current state of the resource,                        e.g.,
@@ -25553,13 +25714,13 @@ paths:
                         success:
                           description: Indicates if the operation was successful
                           type: boolean
-                      required: *id166
+                      required: *id168
                       type: object
                     type: array
                   success:
                     description: Indicates if the overall operation was successful
                     type: boolean
-                required: *id167
+                required: *id169
                 type: object
           description: Resource created.
         '202':
@@ -25655,7 +25816,7 @@ paths:
                       username:
                         description: Username for authentication
                         type: string
-                    required: &id168
+                    required: &id170
                     - username
                     - password
                     type: object
@@ -25674,7 +25835,7 @@ paths:
                   resource_type:
                     description: ceph.smb.join.auth
                     type: string
-                required: &id169
+                required: &id171
                 - resource_type
                 - auth_id
                 - intent
@@ -25693,7 +25854,7 @@ paths:
                       username:
                         description: Username for authentication
                         type: string
-                    required: *id168
+                    required: *id170
                     type: object
                   auth_id:
                     description: Unique identifier for the join auth resource
@@ -25710,7 +25871,7 @@ paths:
                   resource_type:
                     description: ceph.smb.join.auth
                     type: string
-                required: *id169
+                required: *id171
                 type: object
           description: OK
         '400':
@@ -25766,7 +25927,7 @@ paths:
                       volume:
                         description: Name of the CephFS file system
                         type: string
-                    required: &id170
+                    required: &id172
                     - volume
                     - path
                     - provider
@@ -25810,7 +25971,7 @@ paths:
                   write_iops_limit:
                     description: 'QoS: max write IOPS (0=disabled)'
                     type: integer
-                required: &id171
+                required: &id173
                 - resource_type
                 - cluster_id
                 - share_id
@@ -25850,7 +26011,7 @@ paths:
                       volume:
                         description: Name of the CephFS file system
                         type: string
-                    required: *id170
+                    required: *id172
                     type: object
                   cluster_id:
                     description: Unique identifier for the cluster
@@ -25889,7 +26050,7 @@ paths:
                   write_iops_limit:
                     description: 'QoS: max write IOPS (0=disabled)'
                     type: integer
-                required: *id171
+                required: *id173
                 type: object
           description: OK
         '400':
@@ -25957,7 +26118,7 @@ paths:
                                 volume:
                                   description: Name of the CephFS file system
                                   type: string
-                              required: &id172
+                              required: &id174
                               - volume
                               - path
                               - provider
@@ -26001,7 +26162,7 @@ paths:
                             write_iops_limit:
                               description: 'QoS: max write IOPS (0=disabled)'
                               type: integer
-                          required: &id173
+                          required: &id175
                           - resource_type
                           - cluster_id
                           - share_id
@@ -26024,7 +26185,7 @@ paths:
                         success:
                           description: Indicates if the operation was successful
                           type: boolean
-                      required: &id174
+                      required: &id176
                       - resource
                       - state
                       - success
@@ -26033,7 +26194,7 @@ paths:
                   success:
                     description: Indicates if the overall operation was successful
                     type: boolean
-                required: &id175
+                required: &id177
                 - results
                 - success
                 type: object
@@ -26069,7 +26230,7 @@ paths:
                                 volume:
                                   description: Name of the CephFS file system
                                   type: string
-                              required: *id172
+                              required: *id174
                               type: object
                             cluster_id:
                               description: Unique identifier for the cluster
@@ -26108,7 +26269,7 @@ paths:
                             write_iops_limit:
                               description: 'QoS: max write IOPS (0=disabled)'
                               type: integer
-                          required: *id173
+                          required: *id175
                           type: object
                         state:
                           description: The current state of the resource,                        e.g.,
@@ -26117,13 +26278,13 @@ paths:
                         success:
                           description: Indicates if the operation was successful
                           type: boolean
-                      required: *id174
+                      required: *id176
                       type: object
                     type: array
                   success:
                     description: Indicates if the overall operation was successful
                     type: boolean
-                required: *id175
+                required: *id177
                 type: object
           description: Resource created.
         '202':
@@ -26316,7 +26477,7 @@ paths:
                       volume:
                         description: Name of the CephFS file system
                         type: string
-                    required: &id176
+                    required: &id178
                     - volume
                     - path
                     - provider
@@ -26360,7 +26521,7 @@ paths:
                   write_iops_limit:
                     description: 'QoS: max write IOPS (0=disabled)'
                     type: integer
-                required: &id177
+                required: &id179
                 - resource_type
                 - cluster_id
                 - share_id
@@ -26400,7 +26561,7 @@ paths:
                       volume:
                         description: Name of the CephFS file system
                         type: string
-                    required: *id176
+                    required: *id178
                     type: object
                   cluster_id:
                     description: Unique identifier for the cluster
@@ -26439,7 +26600,7 @@ paths:
                   write_iops_limit:
                     description: 'QoS: max write IOPS (0=disabled)'
                     type: integer
-                required: *id177
+                required: *id179
                 type: object
           description: OK
         '400':
@@ -26493,7 +26654,7 @@ paths:
                               name:
                                 description: The name of the group
                                 type: string
-                            required: &id178
+                            required: &id180
                             - name
                             type: object
                           type: array
@@ -26508,17 +26669,17 @@ paths:
                               password:
                                 description: The password for the user
                                 type: string
-                            required: &id179
+                            required: &id181
                             - name
                             - password
                             type: object
                           type: array
-                      required: &id180
+                      required: &id182
                       - users
                       - groups
                       type: object
                   type: object
-                required: &id181
+                required: &id183
                 - resource_type
                 - users_groups_id
                 - intent
@@ -26554,7 +26715,7 @@ paths:
                               name:
                                 description: The name of the group
                                 type: string
-                            required: *id178
+                            required: *id180
                             type: object
                           type: array
                         users:
@@ -26568,13 +26729,13 @@ paths:
                               password:
                                 description: The password for the user
                                 type: string
-                            required: *id179
+                            required: *id181
                             type: object
                           type: array
-                      required: *id180
+                      required: *id182
                       type: object
                   type: object
-                required: *id181
+                required: *id183
                 type: array
           description: OK
         '400':
@@ -26634,7 +26795,7 @@ paths:
                                           username:
                                             description: Username for authentication
                                             type: string
-                                        required: &id182
+                                        required: &id184
                                         - username
                                         - password
                                         type: object
@@ -26655,7 +26816,7 @@ paths:
                                       resource_type:
                                         description: ceph.smb.join.auth
                                         type: string
-                                    required: &id183
+                                    required: &id185
                                     - resource_type
                                     - auth_id
                                     - intent
@@ -26669,7 +26830,7 @@ paths:
                                   success:
                                     description: Indicates if the operation was successful
                                     type: boolean
-                                required: &id184
+                                required: &id186
                                 - resource
                                 - state
                                 - success
@@ -26679,7 +26840,7 @@ paths:
                               description: Indicates if the overall operation was
                                 successful
                               type: boolean
-                          required: &id185
+                          required: &id187
                           - results
                           - success
                           type: object
@@ -26690,7 +26851,7 @@ paths:
                         success:
                           description: Indicates if the operation was successful
                           type: boolean
-                      required: &id186
+                      required: &id188
                       - resource
                       - state
                       - success
@@ -26699,7 +26860,7 @@ paths:
                   success:
                     description: Indicates if the overall operation was successful
                     type: boolean
-                required: &id187
+                required: &id189
                 - results
                 - success
                 type: object
@@ -26729,7 +26890,7 @@ paths:
                                           username:
                                             description: Username for authentication
                                             type: string
-                                        required: *id182
+                                        required: *id184
                                         type: object
                                       auth_id:
                                         description: Unique identifier for the join
@@ -26748,7 +26909,7 @@ paths:
                                       resource_type:
                                         description: ceph.smb.join.auth
                                         type: string
-                                    required: *id183
+                                    required: *id185
                                     type: object
                                   state:
                                     description: The current state of the resource,                        e.g.,
@@ -26757,14 +26918,14 @@ paths:
                                   success:
                                     description: Indicates if the operation was successful
                                     type: boolean
-                                required: *id184
+                                required: *id186
                                 type: object
                               type: array
                             success:
                               description: Indicates if the overall operation was
                                 successful
                               type: boolean
-                          required: *id185
+                          required: *id187
                           type: object
                         state:
                           description: The current state of the resource,                        e.g.,
@@ -26773,13 +26934,13 @@ paths:
                         success:
                           description: Indicates if the operation was successful
                           type: boolean
-                      required: *id186
+                      required: *id188
                       type: object
                     type: array
                   success:
                     description: Indicates if the overall operation was successful
                     type: boolean
-                required: *id187
+                required: *id189
                 type: object
           description: Resource created.
         '202':
@@ -26891,7 +27052,7 @@ paths:
                             name:
                               description: The name of the group
                               type: string
-                          required: &id188
+                          required: &id190
                           - name
                           type: object
                         type: array
@@ -26906,16 +27067,16 @@ paths:
                             password:
                               description: The password for the user
                               type: string
-                          required: &id189
+                          required: &id191
                           - name
                           - password
                           type: object
                         type: array
-                    required: &id190
+                    required: &id192
                     - users
                     - groups
                     type: object
-                required: &id191
+                required: &id193
                 - resource_type
                 - users_groups_id
                 - intent
@@ -26950,7 +27111,7 @@ paths:
                             name:
                               description: The name of the group
                               type: string
-                          required: *id188
+                          required: *id190
                           type: object
                         type: array
                       users:
@@ -26964,12 +27125,12 @@ paths:
                             password:
                               description: The password for the user
                               type: string
-                          required: *id189
+                          required: *id191
                           type: object
                         type: array
-                    required: *id190
+                    required: *id192
                     type: object
-                required: *id191
+                required: *id193
                 type: object
           description: OK
         '400':
@@ -27022,7 +27183,7 @@ paths:
                             pool:
                               description: ''
                               type: integer
-                          required: &id192
+                          required: &id194
                           - pool
                           type: object
                         name:
@@ -27037,7 +27198,7 @@ paths:
                         success:
                           description: ''
                           type: boolean
-                      required: &id193
+                      required: &id195
                       - name
                       - metadata
                       - begin_time
@@ -27070,14 +27231,14 @@ paths:
                       warnings:
                         description: ''
                         type: integer
-                    required: &id194
+                    required: &id196
                     - warnings
                     - errors
                     type: object
                   version:
                     description: ''
                     type: string
-                required: &id195
+                required: &id197
                 - health_status
                 - mgr_id
                 - mgr_host
@@ -27117,7 +27278,7 @@ paths:
                             pool:
                               description: ''
                               type: integer
-                          required: *id192
+                          required: *id194
                           type: object
                         name:
                           description: ''
@@ -27131,7 +27292,7 @@ paths:
                         success:
                           description: ''
                           type: boolean
-                      required: *id193
+                      required: *id195
                       type: object
                     type: array
                   have_mon_connection:
@@ -27155,12 +27316,12 @@ paths:
                       warnings:
                         description: ''
                         type: integer
-                    required: *id194
+                    required: *id196
                     type: object
                   version:
                     description: ''
                     type: string
-                required: *id195
+                required: *id197
                 type: object
           description: OK
         '400':
@@ -27217,7 +27378,7 @@ paths:
                             pool:
                               description: ''
                               type: integer
-                          required: &id196
+                          required: &id198
                           - pool
                           type: object
                         name:
@@ -27232,7 +27393,7 @@ paths:
                         success:
                           description: ''
                           type: boolean
-                      required: &id197
+                      required: &id199
                       - name
                       - metadata
                       - begin_time
@@ -27244,7 +27405,7 @@ paths:
                       - exception
                       type: object
                     type: array
-                required: &id198
+                required: &id200
                 - executing_tasks
                 - finished_tasks
                 type: object
@@ -27276,7 +27437,7 @@ paths:
                             pool:
                               description: ''
                               type: integer
-                          required: *id196
+                          required: *id198
                           type: object
                         name:
                           description: finished tasks name
@@ -27290,10 +27451,10 @@ paths:
                         success:
                           description: ''
                           type: boolean
-                      required: *id197
+                      required: *id199
                       type: object
                     type: array
-                required: *id198
+                required: *id200
                 type: object
           description: OK
         '400':
@@ -27388,7 +27549,7 @@ paths:
                           mode:
                             description: ''
                             type: string
-                        required: &id199
+                        required: &id201
                         - active
                         - mode
                         type: object
@@ -27415,7 +27576,7 @@ paths:
                             items:
                               type: string
                             type: array
-                        required: &id200
+                        required: &id202
                         - cluster_changed
                         - active_changed
                         type: object
@@ -27436,7 +27597,7 @@ paths:
                               straw2:
                                 description: ''
                                 type: integer
-                            required: &id201
+                            required: &id203
                             - straw2
                             type: object
                           bucket_sizes:
@@ -27448,7 +27609,7 @@ paths:
                               '3':
                                 description: ''
                                 type: integer
-                            required: &id202
+                            required: &id204
                             - '1'
                             - '3'
                             type: object
@@ -27461,7 +27622,7 @@ paths:
                               '11':
                                 description: ''
                                 type: integer
-                            required: &id203
+                            required: &id205
                             - '1'
                             - '11'
                             type: object
@@ -27551,7 +27712,7 @@ paths:
                               straw_calc_version:
                                 description: ''
                                 type: integer
-                            required: &id204
+                            required: &id206
                             - choose_local_tries
                             - choose_local_fallback_tries
                             - choose_total_tries
@@ -27573,7 +27734,7 @@ paths:
                             - require_feature_tunables5
                             - has_v5_rules
                             type: object
-                        required: &id205
+                        required: &id207
                         - num_devices
                         - num_types
                         - num_buckets
@@ -27601,7 +27762,7 @@ paths:
                               ever_enabled_multiple:
                                 description: ''
                                 type: boolean
-                            required: &id206
+                            required: &id208
                             - enable_multiple
                             - ever_enabled_multiple
                             type: object
@@ -27616,7 +27777,7 @@ paths:
                           total_num_mds:
                             description: ''
                             type: integer
-                        required: &id207
+                        required: &id209
                         - count
                         - feature_flags
                         - num_standby_mds
@@ -27641,7 +27802,7 @@ paths:
                           num_with_osd:
                             description: ''
                             type: integer
-                        required: &id208
+                        required: &id210
                         - num
                         - num_with_mon
                         - num_with_mds
@@ -27666,7 +27827,7 @@ paths:
                                   x86_64:
                                     description: ''
                                     type: integer
-                                required: &id209
+                                required: &id211
                                 - x86_64
                                 type: object
                               ceph_version:
@@ -27675,7 +27836,7 @@ paths:
                                   ceph version 16.0.0-3151-gf202994fcf:
                                     description: ''
                                     type: integer
-                                required: &id210
+                                required: &id212
                                 - ceph version 16.0.0-3151-gf202994fcf
                                 type: object
                               cpu:
@@ -27684,7 +27845,7 @@ paths:
                                   Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz:
                                     description: ''
                                     type: integer
-                                required: &id211
+                                required: &id213
                                 - Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
                                 type: object
                               distro:
@@ -27693,7 +27854,7 @@ paths:
                                   centos:
                                     description: ''
                                     type: integer
-                                required: &id212
+                                required: &id214
                                 - centos
                                 type: object
                               distro_description:
@@ -27702,7 +27863,7 @@ paths:
                                   CentOS Linux 8 (Core):
                                     description: ''
                                     type: integer
-                                required: &id213
+                                required: &id215
                                 - CentOS Linux 8 (Core)
                                 type: object
                               kernel_description:
@@ -27711,7 +27872,7 @@ paths:
                                   '#1 SMP Wed Jul 1 19:53:01 UTC 2020':
                                     description: ''
                                     type: integer
-                                required: &id214
+                                required: &id216
                                 - '#1 SMP Wed Jul 1 19:53:01 UTC 2020'
                                 type: object
                               kernel_version:
@@ -27720,7 +27881,7 @@ paths:
                                   5.7.7-200.fc32.x86_64:
                                     description: ''
                                     type: integer
-                                required: &id215
+                                required: &id217
                                 - 5.7.7-200.fc32.x86_64
                                 type: object
                               os:
@@ -27729,10 +27890,10 @@ paths:
                                   Linux:
                                     description: ''
                                     type: integer
-                                required: &id216
+                                required: &id218
                                 - Linux
                                 type: object
-                            required: &id217
+                            required: &id219
                             - arch
                             - ceph_version
                             - os
@@ -27751,7 +27912,7 @@ paths:
                                   x86_64:
                                     description: ''
                                     type: integer
-                                required: &id218
+                                required: &id220
                                 - x86_64
                                 type: object
                               ceph_version:
@@ -27760,7 +27921,7 @@ paths:
                                   ceph version 16.0.0-3151-gf202994fcf:
                                     description: ''
                                     type: integer
-                                required: &id219
+                                required: &id221
                                 - ceph version 16.0.0-3151-gf202994fcf
                                 type: object
                               cpu:
@@ -27769,7 +27930,7 @@ paths:
                                   Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz:
                                     description: ''
                                     type: integer
-                                required: &id220
+                                required: &id222
                                 - Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
                                 type: object
                               distro:
@@ -27778,7 +27939,7 @@ paths:
                                   centos:
                                     description: ''
                                     type: integer
-                                required: &id221
+                                required: &id223
                                 - centos
                                 type: object
                               distro_description:
@@ -27787,7 +27948,7 @@ paths:
                                   CentOS Linux 8 (Core):
                                     description: ''
                                     type: integer
-                                required: &id222
+                                required: &id224
                                 - CentOS Linux 8 (Core)
                                 type: object
                               kernel_description:
@@ -27796,7 +27957,7 @@ paths:
                                   '#1 SMP Wed Jul 1 19:53:01 UTC 2020':
                                     description: ''
                                     type: integer
-                                required: &id223
+                                required: &id225
                                 - '#1 SMP Wed Jul 1 19:53:01 UTC 2020'
                                 type: object
                               kernel_version:
@@ -27805,7 +27966,7 @@ paths:
                                   5.7.7-200.fc32.x86_64:
                                     description: ''
                                     type: integer
-                                required: &id224
+                                required: &id226
                                 - 5.7.7-200.fc32.x86_64
                                 type: object
                               os:
@@ -27814,7 +27975,7 @@ paths:
                                   Linux:
                                     description: ''
                                     type: integer
-                                required: &id225
+                                required: &id227
                                 - Linux
                                 type: object
                               osd_objectstore:
@@ -27823,7 +27984,7 @@ paths:
                                   bluestore:
                                     description: ''
                                     type: integer
-                                required: &id226
+                                required: &id228
                                 - bluestore
                                 type: object
                               rotational:
@@ -27832,10 +27993,10 @@ paths:
                                   '1':
                                     description: ''
                                     type: integer
-                                required: &id227
+                                required: &id229
                                 - '1'
                                 type: object
-                            required: &id228
+                            required: &id230
                             - osd_objectstore
                             - rotational
                             - arch
@@ -27847,7 +28008,7 @@ paths:
                             - distro_description
                             - distro
                             type: object
-                        required: &id229
+                        required: &id231
                         - osd
                         - mon
                         type: object
@@ -27870,7 +28031,7 @@ paths:
                                 items:
                                   type: string
                                 type: array
-                            required: &id230
+                            required: &id232
                             - persistent
                             - optional
                             type: object
@@ -27889,7 +28050,7 @@ paths:
                           v2_addr_mons:
                             description: ''
                             type: integer
-                        required: &id231
+                        required: &id233
                         - count
                         - features
                         - min_mon_release
@@ -27913,7 +28074,7 @@ paths:
                           require_osd_release:
                             description: ''
                             type: string
-                        required: &id232
+                        required: &id234
                         - count
                         - require_osd_release
                         - require_min_compat_client
@@ -27956,7 +28117,7 @@ paths:
                             type:
                               description: ''
                               type: string
-                          required: &id233
+                          required: &id235
                           - pool
                           - type
                           - pg_num
@@ -27986,7 +28147,7 @@ paths:
                           num_pools:
                             description: ''
                             type: integer
-                        required: &id234
+                        required: &id236
                         - num_pools
                         - num_images_by_pool
                         - mirroring_by_pool
@@ -28017,7 +28178,7 @@ paths:
                           zones:
                             description: ''
                             type: integer
-                        required: &id235
+                        required: &id237
                         - count
                         - zones
                         - zonegroups
@@ -28029,7 +28190,7 @@ paths:
                           rgw:
                             description: ''
                             type: integer
-                        required: &id236
+                        required: &id238
                         - rgw
                         type: object
                       usage:
@@ -28050,14 +28211,14 @@ paths:
                           total_used_bytes:
                             description: ''
                             type: integer
-                        required: &id237
+                        required: &id239
                         - pools
                         - pg_num
                         - total_used_bytes
                         - total_bytes
                         - total_avail_bytes
                         type: object
-                    required: &id238
+                    required: &id240
                     - leaderboard
                     - report_version
                     - report_timestamp
@@ -28081,7 +28242,7 @@ paths:
                     - balancer
                     - crashes
                     type: object
-                required: &id239
+                required: &id241
                 - report
                 - device_report
                 type: object
@@ -28103,7 +28264,7 @@ paths:
                           mode:
                             description: ''
                             type: string
-                        required: *id199
+                        required: *id201
                         type: object
                       channels:
                         description: ''
@@ -28128,7 +28289,7 @@ paths:
                             items:
                               type: string
                             type: array
-                        required: *id200
+                        required: *id202
                         type: object
                       crashes:
                         description: ''
@@ -28147,7 +28308,7 @@ paths:
                               straw2:
                                 description: ''
                                 type: integer
-                            required: *id201
+                            required: *id203
                             type: object
                           bucket_sizes:
                             description: ''
@@ -28158,7 +28319,7 @@ paths:
                               '3':
                                 description: ''
                                 type: integer
-                            required: *id202
+                            required: *id204
                             type: object
                           bucket_types:
                             description: ''
@@ -28169,7 +28330,7 @@ paths:
                               '11':
                                 description: ''
                                 type: integer
-                            required: *id203
+                            required: *id205
                             type: object
                           compat_weight_set:
                             description: ''
@@ -28257,9 +28418,9 @@ paths:
                               straw_calc_version:
                                 description: ''
                                 type: integer
-                            required: *id204
+                            required: *id206
                             type: object
-                        required: *id205
+                        required: *id207
                         type: object
                       fs:
                         description: ''
@@ -28276,7 +28437,7 @@ paths:
                               ever_enabled_multiple:
                                 description: ''
                                 type: boolean
-                            required: *id206
+                            required: *id208
                             type: object
                           filesystems:
                             description: ''
@@ -28289,7 +28450,7 @@ paths:
                           total_num_mds:
                             description: ''
                             type: integer
-                        required: *id207
+                        required: *id209
                         type: object
                       hosts:
                         description: ''
@@ -28309,7 +28470,7 @@ paths:
                           num_with_osd:
                             description: ''
                             type: integer
-                        required: *id208
+                        required: *id210
                         type: object
                       leaderboard:
                         description: ''
@@ -28329,7 +28490,7 @@ paths:
                                   x86_64:
                                     description: ''
                                     type: integer
-                                required: *id209
+                                required: *id211
                                 type: object
                               ceph_version:
                                 description: ''
@@ -28337,7 +28498,7 @@ paths:
                                   ceph version 16.0.0-3151-gf202994fcf:
                                     description: ''
                                     type: integer
-                                required: *id210
+                                required: *id212
                                 type: object
                               cpu:
                                 description: ''
@@ -28345,7 +28506,7 @@ paths:
                                   Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz:
                                     description: ''
                                     type: integer
-                                required: *id211
+                                required: *id213
                                 type: object
                               distro:
                                 description: ''
@@ -28353,7 +28514,7 @@ paths:
                                   centos:
                                     description: ''
                                     type: integer
-                                required: *id212
+                                required: *id214
                                 type: object
                               distro_description:
                                 description: ''
@@ -28361,7 +28522,7 @@ paths:
                                   CentOS Linux 8 (Core):
                                     description: ''
                                     type: integer
-                                required: *id213
+                                required: *id215
                                 type: object
                               kernel_description:
                                 description: ''
@@ -28369,7 +28530,7 @@ paths:
                                   '#1 SMP Wed Jul 1 19:53:01 UTC 2020':
                                     description: ''
                                     type: integer
-                                required: *id214
+                                required: *id216
                                 type: object
                               kernel_version:
                                 description: ''
@@ -28377,7 +28538,7 @@ paths:
                                   5.7.7-200.fc32.x86_64:
                                     description: ''
                                     type: integer
-                                required: *id215
+                                required: *id217
                                 type: object
                               os:
                                 description: ''
@@ -28385,9 +28546,9 @@ paths:
                                   Linux:
                                     description: ''
                                     type: integer
-                                required: *id216
+                                required: *id218
                                 type: object
-                            required: *id217
+                            required: *id219
                             type: object
                           osd:
                             description: ''
@@ -28398,7 +28559,7 @@ paths:
                                   x86_64:
                                     description: ''
                                     type: integer
-                                required: *id218
+                                required: *id220
                                 type: object
                               ceph_version:
                                 description: ''
@@ -28406,7 +28567,7 @@ paths:
                                   ceph version 16.0.0-3151-gf202994fcf:
                                     description: ''
                                     type: integer
-                                required: *id219
+                                required: *id221
                                 type: object
                               cpu:
                                 description: ''
@@ -28414,7 +28575,7 @@ paths:
                                   Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz:
                                     description: ''
                                     type: integer
-                                required: *id220
+                                required: *id222
                                 type: object
                               distro:
                                 description: ''
@@ -28422,7 +28583,7 @@ paths:
                                   centos:
                                     description: ''
                                     type: integer
-                                required: *id221
+                                required: *id223
                                 type: object
                               distro_description:
                                 description: ''
@@ -28430,7 +28591,7 @@ paths:
                                   CentOS Linux 8 (Core):
                                     description: ''
                                     type: integer
-                                required: *id222
+                                required: *id224
                                 type: object
                               kernel_description:
                                 description: ''
@@ -28438,7 +28599,7 @@ paths:
                                   '#1 SMP Wed Jul 1 19:53:01 UTC 2020':
                                     description: ''
                                     type: integer
-                                required: *id223
+                                required: *id225
                                 type: object
                               kernel_version:
                                 description: ''
@@ -28446,7 +28607,7 @@ paths:
                                   5.7.7-200.fc32.x86_64:
                                     description: ''
                                     type: integer
-                                required: *id224
+                                required: *id226
                                 type: object
                               os:
                                 description: ''
@@ -28454,7 +28615,7 @@ paths:
                                   Linux:
                                     description: ''
                                     type: integer
-                                required: *id225
+                                required: *id227
                                 type: object
                               osd_objectstore:
                                 description: ''
@@ -28462,7 +28623,7 @@ paths:
                                   bluestore:
                                     description: ''
                                     type: integer
-                                required: *id226
+                                required: *id228
                                 type: object
                               rotational:
                                 description: ''
@@ -28470,11 +28631,11 @@ paths:
                                   '1':
                                     description: ''
                                     type: integer
-                                required: *id227
+                                required: *id229
                                 type: object
-                            required: *id228
+                            required: *id230
                             type: object
-                        required: *id229
+                        required: *id231
                         type: object
                       mon:
                         description: ''
@@ -28495,7 +28656,7 @@ paths:
                                 items:
                                   type: string
                                 type: array
-                            required: *id230
+                            required: *id232
                             type: object
                           ipv4_addr_mons:
                             description: ''
@@ -28512,7 +28673,7 @@ paths:
                           v2_addr_mons:
                             description: ''
                             type: integer
-                        required: *id231
+                        required: *id233
                         type: object
                       osd:
                         description: ''
@@ -28529,7 +28690,7 @@ paths:
                           require_osd_release:
                             description: ''
                             type: string
-                        required: *id232
+                        required: *id234
                         type: object
                       pools:
                         description: ''
@@ -28568,7 +28729,7 @@ paths:
                             type:
                               description: ''
                               type: string
-                          required: *id233
+                          required: *id235
                           type: object
                         type: array
                       rbd:
@@ -28587,7 +28748,7 @@ paths:
                           num_pools:
                             description: ''
                             type: integer
-                        required: *id234
+                        required: *id236
                         type: object
                       report_id:
                         description: ''
@@ -28615,7 +28776,7 @@ paths:
                           zones:
                             description: ''
                             type: integer
-                        required: *id235
+                        required: *id237
                         type: object
                       services:
                         description: ''
@@ -28623,7 +28784,7 @@ paths:
                           rgw:
                             description: ''
                             type: integer
-                        required: *id236
+                        required: *id238
                         type: object
                       usage:
                         description: ''
@@ -28643,11 +28804,11 @@ paths:
                           total_used_bytes:
                             description: ''
                             type: integer
-                        required: *id237
+                        required: *id239
                         type: object
-                    required: *id238
+                    required: *id240
                     type: object
-                required: *id239
+                required: *id241
                 type: object
           description: OK
         '400':
@@ -28699,7 +28860,7 @@ paths:
                   username:
                     description: Username of the user
                     type: string
-                required: &id240
+                required: &id242
                 - username
                 - roles
                 - name
@@ -28738,7 +28899,7 @@ paths:
                   username:
                     description: Username of the user
                     type: string
-                required: *id240
+                required: *id242
                 type: object
           description: OK
         '400':

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -310,6 +310,54 @@ class RbdService(object):
         return total_used_size, snap_map
 
     @classmethod
+    def image_diff(cls, image_spec, from_snapshot=None, snapshot_name=None,
+                   offset=0, length=None, whole_object=False):
+        # type: (str, Optional[str], Optional[str], int, Optional[int], bool) -> Dict
+        """Return the changed extents between two states of an image.
+
+        Wraps ``librbd``'s ``diff_iterate2``. With ``from_snapshot`` set it reports
+        the extents that changed since that snapshot; otherwise it reports every
+        allocated extent (a full-image diff). ``snapshot_name`` selects the target
+        state (a snapshot, or the live image when omitted). ``whole_object`` trades
+        byte precision for speed by reporting whole objects via object-map/fast-diff.
+        """
+        pool_name, namespace, image_name = parse_image_spec(image_spec)
+
+        def _diff(ioctx):
+            with rbd.Image(ioctx, image_name, snapshot=snapshot_name,
+                           read_only=True) as img:
+                size = img.size()
+                start = int(offset)
+                if start < 0 or start > size:
+                    raise DashboardException(
+                        msg='offset {} out of range (image size {})'.format(start, size),
+                        code='invalid_offset', component='rbd')
+                diff_length = size - start if length is None else int(length)
+                diff_length = max(0, min(diff_length, size - start))
+
+                diffs = []  # type: List[Dict]
+
+                def _cb(_offset, _length, exists):
+                    diffs.append({'offset': _offset, 'length': _length,
+                                  'exists': bool(exists)})
+
+                if diff_length > 0:
+                    img.diff_iterate(start, diff_length, from_snapshot, _cb,
+                                     whole_object=whole_object)
+                return {
+                    'image_size': size,
+                    'offset': start,
+                    'length': diff_length,
+                    'from_snapshot': from_snapshot,
+                    'snapshot_name': snapshot_name,
+                    'whole_object': whole_object,
+                    'count': len(diffs),
+                    'diffs': diffs,
+                }
+
+        return rbd_call(pool_name, namespace, _diff)
+
+    @classmethod
     def _rbd_image(cls, ioctx, pool_name, namespace, image_name,  # pylint: disable=R0912
                    omit_usage=False):
         with rbd.Image(ioctx, image_name) as img:

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -315,7 +315,7 @@ class RbdService(object):
         # type: (str, Optional[str], Optional[str], int, Optional[int], bool) -> Dict
         """Return the changed extents between two states of an image.
 
-        Wraps ``librbd``'s ``diff_iterate2``. With ``from_snapshot`` set it reports
+        Wraps ``rbd.Image``'s ``diff_iterate``. With ``from_snapshot`` set it reports
         the extents that changed since that snapshot; otherwise it reports every
         allocated extent (a full-image diff). ``snapshot_name`` selects the target
         state (a snapshot, or the live image when omitted). ``whole_object`` trades

--- a/src/pybind/mgr/dashboard/tests/test_rbd_service.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_service.py
@@ -177,3 +177,60 @@ class RbdServiceTest(unittest.TestCase):
             # pylint: disable=protected-access
             res = RbdService._rbd_image_refs(ioctx_mock, str(i))
             self.assertEqual(res, images[i*2:(i*2)+2])
+
+    @mock.patch('dashboard.services.rbd.rbd.Image')
+    def test_image_diff(self, rbd_image_mock):
+        mgr.rados = MagicMock()
+        img = MagicMock()
+        img.size.return_value = 64 * 1024 * 1024
+
+        def _diff_iterate(offset, length, from_snap, callback, whole_object=False):
+            callback(0, 4194304, True)
+            callback(33554432, 4194304, True)
+        img.diff_iterate.side_effect = _diff_iterate
+        rbd_image_mock.return_value.__enter__.return_value = img
+
+        result = RbdService.image_diff('rbd/img', from_snapshot='snap1',
+                                       snapshot_name='snap2', whole_object=True)
+
+        # the target snapshot is opened read-only
+        self.assertEqual(rbd_image_mock.call_args[0][1], 'img')
+        self.assertEqual(rbd_image_mock.call_args[1],
+                         {'snapshot': 'snap2', 'read_only': True})
+        # the whole image is walked from the source snapshot at object granularity
+        diff_args = img.diff_iterate.call_args
+        self.assertEqual(diff_args[0][0], 0)
+        self.assertEqual(diff_args[0][1], 64 * 1024 * 1024)
+        self.assertEqual(diff_args[0][2], 'snap1')
+        self.assertTrue(diff_args[1]['whole_object'])
+        self.assertEqual(result, {
+            'image_size': 64 * 1024 * 1024,
+            'offset': 0,
+            'length': 64 * 1024 * 1024,
+            'from_snapshot': 'snap1',
+            'snapshot_name': 'snap2',
+            'whole_object': True,
+            'count': 2,
+            'diffs': [
+                {'offset': 0, 'length': 4194304, 'exists': True},
+                {'offset': 33554432, 'length': 4194304, 'exists': True},
+            ],
+        })
+
+    @mock.patch('dashboard.services.rbd.rbd.Image')
+    def test_image_diff_length_is_clamped_to_image_size(self, rbd_image_mock):
+        mgr.rados = MagicMock()
+        img = MagicMock()
+        img.size.return_value = 16 * 1024 * 1024
+        img.diff_iterate.side_effect = lambda *a, **k: None
+        rbd_image_mock.return_value.__enter__.return_value = img
+
+        # ask for more than the image holds, starting at a non-zero offset
+        result = RbdService.image_diff('rbd/img', offset=8 * 1024 * 1024,
+                                       length=999 * 1024 * 1024)
+
+        self.assertEqual(result['offset'], 8 * 1024 * 1024)
+        self.assertEqual(result['length'], 8 * 1024 * 1024)  # clamped to size - offset
+        self.assertEqual(img.diff_iterate.call_args[0][1], 8 * 1024 * 1024)
+        self.assertIsNone(result['from_snapshot'])
+        self.assertIsNone(result['snapshot_name'])


### PR DESCRIPTION
## Description

Adds `GET /api/block/image/{image_spec}/diff`, exposing `librbd`'s
`diff_iterate2` through the dashboard REST API. Given an optional
`from_snapshot` and a target `snapshot_name` (or the live image), it
returns the changed extents (`{offset, length, exists}`) of an RBD image.

This is the changed-block primitive that backup/DR tooling needs for
changed-block tracking (CBT). Today it is only reachable through the
`rbd` CLI / `librbd`; there is no way to obtain a diff over the REST API.

The parameters mirror `rbd diff`: `from_snapshot`, `snapshot_name`,
`offset`, `length` and `whole_object` (object-map/fast-diff based;
coarser, but avoids scanning object data). The endpoint opens the image
**read-only** and never mutates cluster state.

`openapi.yaml` was regenerated with `tox -e openapi-fix`; the large diff
is the usual PyYAML `&idNNN` anchor renumbering caused by inserting a new
path earlier in the document — no other endpoints changed.

Tests: added `RbdServiceTest.test_image_diff` and
`test_image_diff_length_is_clamped_to_image_size`.
Documentation: endpoint self-documented via `EndpointDoc` + `openapi.yaml`.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket - 80118
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests