### PR TITLE
rgw/s3vectors: tenant support

### DIFF
--- a/qa/tasks/s3vectors_tests.py
+++ b/qa/tasks/s3vectors_tests.py
@@ -248,7 +248,7 @@ def run_tests(ctx, config):
         (remote,) = ctx.cluster.only(client).remotes.keys()
 
         # test marks to use by default
-        attr = ['vector_bucket_test', 'index_test', 'vector_test']
+        attr = ['vector_bucket_test', 'index_test', 'vector_test', 'tenant_test']
 
         if 'extra_attr' in client_config:
             attr = client_config.get('extra_attr')

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -679,7 +679,7 @@ int RadosVectorBucket::remove(const DoutPrefixProvider* dpp,
       return r;
     }
     // the data of the vector bucket is gone, and so should be its cached session
-    rgw::s3vector::notify_session_delete(dpp, info.bucket.name);
+    rgw::s3vector::notify_session_delete(dpp, info.bucket.tenant, info.bucket.name);
   }
 #endif
 

--- a/src/rgw/lancedb-rgw-store/include/lancedb_rgw_store.h
+++ b/src/rgw/lancedb-rgw-store/include/lancedb_rgw_store.h
@@ -36,16 +36,19 @@ struct LanceDBObjectStoreProvider;
  *
  * @param driver  Non-null pointer to rgw::sal::Driver (env.driver in RGW handlers)
  * @param dpp     Non-null pointer to DoutPrefixProvider for logging
+ * @param tenant  Tenant of the buckets accessed through the provider, NULL or
+ *                empty for the default tenant
  *
  * @return Non-null pointer to LanceDBObjectStoreProvider on success,
- *         NULL if either driver or dpp is NULL
+ *         NULL if either driver or dpp is NULL, or if tenant is not valid UTF-8
  *
  * @note Caller must either:
  *   - Pass to lancedb_registry_insert_provider() (transfers ownership), OR
  *   - Free with rgw_lancedb_store_free_provider()
  * @note Both driver and dpp must remain valid for provider lifetime
  */
