### PR TITLE
script/redmine-upkeep: migrate to list-based flags, optimize queries, and fix logger deprecations

### DIFF
--- a/src/script/redmine-upkeep.py
+++ b/src/script/redmine-upkeep.py
@@ -555,6 +555,54 @@ class RedmineUpkeep:
         log.info("Successfully connected to Redmine.")
         return R
 
+    class FilterClearDuplicate(Filter):
+        """
+        Filter for Duplicate issues that still have PR/Merge/Release fields set.
+        """
+        PRIORITY = 2000000
+        NAME = "ClearDuplicate"
+
+        @staticmethod
+        def get_filters():
+            for field_id in [
+                REDMINE_CUSTOM_FIELD_ID_PULL_REQUEST_ID,
+                REDMINE_CUSTOM_FIELD_ID_MERGE_COMMIT,
+                REDMINE_CUSTOM_FIELD_ID_FIXED_IN,
+                REDMINE_CUSTOM_FIELD_ID_RELEASED_IN,
+            ]:
+                yield {
+                    f"cf_{field_id}": "*",
+                    "status_id": str(REDMINE_STATUS_ID_DUPLICATE),
+                }
+
+        @staticmethod
+        def requires_github_api():
+            return False
+
+    @transformation(2000000)
+    def _transform_clear_duplicate_fields(self, issue_update):
+        """
+        Transformation: Strips Pull Request ID, Merge Commit, Fixed In, and Released In
+        from issues that are marked as Duplicate.
+        """
+        if issue_update.get_current_status_id() != REDMINE_STATUS_ID_DUPLICATE:
+            return False
+
+        issue_update.logger.debug("Running _transform_clear_duplicate_fields")
+        changed = False
+
+        for field_id, name in [
+            (REDMINE_CUSTOM_FIELD_ID_PULL_REQUEST_ID, "Pull Request ID"),
+            (REDMINE_CUSTOM_FIELD_ID_MERGE_COMMIT, "Merge Commit"),
+            (REDMINE_CUSTOM_FIELD_ID_FIXED_IN, "Fixed In"),
+            (REDMINE_CUSTOM_FIELD_ID_RELEASED_IN, "Released In"),
+        ]:
+            if issue_update.get_custom_field(field_id):
+                issue_update.logger.info(f"Clearing '{name}' because issue is a Duplicate.")
+                changed |= issue_update.add_or_update_custom_field(field_id, "")
+
+        return changed
+
     class FilterMigrateLegacyTags(Filter):
         """
         Filter to find issues that still have the legacy text-based tags so they can be migrated.
@@ -837,6 +885,9 @@ class RedmineUpkeep:
         Transformation: Checks if a PR associated with an issue has been merged
         and updates the merge commit and fixed_in fields in the payload.
         """
+        if issue_update.get_current_status_id() == REDMINE_STATUS_ID_DUPLICATE:
+            return False
+
         issue_update.logger.debug("Running _transform_merged")
 
         commit = issue_update.get_custom_field(REDMINE_CUSTOM_FIELD_ID_MERGE_COMMIT)

--- a/src/script/redmine-upkeep.py
+++ b/src/script/redmine-upkeep.py
@@ -1371,7 +1371,7 @@ h2. Update Payload
             response.raise_for_status()
             issue_update.logger.info(f"Successfully added 'upkeep-failed' tag and comment to Redmine issue.")
         except requests.exceptions.HTTPError as err:
-            issue_update.logger.fatal(f"Could not update Redmine issue with failure tag/comment: {err} - Response: {response.text}")
+            issue_update.logger.critical(f"Could not update Redmine issue with failure tag/comment: {err} - Response: {response.text}")
             sys.exit(1)
 
     def filter_and_process_issues(self):
@@ -1627,15 +1627,15 @@ def main():
     log.debug(f"Parsed arguments: {args}")
 
     if not REDMINE_API_KEY:
-        log.fatal("REDMINE_API_KEY not found! Please set REDMINE_API_KEY environment variable or ~/.redmine_key.")
+        log.critical("REDMINE_API_KEY not found! Please set REDMINE_API_KEY environment variable or ~/.redmine_key.")
         sys.exit(1)
 
     if GITHUB_TOKEN is None:
