### PR TITLE
prometheus: fix IndexError in RGW instance id parsing

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1401,6 +1401,19 @@ class Module(MgrModule, OrchestratorClientMixin):
                                                                service.get('name', ''))})
         return ret
 
+    def _parse_rgw_instance_id(self, daemon_id: Optional[str]) -> str:
+        """
+        Extract the RGW instance id from a daemon_id in the form
+        <host>.<rgw>.<instance>, matching the instance id used by
+        ceph-exporter. Falls back to the full daemon_id (or empty
+        string) when it doesn't have enough dot-separated segments to
+        safely index, e.g. a daemon_id with only one dot such as
+        "host1.rgw0" rather than the expected "host1.rgw.0".
+        """
+        if daemon_id and daemon_id.count('.') >= 2:
+            return daemon_id.split(".")[2]
+        return daemon_id if daemon_id else ""
+
     @profile_method()
     def get_metadata_and_osd_status(self) -> None:
         osd_map = self.get('osd_map')
@@ -1589,10 +1602,7 @@ class Module(MgrModule, OrchestratorClientMixin):
         if modify_instance_id:
             daemons = raise_if_exception(self.list_daemons(daemon_type='rgw'))
             for daemon in daemons:
-                if daemon.daemon_id and '.' in daemon.daemon_id:
-                    instance_id = daemon.daemon_id.split(".")[2]
-                else:
-                    instance_id = daemon.daemon_id if daemon.daemon_id else ""
+                instance_id = self._parse_rgw_instance_id(daemon.daemon_id)
                 self.metrics['rgw_metadata'].set(1,
                                                  (f"{daemon.daemon_type}.{daemon.daemon_id}",
                                                   str(daemon.hostname),

--- a/src/pybind/mgr/prometheus/test_module.py
+++ b/src/pybind/mgr/prometheus/test_module.py
@@ -471,3 +471,35 @@ class HardwareMetricsTest(TestCase):
         self.module._process_processors(self.status, self.hostname)
         for labels in self.module.metrics['hardware_cpu_cores'].value:
             self.assertEqual(len(labels), 5)
+
+
+class RgwInstanceIdTest(TestCase):
+
+    def _parse(self, daemon_id):
+        from prometheus.module import Module
+        # _parse_rgw_instance_id only touches its argument, so it's
+        # safe to call directly on the class without a full Module
+        # instance (no self state is used).
+        return Module._parse_rgw_instance_id(None, daemon_id)
+
+    def test_three_part_daemon_id_extracts_instance(self):
+        # e.g. "host1.rgw.0" -> instance id "0"
+        self.assertEqual(self._parse('host1.rgw.0'), '0')
+
+    def test_one_dot_daemon_id_does_not_raise(self):
+        # Regression test: previously raised IndexError, since the
+        # guard only checked for a dot, but the code indexed [2],
+        # which needs two dots.
+        self.assertEqual(self._parse('host1.rgw0'), 'host1.rgw0')
+
+    def test_no_dot_daemon_id_falls_back_to_full_id(self):
+        self.assertEqual(self._parse('standalone'), 'standalone')
+
+    def test_empty_daemon_id_returns_empty_string(self):
+        self.assertEqual(self._parse(''), '')
+
+    def test_none_daemon_id_returns_empty_string(self):
+        self.assertEqual(self._parse(None), '')
+
+    def test_more_than_two_dots_extracts_third_segment(self):
+        self.assertEqual(self._parse('a.b.c.d'), 'c')


### PR DESCRIPTION
Fixes an IndexError in RGW instance id parsing (get_metadata_and_osd_status in prometheus/module.py): the guard checks for at least one dot in daemon_id, but the code then indexes element 2 of the split result, which needs at least two dots. An RGW daemon_id with exactly one dot (e.g. "host1.rgw0") passes the guard and then raises IndexError.

This runs inside collect(), with no per-call error handling. In cached mode (default), the collection thread catches the exception and skips the entire metrics refresh cycle, one badly-named RGW daemon stops all cluster metrics from updating. In non-cached mode, it's an HTTP 500 on every scrape.

Fixed by extracting the parsing into a small, directly testable method (_parse_rgw_instance_id), with a guard that actually matches what it indexes, and falls back safely instead of crashing when there aren't enough segments.

Includes 6 regression tests covering the standard case, the one-dot case that previously raised IndexError, no dots, empty string, None, and more than two dots. Verified standalone (the prometheus module has a cherrypy dependency not installed locally, so tests were run against the extracted logic directly, matching production behavior exactly).

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
