### PR TITLE
mds: fix stuck client requests and stale retries of committing requests

### DIFF
--- a/qa/suites/fs/functional/tasks/mdsc-stress.yaml
+++ b/qa/suites/fs/functional/tasks/mdsc-stress.yaml
@@ -1,0 +1,20 @@
+# MDS request dispatch stress: metadata load + back-to-back rank
+# failovers (double-failover chaos).  The test deliberately fails MDS
+# ranks while clients are loaded, so the resulting cluster noise is
+# expected and ignored below.
+overrides:
+  ceph:
+    log-ignorelist:
+      - evicting unresponsive client
+      - but it is still running
+      - slow request
+      - MDS_SLOW_REQUEST
+      - MDS_CLIENT_LATE_RELEASE
+      - MDS_CLIENTS_LAGGY
+      - failing to respond to capability release
+      - Degraded data redundancy
+      - Reduced data availability
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.cephfs.test_mdsc_stress

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1214,7 +1214,7 @@ class FilesystemBase(MDSClusterBase):
         try:
             self.run_ceph_cmd(args=cmd)
         except CommandFailedError:
-            cmd += ' --yes--i-really-mean-it'
+            cmd += ' --yes-i-really-mean-it'
             self.run_ceph_cmd(args=cmd)
 
     def rank_is_running(self, rank=0, status=None):