-struct LanceDBObjectStoreProvider* rgw_lancedb_store_create_provider(void* driver, const void* dpp);
+struct LanceDBObjectStoreProvider* rgw_lancedb_store_create_provider(void* driver, const void* dpp,
+                                                                    const char* tenant);
 
 /**
  * Free a provider created by rgw_lancedb_store_create_provider.

--- a/src/rgw/lancedb-rgw-store/src/lib.rs
+++ b/src/rgw/lancedb-rgw-store/src/lib.rs
@@ -56,10 +56,11 @@ pub struct LanceDBObjectStoreProvider {
 /// - `driver` must be a valid, non-null pointer to rgw::sal::Driver
 /// - `dpp` must be a valid, non-null pointer to DoutPrefixProvider
 /// - Both pointers must remain valid for the lifetime of the provider
+/// - `tenant`, when not NULL, must be a valid null-terminated string
 ///
 /// # Returns
 /// Non-null pointer to LanceDBObjectStoreProvider on success, NULL if
-/// either `driver` or `dpp` is NULL.
+/// either `driver` or `dpp` is NULL, or if `tenant` is not valid UTF-8.
 /// Caller must either:
 /// - Pass to lancedb_registry_insert_provider() (transfers ownership), OR
 /// - Free with rgw_lancedb_store_free_provider()
@@ -67,10 +68,21 @@ pub struct LanceDBObjectStoreProvider {
 pub unsafe extern "C" fn rgw_lancedb_store_create_provider(
     driver: *mut CRgwDriver,
     dpp: *const CRgwDoutPrefix,
+    tenant: *const std::os::raw::c_char,
 ) -> *mut LanceDBObjectStoreProvider {
     if driver.is_null() || dpp.is_null() {
         return std::ptr::null_mut();
     }
+
+    // a NULL tenant is the default one
+    let tenant = if tenant.is_null() {
+        String::new()
+    } else {
+        match std::ffi::CStr::from_ptr(tenant).to_str() {
+            Ok(tenant) => tenant.to_string(),
+            Err(_) => return std::ptr::null_mut(),
+        }
+    };
 
     // TODO: convert to compile-time check (e.g., via build.rs with constexpr
     // version constants from the C++ header) instead of runtime verification
@@ -80,7 +92,7 @@ pub unsafe extern "C" fn rgw_lancedb_store_create_provider(
     }
 
     let provider: Arc<dyn lance_io::object_store::ObjectStoreProvider> =
-        Arc::new(RGWStoreProvider::new(driver, dpp));
+        Arc::new(RGWStoreProvider::new(driver, dpp, tenant));
 
     Box::into_raw(Box::new(LanceDBObjectStoreProvider {
         inner: Some(provider),
@@ -167,7 +179,11 @@ mod tests {
     #[test]
     fn test_create_provider_null_args() {
         assert!(unsafe {
-            rgw_lancedb_store_create_provider(std::ptr::null_mut(), std::ptr::null())
+            rgw_lancedb_store_create_provider(
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
         }
         .is_null());
     }
@@ -176,12 +192,17 @@ mod tests {
     fn test_provider_lifecycle() {
         let fake_driver = 0x1234usize as *mut CRgwDriver;
         let fake_dpp = 0x5678usize as *const CRgwDoutPrefix;
+        let tenant = std::ffi::CString::new("tenant").unwrap();
 
-        let provider = unsafe { rgw_lancedb_store_create_provider(fake_driver, fake_dpp) };
-        assert!(!provider.is_null());
+        // a provider of the default tenant, and one of a named tenant
+        for tenant in [std::ptr::null(), tenant.as_ptr()] {
+            let provider =
+                unsafe { rgw_lancedb_store_create_provider(fake_driver, fake_dpp, tenant) };
+            assert!(!provider.is_null());
 
-        // Free should not crash
-        unsafe { rgw_lancedb_store_free_provider(provider) };
+            // Free should not crash
+            unsafe { rgw_lancedb_store_free_provider(provider) };
+        }
     }
 
     #[test]

--- a/src/rgw/lancedb-rgw-store/src/provider.rs
+++ b/src/rgw/lancedb-rgw-store/src/provider.rs
@@ -30,6 +30,10 @@ use url::Url;
 pub struct RGWStoreProvider {
     driver: *mut CRgwDriver,
     dpp: *const CRgwDoutPrefix,
+    /// Tenant of the buckets accessed through this provider (empty for the
+    /// default tenant). A provider, and the session holding it, are never
+    /// shared between tenants, since two tenants may use the same bucket name
+    tenant: String,
 }
 
 // To guarantee that driver and dpp are pointers are safe to share across threads
@@ -46,8 +50,14 @@ impl RGWStoreProvider {
     /// # Arguments
     /// * `driver` - Pointer to rgw::sal::Driver (typically env.driver in RGW handlers)
     /// * `dpp` - Pointer to DoutPrefixProvider for logging
-    pub unsafe fn new(driver: *mut CRgwDriver, dpp: *const CRgwDoutPrefix) -> Self {
-        Self { driver, dpp }
+    /// * `tenant` - Tenant of the buckets accessed through this provider (empty
+    ///   for the default tenant)
+    pub unsafe fn new(driver: *mut CRgwDriver, dpp: *const CRgwDoutPrefix, tenant: String) -> Self {
+        Self {
+            driver,
+            dpp,
+            tenant,
+        }
     }
 
     /// Get the driver pointer
@@ -92,12 +102,7 @@ impl lance_io::object_store::ObjectStoreProvider for RGWStoreProvider {
             format!("{}/", path)
         };
 
-        // Extract tenant from URL query param: s3://bucket/?tenant=xxx
-        let tenant = base_path
-            .query_pairs()
-            .find(|(k, _)| k == "tenant")
-            .map(|(_, v)| v.to_string())
-            .unwrap_or_default();
+        let tenant = self.tenant.as_str();
 
         // Create RGW ObjectStore with bucket and prefix
         // Note: The prefix is stored in RGWObjectStore but NOT used for path manipulation
@@ -105,7 +110,7 @@ impl lance_io::object_store::ObjectStoreProvider for RGWStoreProvider {
         //
         // We keep the prefix for debugging/logging and troubleshooting purposes.
         let inner = Arc::new(unsafe {
-            RGWObjectStore::new(self.driver, self.dpp, bucket, &tenant, &prefix)
+            RGWObjectStore::new(self.driver, self.dpp, bucket, tenant, &prefix)
         });
 
         let storage_options =
@@ -159,6 +164,7 @@ mod tests {
             RGWStoreProvider::new(
                 std::ptr::null_mut::<CRgwDriver>(),
                 std::ptr::null::<CRgwDoutPrefix>(),
+                String::new(),
             )
         };
 

--- a/src/rgw/rgw_rest_s3vector.cc
+++ b/src/rgw/rgw_rest_s3vector.cc
@@ -163,7 +163,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if(op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -348,7 +348,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -408,7 +408,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -449,7 +449,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -488,7 +488,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -540,7 +540,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -598,7 +598,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -811,7 +811,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
     }
@@ -874,7 +874,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -932,7 +932,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -995,7 +995,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -1033,7 +1033,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -1072,7 +1072,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -1124,7 +1124,7 @@ private:
     op_ret = driver->load_vector_bucket(this, bucket_id, &bucket, y);
     if (op_ret < 0) {
       if (op_ret == -ENOENT) {
-        rgw::s3vector::notify_session_delete(this, bucket_id.name);
+        rgw::s3vector::notify_session_delete(this, bucket_id.tenant, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
@@ -1159,10 +1159,23 @@ private:
 
 int RGWHandler_REST_s3Vector::init(rgw::sal::Driver* driver, req_state *s, rgw::io::BasicClient *cio) {
   s->dialect = "s3vectors";
-  if (int ret = RGWHandler_REST::init(driver, s, cio); ret < 0) {
+  if (const auto ret = RGWHandler_REST::init(driver, s, cio); ret < 0) {
     return ret;
   }
   return RGWHandler_REST::allocate_formatter(s, RGWFormat::JSON, false);
+}
+
+int RGWHandler_REST_s3Vector::postauth_init(optional_yield y) {
+  // the URL of an s3vector request holds the name of the operation, and not a
+  // bucket, so it cannot hold a tenant either. the tenant of the request is the
+  // one of the user making it, as implied by its credentials
+  const auto& tenant = s->auth.identity->get_tenant();
+  if (const auto ret = rgw_validate_tenant_name(tenant); ret < 0) {
+    ldpp_dout(s, 1) << "ERROR: invalid tenant name: " << tenant << ". error: " << ret << dendl;
+    return ret;
+  }
+  s->bucket_tenant = tenant;
+  return 0;
 }
 
 int RGWHandler_REST_s3Vector::authorize(const DoutPrefixProvider* dpp, optional_yield y) {

--- a/src/rgw/rgw_rest_s3vector.h
+++ b/src/rgw/rgw_rest_s3vector.h
@@ -18,6 +18,6 @@ public:
 
   int init(rgw::sal::Driver* driver, req_state *s, rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider* dpp, optional_yield y) override;
-  int postauth_init(optional_yield y) override { return 0; }
+  int postauth_init(optional_yield y) override;
   int read_permissions(RGWOp* op, optional_yield y) override { return 0; }
 };

--- a/src/rgw/rgw_s3vector.cc
+++ b/src/rgw/rgw_s3vector.cc
@@ -94,6 +94,7 @@ namespace rgw::s3vector {
   // Returns a new session on success, nullptr on failure.
   LanceDBSession* create_rgw_session(const DoutPrefixProvider* dpp,
       rgw::sal::Driver* driver,
+      const std::string& tenant,
       const void* options) {
 #ifdef WITH_RADOSGW_LANCEDB
     if (!driver) {
@@ -107,7 +108,7 @@ namespace rgw::s3vector {
       return nullptr;
     }
 
-    LanceDBObjectStoreProvider* provider = rgw_lancedb_store_create_provider(driver, dpp);
+    LanceDBObjectStoreProvider* provider = rgw_lancedb_store_create_provider(driver, dpp, tenant.c_str());
     if (!provider) {
       ldpp_dout(dpp, 1) << "ERROR: failed to create RGW LanceDB provider" << dendl;
       lancedb_registry_free(registry);
@@ -137,12 +138,27 @@ namespace rgw::s3vector {
 #endif
   }
 
-  // Build RGW backend URI with optional tenant query param
-  std::string make_rgw_uri(const std::string& bucket, const std::string* tenant) {
-    if (!tenant || tenant->empty()) {
-      return fmt::format("{}://{}/", RGW_PROVIDER_SCHEME, bucket);
+  // Build RGW backend URI
+  // the tenant is not part of the URI, it is stored in the session
+  std::string make_rgw_uri(const std::string& bucket) {
+    return fmt::format("{}://{}/", RGW_PROVIDER_SCHEME, bucket);
+  }
+
+  // the tenant of a vector bucket, or an empty string for the default tenant
+  const std::string& tenant_name(const std::string* tenant) {
+    static const std::string default_tenant;
+    return tenant ? *tenant : default_tenant;
+  }
+
+  // the storage of a vector bucket is per tenant, since two tenants may use the
+  // same vector bucket name. tenant names are limited to alphanumeric characters
+  // and "_", so they need no encoding to be used as a path component
+  std::string tenant_qualified_name(const std::string* tenant, const std::string& vector_bucket_name) {
+    const auto& tenant_str = tenant_name(tenant);
+    if (tenant_str.empty()) {
+      return vector_bucket_name;
     }
-    return fmt::format("{}://{}/?tenant={}", RGW_PROVIDER_SCHEME, bucket, *tenant);
+    return fmt::format("{}${}", tenant_str, vector_bucket_name);
   }
 
   // utility functions for connection creation and opening table
@@ -170,7 +186,7 @@ namespace rgw::s3vector {
                           << "rgw_s3vector_local_path to be configured" << dendl;
         return nullptr;
       }
-      uri = fmt::format("{}/{}", local_path, vector_bucket_name);
+      uri = fmt::format("{}/{}", local_path, tenant_qualified_name(tenant, vector_bucket_name));
       builder = lancedb_connect(uri.c_str());
       if (!builder) {
         ldpp_dout(dpp, 1) << "ERROR: s3vector failed to create connection builder for: " << uri << dendl;
@@ -178,7 +194,7 @@ namespace rgw::s3vector {
       }
       ldpp_dout(dpp, 10) << "INFO: s3vector connecting to local backend: " << uri << dendl;
     } else if (is_rgw_backend(backend_type)) {
-      uri = make_rgw_uri(vector_bucket_name, tenant);
+      uri = make_rgw_uri(vector_bucket_name);
       builder = lancedb_connect(uri.c_str());
       if (!builder) {
         ldpp_dout(dpp, 1) << "ERROR: s3vector failed to create connection builder for: " << uri << dendl;
@@ -193,7 +209,7 @@ namespace rgw::s3vector {
     LanceDBSessionOptions opts = {1, 1};
     // the RGW backend needs a session with the object store registry of the SAL
     LanceDBSession* session = is_rgw_backend(backend_type) ?
-        create_rgw_session(dpp, driver, &opts) : lancedb_session_new(&opts);
+        create_rgw_session(dpp, driver, tenant_name(tenant), &opts) : lancedb_session_new(&opts);
     if (!session) {
       ldpp_dout(dpp, 1) << "ERROR: s3vector failed to create session for: " << uri << dendl;
       lancedb_connect_builder_free(builder);
@@ -235,10 +251,10 @@ namespace rgw::s3vector {
       return {};
     }
 
-    auto session_sp = rgw::s3vector::get_session(dpp, vector_bucket_name);
+    auto session_sp = rgw::s3vector::get_session(dpp, tenant_name(tenant), vector_bucket_name);
     if (!session_sp) {
       // No cached session — create a short-lived connection using caller's driver/dpp
-      rgw::s3vector::notify_session_create(dpp, vector_bucket_name);
+      rgw::s3vector::notify_session_create(dpp, tenant_name(tenant), vector_bucket_name);
       return LanceDBSessionConnHandle{
         .conn = connect(dpp, driver, tenant, vector_bucket_name)
       };
@@ -247,9 +263,9 @@ namespace rgw::s3vector {
     std::string uri;
     if (is_local_backend(backend_type)) {
       const std::string local_path = conf.get_val<std::string>("rgw_s3vector_local_path");
-      uri = fmt::format("{}/{}", local_path, vector_bucket_name);
+      uri = fmt::format("{}/{}", local_path, tenant_qualified_name(tenant, vector_bucket_name));
     } else {
-      uri = make_rgw_uri(vector_bucket_name, tenant);
+      uri = make_rgw_uri(vector_bucket_name);
     }
 
     LanceDBConnectBuilder* builder = lancedb_connect(uri.c_str());
@@ -1002,7 +1018,7 @@ namespace rgw::s3vector {
       return lancedb_error_to_errno(result);
     } else { // successfully deleted the index
       // we are not failing the operation if we cannot notify the background process on index removal
-      notify_index_remove(dpp, configuration.vector_bucket_name, configuration.index_name);
+      notify_index_remove(dpp, tenant_name(tenant), configuration.vector_bucket_name, configuration.index_name);
     }
     lancedb_connection_free(conn);
     return 0;
@@ -1304,10 +1320,12 @@ namespace rgw::s3vector {
         return;
       } else { // successfully deleted the index
         // we are not failing the operation if we cannot notify the background process on index removal
-        notify_index_remove(dpp, bucket_name, table_names[i]);
+        notify_index_remove(dpp, tenant_name(ctx->tenant), bucket_name, table_names[i]);
       }
     }
     lancedb_free_table_names(table_names, name_count);
+    ldpp_dout(dpp, 20) << "INFO: deleting in-memory session (if it exists) for bucket: " << bucket_name << dendl;
+    rgw::s3vector::notify_session_delete(dpp, tenant_name(ctx->tenant), bucket_name);
     lancedb_connection_free(conn);
     ctx->result = 0;
   }
@@ -1940,7 +1958,7 @@ namespace rgw::s3vector {
       return;
     }
     // we are not failing the operation if we cannot notify the background process on index update
-    notify_index_update(dpp, configuration.vector_bucket_name, configuration.index_name);
+    notify_index_update(dpp, tenant_name(tenant), configuration.vector_bucket_name, configuration.index_name);
     lancedb_table_free(table);
     lancedb_connection_free(conn);
     ctx->result = 0;

--- a/src/rgw/rgw_s3vector.h
+++ b/src/rgw/rgw_s3vector.h
@@ -80,9 +80,11 @@ inline bool is_rgw_backend(BackendType type) {
   return type == BackendType::RGW;
 }
 
-// Create a LanceDB session with RGW provider
+// Create a LanceDB session with RGW provider. the session is per tenant, since
+// two tenants may use the same vector bucket name
 LanceDBSession* create_rgw_session(const DoutPrefixProvider* dpp,
     rgw::sal::Driver* driver,
+    const std::string& tenant,
     const void* options = nullptr);
 
 /*

--- a/src/rgw/rgw_s3vector_background.cc
+++ b/src/rgw/rgw_s3vector_background.cc
@@ -29,6 +29,7 @@ class Manager : public DoutPrefixProvider {
 public:
     //message_t -> pass in empty index name for session messages (can extend to per table sessions in the future if needed)
     using table_name_t = std::pair<std::string, std::string>; // pair of vector bucket name and index name
+    using session_name_t = std::pair<std::string, std::string>; // pair of tenant and vector bucket name
     struct message_t {
       enum class Op {
         UPDATE,
@@ -36,8 +37,9 @@ public:
         SESSION_CREATE, 
         SESSION_DELETE
       };
-      message_t(const std::string& bucket_name, const std::string& index_name, Op _type) :
-          table_name(bucket_name, index_name), type(_type) {}
+      message_t(const std::string& tenant, const std::string& bucket_name, const std::string& index_name, Op _type) :
+          session_name(tenant, bucket_name), table_name(bucket_name, index_name), type(_type) {}
+      const session_name_t session_name;
       const table_name_t table_name;
       const Op type;
     };
@@ -64,7 +66,7 @@ private:
   };
   using SessionPtr = std::shared_ptr<LanceDBSession>;
   ceph::shared_mutex sessions_mutex = ceph::make_shared_mutex("s3vector::Manager::sessions_mutex"); 
-  std::unordered_map<std::string, SessionPtr> sessions;
+  std::unordered_map<session_name_t, SessionPtr, boost::hash<session_name_t>> sessions;
   std::unordered_map<table_name_t, ceph::coarse_real_time, boost::hash<table_name_t>> tables;
   MessageQueue messages;
   static constexpr auto idle_sleep = std::chrono::milliseconds(1000); // 1s
@@ -151,6 +153,7 @@ private:
       const auto message_count = messages.consume_all([&tables_to_process, this](auto message) {
         std::unique_ptr<message_t> message_guard(message);
         const auto table_name = std::move(message->table_name);
+        const auto session_name = std::move(message->session_name);
         switch(message->type) {
           case message_t::Op::REMOVE:
             ldpp_dout(this, 20) << "INFO: received remove message for table: " << table_name.first << "." << table_name.second << dendl;
@@ -180,10 +183,12 @@ private:
             }            
           case message_t::Op::SESSION_CREATE:
             {
-              ldpp_dout(this, 20) << "INFO: received session create message for bucket: " << table_name.first << dendl;
+              ldpp_dout(this, 20) << "INFO: received session create message for bucket: " << session_name.second <<
+                " of tenant: " << session_name.first << dendl;
               std::unique_lock l(sessions_mutex);
-              if (sessions.find(table_name.first) != sessions.end()) {
-                ldpp_dout(this, 20) << "INFO: session already exists for bucket: " << table_name.first << dendl;
+              if (sessions.find(session_name) != sessions.end()) {
+                ldpp_dout(this, 20) << "INFO: session already exists for bucket: " << session_name.second <<
+                  " of tenant: " << session_name.first << dendl;
                 return;
               }
 
@@ -199,27 +204,32 @@ private:
               const LanceDBSessionOptions* options = nullptr;
 
               if (is_rgw_backend(backend_type)) {
-                session = create_rgw_session(this, driver, options);
+                session = create_rgw_session(this, driver, session_name.first, options);
               } else {
                 session = lancedb_session_new(options);
               }
               if (!session) {
-                ldpp_dout(this, 1) << "ERROR: failed to create session for bucket: " << table_name.first << dendl;
+                ldpp_dout(this, 1) << "ERROR: failed to create session for bucket: " << session_name.second <<
+                  " of tenant: " << session_name.first << dendl;
                 return;
               }
-              ldpp_dout(this, 20) << "INFO: created session for bucket: " << table_name.first << dendl;
+              ldpp_dout(this, 20) << "INFO: created session for bucket: " << session_name.second <<
+                " of tenant: " << session_name.first << dendl;
 
-              sessions[table_name.first] = SessionPtr(session, LanceDBSessionDeleter());
+              sessions[session_name] = SessionPtr(session, LanceDBSessionDeleter());
               return;
             }
           case message_t::Op::SESSION_DELETE:
             {
-              ldpp_dout(this, 20) << "INFO: received session delete message for bucket: " << table_name.first << dendl; 
+              ldpp_dout(this, 20) << "INFO: received session delete message for bucket: " << session_name.second <<
+                " of tenant: " << session_name.first << dendl;
               std::unique_lock l(sessions_mutex);
-              if (sessions.erase(table_name.first) > 0) {
-                ldpp_dout(this, 20) << "INFO: deleted session for bucket: " << table_name.first << dendl;
+              if (sessions.erase(session_name) > 0) {
+                ldpp_dout(this, 20) << "INFO: deleted session for bucket: " << session_name.second <<
+                  " of tenant: " << session_name.first << dendl;
               } else {
-                ldpp_dout(this, 20) << "INFO: session doesn't exist for bucket: " << table_name.first << dendl;
+                ldpp_dout(this, 20) << "INFO: session doesn't exist for bucket: " << session_name.second <<
+                  " of tenant: " << session_name.first << dendl;
               }
               return;
             }
@@ -311,12 +321,13 @@ public:
     ldpp_dout(this, 10) << "INfO: started manager" << dendl;
   }
 
-  bool notify_index(const DoutPrefixProvider* dpp, const std::string& bucket_name, const std::string& index_name, message_t::Op op) {
+  bool notify_index(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name,
+      const std::string& index_name, message_t::Op op) {
     if (shutdown) {
       ldpp_dout(dpp, 1) << "ERROR: failed to notify s3vectors manager about index: manager is shutting down" << dendl;
       return false;
     }
-    auto message_guard = std::make_unique<message_t>(bucket_name, index_name, op);
+    auto message_guard = std::make_unique<message_t>(tenant, bucket_name, index_name, op);
     if (messages.push(message_guard.get())) {
       std::ignore = message_guard.release(); // ownership transferred to the queue
       ldpp_dout(dpp, 20) << "INFO: notified s3vectors manager about index" << dendl;
@@ -326,12 +337,12 @@ public:
     return false;
   }
 
-  bool notify_session(const DoutPrefixProvider* dpp, const std::string& bucket_name, message_t::Op op) {
+  bool notify_session(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name, message_t::Op op) {
     if (shutdown) {
       ldpp_dout(dpp, 1) << "ERROR: failed to notify s3vectors manager about session: manager is shutting down" << dendl;
       return false;
     }
-    auto message_guard = std::make_unique<message_t>(bucket_name, "", op);
+    auto message_guard = std::make_unique<message_t>(tenant, bucket_name, "", op);
     if (messages.push(message_guard.get())) {
       std::ignore = message_guard.release(); // ownership transferred to the queue
       ldpp_dout(dpp, 20) << "INFO: notified s3vectors manager about session" << dendl;
@@ -341,9 +352,9 @@ public:
     return false;
   }
 
-  std::shared_ptr<const LanceDBSession> get_session(const std::string& bucket_name) {
+  std::shared_ptr<const LanceDBSession> get_session(const std::string& tenant, const std::string& bucket_name) {
     std::shared_lock l(sessions_mutex);
-    auto it = sessions.find(bucket_name);
+    auto it = sessions.find(session_name_t(tenant, bucket_name));
     if (it == sessions.end()) {
       return nullptr;
     }
@@ -384,44 +395,44 @@ void resume(const DoutPrefixProvider* dpp, rgw::sal::Driver* driver) {
   init(dpp, driver);
 }
 
-bool notify_index_update(const DoutPrefixProvider* dpp, const std::string& bucket_name, const std::string& index_name) {
+bool notify_index_update(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name, const std::string& index_name) {
   if (!s_manager) {
     ldpp_dout(dpp, 1) << "ERROR: failed to notify s3vectors manager about table update: manager is not initialized" << dendl;
     return false;
   }
-  return s_manager->notify_index(dpp, bucket_name, index_name, Manager::message_t::Op::UPDATE);
+  return s_manager->notify_index(dpp, tenant, bucket_name, index_name, Manager::message_t::Op::UPDATE);
 }
 
-bool notify_index_remove(const DoutPrefixProvider* dpp, const std::string& bucket_name, const std::string& index_name) {
+bool notify_index_remove(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name, const std::string& index_name) {
   if (!s_manager) {
     ldpp_dout(dpp, 1) << "ERROR: failed to notify s3vectors manager about table remove: manager is not initialized" << dendl;
     return false;
   }
-  return s_manager->notify_index(dpp, bucket_name, index_name, Manager::message_t::Op::REMOVE);
+  return s_manager->notify_index(dpp, tenant, bucket_name, index_name, Manager::message_t::Op::REMOVE);
 }
 
-std::shared_ptr<const LanceDBSession> get_session(const DoutPrefixProvider* dpp, const std::string& bucket_name) {
+std::shared_ptr<const LanceDBSession> get_session(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name) {
   if (!s_manager) {
     ldpp_dout(dpp, 1) << "ERROR: failed to get LanceDB session for bucket: manager is not initialized" << dendl;
     return nullptr;
   }
-  return s_manager->get_session(bucket_name);
+  return s_manager->get_session(tenant, bucket_name);
 }
 
-bool notify_session_create(const DoutPrefixProvider* dpp, const std::string& bucket_name) {
+bool notify_session_create(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name) {
   if (!s_manager) {
     ldpp_dout(dpp, 1) << "ERROR: failed to notify s3vectors manager about session creation: manager is not initialized" << dendl;
     return false; 
   }
-  return s_manager->notify_session(dpp, bucket_name, Manager::message_t::Op::SESSION_CREATE);
+  return s_manager->notify_session(dpp, tenant, bucket_name, Manager::message_t::Op::SESSION_CREATE);
 }
 
-bool notify_session_delete(const DoutPrefixProvider* dpp, const std::string& bucket_name) {
+bool notify_session_delete(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name) {
   if (!s_manager) {
     ldpp_dout(dpp, 1) << "ERROR: failed to notify s3vectors manager about session deletion: manager is not initialized" << dendl;
     return false;
   }
-  return s_manager->notify_session(dpp, bucket_name, Manager::message_t::Op::SESSION_DELETE);
+  return s_manager->notify_session(dpp, tenant, bucket_name, Manager::message_t::Op::SESSION_DELETE);
 }
 
 

--- a/src/rgw/rgw_s3vector_background.h
+++ b/src/rgw/rgw_s3vector_background.h
@@ -18,14 +18,14 @@ namespace rgw::s3vector {
   void pause();
   void resume(const DoutPrefixProvider* dpp, rgw::sal::Driver* driver);
   // update whenever new vectors are added to an index
-  bool notify_index_update(const DoutPrefixProvider* dpp, const std::string& bucket_name, const std::string& index_name);
+  bool notify_index_update(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name, const std::string& index_name);
   // update whenever a index is removed
-  bool notify_index_remove(const DoutPrefixProvider* dpp, const std::string& bucket_name, const std::string& index_name);
+  bool notify_index_remove(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name, const std::string& index_name);
   // get LanceDB session for a bucket, returns nullptr if session doesn't exist or manager is not initialized
-  std::shared_ptr<const LanceDBSession> get_session(const DoutPrefixProvider* dpp, const std::string& bucket_name);
+  std::shared_ptr<const LanceDBSession> get_session(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name);
   // notify manager for session creation
-  bool notify_session_create(const DoutPrefixProvider* dpp, const std::string& bucket_name);
+  bool notify_session_create(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name);
   // notify manager for session deletion
-  bool notify_session_delete(const DoutPrefixProvider* dpp, const std::string& bucket_name);
+  bool notify_session_delete(const DoutPrefixProvider* dpp, const std::string& tenant, const std::string& bucket_name);
 }
 

--- a/src/test/rgw/s3vectors/pytest.ini
+++ b/src/test/rgw/s3vectors/pytest.ini
@@ -4,3 +4,4 @@ markers =
   index_test
   vector_test
   multisite_test
+  tenant_test

--- a/src/test/rgw/s3vectors/s3vector_test.py
+++ b/src/test/rgw/s3vectors/s3vector_test.py
@@ -206,53 +206,11 @@ def gen_bucket_name():
     return 'kaboom' + run_prefix + '-' + str(num_buckets)
 
 
-def connection(service_name='s3vectors'):
-    hostname = get_config_host()
-    port_no = get_config_port()
-    access_key = get_access_key()
-    secret_key = get_secret_key()
-    if port_no == 443 or port_no == 8443:
-        scheme = 'https://'
-    else:
-        scheme = 'http://'
-
-    client = boto3.client(service_name,
-            endpoint_url=scheme+hostname+':'+str(port_no),
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-            region_name=get_config_zonegroup())
-
-    return client
-
-def connection2(service_name='s3vectors'):
-    hostname = get_config_host2()
-    if not hostname:
-        log.info("No second host configured")
-        return None
-    port_no = get_config_port2()
-    if not port_no:
-        log.info("No second port configured")
-        return None
-    access_key = get_access_key()
-    secret_key = get_secret_key()
-    if port_no == 443 or port_no == 8443:
-        scheme = 'https://'
-    else:
-        scheme = 'http://'
-
-    client = boto3.client(service_name,
-            endpoint_url=scheme+hostname+':'+str(port_no),
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-            region_name=get_config_zonegroup())
-
-    return client
-
-
-def service_connection(service_name, access_key, secret_key):
-    """ a connection to the tested zone with the given credentials """
-    hostname = get_config_host()
-    port_no = get_config_port()
+def service_connection(service_name, access_key, secret_key, hostname=None, port_no=None):
+    """ a connection with the given credentials, to the tested zone unless a
+    host and a port are given """
+    hostname = hostname or get_config_host()
+    port_no = port_no or get_config_port()
     if port_no == 443 or port_no == 8443:
         scheme = 'https://'
     else:
@@ -263,6 +221,24 @@ def service_connection(service_name, access_key, secret_key):
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
             region_name=get_config_zonegroup())
+
+
+def connection(service_name='s3vectors'):
+    """ a connection of the main user to the tested zone """
+    return service_connection(service_name, get_access_key(), get_secret_key())
+
+
+def connection2(service_name='s3vectors'):
+    """ a connection of the main user to the second zone, None when it is not configured """
+    hostname = get_config_host2()
+    if not hostname:
+        log.info("No second host configured")
+        return None
+    port_no = get_config_port2()
+    if not port_no:
+        log.info("No second port configured")
+        return None
+    return service_connection(service_name, get_access_key(), get_secret_key(), hostname, port_no)
 
 
 def _wait_for_user(uid, tenant=None, retries=12, delay=5):
@@ -300,15 +276,9 @@ def another_user(tenant=None):
     out, result = admin(args, cluster=master_cluster)
     assert result == 0, f"failed to create user '{uid}': {out}"
     _wait_for_user(uid, tenant)
-    hostname = get_config_host()
-    port_no = get_config_port()
-    if port_no == 443 or port_no == 8443:
-        scheme = 'https://'
-    else:
-        scheme = 'http://'
-
     client = service_connection('s3vectors', access_key, secret_key)
     client.uid = uid
+    client.tenant = tenant
     # the "s3" connection of the same user, to create the backing buckets
     client.s3 = service_connection('s3', access_key, secret_key)
     return client
@@ -386,7 +356,7 @@ def _ensure_s3_bucket_for_vector_bucket(bucket_name, s3conn=None, retries=12, de
         except s3conn.exceptions.ClientError as err:
             error_code = err.response['Error']['Code']
             if error_code in ('404', 'NoSuchBucket'):
-                log.info("Creating S3 bucket '%s' for S3/RGW backend", bucket_name)
+                log.info("Creating S3 bucket '%s' for RGW backend", bucket_name)
                 _create_s3bucket(s3conn, bucket_name)
                 return
             if error_code not in ('403', 'AccessDenied', 'Forbidden'):
@@ -442,6 +412,29 @@ def _delete_vector_bucket(conn, bucket_name):
     """Delete a vector bucket together with all of its indexes"""
     _delete_all_indexes(conn, bucket_name)
     return conn.delete_vector_bucket(vectorBucketName=bucket_name)
+
+
+def _create_vector_bucket(conn, bucket_name, s3conn=None):
+    """
+    Create a vector bucket, and its backing bucket. The "s3" connection of the
+    owner must be given when it is not the main user
+    """
+    _ensure_s3_bucket_for_vector_bucket(bucket_name, s3conn)
+    result = conn.create_vector_bucket(vectorBucketName=bucket_name)
+    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+
+
+def _cleanup_vector_bucket(conn, bucket_name, s3conn=None):
+    """
+    Best effort deletion of a vector bucket, with its indexes and its backing
+    bucket. The "s3" connection of the owner must be given when it is not the
+    main user
+    """
+    try:
+        _delete_vector_bucket(conn, bucket_name)
+    except conn.exceptions.ClientError as err:
+        log.warning("failed to delete vector bucket '%s': %s", bucket_name, str(err))
+    _delete_s3_bucket_for_vector_bucket(bucket_name, s3conn)
 
 
 def _delete_all_vector_buckets(conn, conn2=None):
@@ -828,7 +821,7 @@ def test_vector_buckets_deletion_with_buckets():
     assert result['ResponseMetadata']['HTTPStatusCode'] == 200
     # and an s3 bucket with the same name
     _create_s3bucket(s3conn, bucket_name2)
-    # delete the s3 bucket: for S3/SAL backends, empty it first (LanceDB data files);
+    # delete the s3 bucket: for RGW backend, empty it first (LanceDB data files);
     # for local backend, the bucket is empty since LanceDB uses local filesystem.
     if has_backing_bucket():
         paginator = s3conn.get_paginator('list_objects_v2')
@@ -848,7 +841,9 @@ def test_vector_buckets_deletion_with_buckets():
     log.info("list_vector_buckets result: %s", result)
     vector_bucket_names = [b['vectorBucketName'] for b in result['vectorBuckets']]
     assert bucket_name2 in vector_bucket_names
-    # cleanup
+    # cleanup: recreate the backing bucket, so that the vector bucket can be deleted
+    # TODO: remove this once this is merged: https://github.com/ceph/ceph/pull/71377
+    _ensure_s3_bucket_for_vector_bucket(bucket_name2)
     _delete_all_vector_buckets(conn)
 
 
@@ -3385,13 +3380,13 @@ def test_query_vectors_post_filter_topk():
 def test_sal_error_propagation():
     """Verify that SAL errors propagate through LanceDB back to the S3Vector API.
 
-    For S3/SAL backends: create a vector bucket and index, delete the backing
+    For RGW backend: create a vector bucket and index, delete the backing
     S3 bucket, then attempt put_vectors. The operation should fail because the
     underlying storage is gone. This validates the error chain:
     rgw_sal_wrapper -> store.rs -> LanceDB -> lancedb-c -> rgw_s3vector.cc
     """
     if not has_backing_bucket():
-        pytest.skip("error propagation test only applies to S3/SAL backends")
+        pytest.skip("error propagation test only applies to RGW backend")
 
     conn = connection()
     bucket_name = gen_bucket_name()
@@ -3434,7 +3429,7 @@ def test_cross_owner_vector_bucket():
     """When the S3 bucket owner differs from the vector bucket owner,
     operations should fail without a bucket policy and succeed with one."""
     if not has_backing_bucket():
-        pytest.skip("cross-owner test only applies to backends with a backing bucket")
+        pytest.skip("cross-owner test only applies to backend with a backing bucket")
 
     # user A (config user) creates the S3 bucket
     s3conn = connection('s3')
@@ -3556,11 +3551,7 @@ def test_delete_user_with_vector_buckets():
     finally:
         # best effort cleanup, in case the user was not deleted by the test
         admin(['user', 'rm', '--uid', uid, '--purge-data'] + backend_admin_args())
-        try:
-            _delete_vector_bucket(main_conn, bucket_name)
-        except main_conn.exceptions.ClientError as err:
-            log.warning("failed to delete vector bucket '%s': %s", bucket_name, str(err))
-        _delete_s3_bucket_for_vector_bucket(bucket_name)
+        _cleanup_vector_bucket(main_conn, bucket_name)
 
 
 @pytest.mark.vector_bucket_test
@@ -3576,9 +3567,7 @@ def test_account_vector_buckets():
     other = another_account_user(account_id=conn.account_id)
     bucket_name = gen_bucket_name()
     try:
-        _ensure_s3_bucket_for_vector_bucket(bucket_name, conn.s3)
-        result = conn.create_vector_bucket(vectorBucketName=bucket_name)
-        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        _create_vector_bucket(conn, bucket_name, conn.s3)
         result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
                                    dataType='float32', dimension=dimension,
                                    distanceMetric='euclidean')
@@ -3611,11 +3600,7 @@ def test_account_vector_buckets():
     finally:
         # best effort cleanup. the account and its users are left behind, as done
         # for the users created by another_user()
-        try:
-            _delete_vector_bucket(other, bucket_name)
-        except other.exceptions.ClientError as err:
-            log.warning("failed to delete vector bucket '%s': %s", bucket_name, str(err))
-        _delete_s3_bucket_for_vector_bucket(bucket_name, other.s3)
+        _cleanup_vector_bucket(other, bucket_name, other.s3)
 
 
 @pytest.mark.vector_bucket_test
@@ -3631,9 +3616,7 @@ def test_delete_account_with_vector_buckets():
     account_id = conn.account_id
     bucket_name = gen_bucket_name()
     try:
-        _ensure_s3_bucket_for_vector_bucket(bucket_name, conn.s3)
-        result = conn.create_vector_bucket(vectorBucketName=bucket_name)
-        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        _create_vector_bucket(conn, bucket_name, conn.s3)
         result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
                                    dataType='float32', dimension=dimension,
                                    distanceMetric='euclidean')
@@ -3673,13 +3656,10 @@ def test_delete_user_owning_the_backing_bucket():
     index_name = 'index-over-an-owned-bucket'
     conn = another_user()
     uid = conn.uid
-    s3conn = conn.s3
     bucket_name = gen_bucket_name()
     try:
         # unlike the other tests, the backing bucket belongs to the user under test
-        _ensure_s3_bucket_for_vector_bucket(bucket_name, s3conn)
-        result = conn.create_vector_bucket(vectorBucketName=bucket_name)
-        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        _create_vector_bucket(conn, bucket_name, conn.s3)
         result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
                                    dataType='float32', dimension=dimension,
                                    distanceMetric='euclidean')
@@ -3696,3 +3676,174 @@ def test_delete_user_owning_the_backing_bucket():
         # best effort cleanup, in case the user was not deleted by the test. the
         # backing bucket belongs to the user, and is purged together with it
         admin(['user', 'rm', '--uid', uid, '--purge-data'] + backend_admin_args())
+
+
+###############################
+# multi tenancy isolation tests
+###############################
+
+num_tenants = 0
+
+
+def gen_tenant_name():
+    """ tenant names are limited to alphanumeric characters and "_". the tenant
+    is not part of the API: it is implicit in the credentials of the user, so
+    different tenants may use the same names """
+    global num_tenants
+
+    num_tenants += 1
+    return 'tenant' + run_prefix + '_' + str(num_tenants)
+
+
+@pytest.mark.tenant_test
+def test_tenant_vector_buckets_isolated():
+    """ two tenants may hold a vector bucket with the same name, and each of them
+    sees only its own. they also dont collide with an user without a tenant """
+    bucket_name = gen_bucket_name()
+    conn0 = connection()
+    conn0.tenant = None
+    conn1 = another_user(tenant=gen_tenant_name())
+    conn2 = another_user(tenant=gen_tenant_name())
+    try:
+        _create_vector_bucket(conn0, bucket_name)
+        _create_vector_bucket(conn1, bucket_name, conn1.s3)
+        _create_vector_bucket(conn2, bucket_name, conn2.s3)
+
+        for conn in (conn0, conn1, conn2):
+            result = conn.get_vector_bucket(vectorBucketName=bucket_name)
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+            result = conn.list_vector_buckets()
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+            bucket_names = [b['vectorBucketName'] for b in result['vectorBuckets']]
+            assert bucket_names == [bucket_name], \
+                f"tenant '{conn.tenant}' sees the vector buckets: {bucket_names}"
+    finally:
+        _cleanup_vector_bucket(conn0, bucket_name)
+        _cleanup_vector_bucket(conn1, bucket_name, conn1.s3)
+        _cleanup_vector_bucket(conn2, bucket_name, conn2.s3)
+
+
+@pytest.mark.tenant_test
+def test_tenant_indexes_isolated():
+    """ the indexes of a vector bucket of one tenant are not visible in the
+    vector bucket of another tenant that has the same name """
+    dimension = 8
+    bucket_name = gen_bucket_name()
+    index_name1 = 'index-of-tenant-one'
+    index_name2 = 'index-of-tenant-two'
+    conn1 = another_user(tenant=gen_tenant_name())
+    conn2 = another_user(tenant=gen_tenant_name())
+    try:
+        _create_vector_bucket(conn1, bucket_name, conn1.s3)
+        _create_vector_bucket(conn2, bucket_name, conn2.s3)
+
+        for conn, index_name in ((conn1, index_name1), (conn2, index_name2)):
+            result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
+                                       dataType='float32', dimension=dimension,
+                                       distanceMetric='euclidean')
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+
+        # each tenant lists only the index it created
+        for conn, index_name in ((conn1, index_name1), (conn2, index_name2)):
+            result = conn.list_indexes(vectorBucketName=bucket_name)
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+            index_names = [i['indexName'] for i in result['indexes']]
+            assert index_names == [index_name], \
+                f"tenant '{conn.tenant}' sees the indexes: {index_names}"
+
+        # the index of the other tenant cannot be fetched
+        for conn, index_name in ((conn1, index_name2), (conn2, index_name1)):
+            with pytest.raises(conn.exceptions.ClientError) as exc_info:
+                conn.get_index(vectorBucketName=bucket_name, indexName=index_name)
+            assert exc_info.value.response['ResponseMetadata']['HTTPStatusCode'] == 404
+    finally:
+        _cleanup_vector_bucket(conn1, bucket_name, conn1.s3)
+        _cleanup_vector_bucket(conn2, bucket_name, conn2.s3)
+
+
+@pytest.mark.tenant_test
+def test_tenant_vectors_isolated():
+    """ the vectors of two tenants that use the same vector bucket name and the
+    same index name are not mixed """
+    dimension = 8
+    num_vectors = 10
+    bucket_name = gen_bucket_name()
+    index_name = 'shared-index-name'
+    conn1 = another_user(tenant=gen_tenant_name())
+    conn2 = another_user(tenant=gen_tenant_name())
+    keys1 = ['tenant-one-vec-' + str(i) for i in range(num_vectors)]
+    keys2 = ['tenant-two-vec-' + str(i) for i in range(num_vectors)]
+    try:
+        for conn, keys in ((conn1, keys1), (conn2, keys2)):
+            _create_vector_bucket(conn, bucket_name, conn.s3)
+            result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
+                                       dataType='float32', dimension=dimension,
+                                       distanceMetric='euclidean')
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+            vectors = [{'key': key, 'data': generate_data(dimension, i)}
+                       for i, key in enumerate(keys)]
+            result = conn.put_vectors(vectorBucketName=bucket_name, indexName=index_name,
+                                      vectors=vectors)
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+
+        for conn, own_keys, other_keys in ((conn1, keys1, keys2), (conn2, keys2, keys1)):
+            # only the vectors of the tenant are listed
+            result = conn.list_vectors(vectorBucketName=bucket_name, indexName=index_name)
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+            listed_keys = [v['key'] for v in result['vectors']]
+            assert sorted(listed_keys) == sorted(own_keys), \
+                f"tenant '{conn.tenant}' lists the vectors: {listed_keys}"
+
+            # the vectors of the other tenant cannot be fetched by their keys
+            result = conn.get_vectors(vectorBucketName=bucket_name, indexName=index_name,
+                                      keys=other_keys, returnData=True)
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+            assert result['vectors'] == [], \
+                f"tenant '{conn.tenant}' fetched the vectors of the other tenant: {result['vectors']}"
+
+            # a query returns only the vectors of the tenant, even when more
+            # results than it holds are asked for
+            result = conn.query_vectors(vectorBucketName=bucket_name, indexName=index_name,
+                                        queryVector=generate_data(dimension, 0),
+                                        topK=2*num_vectors)
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+            queried_keys = [v['key'] for v in result['vectors']]
+            assert sorted(queried_keys) == sorted(own_keys), \
+                f"tenant '{conn.tenant}' queried the vectors: {queried_keys}"
+    finally:
+        _cleanup_vector_bucket(conn1, bucket_name, conn1.s3)
+        _cleanup_vector_bucket(conn2, bucket_name, conn2.s3)
+
+
+@pytest.mark.tenant_test
+def test_tenant_delete_vector_bucket_isolated():
+    """ an empty vector bucket may be deleted even when another tenant holds
+    indexes in a vector bucket with the same name """
+    dimension = 8
+    bucket_name = gen_bucket_name()
+    index_name = 'index-of-tenant-one'
+    conn1 = another_user(tenant=gen_tenant_name())
+    conn2 = another_user(tenant=gen_tenant_name())
+    try:
+        _create_vector_bucket(conn1, bucket_name, conn1.s3)
+        result = conn1.create_index(vectorBucketName=bucket_name, indexName=index_name,
+                                    dataType='float32', dimension=dimension,
+                                    distanceMetric='euclidean')
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+
+        # the vector bucket of the second tenant holds no indexes, so it may be deleted
+        _create_vector_bucket(conn2, bucket_name, conn2.s3)
+        result = conn2.delete_vector_bucket(vectorBucketName=bucket_name)
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        _delete_s3_bucket_for_vector_bucket(bucket_name, conn2.s3)
+
+        # the index of the first tenant is not affected
+        result = conn1.list_indexes(vectorBucketName=bucket_name)
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        index_names = [i['indexName'] for i in result['indexes']]
+        assert index_names == [index_name], \
+            f"tenant '{conn1.tenant}' sees the indexes: {index_names}"
+    finally:
+        _cleanup_vector_bucket(conn1, bucket_name, conn1.s3)
+
+


### PR DESCRIPTION
* tenants were only supported for s3 backend
* support added based on directory structure for local backend
* tenant added as a parameter to the session for rgw backend


Assisted-by: claude-code:claude-opus-5





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