-        log.fatal("GITHUB_TOKEN not found! Please set GITHUB_TOKEN environment variable or ~/.github_token.")
+        log.critical("GITHUB_TOKEN not found! Please set GITHUB_TOKEN environment variable or ~/.github_token.")
         sys.exit(1)
 
     if IS_GITHUB_ACTION and GITHUB_REPOSITORY != "ceph/ceph":
-        log.fatal("refusing to run ceph/ceph.git github action for repository {GITHUB_REPOSITORY}")
+        log.critical(f"refusing to run ceph/ceph.git github action for repository {GITHUB_REPOSITORY}")
         sys.exit(0)
 
     RU = None
@@ -1643,7 +1643,7 @@ def main():
         RU = RedmineUpkeep(args)
         RU.filter_and_process_issues() # No arguments needed here anymore
     except Exception as e:
-        log.fatal(f"An unhandled error occurred during Redmine upkeep: {e}", exc_info=True)
+        log.critical(f"An unhandled error occurred during Redmine upkeep: {e}", exc_info=True)
         if IS_GITHUB_ACTION:
              print(f"::error::An unhandled error occurred: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/script/redmine-upkeep.py
+++ b/src/script/redmine-upkeep.py
@@ -54,6 +54,7 @@ REDMINE_CUSTOM_FIELD_ID_BACKPORT = 2
 REDMINE_CUSTOM_FIELD_ID_RELEASE = 16
 REDMINE_CUSTOM_FIELD_ID_PULL_REQUEST_ID = 21
 REDMINE_CUSTOM_FIELD_ID_TAGS = 31
+REDMINE_CUSTOM_FIELD_ID_UPKEEP_FLAGS = 48
 REDMINE_CUSTOM_FIELD_ID_MERGE_COMMIT = 33
 REDMINE_CUSTOM_FIELD_ID_FIXED_IN = 34
 REDMINE_CUSTOM_FIELD_ID_RELEASED_IN = 35
@@ -263,6 +264,17 @@ class IssueUpdate:
                 return field['value']
         return self.get_raw_custom_field(field_id)
 
+    def get_list_custom_field(self, field_id, raw=False):
+        """ Helper to safely get a list custom field, handling strings and None """
+        val = self.get_raw_custom_field(field_id) if raw else self.get_custom_field(field_id)
+        if not val:
+            return []
+        if isinstance(val, list):
+            return val.copy()
+        if isinstance(val, str):
+            return [v.strip() for v in val.split(',') if v.strip()]
+        return []
+
     def add_or_update_custom_field(self, field_id, value):
         """Helper to add or update a custom field in the payload."""
         custom_fields = self.update_payload.setdefault("custom_fields", [])
@@ -295,20 +307,16 @@ class IssueUpdate:
             return True
 
     def add_tag(self, tag):
-        current_tags_str = self.get_custom_field(REDMINE_CUSTOM_FIELD_ID_TAGS)
-        current_tags = []
-        if current_tags_str:
-            current_tags = [current_tag.strip() for current_tag in current_tags_str.split(',') if current_tag.strip()]
+        current_flags = self.get_list_custom_field(REDMINE_CUSTOM_FIELD_ID_UPKEEP_FLAGS)
 
-        if tag in current_tags:
-            self.logger.debug(f"tag '{tag}' already in tags")
+        if tag in current_flags:
+            self.logger.debug(f"flag '{tag}' already in flags")
             return
         else:
-            current_tags.append(tag)
-            self.logger.info(f"Adding '{tag}' tag.")
+            current_flags.append(tag)
+            self.logger.info(f"Adding '{tag}' flag.")
 
-        new_tags = ", ".join(current_tags)
-        self.add_or_update_custom_field(REDMINE_CUSTOM_FIELD_ID_TAGS, new_tags)
+        self.add_or_update_custom_field(REDMINE_CUSTOM_FIELD_ID_UPKEEP_FLAGS, current_flags)
 
     def has_open_subtasks(self):
         """
@@ -337,25 +345,20 @@ class IssueUpdate:
             self.logger.debug("Issue has no subtasks (ResourceAttrError on 'children' attribute).")
             return False
 
-    def get_update_payload(self, suppress_mail=True): # Added suppress_mail parameter
+    def get_update_payload(self, suppress_mail=True, keep_failure_flag=False): # Added suppress_mail parameter
         today = datetime.now(timezone.utc).isoformat(timespec='seconds')
         self.add_or_update_custom_field(REDMINE_CUSTOM_FIELD_ID_UPKEEP_TIMESTAMP, today)
 
-        current_tags_str = self.get_custom_field(REDMINE_CUSTOM_FIELD_ID_TAGS)
-        current_tags = []
-        if current_tags_str:
-            current_tags = [tag.strip() for tag in current_tags_str.split(',') if tag.strip()]
-            modified_tags = False
-            if "upkeep-failed" in current_tags:
-                self.logger.info(f"'upkeep-failed' tag found in '{current_tags_str}'. Removing for update.")
-                current_tags.remove("upkeep-failed")
-                modified_tags = True
-            if "backport_processed" in current_tags:
-                self.logger.info(f"'backport_processed' tag found in '{current_tags_str}'. Removing for update.")
-                current_tags.remove("backport_processed")
-                modified_tags = True
-            if modified_tags:
-                self.add_or_update_custom_field(REDMINE_CUSTOM_FIELD_ID_TAGS, ", ".join(current_tags))
+        if not keep_failure_flag:
+            # Cleanup new flags field
+            current_flags = self.get_list_custom_field(REDMINE_CUSTOM_FIELD_ID_UPKEEP_FLAGS)
+            modified_flags = False
+            if "upkeep-failed" in current_flags:
+                self.logger.info(f"'upkeep-failed' flag found. Removing for update.")
+                current_flags.remove("upkeep-failed")
+                modified_flags = True
+            if modified_flags:
+                self.add_or_update_custom_field(REDMINE_CUSTOM_FIELD_ID_UPKEEP_FLAGS, current_flags)
 
         payload = {
             'issue': self.update_payload,
@@ -454,6 +457,10 @@ class RedmineUpkeep:
         NAME = "undefined"
 
         @staticmethod
+        def disabled():
+            return False
+
+        @staticmethod
         def get_filters():
             raise NotImplementedError("NI")
 
@@ -513,7 +520,8 @@ class RedmineUpkeep:
         for name, v in RedmineUpkeep.__dict__.items():
             if inspect.isclass(v) and issubclass(v, self.Filter) and v != self.Filter:
                 log.debug("discovered filter %s", v.NAME)
-                self.filters.append(v)
+                if not v.disabled():
+                    self.filters.append(v)
         random.shuffle(self.filters) # to shuffle equivalent PRIORITY
         self.filters.sort(key = lambda filter: filter.PRIORITY, reverse=True)
         log.debug(f"Discovered filters: {[f.__name__ for f in self.filters]}")
@@ -547,6 +555,63 @@ class RedmineUpkeep:
         log.info("Successfully connected to Redmine.")
         return R
 
+    class FilterMigrateLegacyTags(Filter):
+        """
+        Filter to find issues that still have the legacy text-based tags so they can be migrated.
+        """
+        PRIORITY = 1000000
+        NAME = "MigrateLegacyTags"
+
+        @staticmethod
+        def disabled():
+            return True
+
+        @staticmethod
+        def get_filters():
+            yield {f"cf_{REDMINE_CUSTOM_FIELD_ID_TAGS}": "~upkeep-"}
+            yield {f"cf_{REDMINE_CUSTOM_FIELD_ID_TAGS}": "~backport_processed"}
+
+        @staticmethod
+        def requires_github_api():
+            return False
+
+    @transformation(1000000)
+    def _transform_migrate_legacy_tags(self, issue_update):
+        """
+        Transformation: Migrates old text-based tags to the new Upkeep Flags list field.
+        """
+        issue_update.logger.debug("Running _transform_migrate_legacy_tags")
+        current_tags_str = issue_update.get_custom_field(REDMINE_CUSTOM_FIELD_ID_TAGS)
+        if not current_tags_str:
+            return False
+
+        current_tags = [tag.strip() for tag in re.split(r'[, ]', current_tags_str) if tag.strip()]
+        log.debug(f"current_tags: {current_tags}")
+        if not current_tags:
+            return False
+
+        changed = False
+        if "upkeep-failed" in current_tags:
+            issue_update.logger.info("Migrating legacy 'upkeep-failed' tag.")
+            current_tags.remove("upkeep-failed")
+            issue_update.add_tag("upkeep-failed")
+            changed = True
+        if "upkeep-bad-parentage" in current_tags:
+            issue_update.logger.info("Migrating legacy 'upkeep-bad-parentage' tag.")
+            current_tags.remove("upkeep-bad-parentage")
+            issue_update.add_tag("upkeep-bad-parentage")
+            changed = True
+        if "backport_processed" in current_tags:
+            issue_update.logger.info("Removing obsolete 'backport_processed' tag.")
+            current_tags.remove("backport_processed")
+            changed = True
+
+        if changed:
+            new_tags_str = ", ".join(current_tags)
+            issue_update.add_or_update_custom_field(REDMINE_CUSTOM_FIELD_ID_TAGS, new_tags_str)
+
+        return changed
+
     class FilterMergedBug1(Filter):
         """
         Filter issues with erroneous merge commits.
@@ -557,12 +622,11 @@ class RedmineUpkeep:
 
         @staticmethod
         def get_filters():
-            filter_set = {
+            yield {
                 f"cf_{REDMINE_CUSTOM_FIELD_ID_PULL_REQUEST_ID}": '>=0',
                 f"cf_{REDMINE_CUSTOM_FIELD_ID_RELEASED_IN}": '~^',
+                f"cf_{REDMINE_CUSTOM_FIELD_ID_UPKEEP_FLAGS}": "!upkeep-bad-parentage"
             }
-            yield {**filter_set, **{f"cf_{REDMINE_CUSTOM_FIELD_ID_TAGS}": "!*"}}
-            yield {**filter_set, **{f"cf_{REDMINE_CUSTOM_FIELD_ID_TAGS}": "!~upkeep-bad-parentage"}}
 
         @staticmethod
         def requires_github_api():
@@ -1252,6 +1316,9 @@ class RedmineUpkeep:
                 if transform_method(issue_update):
                     issue_update.logger.info(f"Transformation {transform_method.__name__} resulted in a change.")
                     applied_transformations.append(transform_method.__name__)
+                    if transform_name == "migrate_legacy_tags":
+                        issue_update.logger.info("Short-circuiting remaining transformations to isolate tag migration.")
+                        break
 
             issue_update.set_transform(None)
             if issue_update.has_changes:
@@ -1259,7 +1326,8 @@ class RedmineUpkeep:
                 try:
                     # We cannot put top-level changes in the PUT request against
                     # the redmine API via redminelib. So we send it manually.
-                    payload = issue_update.get_update_payload()
+                    keep_failure = "_transform_migrate_legacy_tags" in applied_transformations
+                    payload = issue_update.get_update_payload(keep_failure_flag=keep_failure)
                     issue_update.logger.debug("PUT payload:\n%s", json.dumps(payload, indent=4))
                     headers = {
                         'Content-Type': 'application/json',
@@ -1310,9 +1378,9 @@ class RedmineUpkeep:
         comment = f"""
 h1. Redmine Upkeep failure
 
-The "redmine-upkeep.py script":https://github.com/ceph/ceph/blob/main/src/script/redmine-upkeep.py failed to update this issue. I have added the tag "upkeep-failed" to avoid looking at this issue again.
+The "redmine-upkeep.py script":https://github.com/ceph/ceph/blob/main/src/script/redmine-upkeep.py failed to update this issue. I have added the flag "upkeep-failed" to avoid looking at this issue again.
 
-**Please manually fix the issue and remove "upkeep-failed" tag to allow future upkeep operations.**
+**Please manually fix the issue and remove "upkeep-failed" flag to allow future upkeep operations.**
 
 h2. Transformation
 
@@ -1340,24 +1408,21 @@ h2. Update Payload
         issue_update.logger.debug("Created update failure comment:\n%s", comment)
         failure_payload['issue']['notes'] = comment
 
-        # Get existing tags or initialize if none
-        current_tags_str = issue_update.get_raw_custom_field(REDMINE_CUSTOM_FIELD_ID_TAGS)
-        current_tags = []
-        if current_tags_str:
-            current_tags = [tag.strip() for tag in current_tags_str.split(',') if tag.strip()]
+        # Get existing flags directly from the raw issue (ignoring pending payload)
+        current_flags = issue_update.get_list_custom_field(REDMINE_CUSTOM_FIELD_ID_UPKEEP_FLAGS, raw=True)
 
         new_tag = "upkeep-failed"
-        if new_tag in current_tags:
-            issue_update.logger.warning(f"'upkeep-failed' tag is already present")
+        if new_tag in current_flags:
+            issue_update.logger.warning(f"'upkeep-failed' flag is already present")
             return
         else:
-            current_tags.append(new_tag)
-            issue_update.logger.info(f"Adding '{new_tag}' tag.")
+            current_flags.append(new_tag)
+            issue_update.logger.info(f"Adding '{new_tag}' flag.")
 
-        # Update custom field for tags in the failure payload
+        # Update custom field for flags in the failure payload
         custom_fields_payload = failure_payload['issue'].setdefault('custom_fields', [])
         custom_fields_payload.append(
-            {'id': REDMINE_CUSTOM_FIELD_ID_TAGS, 'value': ", ".join(current_tags)}
+            {'id': REDMINE_CUSTOM_FIELD_ID_UPKEEP_FLAGS, 'value': current_flags}
         )
 
         try:
@@ -1548,8 +1613,9 @@ h2. Update Payload
             "status_id": "*",
         }
         upkeep_failed_filters = [
-            {f"cf_{REDMINE_CUSTOM_FIELD_ID_TAGS}": "!*",},
-            {f"cf_{REDMINE_CUSTOM_FIELD_ID_TAGS}": "!~upkeep-failed",}
+            {
+                f"cf_{REDMINE_CUSTOM_FIELD_ID_UPKEEP_FLAGS}": "!upkeep-failed",
+            }
         ]
         #f"cf_{REDMINE_CUSTOM_FIELD_ID_UPKEEP_TIMESTAMP}": f"<={cutoff_date}", # Not updated recently
 

--- a/src/script/redmine-upkeep.py
+++ b/src/script/redmine-upkeep.py
@@ -1559,8 +1559,12 @@ h2. Update Payload
                 log.info("Issue processing limit reached. Stopping filter execution.")
                 break
             for filter_set in f.get_filters():
+                if limit <= 0:
+                    break
                 log.debug(f"Generated filter set: {filter_set}")
                 for upkeep_failed_filter in upkeep_failed_filters:
+                    if limit <= 0:
+                        break
                     issue_filter = {**common_filters, **upkeep_failed_filter, **filter_set}
                     issue_filter['limit'] = limit
                     needs_github_api = f.requires_github_api()
@@ -1579,8 +1583,6 @@ h2. Update Payload
                                 break
                     except redminelib.exceptions.ResourceAttrError as e:
                         log.warning(f"Redmine API error with filter {issue_filter}: {e}")
-                    if limit <= 0:
-                        break
 
 def main():
     parser = argparse.ArgumentParser(description="Ceph redmine upkeep tool")

--- a/src/script/redmine-upkeep.py
+++ b/src/script/redmine-upkeep.py
@@ -824,6 +824,9 @@ class RedmineUpkeep:
         """
         pr_id = issue_update.get_pr_id()
 
+        if not pr_id:
+            return None
+
         ref = f"refs/pull/{pr_id}/head"
 
         try:


### PR DESCRIPTION
This PR introduces several structural improvements, optimizations, and maintenance updates to the `redmine-upkeep.py` script. 

Key Changes:
* Migrate to List-Based Upkeep Flags: Replaces the legacy text-based "Tags" custom field with a new "Upkeep Flags" list field (ID 48). 
* Legacy Tag Migration: Includes a new transformation that seamlessly migrates existing legacy tags (such as `upkeep-failed` and `upkeep-bad-parentage`) to the new list format on affected issues. 
* **Query Simplification & Performance: Updates all relevant filters and payload generators to use the new list format, which will simplify queries and improve overall query performance.**
* Query Limits: Adds logic to break out of query generation loops immediately when the issue processing limit is reached, preventing unnecessary execution.
* Deprecation Fixes: Replaces all instances of the deprecated Python `logging.fatal()` method with `logging.critical()` across the script.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