--- a/qa/tasks/cephfs/test_mdsc_stress.py
+++ b/qa/tasks/cephfs/test_mdsc_stress.py
@@ -1,0 +1,407 @@
+"""
+Stress the CephFS MDS request dispatch paths with a metadata load
+generator and concurrent MDS failovers (double-failover chaos).
+
+The load generator is qa/workunits/fs/mdsc_stress/mdsc_stress.c: a
+POSIX-only program that needs nothing but a mounted cephfs.  It runs a
+weighted metadata operation mix (write-heavy, fsync-light so that
+plenty of unsafe requests are replayed on reconnect), publishes every
+in-flight operation in a per-worker slot so a watchdog thread can
+report operations that never come back (the userspace symptom of a
+lost wakeup), and repeatedly SIGKILLs and restarts "victim" processes
+so that requests are aborted while the MDS dispatch paths drain their
+wait lists.  Each mount type is supported: kernel client and ceph-fuse
+(ceph.dir.pin, victims and watchdog all work on both).
+
+The chaos pattern is two distinct ranks failed back-to-back, so the
+second session replacement lands while the first is still being
+processed and the client's request collectors overlap, plus an
+occasional small batch of ceph.dir.pin re-rolls so requests get
+forwarded between ranks.  A broken kernel-side request collection
+shows up as list_add/list_del corruption or an endless collector
+loop.
+
+Verdict per test:
+  - the load generator's exit code: 1 = an operation was still in
+    flight when the run ended (suspected lost wakeup), 2 = unexpected
+    errno, 3 = setup error
+  - "HUNG:" lines in the load log
+  - on kernel client jobs additionally: kernel splats in the client's
+    dmesg during the window (list corruption, KASAN/UAF, lockdep
+    reports, hung task warnings, ...)
+
+errnos are classified by the load generator itself: races between
+workers (ENOENT/EEXIST/...) are benign, session teardown errors during
+chaos (EIO/ESTALE/ETIMEDOUT/...) are expected, anything else fails the
+test.
+"""
+import logging
+import os
+import re
+import time
+from io import StringIO
+from random import randint, sample
+
+from teuthology.exceptions import CommandFailedError
+
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
+from tasks.cephfs.kernel_mount import KernelMount
+
+log = logging.getLogger(__name__)
+
+SPLAT_RE = re.compile(
+    r"BUG:|KASAN|UBSAN|KCSAN|WARNING:|general protection fault|"
+    r"kernel NULL pointer|Oops|list_del corruption|list_add corruption|"
+    r"list_add double add|refcount_t:|blocked for more than|"
+    r"possible circular locking|possible recursive locking|"
+    r"trying to register non-static key|held lock freed|"
+    r"suspicious RCU usage|soft lockup|detected stalls|"
+    r"slab-out-of-bounds|use-after-free|double free|Kernel panic|"
+    r"Objects remaining")
+
+
+class TestMdscStress(CephFSTestCase):
+    CLIENTS_REQUIRED = 1
+    MDSS_REQUIRED = 3
+
+    # test tree inside the mountpoint; the load generator creates one
+    # subdirectory per worker (w00..) and one per victim (v00..) below it
+    TEST_DIR = "mdsc_stress"
+    LOAD_SRC = "/tmp/mdsc_stress.c"
+    LOAD_BIN = "/tmp/mdsc_stress"
+
+    THREADS = 8
+    VICTIMS = 4
+    WATCHDOG_SECS = 120  # report operations in flight longer than this
+    REPORT_SECS = 30
+
+    LOAD_ONLY_SECS = 90  # smoke test: load without chaos
+    CHAOS_SECS = 240  # double-failover chaos duration
+    SETTLE_SECS = 60  # grace after the cluster is healthy again
+
+    def setUp(self):
+        super().setUp()
+        self._load_pid = None
+
+        # the load generator is a plain C file in the checked-out tree:
+        # copy it onto the client and compile it there
+        src = os.path.normpath(os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "..", "..",
+            "workunits", "fs", "mdsc_stress", "mdsc_stress.c"))
+        with open(src) as f:
+            code = f.read()
+        self.mount_a.client_remote.write_file(self.LOAD_SRC, code)
+        self.mount_a.client_remote.run(
+            args=["cc", "-O2", "-g", "-pthread", "-Wall", "-Wextra",
+                  "-Wno-format-truncation", "-o", self.LOAD_BIN,
+                  self.LOAD_SRC],
+            omit_sudo=True)
+
+    def tearDown(self):
+        # make sure no load generator (or victim) survives the test
+        self._signal_load("KILL")
+        self._load_pid = None
+        # a victim that was killed mid-operation may still hold the
+        # directory for a moment, so retry once before giving up
+        for attempt in range(2):
+            try:
+                self.mount_a.run_shell(
+                    ["rm", "-rf", "--", self.TEST_DIR, "mdsc_stress.log",
+                     "mdsc_stress.rc", "mdsc_stress.pid"],
+                    timeout=300)
+                break
+            except CommandFailedError:
+                if attempt == 0:
+                    time.sleep(5)
+                else:
+                    log.warning("could not clean up %s on %s", self.TEST_DIR,
+                                self.mount_a.client_remote.hostname)
+        super().tearDown()
+
+    # ------------------------------------------------------------------
+    # load generator control
+    # ------------------------------------------------------------------
+
+    def _start_load(self, seconds=0, kill_range="200:2000"):
+        """
+        Start the load generator in the background on the client.
+
+        seconds=0 means "run until signalled"; the wrapper records the
+        exit code in mdsc_stress.rc.  The load generator runs under
+        setsid as its own session and process-group leader, so the pid
+        file names the binary itself (its worker threads and victim
+        children live in the same group).  Signalling the wrapper
+        subshell instead would stop the rc writer and orphan the load.
+        """
+        self.mount_a.run_shell(["mkdir", "-p", "--", self.TEST_DIR])
+        # drop leftovers from an aborted run, or the poll below may
+        # pick up a stale pid from a dead wrapper
+        self.mount_a.run_shell(
+            ["rm", "-f", "--", "mdsc_stress.pid", "mdsc_stress.rc"])
+        cmd = (f"( setsid {self.LOAD_BIN} -d {self.TEST_DIR} -t {self.THREADS} "
+               f"-k {self.VICTIMS} -K {kill_range} -s {seconds} "
+               f"-w {self.WATCHDOG_SECS} -i {self.REPORT_SECS} -C & "
+               f"child=$!; echo $child > mdsc_stress.pid; "
+               f"wait $child; echo $? > mdsc_stress.rc "
+               f") > mdsc_stress.log 2>&1 &")
+        self.mount_a.run_shell(["bash", "-c", cmd])
+        # the pid file is written by the wrapper for its setsid child,
+        # i.e. the load generator itself (setsid execs, pid unchanged)
+        for _ in range(30):
+            try:
+                pid = self.mount_a.run_shell(
+                    ["cat", "mdsc_stress.pid"],
+                    timeout=30).stdout.getvalue().strip()
+                self._load_pid = int(pid)
+                break
+            except (CommandFailedError, ValueError):
+                time.sleep(0.5)
+        else:
+            raise RuntimeError(
+                "load generator did not start:\n" + self._load_log())
+        log.info("load generator running on %s (pid %d, threads=%d, "
+                 "victims=%d)",
+                 self.mount_a.client_remote.hostname, self._load_pid,
+                 self.THREADS, self.VICTIMS)
+        # let the worker threads and victims come up before the first
+        # chaos hit
+        time.sleep(10)
+        if not self._load_running():
+            self._load_pid = None
+            raise RuntimeError(
+                "load generator exited during startup:\n" + self._load_log())
+
+    def _signal_load(self, sig):
+        if self._load_pid is None:
+            return
+        # TERM/KILL go to the process group (the load generator is the
+        # leader, its victim children are in the same group); SIGUSR1
+        # is for the load generator only (in-flight dump).
+        target = (f"-- -{self._load_pid}" if sig in ("TERM", "KILL")
+                  else str(self._load_pid))
+        self.mount_a.run_shell(
+            ["bash", "-c", f"kill -{sig} {target} || true"],
+            timeout=30)
+
+    def _load_running(self):
+        try:
+            self.mount_a.run_shell(
+                ["bash", "-c", f"kill -0 {self._load_pid}"], timeout=30)
+            return True
+        except CommandFailedError:
+            return False
+
+    def _wait_load_exit(self, timeout):
+        self.wait_until_true(lambda: not self._load_running(),
+                             timeout=timeout)
+
+    def _stop_load(self):
+        """
+        SIGTERM the load and wait for the summary; escalate to KILL.
+        Raises RuntimeError if even SIGKILL does not end it - a process
+        that survives SIGKILL is stuck in an uninterruptible kernel
+        wait, which is exactly the hang this test exists to find.
+        """
+        if self._load_pid is None:
+            return
+        self._signal_load("TERM")
+        try:
+            self._wait_load_exit(120)
+        except RuntimeError:
+            log.warning("load generator did not exit after SIGTERM; "
+                        "sending SIGKILL")
+            self._signal_load("KILL")
+            try:
+                self._wait_load_exit(60)
+            except RuntimeError:
+                pid = self._load_pid
+                # leave _load_pid set so tearDown makes one last attempt
+                raise RuntimeError(
+                    f"load generator (pid {pid}) survived SIGKILL: stuck "
+                    "in an uninterruptible kernel wait") from None
+        self._load_pid = None
+
+    def _load_rc(self):
+        """Read the load generator's exit code (written by the wrapper)."""
+        def written():
+            try:
+                self.mount_a.run_shell(
+                    ["test", "-s", "mdsc_stress.rc"], timeout=30)
+                return True
+            except CommandFailedError:
+                return False
+
+        try:
+            self.wait_until_true(written, timeout=120)
+        except RuntimeError:
+            return None
+        return int(self.mount_a.run_shell(
+            ["cat", "mdsc_stress.rc"]).stdout.getvalue().strip())
+
+    def _load_log(self):
+        try:
+            return self.mount_a.run_shell(
+                ["cat", "mdsc_stress.log"], timeout=300).stdout.getvalue()
+        except CommandFailedError:
+            return ""
+
+    def _load_verdict(self, rc):
+        """Turn the load outcome into a list of failure strings."""
+        problems = []
+        txt = self._load_log()
+
+        # keep the interesting lines in the teuthology log
+        for line in txt.splitlines():
+            if re.search(r"^(RESULT|REASON|SLOW|HUNG|INFLIGHT|"
+                         r"UNEXPECTED|WARNING)", line):
+                log.info("load: %s", line)
+
+        if rc is None:
+            problems.append("load generator produced no exit code")
+        elif rc == 1:
+            problems.append("load exit 1: worker(s) stuck in an MDS "
+                            "request (suspected lost wakeup)")
+        elif rc == 2:
+            problems.append("load exit 2: unexpected errno")
+        elif rc == 3:
+            problems.append("load exit 3: usage/setup error")
+        elif rc != 0:
+            problems.append(f"load exited with {rc} (crash/signal?)")
+
+        if "HUNG:" in txt:
+            problems.append("HUNG operations in the load log")
+
+        return problems
+
+    # ------------------------------------------------------------------
+    # kernel-side oracle (kernel client jobs only)
+    # ------------------------------------------------------------------
+
+    def _is_kernel_mount(self):
+        return isinstance(self.mount_a, KernelMount)
+
+    def _dmesg_baseline(self):
+        out = self.mount_a.client_remote.run(
+            args=["sudo", "bash", "-c", "dmesg | wc -l"],
+            stdout=StringIO(), omit_sudo=True).stdout.getvalue()
+        return int(out.strip())
+
+    def _dmesg_splats(self, baseline):
+        out = self.mount_a.client_remote.run(
+            args=["sudo", "bash", "-c", f"dmesg | tail -n +{baseline + 1}"],
+            stdout=StringIO(), omit_sudo=True).stdout.getvalue()
+        return [line for line in out.splitlines() if SPLAT_RE.search(line)]
+
+    # ------------------------------------------------------------------
+    # chaos: two ranks failed back-to-back
+    # ------------------------------------------------------------------
+
+    def _grow_to_two_ranks(self):
+        self.fs.set_max_mds(2)
+        self.fs.wait_for_daemons()
+        ranks = [r["rank"] for r in self.fs.get_ranks()]
+        if len(ranks) != 2:
+            raise RuntimeError(f"expected 2 active ranks, got {ranks}")
+        return ranks
+
+    def _repin(self):
+        """
+        Re-pin a small random batch of worker dirs: cross-rank
+        forwards need auth movement, but re-pinning everything every
+        cycle is a migration storm that wedges the migrator under
+        load.
+        """
+        for _ in range(min(8, self.THREADS)):
+            d = f"{self.TEST_DIR}/w{randint(0, self.THREADS - 1):02d}"
+            try:
+                self.mount_a.setfattr(d, "ceph.dir.pin", str(randint(0, 1)))
+            except CommandFailedError:
+                pass
+        time.sleep(randint(45, 90))
+
+    def _chaos_double_failover(self, seconds):
+        """
+        Fail two distinct ranks back-to-back for the whole duration, so
+        the second session replacement lands while the first is still
+        being processed.  Wait for a healthy cluster between cycles so
+        the next pair of failures does not interrupt an ongoing
+        recovery (which wedges subtree migration), and re-pin a small
+        batch of dirs every few cycles.
+        """
+        ranks = self._grow_to_two_ranks()
+        start = time.time()
+        cycles = 0
+        while time.time() - start < seconds:
+            a, b = sample(ranks, 2)
+            self.fs.rank_fail(rank=a)
+            time.sleep(randint(1, 3))
+            self.fs.rank_fail(rank=b)
+            self.fs.wait_for_daemons(timeout=300)
+            if cycles % 3 == 0:
+                self._repin()
+            cycles += 1
+            time.sleep(randint(3, 6))
+        log.info("chaos: %d double-failover cycles", cycles)
+
+    def _settle_and_dump(self):
+        """
+        Let the cluster settle while the load keeps running, then ask
+        the load which operations are still in flight.  Anything still
+        blocked once the cluster is healthy again is a lost wakeup.
+        """
+        time.sleep(self.SETTLE_SECS // 2)
+        self._signal_load("USR1")
+        time.sleep(self.SETTLE_SECS // 2)
+        self._signal_load("USR1")
+        time.sleep(5)
+
+    # ------------------------------------------------------------------
+    # the tests
+    # ------------------------------------------------------------------
+
+    def test_load_only(self):
+        """
+        Smoke test: metadata load without cluster chaos must finish on
+        its own, with no HUNG operation and no unexpected errno.
+        """
+        self._start_load(seconds=self.LOAD_ONLY_SECS,
+                         kill_range="1000:2000")
+        try:
+            self._wait_load_exit(self.LOAD_ONLY_SECS + 240)
+        except RuntimeError:
+            self._signal_load("KILL")
+        problems = self._load_verdict(self._load_rc())
+        self.assertFalse(problems, "; ".join(problems))
+
+    def test_double_failover(self):
+        """
+        Back-to-back MDS failovers while metadata load is in flight,
+        so overlapping session replacements collect the same requests
+        concurrently, plus occasional pin re-rolls for cross-rank
+        forwards.
+        """
+        dmesg_base = self._dmesg_baseline() if self._is_kernel_mount() \
+            else None
+
+        self._start_load(seconds=0)
+        self._chaos_double_failover(self.CHAOS_SECS)
+        self._settle_and_dump()
+        try:
+            self._stop_load()
+            problems = self._load_verdict(self._load_rc())
+        except RuntimeError as e:
+            # unkillable load: report it together with everything else
+            # that went wrong instead of losing the verdicts below
+            problems = [str(e)]
+            problems += self._load_verdict(self._load_rc())
+
+        if dmesg_base is not None:
+            splats = self._dmesg_splats(dmesg_base)
+            for line in splats:
+                log.error("kernel splat on client: %s", line)
+            if splats:
+                problems.append(
+                    f"{len(splats)} kernel splat(s) on the client "
+                    "(see teuthology.log)")
+
+        self.assertFalse(problems, "; ".join(problems))

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -698,6 +698,11 @@ class LocalCephFSMount():
         log.info('Ready to start {}...'.format(type(self).__name__))
 
     def is_blocked(self):
+        if self.addr is None:
+            # gather_mount_info() failed on this local setup (e.g. no
+            # debugfs), so the client addr is unknown; skip the
+            # blocklist check and do a normal umount
+            return False
         self.fs = LocalFilesystem(self.ctx, name=self.cephfs_name)
 
         output = self.fs.mon_manager.raw_cluster_cmd(args='osd blocklist ls')
@@ -1486,6 +1491,18 @@ def exec_test():
     mds_cluster = LocalMDSCluster(ctx)
     mgr_cluster = LocalMgrCluster(ctx)
 
+    if use_kernel_client:
+        # The kernel client only supports AES (CEPH_CRYPTO_AES) cephx
+        # keys, while "auth get-or-create" issues the preferred cipher
+        # (aes256k on current releases).  aes counts as an insecure
+        # cipher, so allow it explicitly.  Same dance as the kclient
+        # task in qa/tasks/kclient.py.
+        remote.run(args=[CEPH_CMD, "config", "set", "mon",
+                         "mon_auth_allow_insecure_key", "true"],
+                   stdout=StringIO())
+        remote.run(args=[CEPH_CMD, "mon", "set", "auth_allowed_ciphers",
+                         "aes,aes256k"], stdout=StringIO())
+
     # Construct Mount classes
     mounts = []
     for client_id in clients:
@@ -1502,6 +1519,15 @@ def exec_test():
             open("./keyring", "at").write(p.stdout.getvalue())
 
         if use_kernel_client:
+            # The key may have been created (by an earlier run) with
+            # the preferred cipher, which the kernel client rejects;
+            # rotate it to aes and refresh the local keyring entry
+            # (the last entry for an entity wins when the keyring is
+            # loaded).
+            p = remote.run(args=[CEPH_CMD, "auth", "rotate", client_name,
+                                 "--key-type=aes"], stdout=StringIO())
+            open("./keyring", "at").write(p.stdout.getvalue())
+
             mount = LocalKernelMount(ctx=ctx, test_dir=test_dir,
                                      client_id=client_id, brxnet=opt_brxnet)
         else:

--- a/qa/workunits/fs/mdsc_stress/Makefile
+++ b/qa/workunits/fs/mdsc_stress/Makefile
@@ -1,0 +1,12 @@
+CFLAGS = -O2 -g -Wall -Wextra -Wno-format-truncation -D_GNU_SOURCE
+LDFLAGS = -pthread
+
+TARGETS = mdsc_stress
+
+.c:
+	$(CC) $(CFLAGS) $@.c -o $@ $(LDFLAGS)
+
+all: $(TARGETS)
+
+clean:
+	rm -f $(TARGETS)

--- a/qa/workunits/fs/mdsc_stress/mdsc_stress.c
+++ b/qa/workunits/fs/mdsc_stress/mdsc_stress.c
@@ -1,0 +1,1190 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * mdsc_stress.c - CephFS MDS request dispatch stress generator.
+ *
+ * This is the teuthology version: it is driven by
+ * qa/tasks/cephfs/test_mdsc_stress.py (double-failover chaos) and
+ * also runs standalone as a workunit on any client mount - both kclient
+ * and ceph-fuse.  It needs no ceph tooling: it only speaks POSIX
+ * filesystem calls against the mount.
+ *
+ * The program only generates load and detects *client visible* symptoms;
+ * the kernel-side oracles (lockdep, KASAN, KCSAN, DEBUG_LIST, refcount)
+ * are collected from dmesg by the test on kernel client jobs.  What
+ * this program adds on top of a generic metadata stressor is:
+ *
+ *   - a per-operation watchdog.  A metadata request that never comes
+ *     back produces no dmesg output at all until the hung-task timer
+ *     fires, so it has to be observed from userspace.
+ *
+ *   - SIGKILLed victim processes.  Killing a task that is blocked on a
+ *     parked request aborts the request while the client may be
+ *     draining the very wait list it is parked on, which the request
+ *     ownership rules have to survive.
+ *
+ *   - an operation mix that is heavy on write requests and light on
+ *     fsync, so that plenty of unsafe requests are replayed on
+ *     reconnect.
+ *
+ * Usage:
+ *	mdsc_stress -d <dir> [-t threads] [-s seconds] [-w watchdog_secs]
+ *		    [-k victims] [-K min_ms:max_ms] [-i report_secs] [-C] [-v]
+ *
+ * Internal mode (spawned by the killer thread, not for direct use):
+ *	mdsc_stress --victim <dir> <seed>
+ *
+ * Signals:
+ *	SIGTERM/SIGINT	stop the run and print the summary
+ *	SIGUSR1		dump the operations that are currently in flight
+ *
+ * Exit codes:
+ *	0	no hang, no unexpected error
+ *	1	an operation was still in flight when the run ended, or a
+ *		worker thread could not be joined (suspected lost wakeup)
+ *	2	an unexpected errno was returned by an operation
+ *	3	usage/setup error
+ */
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/xattr.h>
+#include <time.h>
+#include <unistd.h>
+
+#define MAX_WORKERS	256
+#define MAX_VICTIMS	64
+#define NAME_SLOTS	64
+#define LAT_BUCKETS	32
+
+/* ------------------------------------------------------------------ */
+/* operations							      */
+/* ------------------------------------------------------------------ */
+
+enum {
+	OP_LOOKUP,	/* stat() of a name that cannot be cached	*/
+	OP_CREATE,
+	OP_UNLINK,
+	OP_MKDIR,
+	OP_RMDIR,
+	OP_RENAME,
+	OP_LINK,
+	OP_SYMLINK,
+	OP_READLINK,
+	OP_CHMOD,
+	OP_TRUNCATE,
+	OP_UTIMES,
+	OP_SETXATTR,
+	OP_GETXATTR,
+	OP_READDIR,
+	OP_STAT,
+	OP_OPEN,
+	OP_FSYNC,
+	OP_CROSS,	/* touch another worker's directory		*/
+	OP_NR
+};
+
+static const char * const op_name[OP_NR] = {
+	[OP_LOOKUP]	= "lookup",
+	[OP_CREATE]	= "create",
+	[OP_UNLINK]	= "unlink",
+	[OP_MKDIR]	= "mkdir",
+	[OP_RMDIR]	= "rmdir",
+	[OP_RENAME]	= "rename",
+	[OP_LINK]	= "link",
+	[OP_SYMLINK]	= "symlink",
+	[OP_READLINK]	= "readlink",
+	[OP_CHMOD]	= "chmod",
+	[OP_TRUNCATE]	= "truncate",
+	[OP_UTIMES]	= "utimes",
+	[OP_SETXATTR]	= "setxattr",
+	[OP_GETXATTR]	= "getxattr",
+	[OP_READDIR]	= "readdir",
+	[OP_STAT]	= "stat",
+	[OP_OPEN]	= "open",
+	[OP_FSYNC]	= "fsync",
+	[OP_CROSS]	= "cross",
+};
+
+/*
+ * Weights.  Write operations dominate so that unsafe requests keep
+ * piling up between reconnects; OP_LOOKUP is cheap and always reaches
+ * the MDS, which is what makes requests pile up on the wait lists while
+ * a rank is not active.
+ */
+static const int op_weight[OP_NR] = {
+	[OP_LOOKUP]	= 15,
+	[OP_CREATE]	= 12,
+	[OP_UNLINK]	= 10,
+	[OP_MKDIR]	= 6,
+	[OP_RMDIR]	= 5,
+	[OP_RENAME]	= 10,
+	[OP_LINK]	= 4,
+	[OP_SYMLINK]	= 5,
+	[OP_READLINK]	= 3,
+	[OP_CHMOD]	= 6,
+	[OP_TRUNCATE]	= 5,
+	[OP_UTIMES]	= 4,
+	[OP_SETXATTR]	= 5,
+	[OP_GETXATTR]	= 3,
+	[OP_READDIR]	= 4,
+	[OP_STAT]	= 4,
+	[OP_OPEN]	= 4,
+	[OP_FSYNC]	= 2,
+	[OP_CROSS]	= 8,
+};
+
+static int op_pick[256];
+static int op_pick_nr;
+
+static void build_op_table(void)
+{
+	int op, i;
+
+	for (op = 0; op < OP_NR; op++)
+		for (i = 0; i < op_weight[op]; i++)
+			op_pick[op_pick_nr++] = op;
+}
+
+/* ------------------------------------------------------------------ */
+/* error classification						      */
+/* ------------------------------------------------------------------ */
+
+enum err_class {
+	ERR_OK,
+	ERR_BENIGN,	/* races between workers over a shared name space  */
+	ERR_CHAOS,	/* expected while the cluster is being disrupted	  */
+	ERR_BAD		/* nothing in this test should ever produce this	  */
+};
+
+static enum err_class classify(int op, int err)
+{
+	if (!err)
+		return ERR_OK;
+
+	/* per-operation exceptions */
+	switch (op) {
+	case OP_READLINK:
+		if (err == EINVAL)		/* not a symlink */
+			return ERR_BENIGN;
+		break;
+	case OP_LINK:
+		if (err == EPERM || err == EMLINK)
+			return ERR_BENIGN;
+		break;
+	case OP_TRUNCATE:
+	case OP_OPEN:
+	case OP_FSYNC:
+		if (err == EISDIR)
+			return ERR_BENIGN;
+		break;
+	default:
+		break;
+	}
+
+	switch (err) {
+	case ENOENT:
+	case EEXIST:
+	case ENOTEMPTY:
+	case ENOTDIR:
+	case EISDIR:
+	case ENODATA:
+	case EBUSY:
+	case ELOOP:
+		return ERR_BENIGN;
+
+	/*
+	 * Session teardown, blocklisting and forced reconnects are part
+	 * of the test; they must not be silently ignored, but they are
+	 * not failures either.  The runner reports the counts.
+	 */
+	case EIO:
+	case ESTALE:
+	case ENOTCONN:
+	case ESHUTDOWN:
+	case ETIMEDOUT:
+	case EINTR:
+	case EAGAIN:
+	case EACCES:
+	case EPERM:
+	case ECONNABORTED:
+	case ECONNRESET:
+	case EHOSTUNREACH:
+	case ENOMEM:
+		return ERR_CHAOS;
+
+	default:
+		return ERR_BAD;
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* shared state							      */
+/* ------------------------------------------------------------------ */
+
+/*
+ * One publication slot per worker.  The worker publishes the operation
+ * it is about to issue, runs it, then retires the slot.  seq is a plain
+ * sequence counter: odd means "in flight".  The watchdog reads it to
+ * find operations that never came back, which is the only userspace
+ * visible symptom of a lost wakeup on a request with r_timeout == 0.
+ */
+struct slot {
+	_Atomic unsigned long	seq;
+	_Atomic uint64_t	start_ns;
+	_Atomic int		op;
+	char			path[PATH_MAX];
+	char			pad[64];
+} __attribute__((aligned(64)));
+
+struct worker {
+	pthread_t		tid;
+	int			idx;
+	unsigned int		seed;
+	char			dir[PATH_MAX];
+	unsigned long		ops[OP_NR];
+	unsigned long		errs[OP_NR][4];		/* by err_class */
+	unsigned long		errno_hist[256];
+	unsigned long		lat[LAT_BUCKETS];
+	uint64_t		max_lat_ns;
+	int			max_lat_op;
+	bool			joined;
+};
+
+static struct slot		g_slot[MAX_WORKERS];
+static struct worker		g_worker[MAX_WORKERS];
+static int			g_nworkers = 16;
+static int			g_nvictims = 6;
+static int			g_seconds = 60;
+static int			g_watchdog = 120;
+static int			g_report = 10;
+static int			g_kill_min_ms = 200;
+static int			g_kill_max_ms = 2000;
+static bool			g_keep;
+static bool			g_verbose;
+static char			g_root[PATH_MAX];
+
+static volatile sig_atomic_t	g_stop;
+static volatile sig_atomic_t	g_dump;
+static atomic_ulong		g_total_ops;
+static atomic_int		g_slow_events;
+static atomic_int		g_victim_kills;
+static uint64_t			g_start_ns;
+
+static pid_t			g_victim[MAX_VICTIMS];
+static pthread_mutex_t		g_victim_lock = PTHREAD_MUTEX_INITIALIZER;
+static char			g_self[PATH_MAX];
+
+/* ------------------------------------------------------------------ */
+/* helpers							      */
+/* ------------------------------------------------------------------ */
+
+static uint64_t now_ns(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000000000ull + ts.tv_nsec;
+}
+
+static void msleep(unsigned int ms)
+{
+	struct timespec ts = {
+		.tv_sec  = ms / 1000,
+		.tv_nsec = (long)(ms % 1000) * 1000000L,
+	};
+
+	while (nanosleep(&ts, &ts) < 0 && errno == EINTR)
+		;
+}
+
+static int lat_bucket(uint64_t ns)
+{
+	int b = 0;
+	uint64_t us = ns / 1000;
+
+	while (us) {
+		b++;
+		us >>= 1;
+	}
+	return b < LAT_BUCKETS ? b : LAT_BUCKETS - 1;
+}
+
+static void die(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fprintf(stderr, "mdsc_stress: ");
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	fprintf(stderr, "\n");
+	exit(3);
+}
+
+static void on_stop(int sig)
+{
+	(void)sig;
+	g_stop = 1;
+}
+
+static void on_dump(int sig)
+{
+	(void)sig;
+	g_dump = 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* the operations						      */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Every operation below issues at least one MDS request when it is not
+ * satisfied from the dentry/inode cache.  run_op() returns 0 or -errno.
+ */
+static int run_op(const char *dir, int op, unsigned int *seed, char *pub,
+		  size_t publen)
+{
+	char p1[PATH_MAX], p2[PATH_MAX], buf[256];
+	int a = rand_r(seed) % NAME_SLOTS;
+	int b = rand_r(seed) % NAME_SLOTS;
+	struct timeval tv[2];
+	struct stat st;
+	DIR *d;
+	int fd, ret;
+
+	switch (op) {
+	case OP_LOOKUP:
+		/*
+		 * A name that has never existed: not in the dentry cache,
+		 * so this always reaches the MDS.  It is the cheapest way
+		 * to keep requests parked while a rank is not active.
+		 */
+		snprintf(p1, sizeof(p1), "%s/miss-%u-%u", dir,
+			 (unsigned)getpid(), (unsigned)rand_r(seed));
+		snprintf(pub, publen, "%s", p1);
+		ret = lstat(p1, &st);
+		if (ret < 0 && errno == ENOENT)
+			ret = 0;	/* the miss is the expected result */
+		break;
+
+	case OP_CREATE:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		fd = open(p1, O_CREAT | O_WRONLY, 0644);
+		if (fd < 0) {
+			ret = -1;
+			break;
+		}
+		ret = write(fd, "x", 1) < 0 ? -1 : 0;
+		close(fd);
+		break;
+
+	case OP_UNLINK:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		ret = unlink(p1);
+		break;
+
+	case OP_MKDIR:
+		snprintf(p1, sizeof(p1), "%s/d%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		ret = mkdir(p1, 0755);
+		break;
+
+	case OP_RMDIR:
+		snprintf(p1, sizeof(p1), "%s/d%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		ret = rmdir(p1);
+		break;
+
+	case OP_RENAME:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(p2, sizeof(p2), "%s/f%02d", dir, b);
+		snprintf(pub, publen, "%s -> %s", p1, p2);
+		ret = (a == b) ? 0 : rename(p1, p2);
+		break;
+
+	case OP_LINK:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(p2, sizeof(p2), "%s/h%02d", dir, b);
+		snprintf(pub, publen, "%s => %s", p1, p2);
+		unlink(p2);
+		ret = link(p1, p2);
+		break;
+
+	case OP_SYMLINK:
+		snprintf(p1, sizeof(p1), "%s/s%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		unlink(p1);
+		snprintf(buf, sizeof(buf), "f%02d", b);
+		ret = symlink(buf, p1);
+		break;
+
+	case OP_READLINK:
+		snprintf(p1, sizeof(p1), "%s/s%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		ret = readlink(p1, buf, sizeof(buf)) < 0 ? -1 : 0;
+		break;
+
+	case OP_CHMOD:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		ret = chmod(p1, (rand_r(seed) & 1) ? 0644 : 0600);
+		break;
+
+	case OP_TRUNCATE:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		ret = truncate(p1, rand_r(seed) % 4096);
+		break;
+
+	case OP_UTIMES:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		gettimeofday(&tv[0], NULL);
+		tv[1] = tv[0];
+		ret = utimes(p1, tv);
+		break;
+
+	case OP_SETXATTR:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		snprintf(buf, sizeof(buf), "v%u", (unsigned)rand_r(seed));
+		ret = setxattr(p1, "user.mdsc", buf, strlen(buf), 0);
+		break;
+
+	case OP_GETXATTR:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		ret = getxattr(p1, "user.mdsc", buf, sizeof(buf)) < 0 ? -1 : 0;
+		break;
+
+	case OP_READDIR:
+		snprintf(pub, publen, "%s", dir);
+		d = opendir(dir);
+		if (!d) {
+			ret = -1;
+			break;
+		}
+		errno = 0;
+		while (readdir(d))
+			;
+		ret = errno ? -1 : 0;
+		closedir(d);
+		break;
+
+	case OP_STAT:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		ret = lstat(p1, &st);
+		break;
+
+	case OP_OPEN:
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		fd = open(p1, O_RDONLY);
+		if (fd < 0) {
+			ret = -1;
+			break;
+		}
+		close(fd);
+		ret = 0;
+		break;
+
+	case OP_FSYNC:
+		/*
+		 * Kept rare on purpose: fsync() waits for the safe reply
+		 * and thereby drains the unsafe requests, while the replay
+		 * path is only interesting when there are unsafe requests
+		 * to replay.
+		 */
+		snprintf(p1, sizeof(p1), "%s/f%02d", dir, a);
+		snprintf(pub, publen, "%s", p1);
+		fd = open(p1, O_WRONLY | O_CREAT, 0644);
+		if (fd < 0) {
+			ret = -1;
+			break;
+		}
+		if (write(fd, "y", 1) < 0) {
+			close(fd);
+			ret = -1;
+			break;
+		}
+		ret = fsync(fd);
+		close(fd);
+		break;
+
+	case OP_CROSS:
+		/*
+		 * Reach into another worker's directory.  With the per
+		 * directory pins that qa/tasks/cephfs/test_mdsc_stress.py
+		 * sets up, these paths resolve on a different rank than
+		 * the caller's own tree, which is what makes the MDS
+		 * forward the request to the authoritative rank.
+		 */
+		snprintf(p1, sizeof(p1), "%s/w%02d/f%02d", g_root,
+			 rand_r(seed) % g_nworkers, a);
+		snprintf(pub, publen, "%s", p1);
+		if (rand_r(seed) & 1) {
+			ret = lstat(p1, &st);
+		} else {
+			fd = open(p1, O_CREAT | O_WRONLY, 0644);
+			if (fd < 0) {
+				ret = -1;
+				break;
+			}
+			close(fd);
+			ret = 0;
+		}
+		break;
+
+	default:
+		snprintf(pub, publen, "?");
+		ret = 0;
+		break;
+	}
+
+	return ret < 0 ? -errno : 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* worker							      */
+/* ------------------------------------------------------------------ */
+
+static void *worker_fn(void *arg)
+{
+	struct worker *w = arg;
+	struct slot *s = &g_slot[w->idx];
+	char pub[PATH_MAX];
+
+	while (!g_stop) {
+		int op = op_pick[rand_r(&w->seed) % op_pick_nr];
+		unsigned long seq;
+		uint64_t t0, dt;
+		int err, cls, b;
+
+		pub[0] = '\0';
+		snprintf(pub, sizeof(pub), "%s", w->dir);
+
+		/* publish: odd seq means "in flight" */
+		seq = atomic_load_explicit(&s->seq, memory_order_relaxed);
+		atomic_store_explicit(&s->seq, seq + 1, memory_order_relaxed);
+		atomic_store_explicit(&s->op, op, memory_order_relaxed);
+		memcpy(s->path, pub, strlen(pub) + 1);
+		t0 = now_ns();
+		atomic_store_explicit(&s->start_ns, t0, memory_order_release);
+
+		err = -run_op(w->dir, op, &w->seed, s->path, sizeof(s->path));
+
+		dt = now_ns() - t0;
+		atomic_store_explicit(&s->start_ns, 0, memory_order_release);
+		atomic_store_explicit(&s->seq, seq + 2, memory_order_relaxed);
+
+		w->ops[op]++;
+		b = lat_bucket(dt);
+		w->lat[b]++;
+		if (dt > w->max_lat_ns) {
+			w->max_lat_ns = dt;
+			w->max_lat_op = op;
+		}
+
+		cls = classify(op, err);
+		w->errs[op][cls]++;
+		if (err > 0 && err < 256)
+			w->errno_hist[err]++;
+		if (cls == ERR_BAD)
+			fprintf(stderr,
+				"UNEXPECTED: op=%s path=%s errno=%d (%s)\n",
+				op_name[op], s->path, err, strerror(err));
+
+		atomic_fetch_add_explicit(&g_total_ops, 1,
+					  memory_order_relaxed);
+	}
+
+	return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* watchdog							      */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Read one publication slot consistently.  The producer retires a slot
+ * by clearing start_ns and bumping seq (odd -> even), and can
+ * immediately re-publish it (even -> odd, new start_ns).  A reader must
+ * therefore treat seq and start_ns as a pair: if a re-read of seq does
+ * not match the first read, the start_ns value belonged to a different
+ * generation and must not be used to compute an elapsed time (the
+ * absurd "585 years" reports in the first run were exactly this race).
+ */
+enum slot_state {
+	SLOT_IDLE,	/* even seq: nothing in flight		    */
+	SLOT_BUSY,	/* odd seq, start_ns set, op valid	    */
+	SLOT_TORN	/* changed between the two seq reads: retry */
+};
+
+static enum slot_state read_slot(struct slot *s, unsigned long *seq,
+				 uint64_t *t0, int *op)
+{
+	unsigned long a, b;
+	int i;
+
+	for (i = 0; i < 4; i++) {
+		a = atomic_load_explicit(&s->seq, memory_order_relaxed);
+		*t0 = atomic_load_explicit(&s->start_ns,
+					   memory_order_relaxed);
+		b = atomic_load_explicit(&s->seq, memory_order_relaxed);
+
+		if (a != b)
+			continue;
+		*seq = a;
+		if (!(a & 1) || !*t0) {
+			*op = -1;
+			return SLOT_IDLE;
+		}
+		*op = atomic_load_explicit(&s->op, memory_order_relaxed);
+		return SLOT_BUSY;
+	}
+	return SLOT_TORN;
+}
+
+/*
+ * Report an operation that has been in flight for longer than
+ * g_watchdog seconds.  Each (worker, seq) pair is reported once so a
+ * genuinely hung request does not flood the log.
+ */
+static void *watchdog_fn(void *arg)
+{
+	static unsigned long reported[MAX_WORKERS];
+	uint64_t thresh = (uint64_t)g_watchdog * 1000000000ull;
+	int i;
+
+	(void)arg;
+
+	while (!g_stop) {
+		uint64_t now;
+		bool dump;
+
+		msleep(500);
+		dump = g_dump;
+		g_dump = 0;
+		now = now_ns();
+
+		for (i = 0; i < g_nworkers; i++) {
+			struct slot *s = &g_slot[i];
+			unsigned long seq;
+			uint64_t t0;
+			int op;
+
+			if (read_slot(s, &seq, &t0, &op) != SLOT_BUSY)
+				continue;
+
+			/*
+			 * Take "now" per slot, after the slot is confirmed
+			 * busy: a worker can publish between the scan-wide
+			 * timestamp above and this read, putting t0 in the
+			 * future relative to it and wrapping the elapsed
+			 * computation.  t0 was read inside read_slot() and
+			 * the clock is monotonic, so now >= t0 here.
+			 */
+			now = now_ns();
+
+			if (dump) {
+				printf("INFLIGHT: worker=%d op=%s elapsed=%.1fs path=%s\n",
+				       i, op_name[op],
+				       (double)(now - t0) / 1e9, s->path);
+				continue;
+			}
+
+			if (now - t0 < thresh || reported[i] == seq)
+				continue;
+
+			reported[i] = seq;
+			atomic_fetch_add_explicit(&g_slow_events, 1,
+						  memory_order_relaxed);
+			printf("SLOW: worker=%d op=%s elapsed=%.1fs path=%s\n",
+			       i, op_name[op], (double)(now - t0) / 1e9,
+			       s->path);
+			fflush(stdout);
+		}
+		if (dump)
+			fflush(stdout);
+	}
+
+	return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* victims							      */
+/* ------------------------------------------------------------------ */
+
+/*
+ * A victim is a separate single threaded process running the same
+ * operation mix in its own subtree.  The killer thread SIGKILLs it at
+ * random and restarts it.  When the victim happens to be blocked on a
+ * request that is parked on a wait list, the kill aborts that request
+ * while the client may be draining the very same list.
+ */
+static pid_t spawn_victim(int idx)
+{
+	char dir[PATH_MAX], seed[32], nw[32];
+	pid_t pid;
+
+	snprintf(dir, sizeof(dir), "%s/v%02d", g_root, idx);
+	snprintf(seed, sizeof(seed), "%u",
+		 (unsigned)(now_ns() ^ ((uint64_t)idx << 16)));
+	snprintf(nw, sizeof(nw), "%d", g_nworkers);
+
+	pid = fork();
+	if (pid < 0)
+		return -1;
+	if (pid == 0) {
+		/* do not outlive the parent if it is killed outright */
+		prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0);
+		/*
+		 * Re-exec immediately: fork() from a multithreaded parent
+		 * only guarantees async-signal-safe calls in the child.
+		 */
+		execl(g_self, "mdsc_stress", "--victim", dir, seed, nw,
+		      (char *)NULL);
+		_exit(127);
+	}
+	return pid;
+}
+
+/*
+ * Reap a SIGKILLed victim, but never block forever on it: a task that
+ * is inside an MDS request only dies once the request is aborted, and
+ * if that never happens the run must still be able to report the hang
+ * instead of stalling here.
+ */
+static void reap_victim(pid_t pid, int timeout_ms)
+{
+	int waited = 0;
+
+	while (waited < timeout_ms) {
+		if (waitpid(pid, NULL, WNOHANG) == pid)
+			return;
+		msleep(50);
+		waited += 50;
+	}
+	fprintf(stderr, "WARNING: victim %d did not die within %dms\n",
+		(int)pid, timeout_ms);
+}
+
+static void *killer_fn(void *arg)
+{
+	unsigned int seed = (unsigned int)now_ns();
+	int span = g_kill_max_ms - g_kill_min_ms;
+	int i;
+
+	(void)arg;
+
+	if (span < 1)
+		span = 1;
+
+	while (!g_stop) {
+		pid_t pid;
+		int idx;
+
+		msleep(g_kill_min_ms + rand_r(&seed) % span);
+		if (g_stop)
+			break;
+
+		idx = rand_r(&seed) % g_nvictims;
+
+		pthread_mutex_lock(&g_victim_lock);
+		pid = g_victim[idx];
+		if (pid > 0) {
+			kill(pid, SIGKILL);
+			reap_victim(pid, 30000);
+			g_victim[idx] = 0;
+			atomic_fetch_add_explicit(&g_victim_kills, 1,
+						  memory_order_relaxed);
+		}
+		if (!g_stop)
+			g_victim[idx] = spawn_victim(idx);
+		pthread_mutex_unlock(&g_victim_lock);
+
+		/* reap and restart victims that died on their own */
+		pthread_mutex_lock(&g_victim_lock);
+		for (i = 0; i < g_nvictims; i++) {
+			if (g_victim[i] <= 0)
+				continue;
+			if (waitpid(g_victim[i], NULL, WNOHANG) ==
+			    g_victim[i])
+				g_victim[i] = g_stop ? 0 : spawn_victim(i);
+		}
+		pthread_mutex_unlock(&g_victim_lock);
+	}
+
+	pthread_mutex_lock(&g_victim_lock);
+	for (i = 0; i < g_nvictims; i++) {
+		if (g_victim[i] > 0)
+			kill(g_victim[i], SIGKILL);
+	}
+	for (i = 0; i < g_nvictims; i++) {
+		if (g_victim[i] > 0) {
+			reap_victim(g_victim[i], 30000);
+			g_victim[i] = 0;
+		}
+	}
+	pthread_mutex_unlock(&g_victim_lock);
+
+	return NULL;
+}
+
+static int victim_main(const char *dir, unsigned int seed, int nworkers)
+{
+	char pub[PATH_MAX];
+	char *slash;
+
+	/*
+	 * OP_CROSS builds paths from g_root, which the option parser
+	 * never fills in for a victim: derive it from the victim's own
+	 * directory ("<root>/vNN") so that cross-rank traffic stays
+	 * inside the test tree.
+	 */
+	snprintf(g_root, sizeof(g_root), "%s", dir);
+	slash = strrchr(g_root, '/');
+	if (slash && slash != g_root)
+		*slash = '\0';
+	if (nworkers > 0 && nworkers <= MAX_WORKERS)
+		g_nworkers = nworkers;
+
+	if (mkdir(dir, 0755) < 0 && errno != EEXIST)
+		return 1;
+
+	/*
+	 * No stop condition: the process exists to be SIGKILLed while it
+	 * is blocked inside an MDS request.
+	 */
+	for (;;) {
+		int op = op_pick[rand_r(&seed) % op_pick_nr];
+
+		run_op(dir, op, &seed, pub, sizeof(pub));
+	}
+	return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* setup / teardown / reporting					      */
+/* ------------------------------------------------------------------ */
+
+static void mkdir_p(const char *path)
+{
+	if (mkdir(path, 0755) < 0 && errno != EEXIST)
+		die("mkdir %s: %s", path, strerror(errno));
+}
+
+static void rm_rf(const char *path)
+{
+	char cmd[PATH_MAX + 32];
+
+	snprintf(cmd, sizeof(cmd), "rm -rf -- '%s'", path);
+	if (system(cmd) != 0)
+		fprintf(stderr, "mdsc_stress: cleanup of %s failed\n", path);
+}
+
+static void report(int hung, int bad)
+{
+	unsigned long tot[OP_NR] = { 0 };
+	unsigned long cls[4] = { 0 };
+	unsigned long errno_hist[256] = { 0 };
+	unsigned long lat[LAT_BUCKETS] = { 0 };
+	uint64_t max_lat = 0;
+	int max_lat_op = 0;
+	unsigned long total = 0;
+	double secs;
+	int i, op;
+
+	for (i = 0; i < g_nworkers; i++) {
+		struct worker *w = &g_worker[i];
+
+		for (op = 0; op < OP_NR; op++) {
+			int c;
+
+			tot[op] += w->ops[op];
+			total += w->ops[op];
+			for (c = 0; c < 4; c++)
+				cls[c] += w->errs[op][c];
+		}
+		for (op = 0; op < 256; op++)
+			errno_hist[op] += w->errno_hist[op];
+		for (op = 0; op < LAT_BUCKETS; op++)
+			lat[op] += w->lat[op];
+		if (w->max_lat_ns > max_lat) {
+			max_lat = w->max_lat_ns;
+			max_lat_op = w->max_lat_op;
+		}
+	}
+
+	secs = (double)(now_ns() - g_start_ns) / 1e9;
+
+	printf("\n===== mdsc_stress summary =====\n");
+	printf("duration      : %.1fs\n", secs);
+	printf("workers       : %d\n", g_nworkers);
+	printf("victims       : %d (killed %d times)\n", g_nvictims,
+	       atomic_load(&g_victim_kills));
+	printf("operations    : %lu (%.0f op/s)\n", total,
+	       secs > 0 ? total / secs : 0.0);
+	printf("  ok          : %lu\n", cls[ERR_OK]);
+	printf("  benign      : %lu\n", cls[ERR_BENIGN]);
+	printf("  chaos       : %lu\n", cls[ERR_CHAOS]);
+	printf("  unexpected  : %lu\n", cls[ERR_BAD]);
+	printf("slow events   : %d (> %ds in flight)\n",
+	       atomic_load(&g_slow_events), g_watchdog);
+	printf("max latency   : %.1fs (%s)\n", (double)max_lat / 1e9,
+	       op_name[max_lat_op]);
+
+	printf("\nper operation:\n");
+	for (op = 0; op < OP_NR; op++) {
+		if (!tot[op])
+			continue;
+		printf("  %-9s %8lu\n", op_name[op], tot[op]);
+	}
+
+	printf("\nerrno histogram:\n");
+	for (i = 0; i < 256; i++) {
+		if (errno_hist[i])
+			printf("  %-14s %8lu\n", strerror(i), errno_hist[i]);
+	}
+
+	if (g_verbose) {
+		printf("\nlatency (log2 us buckets):\n");
+		for (i = 0; i < LAT_BUCKETS; i++) {
+			if (lat[i])
+				printf("  2^%-2d us %10lu\n", i, lat[i]);
+		}
+	}
+
+	printf("\nRESULT: %s\n",
+	       (hung || bad) ? "FAIL" : "PASS");
+	if (hung)
+		printf("REASON: %d worker(s) still blocked in an MDS request "
+		       "(suspected lost wakeup)\n", hung);
+	if (bad)
+		printf("REASON: %lu unexpected errno(s)\n", cls[ERR_BAD]);
+	fflush(stdout);
+}
+
+static void usage(void)
+{
+	fprintf(stderr,
+"usage: mdsc_stress -d <dir> [options]\n"
+"  -d DIR      test directory on a cephfs mount (required)\n"
+"  -t N        worker threads              (default 16)\n"
+"  -s SEC      run duration, 0 = until signalled (default 60)\n"
+"  -w SEC      watchdog threshold          (default 120)\n"
+"  -k N        victim processes, 0 = off   (default 6)\n"
+"  -K MIN:MAX  victim kill interval in ms  (default 200:2000)\n"
+"  -i SEC      progress interval, 0 = off  (default 10)\n"
+"  -C          keep the test tree on exit\n"
+"  -v          verbose (latency histogram)\n");
+	exit(3);
+}
+
+int main(int argc, char **argv)
+{
+	pthread_t watchdog, killer;
+	struct timespec deadline;
+	struct sigaction sa;
+	int i, c, hung = 0, bad = 0;
+	unsigned long last_ops = 0;
+	uint64_t last_report;
+	ssize_t n;
+
+	build_op_table();
+
+	if (argc >= 4 && !strcmp(argv[1], "--victim"))
+		return victim_main(argv[2],
+				   (unsigned int)strtoul(argv[3], NULL, 0),
+				   argc >= 5 ? atoi(argv[4]) : 0);
+
+	while ((c = getopt(argc, argv, "d:t:s:w:k:K:i:Cvh")) != -1) {
+		switch (c) {
+		case 'd':
+			snprintf(g_root, sizeof(g_root), "%s", optarg);
+			break;
+		case 't':
+			g_nworkers = atoi(optarg);
+			break;
+		case 's':
+			g_seconds = atoi(optarg);
+			break;
+		case 'w':
+			g_watchdog = atoi(optarg);
+			break;
+		case 'k':
+			g_nvictims = atoi(optarg);
+			break;
+		case 'K':
+			if (sscanf(optarg, "%d:%d", &g_kill_min_ms,
+				   &g_kill_max_ms) != 2)
+				usage();
+			break;
+		case 'i':
+			g_report = atoi(optarg);
+			break;
+		case 'C':
+			g_keep = true;
+			break;
+		case 'v':
+			g_verbose = true;
+			break;
+		default:
+			usage();
+		}
+	}
+
+	if (!g_root[0])
+		usage();
+	if (g_nworkers < 1 || g_nworkers > MAX_WORKERS)
+		die("threads must be 1..%d", MAX_WORKERS);
+	if (g_nvictims < 0 || g_nvictims > MAX_VICTIMS)
+		die("victims must be 0..%d", MAX_VICTIMS);
+
+	n = readlink("/proc/self/exe", g_self, sizeof(g_self) - 1);
+	if (n < 0)
+		die("readlink /proc/self/exe: %s", strerror(errno));
+	g_self[n] = '\0';
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = on_stop;
+	sigaction(SIGTERM, &sa, NULL);
+	sigaction(SIGINT, &sa, NULL);
+	sa.sa_handler = on_dump;
+	sigaction(SIGUSR1, &sa, NULL);
+	signal(SIGPIPE, SIG_IGN);
+
+	mkdir_p(g_root);
+	for (i = 0; i < g_nworkers; i++) {
+		struct worker *w = &g_worker[i];
+
+		w->idx = i;
+		w->seed = (unsigned int)(now_ns() >> 3) + i * 2654435761u;
+		snprintf(w->dir, sizeof(w->dir), "%s/w%02d", g_root, i);
+		mkdir_p(w->dir);
+	}
+
+	printf("mdsc_stress: root=%s workers=%d victims=%d duration=%ds "
+	       "watchdog=%ds\n", g_root, g_nworkers, g_nvictims, g_seconds,
+	       g_watchdog);
+	fflush(stdout);
+
+	g_start_ns = now_ns();
+	last_report = g_start_ns;
+
+	for (i = 0; i < g_nvictims; i++)
+		g_victim[i] = spawn_victim(i);
+
+	for (i = 0; i < g_nworkers; i++) {
+		if (pthread_create(&g_worker[i].tid, NULL, worker_fn,
+				   &g_worker[i]))
+			die("pthread_create: %s", strerror(errno));
+	}
+	if (pthread_create(&watchdog, NULL, watchdog_fn, NULL))
+		die("pthread_create watchdog: %s", strerror(errno));
+	if (g_nvictims && pthread_create(&killer, NULL, killer_fn, NULL))
+		die("pthread_create killer: %s", strerror(errno));
+
+	while (!g_stop) {
+		uint64_t now;
+
+		msleep(200);
+		now = now_ns();
+
+		if (g_seconds > 0 &&
+		    now - g_start_ns >= (uint64_t)g_seconds * 1000000000ull)
+			g_stop = 1;
+
+		if (g_report > 0 &&
+		    now - last_report >= (uint64_t)g_report * 1000000000ull) {
+			unsigned long ops = atomic_load(&g_total_ops);
+
+			printf("[%6.0fs] ops=%lu (+%lu, %.0f op/s) slow=%d "
+			       "kills=%d\n",
+			       (double)(now - g_start_ns) / 1e9, ops,
+			       ops - last_ops,
+			       (double)(ops - last_ops) /
+			       ((double)(now - last_report) / 1e9),
+			       atomic_load(&g_slow_events),
+			       atomic_load(&g_victim_kills));
+			fflush(stdout);
+			last_ops = ops;
+			last_report = now;
+		}
+	}
+
+	g_stop = 1;
+
+	if (g_nvictims)
+		pthread_join(killer, NULL);
+	pthread_join(watchdog, NULL);
+
+	/*
+	 * The definitive lost-wakeup oracle: after the run has been told
+	 * to stop, every worker must come back.  A worker that is still
+	 * inside an MDS request 60s later is either waiting for a reply
+	 * that will never arrive or was never re-dispatched.
+	 */
+	clock_gettime(CLOCK_REALTIME, &deadline);
+	deadline.tv_sec += 60;
+
+	for (i = 0; i < g_nworkers; i++) {
+		unsigned long seq;
+		uint64_t t0;
+		int op;
+
+		if (pthread_timedjoin_np(g_worker[i].tid, NULL,
+					 &deadline) == 0) {
+			g_worker[i].joined = true;
+			continue;
+		}
+
+		hung++;
+		if (read_slot(&g_slot[i], &seq, &t0, &op) != SLOT_BUSY)
+			printf("HUNG: worker=%d (slot %s)\n", i,
+			       seq & 1 ? "mid-publication" : "idle");
+		else
+			printf("HUNG: worker=%d op=%s elapsed=%.1fs path=%s\n",
+			       i, op_name[op],
+			       (double)(now_ns() - t0) / 1e9,
+			       g_slot[i].path);
+		fflush(stdout);
+	}
+
+	for (i = 0; i < g_nworkers; i++) {
+		int op;
+
+		for (op = 0; op < OP_NR; op++)
+			bad += (int)g_worker[i].errs[op][ERR_BAD];
+	}
+
+	report(hung, bad);
+
+	if (!g_keep && !hung)
+		rm_rf(g_root);
+
+	if (hung)
+		return 1;
+	if (bad)
+		return 2;
+	return 0;
+}

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2028,6 +2028,16 @@ bool Locker::wrlock_start(const MutationImpl::LockOp &op, const MDRequestRef& mu
 	dout(10) << "requesting scatter from auth on "
 		 << *lock << " on " << *lock->get_parent() << dendl;
 	mds->send_message_mds(make_message<MLock>(lock, LOCK_AC_REQSCATTER, mds->get_nodeid()), auth);
+      } else {
+	/*
+	 * The scatter request cannot be sent (or answered) while the
+	 * auth is down.  Wait for the rank to come back and retry
+	 * instead of parking the request on WAIT_STABLE forever: no
+	 * lock state change will ever fire that waiter.
+	 */
+	dout(10) << "auth mds." << auth << " is down, waiting for it to come back"
+		 << dendl;
+	mds->wait_for_active_peer(auth, new C_MDS_RetryRequest(mdcache, mut));
       }
       break;
     }

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -13193,10 +13193,24 @@ int MDCache::dump_cache(std::string_view fn, Formatter *f, double timeout)
 
 void C_MDS_RetryRequest::finish(int r)
 {
-  mdr->retry++;
-  if (mdr) {
-    cache->dispatch_request(mdr);
+  if (!mdr || mdr->committing) {
+    /*
+     * The request's journal entry is already in flight: this is a
+     * stale waiter firing.  A lock waiter registered on an earlier
+     * retry (e.g. the WAIT_STABLE waiter parked by wrlock_start() on
+     * a gathering scatterlock) stays queued on the lock, and when
+     * the lock state eventually changes -- long after the mutation
+     * acquired the lock through another path, projected its linkage
+     * changes and submitted the journal -- the waiter fires here.
+     * Re-dispatching the request now would re-enter its handler
+     * mid-operation and trip the entry-state assertions; the
+     * journal finisher completes the request.
+     */
+    dout(10) << __func__ << " on a committing request, ignoring" << dendl;
+    return;
   }
+  mdr->retry++;
+  cache->dispatch_request(mdr);
 }
 
 MDSContext *CF_MDS_RetryRequestFactory::build()

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4852,94 +4852,116 @@ void Server::handle_client_openc(const MDRequestRef& mdr)
   if (!dn)
     return;
 
+  CDir *dir = dn->get_dir();
+  CInode *diri = dir->get_inode();
+
   CDentry::linkage_t *dnl = dn->get_projected_linkage();
-  if (!excl && !dnl->is_null()) {
+  if (!dnl->is_null() && mdr->committing) {
+    /*
+     * Retried after the create was already journaled in a previous
+     * pass: the dn locks are no longer guaranteed to be held and
+     * re-running the create would double-create.  The finisher
+     * (C_MDS_openc_finish) will complete the request once the
+     * journal entry commits.
+     */
+    return;
+  }
+
+  CInode *newi;
+  if (!dnl->is_null() && mdr->is_xlocked(&dn->lock)) {
+    /*
+     * Retried after the create was projected in a previous pass:
+     * the projected linkage is our own.  Resume just after the
+     * projection instead of re-running the create (which would
+     * double-create) or taking the "it existed" branch below
+     * (which would reply without journaling the create).
+     */
+    newi = dnl->get_inode();
+  } else if (!excl && !dnl->is_null()) {
     // it existed.
     ceph_assert(mdr.get()->is_rdlocked(&dn->lock));
 
     handle_client_open(mdr);
     return;
-  }
+  } else {
+    ceph_assert(dnl->is_null());
 
-  ceph_assert(dnl->is_null());
-
-  if (!can_handle_charmap(mdr, dn)) {
-    return;
-  }
-
-  if (req->get_alternate_name().size() > alternate_name_max) {
-    dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
-    respond_to_request(mdr, -ENAMETOOLONG);
-    return;
-  }
-  dn->set_alternate_name(req->get_alternate_name());
-
-  // set layout
-  file_layout_t layout;
-  if (mdr->dir_layout != file_layout_t())
-    layout = mdr->dir_layout;
-  else
-    layout = mdcache->default_file_layout;
-
-  // What kind of client caps are required to complete this operation
-  uint64_t access = MAY_WRITE;
-
-  const auto default_layout = layout;
-
-  // fill in any special params from client
-  if (req->head.args.open.stripe_unit)
-    layout.stripe_unit = req->head.args.open.stripe_unit;
-  if (req->head.args.open.stripe_count)
-    layout.stripe_count = req->head.args.open.stripe_count;
-  if (req->head.args.open.object_size)
-    layout.object_size = req->head.args.open.object_size;
-  if (req->get_connection()->has_feature(CEPH_FEATURE_CREATEPOOLID) &&
-      (__s32)req->head.args.open.pool >= 0) {
-    layout.pool_id = req->head.args.open.pool;
-
-    // make sure we have as new a map as the client
-    if (req->get_mdsmap_epoch() > mds->mdsmap->get_epoch()) {
-      mds->wait_for_mdsmap(req->get_mdsmap_epoch(), new C_MDS_RetryRequest(mdcache, mdr));
+    if (!can_handle_charmap(mdr, dn)) {
       return;
     }
+
+    if (req->get_alternate_name().size() > alternate_name_max) {
+      dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
+      respond_to_request(mdr, -ENAMETOOLONG);
+      return;
+    }
+    dn->set_alternate_name(req->get_alternate_name());
+
+    // set layout
+    file_layout_t layout;
+    if (mdr->dir_layout != file_layout_t())
+      layout = mdr->dir_layout;
+    else
+      layout = mdcache->default_file_layout;
+
+    // What kind of client caps are required to complete this operation
+    uint64_t access = MAY_WRITE;
+
+    const auto default_layout = layout;
+
+    // fill in any special params from client
+    if (req->head.args.open.stripe_unit)
+      layout.stripe_unit = req->head.args.open.stripe_unit;
+    if (req->head.args.open.stripe_count)
+      layout.stripe_count = req->head.args.open.stripe_count;
+    if (req->head.args.open.object_size)
+      layout.object_size = req->head.args.open.object_size;
+    if (req->get_connection()->has_feature(CEPH_FEATURE_CREATEPOOLID) &&
+        (__s32)req->head.args.open.pool >= 0) {
+      layout.pool_id = req->head.args.open.pool;
+
+      // make sure we have as new a map as the client
+      if (req->get_mdsmap_epoch() > mds->mdsmap->get_epoch()) {
+        mds->wait_for_mdsmap(req->get_mdsmap_epoch(), new C_MDS_RetryRequest(mdcache, mdr));
+        return;
+      }
+    }
+
+    // If client doesn't have capability to modify layout pools, then
+    // only permit this request if the requested pool matches what the
+    // file would have inherited anyway from its parent.
+    if (default_layout != layout) {
+      access |= MAY_SET_VXATTR;
+    }
+
+    if (!is_valid_layout(&layout)) {
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+
+    // created null dn.
+    if (!check_access(mdr, diri, access))
+      return;
+    if (!check_fragment_space(mdr, dir))
+      return;
+    if (!check_dir_max_entries(mdr, dir))
+      return;
+
+    if (mds_allow_async_dirops && mdr->dn[0].size() == 1)
+      mds->locker->create_lock_cache(mdr, diri, &mdr->dir_layout);
+
+    // create inode.
+    newi = prepare_new_inode(mdr, dn->get_dir(), inodeno_t(req->head.ino),
+			     req->head.args.open.mode | S_IFREG, &layout);
+    ceph_assert(newi);
+
+    // it's a file.
+    dn->push_projected_linkage(newi);
   }
-
-  // If client doesn't have capability to modify layout pools, then
-  // only permit this request if the requested pool matches what the
-  // file would have inherited anyway from its parent.
-  if (default_layout != layout) {
-    access |= MAY_SET_VXATTR;
-  }
-
-  if (!is_valid_layout(&layout)) {
-    respond_to_request(mdr, -EINVAL);
-    return;
-  }
-
-  // created null dn.
-  CDir *dir = dn->get_dir();
-  CInode *diri = dir->get_inode();
-  if (!check_access(mdr, diri, access))
-    return;
-  if (!check_fragment_space(mdr, dir))
-    return;
-  if (!check_dir_max_entries(mdr, dir))
-    return;
-
-  if (mds_allow_async_dirops && mdr->dn[0].size() == 1)
-    mds->locker->create_lock_cache(mdr, diri, &mdr->dir_layout);
-
-  // create inode.
-  CInode *newi = prepare_new_inode(mdr, dn->get_dir(), inodeno_t(req->head.ino),
-				   req->head.args.open.mode | S_IFREG, &layout);
-  ceph_assert(newi);
-
-  // it's a file.
-  dn->push_projected_linkage(newi);
 
   auto _inode = newi->_get_inode();
   _inode->version = dn->pre_dirty();
-  if (layout.pool_id != mdcache->default_file_layout.pool_id)
+  if (_inode->layout.pool_id != mdcache->default_file_layout.pool_id)
     _inode->add_old_pool(mdcache->default_file_layout.pool_id);
   _inode->update_backtrace();
   _inode->rstat.rfiles = 1;
@@ -7496,37 +7518,59 @@ void Server::handle_client_mknod(const MDRequestRef& mdr)
   if (!check_dir_max_entries(mdr, dir))
     return;
 
-  ceph_assert(dn->get_projected_linkage()->is_null());
-  if (req->get_alternate_name().size() > alternate_name_max) {
-    dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
-    respond_to_request(mdr, -ENAMETOOLONG);
+  CInode *newi;
+  CDentry::linkage_t *dnl = dn->get_projected_linkage();
+  if (!dnl->is_null() && mdr->committing) {
+    /*
+     * Retried after the create was already journaled in a previous
+     * pass: the dn locks are no longer guaranteed to be held and
+     * re-running the create would double-create.  The finisher
+     * (C_MDS_mknod_finish) will complete the request once the
+     * journal entry commits.
+     */
     return;
   }
-  dn->set_alternate_name(req->get_alternate_name());
+  if (!dnl->is_null() && mdr->is_xlocked(&dn->lock)) {
+    /*
+     * Retried after the create was projected in a previous pass:
+     * the projected linkage is our own.  Resume just after the
+     * projection instead of re-running the create (which would
+     * double-create).
+     */
+    newi = dnl->get_inode();
+  } else {
+    ceph_assert(dnl->is_null());
+    if (req->get_alternate_name().size() > alternate_name_max) {
+      dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
+      respond_to_request(mdr, -ENAMETOOLONG);
+      return;
+    }
+    dn->set_alternate_name(req->get_alternate_name());
 
-  // set layout
-  file_layout_t layout;
-  if (mdr->dir_layout != file_layout_t())
-    layout = mdr->dir_layout;
-  else
-    layout = mdcache->default_file_layout;
+    // set layout
+    file_layout_t layout;
+    if (mdr->dir_layout != file_layout_t())
+      layout = mdr->dir_layout;
+    else
+      layout = mdcache->default_file_layout;
 
-  if (!is_valid_layout(&layout)) {
-    respond_to_request(mdr, -EINVAL);
-    return;
+    if (!is_valid_layout(&layout)) {
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+
+    newi = prepare_new_inode(mdr, dn->get_dir(), inodeno_t(req->head.ino), mode, &layout);
+    ceph_assert(newi);
+
+    dn->push_projected_linkage(newi);
   }
-
-  CInode *newi = prepare_new_inode(mdr, dn->get_dir(), inodeno_t(req->head.ino), mode, &layout);
-  ceph_assert(newi);
-
-  dn->push_projected_linkage(newi);
 
   auto _inode = newi->_get_inode();
   _inode->version = dn->pre_dirty();
   _inode->rdev = req->head.args.mknod.rdev;
   _inode->rstat.rfiles = 1;
   _inode->accounted_rstat = _inode->rstat;
-  if (layout.pool_id != mdcache->default_file_layout.pool_id)
+  if (_inode->layout.pool_id != mdcache->default_file_layout.pool_id)
     _inode->add_old_pool(mdcache->default_file_layout.pool_id);
   _inode->update_backtrace();
 
@@ -7600,28 +7644,50 @@ void Server::handle_client_mkdir(const MDRequestRef& mdr)
   if (!check_dir_max_entries(mdr, dir))
     return;
 
-  ceph_assert(dn->get_projected_linkage()->is_null());
-
-  if (!can_handle_charmap(mdr, dn)) {
+  CInode *newi;
+  CDentry::linkage_t *dnl = dn->get_projected_linkage();
+  if (!dnl->is_null() && mdr->committing) {
+    /*
+     * Retried after the create was already journaled in a previous
+     * pass: the dn locks are no longer guaranteed to be held and
+     * re-running the create would double-create.  The finisher
+     * (C_MDS_mknod_finish) will complete the request once the
+     * journal entry commits.
+     */
     return;
   }
+  if (!dnl->is_null() && mdr->is_xlocked(&dn->lock)) {
+    /*
+     * Retried after the create was projected in a previous pass:
+     * the projected linkage is our own.  Resume just after the
+     * projection instead of re-running the create (which would
+     * double-create).
+     */
+    newi = dnl->get_inode();
+  } else {
+    ceph_assert(dnl->is_null());
 
-  if (req->get_alternate_name().size() > alternate_name_max) {
-    dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
-    respond_to_request(mdr, -ENAMETOOLONG);
-    return;
+    if (!can_handle_charmap(mdr, dn)) {
+      return;
+    }
+
+    if (req->get_alternate_name().size() > alternate_name_max) {
+      dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
+      respond_to_request(mdr, -ENAMETOOLONG);
+      return;
+    }
+    dn->set_alternate_name(req->get_alternate_name());
+
+    // new inode
+    unsigned mode = req->head.args.mkdir.mode;
+    mode &= ~S_IFMT;
+    mode |= S_IFDIR;
+    newi = prepare_new_inode(mdr, dir, inodeno_t(req->head.ino), mode);
+    ceph_assert(newi);
+
+    // it's a directory.
+    dn->push_projected_linkage(newi);
   }
-  dn->set_alternate_name(req->get_alternate_name());
-
-  // new inode
-  unsigned mode = req->head.args.mkdir.mode;
-  mode &= ~S_IFMT;
-  mode |= S_IFDIR;
-  CInode *newi = prepare_new_inode(mdr, dir, inodeno_t(req->head.ino), mode);
-  ceph_assert(newi);
-
-  // it's a directory.
-  dn->push_projected_linkage(newi);
 
   auto* _inode = newi->_get_inode();
   _inode->version = dn->pre_dirty();
@@ -7702,25 +7768,47 @@ void Server::handle_client_symlink(const MDRequestRef& mdr)
   if (!check_dir_max_entries(mdr, dir))
     return;
 
-  ceph_assert(dn->get_projected_linkage()->is_null());
-
-  if (!can_handle_charmap(mdr, dn)) {
+  CInode *newi = nullptr;
+  CDentry::linkage_t *dnl = dn->get_projected_linkage();
+  if (!dnl->is_null() && mdr->committing) {
+    /*
+     * Retried after the create was already journaled in a previous
+     * pass: the dn locks are no longer guaranteed to be held and
+     * re-running the create would double-create.  The finisher
+     * (C_MDS_mknod_finish) will complete the request once the
+     * journal entry commits.
+     */
     return;
   }
+  if (!dnl->is_null() && mdr->is_xlocked(&dn->lock)) {
+    /*
+     * Retried after the create was projected in a previous pass:
+     * the projected linkage is our own.  Resume just after the
+     * projection instead of re-running the create (which would
+     * double-create).
+     */
+    newi = dnl->get_inode();
+  } else {
+    ceph_assert(dnl->is_null());
 
-  if (req->get_alternate_name().size() > alternate_name_max) {
-    dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
-    respond_to_request(mdr, -ENAMETOOLONG);
-    return;
+    if (!can_handle_charmap(mdr, dn)) {
+      return;
+    }
+
+    if (req->get_alternate_name().size() > alternate_name_max) {
+      dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
+      respond_to_request(mdr, -ENAMETOOLONG);
+      return;
+    }
+    dn->set_alternate_name(req->get_alternate_name());
+
+    unsigned mode = S_IFLNK | 0777;
+    newi = prepare_new_inode(mdr, dir, inodeno_t(req->head.ino), mode);
+    ceph_assert(newi);
+
+    // it's a symlink
+    dn->push_projected_linkage(newi);
   }
-  dn->set_alternate_name(req->get_alternate_name());
-
-  unsigned mode = S_IFLNK | 0777;
-  CInode *newi = prepare_new_inode(mdr, dir, inodeno_t(req->head.ino), mode);
-  ceph_assert(newi);
-
-  // it's a symlink
-  dn->push_projected_linkage(newi);
 
   newi->symlink = req->get_path2();
   auto _inode = newi->_get_inode();


### PR DESCRIPTION
Under double-failover stress (two ranks failed back-to-back while
metadata load is in flight), two request-dispatch bugs surface.
Fix both, and add the teuthology test that reproduces them.

### mds: retry wrlock on a replica when the scatter auth is down
(#80084)

`Locker::wrlock_start()` on a replica inode asks the auth rank for
the scatter when the lock can't be taken directly.  When the auth
rank is down, the request is parked on the lock's WAIT_STABLE waiter
list without sending a scatter request and without queueing any
recovery callback — the only possible wakeup is a lock state change
that will never happen, and every later request touching the same
lock wedges behind it:

    client_request(client.4275:2606277 rename ...) currently failed
    to wrlock, waiting

The rdlock path and `remote_wrlock_start()` already wait for the
Also fixes a regression from 8ea6e084e66d ("mds: optimize state
check of peer mds").

### mds: ignore retries of committing requests
(#80086)

A stale `C_MDS_RetryRequest` waiter can re-dispatch a request from
scratch after it has already projected its linkage changes and
submitted the journal entry.  The handlers re-enter, see their own
projected state instead of the pre-operation state, and trip their
assertions (mknod's null-linkage assert, openc's is_rdlocked()
assert, unlink's !is_null() assert — all seen crashing MDSes during
failover stress).

Since `mdr->committing` is set by `journal_and_reply()` and never
cleared before the request completes, and no journal code path uses
`C_MDS_RetryRequest`, a retry of a committing request is always
stale: the only valid forward progress is the journal finisher.
Ignore it in `C_MDS_RetryRequest::finish()`, and make the create
handlers (openc/mknod/mkdir/symlink) tolerant of retry re-entry as
defense in depth.

### QA

Teuthology port of the r2 reproducer (`run_mdsc_test.sh -p r2`):

- `qa/workunits/fs/mdsc_stress/mdsc_stress.c` — POSIX-only metadata
  load generator: 8 workers running a weighted mix of 19 metadata
  operations (write-heavy, fsync-light, so unsafe requests replay on
  reconnect), a watchdog reporting operations stuck in flight
  (#80084's symptom), and victim processes SIGKILLed and restarted
  every 200–2000 ms.
- `qa/tasks/cephfs/test_mdsc_stress.py` — `test_load_only` (smoke)
  and `test_double_failover` (240 s of back-to-back rank failures
  plus occasional `ceph.dir.pin` re-rolls, then settle and dump
  in-flight operations).  Runs on kernel client and ceph-fuse; on
  kclient it also scans dmesg for kernel splats.
- `qa/suites/fs/functional/tasks/mdsc-stress.yaml` — fs:functional
  registration with an ignorelist for expected failover noise.

Two small qa framework fixes found while running locally:
`--yes-i-really-mean-it` typo in `rank_fail()`, and vstart_runner
kernel client key handling/blocklist check.

Fixes: https://tracker.ceph.com/issues/80084
Fixes: https://tracker.ceph.com/issues/80086





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
