### PR TITLE
mgr/dashboard: fix the two flakiest dashboard e2e tests

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/logs.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/logs.po.ts
@@ -26,13 +26,20 @@ export class LogsPageHelper extends PageHelper {
     // go to audit logs tab
     cy.contains('.nav-link', 'Audit Logs').click();
 
+    // The filter toolbar is re-created on every tab switch. Wait until the
+    // new pane's keyword filter is interactable before driving the filter
+    // inputs, otherwise the clear/type intermittently hits the input while
+    // it is still initializing and fails on a disabled element.
+    cy.get('.tab-pane.active #logs-keyword').should('be.visible').and('be.enabled');
+
     // Enter an earliest time so that no old messages with the same pool name show up
     this.setTimepickerValue(0, hour);
     this.setTimepickerValue(1, minute);
 
     // Enter the pool name into the filter box
-    cy.get('#logs-keyword').clear();
-    cy.get('#logs-keyword').type(poolname);
+    cy.get('.tab-pane.active #logs-keyword').clear();
+    cy.get('.tab-pane.active #logs-keyword').type(poolname);
+    cy.get('.tab-pane.active #logs-keyword').should('have.value', poolname);
 
     cy.get('.tab-pane.active')
       .get('.log-viewer')
@@ -47,13 +54,17 @@ export class LogsPageHelper extends PageHelper {
     // go to audit logs tab
     cy.contains('.nav-link', 'Audit Logs').click();
 
+    // See checkAuditForPoolFunction: wait for the re-created filter toolbar.
+    cy.get('.tab-pane.active #logs-keyword').should('be.visible').and('be.enabled');
+
     // Enter an earliest time so that no old messages with the same config name show up
     this.setTimepickerValue(0, hour);
     this.setTimepickerValue(1, minute);
 
     // Enter the config name into the filter box
-    cy.get('#logs-keyword').clear();
-    cy.get('#logs-keyword').type(configname);
+    cy.get('.tab-pane.active #logs-keyword').clear();
+    cy.get('.tab-pane.active #logs-keyword').type(configname);
+    cy.get('.tab-pane.active #logs-keyword').should('have.value', configname);
 
     cy.get('.tab-pane.active')
       .get('.log-viewer')

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/forms-helper.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/forms-helper.feature.po.ts
@@ -78,6 +78,18 @@ And('I click on submit button', () => {
 });
 
 /**
+ * Clicks a button in the carbon modal and waits for the modal to close.
+ * The form must be done validating before the click: the submit button
+ * silently ignores clicks while the form is invalid or has pending
+ * validators, which leaves the modal open and fails every later step.
+ */
+And('I submit the carbon modal with {string}', (button: string) => {
+  cy.get('cds-modal form').should('have.class', 'ng-valid');
+  cy.get(`cds-modal button[aria-label="${button}"]`).should('be.enabled').click();
+  cy.get('cds-modal').should('not.exist');
+});
+
+/**
  * Some modals have an additional confirmation to be provided
  * by ticking the 'Are you sure?' box.
  */

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/snapshots.e2e-spec.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/snapshots.e2e-spec.feature
@@ -23,7 +23,7 @@ Feature: CephFS Snapshot Management
     And I go to the "Subvolumes" tab
     And I click on "Create" button from the expanded row
     And enter "subvolumeName" "test_subvolume" in the carbon modal
-    And I click on "Create Subvolume" button
+    And I submit the carbon modal with "Create Subvolume"
     Then I should see a row with "test_subvolume" in the expanded row
 
   Scenario: Show the CephFS Snapshots view
@@ -39,7 +39,7 @@ Feature: CephFS Snapshot Management
     And the table in the expanded row is ready
     And I click on "Create" button from the expanded row
     And enter "snapshotName" "test_snapshot" in the carbon modal
-    And I click on "Create Snapshot" button
+    And I submit the carbon modal with "Create Snapshot"
     Then I should see a row with "test_snapshot" in the expanded row
 
   Scenario: Create a CephFS Subvolume Snapshot Clone
@@ -51,7 +51,7 @@ Feature: CephFS Snapshot Management
     When I select a row "test_snapshot" in the expanded row
     And I click on "Clone" button from the table actions in the expanded row
     And enter "cloneName" "test_clone" in the carbon modal
-    And I click on "Create Clone" button
+    And I submit the carbon modal with "Create Clone"
     Then I wait for "5" seconds
     And I go to the "Subvolumes" tab
     Then I should see a row with "test_clone" in the expanded row
@@ -64,7 +64,7 @@ Feature: CephFS Snapshot Management
     And I select a row "test_clone" in the expanded row
     And I click on "Remove" button from the table actions in the expanded row
     And I confirm the resource "test_clone"
-    And I click on "Remove Subvolume" button
+    And I submit the carbon modal with "Remove Subvolume"
     Then I wait for "5" seconds
     And I should not see a row with "test_clone" in the expanded row
 
@@ -76,7 +76,7 @@ Feature: CephFS Snapshot Management
     When I select a row "test_snapshot" in the expanded row
     And I click on "Remove" button from the table actions in the expanded row
     And I confirm the resource "test_snapshot"
-    And I click on "Remove Snapshot" button
+    And I submit the carbon modal with "Remove Snapshot"
     Then I should not see a row with "test_snapshot" in the expanded row
 
   Scenario: Remove a CephFS Subvolume
@@ -86,7 +86,7 @@ Feature: CephFS Snapshot Management
     When I select a row "test_subvolume" in the expanded row
     And I click on "Remove" button from the table actions in the expanded row
     And I confirm the resource "test_subvolume"
-    And I click on "Remove Subvolume" button
+    And I submit the carbon modal with "Remove Subvolume"
     Then I should not see a row with "test_subvolume" in the expanded row
 
   Scenario: Remove CephFS Volume
@@ -95,5 +95,5 @@ Feature: CephFS Snapshot Management
     And I click on "Remove" button from the table actions
     Then I should see the carbon modal
     And I confirm the resource "test_cephfs"
-    And I click on "Remove File System" button
+    And I submit the carbon modal with "Remove File System"
     Then I should not see a row with "test_cephfs"


### PR DESCRIPTION
## Description

The `ceph-dashboard-pull-requests` Jenkins job has been failing roughly one in three runs on unrelated PRs. Digging through the last ~300 builds, nearly all non-PR-caused failures come from two flaky e2e suites:

**1. `cluster/logs.e2e-spec.ts` — "audit logs respond to pool creation and deletion"** (9 of the last 13 failed builds)

```
CypressError: `cy.type()` failed because it targeted a disabled element.
  > <input id="logs-keyword" type="text" class="form-control ng-untouched ng-pristine ng-valid" ...>
```

Since 38a06d81f17 moved the filter toolbar inside each tab pane, the toolbar is destroyed and re-created on every tab switch, and the helper types into `#logs-keyword` immediately after clicking the *Audit Logs* tab — intermittently hitting the input while it is still initializing. The fix waits for the active pane's keyword filter to be visible and enabled first, scopes the queries to the active pane, and asserts the typed value landed.

**2. `filesystems/snapshots.e2e-spec.feature` — CephFS Snapshot Management** (e.g. builds 26056/26062, plus a large cluster of failures around Aug 22–24)

```
CypressError: Timed out retrying after 120000ms: `cy.clear()` failed because this element ...
is being covered by another element:
  <input ... id="snapshotName" ... >
```

The scenarios submit carbon modals via the generic `I click on {string} button` step, which **force-clicks** and moves on. `SubmitButtonComponent.submit()` silently returns while the form is invalid or has pending validators, so an early click does nothing — the modal stays open, the following table search is "covered by" the modal, and the remaining scenarios cascade-fail because `test_snapshot` was never created.

The fix adds an `I submit the carbon modal with {string}` step that waits for the modal form to finish validating (`ng-valid`), clicks without `force` so Cypress retries until the button is actionable, and requires `cds-modal` to actually close before proceeding — so a genuinely failed submission now fails *at the submit step* with a clear message instead of 5 misleading downstream timeouts. All modal submits in the snapshots feature now use it.

## Evidence

Example failing runs: [26061](https://jenkins.ceph.com/job/ceph-dashboard-pull-requests/26061/), [26057](https://jenkins.ceph.com/job/ceph-dashboard-pull-requests/26057/) (audit logs), [26062](https://jenkins.ceph.com/job/ceph-dashboard-pull-requests/26062/), [26056](https://jenkins.ceph.com/job/ceph-dashboard-pull-requests/26056/) (snapshots). The same branches pass on re-trigger (e.g. PR #71184 failed 6× / passed 1× on identical code), confirming flake rather than regression.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
