### PR TITLE
cephadm: fix timezone-naive certificate expiry check

### DIFF
--- a/src/pybind/mgr/cephadm/ssl_cert_utils.py
+++ b/src/pybind/mgr/cephadm/ssl_cert_utils.py
@@ -2,7 +2,7 @@
 from typing import Any, Tuple, IO, List, Union, Optional, Dict
 import ipaddress
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from cryptography import x509
 from cryptography.x509 import Certificate
 from cryptography.x509.oid import NameOID, ExtensionOID
@@ -342,8 +342,20 @@ class SSLCerts:
 
     def load_root_credentials(self, cert: str, priv_key: str) -> None:
         given_cert = x509.load_pem_x509_certificate(cert.encode('utf-8'), backend=default_backend())
-        tz = given_cert.not_valid_after.tzinfo
-        if datetime.now(tz) >= given_cert.not_valid_after:
+        # `not_valid_after` returns a timezone-naive datetime whose value is
+        # in UTC. Using its (always-None) tzinfo for the comparison silently
+        # produces a naive-local-vs-naive-UTC comparison instead of a correct
+        # UTC-vs-UTC one: on a host running behind UTC this accepts an
+        # already-expired certificate for several hours; on a host running
+        # ahead of UTC this rejects a still-valid certificate as expired.
+        # `not_valid_after_utc` (cryptography >= 42.0) returns a proper
+        # timezone-aware UTC datetime and avoids this entirely; fall back to
+        # treating the naive value as UTC on older cryptography versions.
+        try:
+            not_valid_after = given_cert.not_valid_after_utc
+        except AttributeError:
+            not_valid_after = given_cert.not_valid_after.replace(tzinfo=timezone.utc)
+        if datetime.now(timezone.utc) >= not_valid_after:
             raise SSLConfigException('Given cert is expired')
         self.root_cert = given_cert
         self.root_key = serialization.load_pem_private_key(

--- a/src/pybind/mgr/cephadm/tests/test_load_root_credentials.py
+++ b/src/pybind/mgr/cephadm/tests/test_load_root_credentials.py
@@ -1,0 +1,95 @@
+import os
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.backends import default_backend
+
+from cephadm.ssl_cert_utils import SSLCerts, SSLConfigException
+
+
+def _build_self_signed_cert(not_valid_after):
+    """Build a minimal self-signed cert/key pair with a specific expiry."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-root")])
+    builder = x509.CertificateBuilder().subject_name(name).issuer_name(name)
+    builder = builder.public_key(key.public_key()).serial_number(x509.random_serial_number())
+    builder = builder.not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+    builder = builder.not_valid_after(not_valid_after)
+    cert = builder.sign(private_key=key, algorithm=hashes.SHA256(), backend=default_backend())
+
+    cert_pem = cert.public_bytes(encoding=serialization.Encoding.PEM).decode('utf-8')
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode('utf-8')
+    return cert_pem, key_pem
+
+
+class TestLoadRootCredentialsExpiryCheck(unittest.TestCase):
+    """
+    Regression tests for the UTC-vs-local timezone bug in
+    load_root_credentials(). `not_valid_after` returns a timezone-naive
+    datetime that represents UTC; using its (always-None) tzinfo for the
+    expiry comparison silently degrades to a naive-local-vs-naive-UTC
+    comparison, which is wrong on any mgr host not running in UTC.
+    """
+
+    def setUp(self):
+        self.certs = SSLCerts(fsid="test-fsid-0000")
+
+    def test_valid_cert_is_accepted(self):
+        """A certificate with time remaining must not be rejected as expired."""
+        not_after = datetime.now(timezone.utc) + timedelta(hours=1)
+        cert_pem, key_pem = _build_self_signed_cert(not_after)
+        # Should not raise
+        self.certs.load_root_credentials(cert_pem, key_pem)
+
+    def test_expired_cert_is_rejected(self):
+        """A certificate whose expiry has passed must raise SSLConfigException."""
+        not_after = datetime.now(timezone.utc) - timedelta(minutes=5)
+        cert_pem, key_pem = _build_self_signed_cert(not_after)
+        with self.assertRaises(SSLConfigException):
+            self.certs.load_root_credentials(cert_pem, key_pem)
+
+    def test_expiry_check_is_timezone_independent(self):
+        """
+        The comparison must be based on absolute UTC time, not on the
+        mgr host's local timezone. This directly exercises the bug: the
+        original implementation used `datetime.now(tz)` where `tz` was
+        always None (since `not_valid_after` is naive), which returns
+        naive *local* time and compares it against a naive *UTC* value.
+
+        This test genuinely changes the process's local timezone (via
+        TZ env var + time.tzset(), Unix-only) to IST (UTC+5:30) and
+        confirms a certificate expiring in 1 hour is still correctly
+        accepted. Against the original buggy implementation, this case
+        fails: local IST "now" is ~5.5 hours ahead of the naive-UTC
+        `not_valid_after` value, so the (broken) comparison treats a
+        still-valid certificate as already expired.
+        """
+        original_tz = os.environ.get('TZ')
+        try:
+            os.environ['TZ'] = 'Asia/Kolkata'  # UTC+5:30
+            time.tzset()
+
+            not_after = datetime.now(timezone.utc) + timedelta(hours=1)
+            cert_pem, key_pem = _build_self_signed_cert(not_after)
+
+            # Should not raise, regardless of the process's local timezone
+            self.certs.load_root_credentials(cert_pem, key_pem)
+        finally:
+            if original_tz is not None:
+                os.environ['TZ'] = original_tz
+            else:
+                os.environ.pop('TZ', None)
+            time.tzset()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes a timezone bug in cephadm's certificate expiry check (load_root_credentials): the comparison silently degrades to naive-local-vs-naive-UTC on any mgr host not running in UTC, which can accept an already-expired root CA (hosts behind UTC) or reject a still-valid one (hosts ahead of UTC).

Found while working through a separate cephadm certificate issue in the same file (see #71407). This is a distinct, unrelated bug in a different method, kept as a separate PR so each can be reviewed independently.

The fix uses cryptography's not_valid_after_utc (timezone-aware, available since cryptography 42.0) instead of the deprecated, timezone-naive not_valid_after, with a fallback for older cryptography versions. Comparison is always done in UTC, removing the host-timezone dependency entirely.

Includes 4 regression tests, including one that genuinely forces the process's local timezone to UTC+5:30 (via TZ env var + time.tzset()) and confirms the bug reproduces against the original code and is fixed by this change. Verified passing locally in a standalone environment; full test suite integration will run via CI once labeled.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
