### PR TITLE
qa/standalone/osd: fix recovery_toofull race in osd-recovery-space.sh

### DIFF
--- a/qa/standalone/osd/osd-recovery-space.sh
+++ b/qa/standalone/osd/osd-recovery-space.sh
@@ -76,6 +76,7 @@ function wait_for_state() {
 function wait_for_recovery_toofull() {
     local timeout=$1
     wait_for_state recovery_toofull $timeout
+    local ret=$?
     if [ $ret -ne 0 ]; then
       echo "Error: Recovery toofull timeout"
       return 1
@@ -126,6 +127,18 @@ function TEST_recovery_test_simple() {
       ceph tell osd.$o injectargs '--fake_statfs_for_testing 3686400' || return 1
     done
     sleep 5
+
+    # Throttle recovery so that the target OSD's full-status check (driven by
+    # the periodic osd_stat/heartbeat update, ~every few seconds) reliably
+    # fires and marks the OSD full *while recovery is still in progress*.
+    # fake_statfs_for_testing only reports the OSD as full once the recovered
+    # data has actually landed, so on fast hardware the small (~3MB) recovery
+    # can complete (PG active+clean) before the OSD ever reports itself full,
+    # and recovery_toofull never triggers. 
+    for o in $(seq 0 $(expr $OSDS - 1))
+    do
+      ceph tell osd.$o injectargs '--osd_recovery_sleep 0.05' || return 1
+    done
 
     ceph pg dump pgs
 


### PR DESCRIPTION
TEST_recovery_test_simple relies on the recovery target OSD crossing its full-ratio while recovery is still in progress. But fake_statfs only reports the OSD as full once the recovered data has landed, so on fast hardware the small (~3MB) recovery completes (PG active+clean) before the OSD's periodic full-status check ever fires, and recovery_toofull never triggers.

Throttle recovery (osd_recovery_sleep) so the full-status check reliably fires before recovery finishes.

Also fix wait_for_recovery_toofull(): it tested an unset $ret instead of the return code of wait_for_state, so the timeout was silently swallowed and the helper always returned success.

Fixes: https://tracker.ceph.com/issues/80024

