### PR TITLE
tentacle: rgw/cloud-restore: strip quotes from ETag on cloud tier fetch

### DIFF
--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -405,7 +405,20 @@ int rgw_cloud_tier_get_object(RGWLCCloudTierCtx& tier_ctx, bool head,
     }
   }
 
-  ldpp_dout(tier_ctx.dpp, 20) << __func__ << "(): Sucessfully fetched object from cloud bucket:" << dest_bucket << ", object: " << target_obj_name << dendl;
+  /*
+   * The HTTP ETag header value is a quoted-string per RFC 7232.
+   * Strip the surrounding quotes so we do not double quote them.
+   */
+  etag = rgw_string_unquote(etag);
+
+  if (auto i = attrs.find(RGW_ATTR_ETAG); i != attrs.end()) {
+    const string unquoted = rgw_string_unquote(i->second.to_str());
+    bufferlist bl;
+    bl.append(unquoted);
+    i->second = std::move(bl);
+  }
+
+  ldpp_dout(tier_ctx.dpp, 20) << __func__ << "(): Successfully fetched object from cloud bucket:" << dest_bucket << ", object: " << target_obj_name << dendl;
   return ret;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80060

---

backport of https://github.com/ceph/ceph/pull/67560
parent tracker: https://tracker.ceph.com/issues/75198

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh