### PR TITLE
doc: fix Sphinx warnings

### DIFF
--- a/doc/architecture/ceph-clients.rst
+++ b/doc/architecture/ceph-clients.rst
@@ -160,3 +160,5 @@ either for high availability or for scalability.
 Combinations of `standby` and `active` etc are possible, for example
 running 3 `active` ``ceph-mds`` instances for scaling, and one `standby`
 instance for high availability.
+
+.. _RESTful: https://en.wikipedia.org/wiki/RESTful

--- a/doc/architecture/index.rst
+++ b/doc/architecture/index.rst
@@ -12,8 +12,6 @@ intelligent daemons, and a :term:`Ceph Storage Cluster` accommodates large
 numbers of nodes, which communicate with each other to replicate and
 redistribute data dynamically.
 
-.. image:: images/stack.png
-
 .. image:: ../images/stack.png
 
 .. toctree::

--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -221,7 +221,7 @@ See the `Network Configuration Reference`_ for details.
 
 Once you deploy a Ceph cluster, you **SHOULD NOT** change the IP addresses of
 Monitors. However, if you decide to change the Monitor's IP address, you
-must follow a specific procedure. See :ref:`Changing a Monitor's IP address` for
+must follow a specific procedure. See :ref:`change-monitor-address` for
 details.
 
 Monitors can also be found by clients by using DNS SRV records. See :ref:`mon-dns-lookup` for details.

--- a/doc/radosgw/cloud-transition.rst
+++ b/doc/radosgw/cloud-transition.rst
@@ -1,3 +1,5 @@
+.. _radosgw-cloud-transition:
+
 ================
 Cloud Transition
 ================


### PR DESCRIPTION
Rename a `ref` link in `rados/configuration/mon-config-ref.rst` that was undefined after 2b1f02c87490b5dea324cf7fe83dc90e26f12a0e renamed the destination label.

Add a label in `radosgw/cloud-transition.rst` for a `ref` link to an undefined destination added in e87c19de371973f91f6a575b312839f932d1a1fa.

Add an external link definition in `architecture/ceph-clients.rst` that was lost splitting the old arch doc in
fc2c00d350e0be7fdc5c7366da4dc1892e880deb.

Remove a dupe and broken image reference in `architecture/index.rst` that was added in splitting the old arch doc in
fc2c00d350e0be7fdc5c7366da4dc1892e880deb.

```console
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/71401/doc/rados/configuration/mon-config-ref.rst:222: WARNING: undefined label: "changing a monitor's ip address" [ref.ref]
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/71401/doc/radosgw/cloud-restore.rst:300: WARNING: undefined label: 'radosgw-cloud-transition' [ref.ref]
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/71401/doc/architecture/ceph-clients.rst:53: ERROR: Unknown target name: "restful". [docutils]
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/71401/doc/architecture/index.rst:15: WARNING: image file not readable: architecture/images/stack.png [image.not_readable]
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
