### PR TITLE
mgr/cephadm: map MDS daemon to the filesystem it actually serves in ok-to-stop check

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -789,6 +789,27 @@ def test_enough_mds_for_ok_to_stop(get, get_daemons_by_service, cephadm_module: 
         DaemonDescription(daemon_type='mds', daemon_id='myfs.test.host1.gfknd', service_name='mds.myfs.test'))
 
 
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.HostCache.get_daemons_by_service")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_enough_mds_for_ok_to_stop_uses_actual_fs_membership(
+        get, get_daemons_by_service, cephadm_module: CephadmOrchestrator):
+    # A daemon from service mds.fs2 currently holds a rank in fs1 (standby
+    # takeover: mds_join_fs is only a preference). The filesystem actually
+    # served (fs1, max_mds=2) must be evaluated, not the service's (fs2,
+    # max_mds=1).
+    fsmap = {'filesystems': [
+        {'mdsmap': {'fs_name': 'fs1', 'max_mds': 2,
+                    'info': {'gid_1': {'name': 'fs2.host1.gfknd'}}}},
+        {'mdsmap': {'fs_name': 'fs2', 'max_mds': 1, 'info': {}}},
+    ]}
+    get.side_effect = [fsmap]
+    get_daemons_by_service.side_effect = [[DaemonDescription(), DaemonDescription()]]
+    assert not cephadm_module.upgrade._enough_mds_for_ok_to_stop(
+        DaemonDescription(daemon_type='mds', daemon_id='fs2.host1.gfknd',
+                          service_name='mds.fs2'))
+
+
 def _mds_need_upgrade_entries() -> List[Tuple[DaemonDescription, bool]]:
     return [
         (DaemonDescription(

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1415,23 +1415,33 @@ class CephadmUpgrade:
     def _enough_mds_for_ok_to_stop(self, mds_daemon: DaemonDescription) -> bool:
         # type (DaemonDescription) -> bool
 
-        # find fs this mds daemon belongs to
+        # find the fs this mds daemon serves: prefer actual membership from
+        # the fsmap over the mds.<fs_name> service naming convention, since
+        # mds_join_fs is only a preference and a daemon can hold a rank in
+        # a filesystem short on MDS other than its service's
+        assert mds_daemon.daemon_id
+        service_fs_name = mds_daemon.service_name().split('.', 1)[1]
         fsmap = self.mgr.get("fs_map")
+        target_mdsmap = None
+        service_mdsmap = None
         for fs in fsmap.get('filesystems', []):
             mdsmap = fs["mdsmap"]
-            fs_name = mdsmap["fs_name"]
-
-            assert mds_daemon.daemon_id
-            if fs_name != mds_daemon.service_name().split('.', 1)[1]:
-                # wrong fs for this mds daemon
-                continue
-
+            if any(info.get('name') == mds_daemon.daemon_id
+                   for info in (mdsmap.get('info') or {}).values()):
+                # the fs this daemon actually serves
+                target_mdsmap = mdsmap
+                break
+            if mdsmap["fs_name"] == service_fs_name:
+                service_mdsmap = mdsmap
+        if target_mdsmap is None:
+            target_mdsmap = service_mdsmap
+        if target_mdsmap is not None:
             # get number of mds daemons for this fs
             mds_count = len(
                 [daemon for daemon in self.mgr.cache.get_daemons_by_service(mds_daemon.service_name())])
 
             # standby mds daemons for this fs?
-            if mdsmap["max_mds"] < mds_count:
+            if target_mdsmap["max_mds"] < mds_count:
                 return True
             return False
 


### PR DESCRIPTION
`_enough_mds_for_ok_to_stop` maps an MDS daemon to a filesystem by assuming service `mds.<fs_name>` serves `<fs_name>`. `mds_join_fs` (set by cephadm's MdsService) is only a preference, not a constraint: a daemon from another service can be promoted to a rank of a filesystem short on MDS (standby takeover).

In that case the function evaluates the wrong filesystem. It can return False (skipping the ok-to-stop check entirely) for a daemon actively holding a rank in another filesystem, allowing cephadm to restart it during an upgrade without any safety check, causing an unprepared failover on that filesystem.

Prefer actual membership from the fsmap when mapping the daemon to a filesystem, falling back to the service naming convention.

Fixes: https://tracker.ceph.com/issues/80088

Related: https://github.com/ceph/ceph/pull/69260 (hardened the same heuristic in `_prepare_for_mds_upgrade`)

Assisted-by: Claude Fable 5 High.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [x] Affects Orchestrator, opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests