### PR TITLE
doc: add RGW AWS CLI quickstart guide

### DIFF
--- a/doc/radosgw/aws-cli-quickstart.rst
+++ b/doc/radosgw/aws-cli-quickstart.rst
@@ -1,0 +1,115 @@
+==============================
+ Quickstart: Using the AWS CLI
+==============================
+
+.. note:: This guide assumes you have already deployed a Ceph cluster
+   and have at least one RGW (RADOS Gateway) daemon running.
+   See :doc:`../cephadm/services/rgw` for deployment instructions.
+
+This page walks through the smallest possible path from a freshly
+deployed RGW daemon to successfully creating a bucket and
+uploading/downloading an object using the standard AWS CLI. It is
+intended as a companion to the RGW service deployment docs and the
+:doc:`s3` protocol reference, neither of which currently connects
+"RGW is deployed" to "here is a working S3 client command."
+
+Prerequisites
+=============
+
+- A running RGW daemon (verify with ``ceph orch ps --daemon-type rgw``)
+- The internal or external IP/hostname and port RGW is listening on
+  (default port is 80 unless configured otherwise)
+
+Get RGW credentials
+====================
+
+This guide assumes you already have an RGW ``access_key`` and
+``secret_key``. Most users configuring an S3 client will already have
+been given these by whoever administers the cluster, this guide
+focuses on using them, not creating them.
+
+If you're a cluster administrator and need to create a new user, see
+:ref:`radosgw-user-management` for the full ``radosgw-admin user
+create`` workflow.
+
+.. warning:: Treat your access and secret keys like any other
+   credential. Do not commit them to version control or include them
+   in screenshots you intend to share publicly.
+
+Install and configure the AWS CLI
+==================================
+
+The standard AWS CLI works against any S3-compatible endpoint,
+including RGW, by pointing it at your RGW address instead of AWS's.
+
+.. prompt:: bash $
+
+   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+   unzip awscliv2.zip
+   sudo ./aws/install
+
+Set the endpoint for your profile once, so you don't need to repeat
+it on every command:
+
+.. prompt:: bash $
+
+   aws --profile ceph configure set endpoint_url http://<RGW_HOST>:80
+   aws --profile ceph configure
+
+When prompted, enter the ``access_key`` and ``secret_key`` from the
+previous step. Leave region and output format blank, RGW does not
+require them.
+
+This writes the endpoint into ``~/.aws/config`` under the
+``[profile ceph]`` section, so commands using ``--profile ceph``
+automatically use it, no need for ``--endpoint-url`` on every command.
+
+.. note:: This uses AWS's official bundled installer for Linux, the
+   recommended method per AWS's own documentation. It installs to
+   ``/usr/local/aws-cli`` with a symlink at ``/usr/local/bin/aws``, and
+   doesn't rely on ``pip`` or your system's Python packages at all.
+
+Verify it works
+================
+
+Since the endpoint is already set on the ``ceph`` profile, these
+commands work the same way you'd use them against real AWS S3:
+
+.. prompt:: bash $
+
+   aws --profile ceph s3 mb s3://my-test-bucket
+   echo "hello from RGW" > test.txt
+   aws --profile ceph s3 cp test.txt s3://my-test-bucket/
+   aws --profile ceph s3 ls s3://my-test-bucket/
+   aws --profile ceph s3 cp s3://my-test-bucket/test.txt downloaded.txt
+   cat downloaded.txt
+
+If the final ``cat`` prints ``hello from RGW``, the round trip worked
+and your RGW deployment is serving S3-compatible traffic correctly.
+
+Common issues
+=============
+
+**"Connection refused" or timeout**
+   Confirm the RGW daemon is actually running and listening on the
+   port you're targeting: ``ceph orch ps --daemon-type rgw``. If
+   you're connecting from outside the cluster's network, confirm the
+   port is reachable through any firewall or security group rules.
+
+**"SignatureDoesNotMatch" or auth errors**
+   Double-check the access/secret key were copied exactly, and that
+   the ``--profile`` flag matches the profile name used in
+   ``aws configure``.
+
+**Using HTTPS instead of HTTP**
+   Many production RGW deployments enable TLS. If your cluster uses
+   HTTPS, replace ``http://`` with ``https://`` and port ``80`` with
+   ``443`` (or whatever port your deployment uses) in the commands
+   above. If the certificate is self-signed, you'll also need to add
+   ``--no-verify-ssl`` to AWS CLI commands.
+
+.. note:: RGW also supports several extensions to the standard S3 API
+   (e.g. unordered bucket listings, bucket notification filtering).
+   These aren't covered here to keep this guide beginner-focused, but
+   if you want to explore them, see the `RGW boto3/AWS CLI examples
+   <https://github.com/ceph/ceph/tree/main/examples/rgw/boto3>`_.

--- a/doc/radosgw/index.rst
+++ b/doc/radosgw/index.rst
@@ -51,6 +51,7 @@ Cluster with one API and then retrieve that data with the other API.
    Admin Guide <admin>
    User Accounts <account>
    S3 API <s3>
+   AWS CLI Quickstart <aws-cli-quickstart>
    IAM API <iam>
    Data Caching and CDN <rgw-cache.rst>
    Swift API <swift>


### PR DESCRIPTION
Adds a beginner-focused walkthrough connecting a cephadm-deployed RGW to a working AWS CLI S3 client: creating an RGW user, configuring the AWS CLI, and verifying a full upload/download round trip. Also covers common connection and authentication issues.

This fills a gap between the RGW deployment docs and the S3 protocol reference, neither of which currently shows the end-to-end path from 'RGW is deployed' to 'here is a working S3 client command.' Steps were tested end-to-end on a personal 3-node cephadm cluster.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
