### PR TITLE
mgr/cephadm: prevent NVMe-oF deployment on erasure-coded pools

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3868,19 +3868,24 @@ Then run the following:
             raise OrchestratorError(f'Cannot find pool "{pool}" for '
                                     f'service {service_name}')
 
-    def _check_pool_not_erasure_coded(self, pool: str, service_name: str) -> None:
+    def _check_pool_supports_omap(self, pool: str, service_name: str) -> None:
         osd_map = self.get('osd_map')
         pools = osd_map.get('pools', []) if isinstance(osd_map, dict) else []
         for p in pools:
             if p['pool_name'] == pool:
-                if p.get('type') == 3:
-                    raise OrchestratorError(
-                        f'Pool "{pool}" is an erasure-coded pool. '
-                        f'Service "{service_name}" requires a replicated pool '
-                        f'because it uses OMAP objects which are not supported '
-                        f'on erasure-coded pools.'
-                    )
-                return
+                if p.get('type') == 1:
+                    return
+                flags_names = p.get('flags_names', '')
+                if 'supports_omap' in flags_names:
+                    return
+                raise OrchestratorError(
+                    f'Pool "{pool}" does not support OMAP. '
+                    f'Service "{service_name}" requires a pool with OMAP support '
+                    f'because it uses OMAP objects for gateway state. '
+                    f'Use a replicated pool, or enable OMAP support on the '
+                    f'erasure-coded pool with '
+                    f'"ceph osd pool set {pool} allow_ec_optimizations true".'
+                )
 
     def _add_daemon(self,
                     daemon_type: str,
@@ -4675,7 +4680,7 @@ Then run the following:
                 NvmeofMetadataPoolHelper(self).create_pool_if_needed()
             try:
                 self._check_pool_exists(nvmeof_spec.pool, nvmeof_spec.service_name())
-                self._check_pool_not_erasure_coded(nvmeof_spec.pool, nvmeof_spec.service_name())
+                self._check_pool_supports_omap(nvmeof_spec.pool, nvmeof_spec.service_name())
             except OrchestratorError as e:
                 self.log.debug(f"{e}")
                 raise

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3868,6 +3868,20 @@ Then run the following:
             raise OrchestratorError(f'Cannot find pool "{pool}" for '
                                     f'service {service_name}')
 
+    def _check_pool_not_erasure_coded(self, pool: str, service_name: str) -> None:
+        osd_map = self.get('osd_map')
+        pools = osd_map.get('pools', []) if isinstance(osd_map, dict) else []
+        for p in pools:
+            if p['pool_name'] == pool:
+                if p.get('type') == 3:
+                    raise OrchestratorError(
+                        f'Pool "{pool}" is an erasure-coded pool. '
+                        f'Service "{service_name}" requires a replicated pool '
+                        f'because it uses OMAP objects which are not supported '
+                        f'on erasure-coded pools.'
+                    )
+                return
+
     def _add_daemon(self,
                     daemon_type: str,
                     spec: ServiceSpec) -> List[str]:
@@ -4661,6 +4675,7 @@ Then run the following:
                 NvmeofMetadataPoolHelper(self).create_pool_if_needed()
             try:
                 self._check_pool_exists(nvmeof_spec.pool, nvmeof_spec.service_name())
+                self._check_pool_not_erasure_coded(nvmeof_spec.pool, nvmeof_spec.service_name())
             except OrchestratorError as e:
                 self.log.debug(f"{e}")
                 raise

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -63,6 +63,7 @@ class NvmeofService(CephService):
         # that reason we make no attempt to catch the OrchestratorError
         # this may raise
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
+        self.mgr._check_pool_not_erasure_coded(spec.pool, spec.service_name())
 
     def configure_tls(self, spec: NvmeofServiceSpec, daemon_spec: CephadmDaemonDeploySpec) -> None:
         """

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -63,7 +63,7 @@ class NvmeofService(CephService):
         # that reason we make no attempt to catch the OrchestratorError
         # this may raise
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
-        self.mgr._check_pool_not_erasure_coded(spec.pool, spec.service_name())
+        self.mgr._check_pool_supports_omap(spec.pool, spec.service_name())
 
     def configure_tls(self, spec: NvmeofServiceSpec, daemon_spec: CephadmDaemonDeploySpec) -> None:
         """

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -318,10 +318,10 @@ timeout = 1.0\n"""
         assert spec.pool == ".nvmeof"
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    def test_nvmeof_reject_erasure_coded_pool(self, cephadm_module: CephadmOrchestrator):
+    def test_nvmeof_reject_ec_pool_without_omap(self, cephadm_module: CephadmOrchestrator):
         cephadm_module.mock_store_set('_ceph_get', 'osd_map', {
             'pools': [
-                {'pool': 1, 'pool_name': 'ecpool', 'type': 3},
+                {'pool': 1, 'pool_name': 'ecpool', 'type': 3, 'flags_names': ''},
             ]
         })
         nvmeof_spec = NvmeofServiceSpec(
@@ -332,7 +332,7 @@ timeout = 1.0\n"""
         with with_host(cephadm_module, 'test'):
             with pytest.raises(
                 OrchestratorError,
-                match='Pool "ecpool" is an erasure-coded pool'
+                match='Pool "ecpool" does not support OMAP'
             ):
                 cephadm_module._apply_service_spec(nvmeof_spec)
 
@@ -347,6 +347,23 @@ timeout = 1.0\n"""
             service_id='reppool.testgroup',
             group='testgroup',
             pool='reppool'
+        )
+        with with_host(cephadm_module, 'test'):
+            out = cephadm_module._apply_service_spec(nvmeof_spec)
+            assert 'Scheduled' in out
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_nvmeof_allow_ec_pool_with_omap(self, cephadm_module: CephadmOrchestrator):
+        cephadm_module.mock_store_set('_ceph_get', 'osd_map', {
+            'pools': [
+                {'pool': 1, 'pool_name': 'fastec', 'type': 3,
+                 'flags_names': 'ec_optimizations,supports_omap'},
+            ]
+        })
+        nvmeof_spec = NvmeofServiceSpec(
+            service_id='fastec.testgroup',
+            group='testgroup',
+            pool='fastec'
         )
         with with_host(cephadm_module, 'test'):
             out = cephadm_module._apply_service_spec(nvmeof_spec)

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -317,6 +317,41 @@ timeout = 1.0\n"""
 
         assert spec.pool == ".nvmeof"
 
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_nvmeof_reject_erasure_coded_pool(self, cephadm_module: CephadmOrchestrator):
+        cephadm_module.mock_store_set('_ceph_get', 'osd_map', {
+            'pools': [
+                {'pool': 1, 'pool_name': 'ecpool', 'type': 3},
+            ]
+        })
+        nvmeof_spec = NvmeofServiceSpec(
+            service_id='ecpool.testgroup',
+            group='testgroup',
+            pool='ecpool'
+        )
+        with with_host(cephadm_module, 'test'):
+            with pytest.raises(
+                OrchestratorError,
+                match='Pool "ecpool" is an erasure-coded pool'
+            ):
+                cephadm_module._apply_service_spec(nvmeof_spec)
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_nvmeof_allow_replicated_pool(self, cephadm_module: CephadmOrchestrator):
+        cephadm_module.mock_store_set('_ceph_get', 'osd_map', {
+            'pools': [
+                {'pool': 1, 'pool_name': 'reppool', 'type': 1},
+            ]
+        })
+        nvmeof_spec = NvmeofServiceSpec(
+            service_id='reppool.testgroup',
+            group='testgroup',
+            pool='reppool'
+        )
+        with with_host(cephadm_module, 'test'):
+            out = cephadm_module._apply_service_spec(nvmeof_spec)
+            assert 'Scheduled' in out
+
     @patch("cephadm.inventory.Inventory.get_addr", lambda _, __: '192.168.100.100')
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",


### PR DESCRIPTION
**Summary**

NVMe-oF gateway metadata is stored in OMAP objects. Since erasure-coded
pools do not support OMAP metadata required by NVMe-oF, deploying an
NVMe-oF gateway on an EC pool results in an invalid configuration.

This change adds validation in cephadm to reject NVMe-oF deployments
targeting erasure-coded pools and returns a clear error message to the
user.

Fixes: https://tracker.ceph.com/issues/80022
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]

**Changes**

- Add pool type validation during NVMe-oF service deployment.
- Reject deployments on erasure-coded pools.
- Allow deployments on replicated pools.
- Add unit tests for both success and failure scenarios.

**Validation**

**CLI**
```
Attempting deployment on an EC pool:

```bash
ceph orch apply nvmeof \
  --pool ecpool \
  --group ec-test \
  --placement="ceph-node-02"
```

**Result:**

```
Error EINVAL: Pool "ecpool" is an erasure-coded pool.
Service "nvmeof.ecpool.ec-test" requires a replicated pool because it uses OMAP objects which are not supported on erasure-coded pools.
```

**Deployment on a replicated pool:**

```
ceph orch apply nvmeof \
  --pool replpool \
  --group repl-test \
  --placement="ceph-node-02"
```

**Result:**

`Scheduled nvmeof.replpool.repl-test update...`

**Service status:**

```
nvmeof.replpool.repl-test  1/1
Dashboard
Created NVMe-oF gateway group successfully.
Created subsystem successfully.
Verified NVMe-oF service reaches running state.
nvmeof.dashboard-test  1/1
```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
