### PR TITLE
cephadm: use timezone-aware datetime for OSD drain timestamps

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -826,7 +826,7 @@ class OSD:
             self.rm_util.set_osd_flag([self], 'out')
         else:
             self.rm_util.reweight_osd(self, 0.0)
-        self.drain_started_at = datetime.utcnow()
+        self.drain_started_at = datetime_now()
         self.draining = True
         logger.debug(f"Started draining {self}.")
         return True
@@ -837,7 +837,7 @@ class OSD:
         else:
             if self.original_weight:
                 self.rm_util.reweight_osd(self, self.original_weight)
-        self.drain_stopped_at = datetime.utcnow()
+        self.drain_stopped_at = datetime_now()
         self.draining = False
         logger.debug(f"Stopped draining {self}.")
         return True
@@ -866,7 +866,7 @@ class OSD:
     def is_empty(self) -> bool:
         if self.get_pg_count() == 0:
             if not self.drain_done_at:
-                self.drain_done_at = datetime.utcnow()
+                self.drain_done_at = datetime_now()
                 self.draining = False
             return True
         return False

--- a/src/pybind/mgr/cephadm/tests/test_osd_removal.py
+++ b/src/pybind/mgr/cephadm/tests/test_osd_removal.py
@@ -145,6 +145,47 @@ class TestOSD:
         assert osd_obj.replace is False
         assert ret is True
 
+    def test_start_draining_sets_timezone_aware_timestamp(self, osd_obj):
+        """
+        Regression test: start_draining() previously used datetime.utcnow(),
+        which returns a timezone-naive datetime. Naive values get
+        mishandled by datetime_to_str()'s astimezone() call (it assumes
+        a naive input is local time and shifts it), causing drain
+        timestamps to be persisted incorrectly on any non-UTC mgr host.
+        drain_started_at must be timezone-aware (UTC) so serialization
+        via datetime_to_str() is correct regardless of host timezone.
+        """
+        osd_obj.start_draining()
+        assert osd_obj.drain_started_at.tzinfo is not None
+
+    def test_stop_draining_sets_timezone_aware_timestamp(self, osd_obj):
+        """Same regression as above, for drain_stopped_at."""
+        osd_obj.stop_draining()
+        assert osd_obj.drain_stopped_at.tzinfo is not None
+
+    def test_drain_timestamp_round_trips_through_serialization(self, osd_obj):
+        """
+        The actual failure mode: a naive drain_started_at, once run
+        through datetime_to_str() and back through str_to_datetime(),
+        must represent the same instant it started as. Against the
+        original datetime.utcnow() implementation, this round trip
+        silently shifts the value by the host's UTC offset.
+        """
+        from ceph.utils import datetime_to_str, str_to_datetime
+
+        osd_obj.start_draining()
+        original = osd_obj.drain_started_at
+
+        serialized = datetime_to_str(original)
+        restored = str_to_datetime(serialized)
+
+        # allow a small tolerance for the time elapsed during the test itself
+        delta = abs((restored - original).total_seconds())
+        assert delta < 1, (
+            f"drain_started_at did not round-trip correctly: "
+            f"original={original}, restored={restored}, delta={delta}s"
+        )
+
     def test_start_draining_replace(self, osd_obj):
         assert osd_obj.draining is False
         assert osd_obj.drain_started_at is None


### PR DESCRIPTION
Fixes a timezone bug in OSD drain timestamps (start_draining, stop_draining, is_empty in cephadm/services/osd.py): these three used datetime.utcnow(), which returns a timezone-naive datetime, while the rest of the module already uses the timezone-aware datetime_now() from ceph.utils.

The naive values later get serialized via datetime_to_str(), which calls astimezone() on the input. astimezone() on a naive datetime assumes it represents local time and converts it to UTC. Since the naive value already held UTC wall-clock time, it gets shifted a second time by the mgr host's UTC offset, e.g. a drain that started at 12:00 UTC gets persisted as roughly 16:00Z on a host running US Eastern time. This value is written to the mgr KV store and persists across mgr restarts and failovers.

Fixed by using the already-imported datetime_now() at all three call sites, matching the rest of the module.

Includes 3 regression tests: confirming drain_started_at/drain_stopped_at are timezone-aware, and a round-trip test through datetime_to_str()/str_to_datetime() confirming the persisted instant matches the original. Verified the underlying mechanism (naive datetime + astimezone() double-shift) with standalone reproduction before writing the fix.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
