### PR TITLE
mgr/dashboard: fix spacing in resource page from 24px to 16px

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-resource-page/host-resource-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-resource-page/host-resource-page.component.html
@@ -10,7 +10,7 @@
       </cd-resource-overview-card>
     }
     @case ('storage-devices') {
-      <section class="host-resource-section cds-mb-6">
+      <section class="host-resource-section cds-mb-5">
         <h2
           class="host-resource-section__title cds--type-heading-03"
           i18n
@@ -28,7 +28,7 @@
       </section>
 
       @if (permissions.hosts.read) {
-        <section class="host-resource-section cds-mb-6">
+        <section class="host-resource-section cds-mb-5">
           <h2
             class="host-resource-section__title cds--type-heading-03"
             i18n
@@ -50,7 +50,7 @@
         </section>
       }
 
-      <section class="host-resource-section cds-mb-6">
+      <section class="host-resource-section cds-mb-5">
         <h2
           class="host-resource-section__title cds--type-heading-03"
           i18n

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-capacity-protection-card/pool-capacity-protection-card.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-capacity-protection-card/pool-capacity-protection-card.component.html
@@ -1,4 +1,4 @@
-<cds-tile class="pool-overview-card cds-mt-6">
+<cds-tile class="pool-overview-card cds-mt-5">
   <div class="pool-overview-panels">
     <section class="pool-detail-panel">
       <h4

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-io-card/pool-io-card.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-io-card/pool-io-card.component.html
@@ -1,4 +1,4 @@
-<cds-tile class="pool-overview-card cds-mt-6">
+<cds-tile class="pool-overview-card cds-mt-5">
   <div class="pool-overview-panels">
     <section class="pool-detail-panel">
       <h4

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-resource-page/pool-resource-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-resource-page/pool-resource-page.component.html
@@ -27,7 +27,7 @@
       </cd-grafana>
     }
     @case ('configuration') {
-      <section class="pool-resource-section cds-mb-6">
+      <section class="pool-resource-section cds-mb-5">
         <h2
           class="pool-resource-section__title cds--type-heading-03"
           i18n
@@ -43,7 +43,7 @@
         <cd-rbd-configuration-table [data]="selectedPoolConfiguration"></cd-rbd-configuration-table>
       </section>
 
-      <section class="pool-resource-section cds-mb-6">
+      <section class="pool-resource-section cds-mb-5">
         <h2
           class="pool-resource-section__title cds--type-heading-03"
           i18n

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-resource-page/rgw-bucket-resource-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-resource-page/rgw-bucket-resource-page.component.html
@@ -12,7 +12,7 @@
         </cd-resource-overview-card>
       </section>
 
-      <section class="cds-mt-6">
+      <section class="cds-mt-5">
         <cd-resource-overview-card
           title="Configuration summary"
           i18n-title
@@ -32,7 +32,7 @@
       }
 
       @if (!!bucketRateLimit && selection) {
-        <section class="cds-mt-6">
+        <section class="cds-mt-5">
           <cds-tile>
             <div class="cds-pr-6">
               <h3
@@ -137,7 +137,7 @@
               </div>
             }
 
-            <section class="rgw-bucket-resource-section cds-mt-6">
+            <section class="rgw-bucket-resource-section cds-mt-5">
               <h2
                 class="bucket-resource-section__title cds--type-heading-03"
                 i18n

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tags-table/rgw-bucket-tags-table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tags-table/rgw-bucket-tags-table.component.scss
@@ -1,7 +1,7 @@
 @use '@carbon/layout';
 
 .rgw-bucket-tags-section {
-  margin-top: layout.$spacing-06;
+  margin-top: layout.$spacing-05;
 }
 
 .rgw-bucket-tags-section__description {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-page/rgw-user-accounts-resource-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-resource-page/rgw-user-accounts-resource-page.component.html
@@ -10,7 +10,7 @@
       </cd-resource-overview-card>
 
       @if (selection?.quota) {
-        <section class="cds-mt-6 cds-mb-6">
+        <section class="cds-mt-5 cds-mb-5">
           <h2
             class="user-account-resource-section__title cds--type-heading-03"
             i18n
@@ -28,7 +28,7 @@
       }
 
       @if (selection?.bucket_quota) {
-        <section class="cds-mb-6">
+        <section class="cds-mb-5">
           <h2
             class="user-account-resource-section__title cds--type-heading-03"
             i18n

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-resource-page/rgw-user-resource-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-resource-page/rgw-user-resource-page.component.html
@@ -11,7 +11,7 @@
       </cd-resource-overview-card>
 
       @if (user && keys.length) {
-        <div class="cds-mt-6 cds-mb-6">
+        <div class="cds-mt-5 cds-mb-5">
           <h2
             class="cds--type-heading-03"
             i18n
@@ -35,7 +35,7 @@
       }
 
       @if (user?.user_quota) {
-        <section class="cds-mt-6 cds-mb-6">
+        <section class="cds-mt-5 cds-mb-5">
           <h2
             class="cds--type-heading-03"
             i18n
@@ -53,7 +53,7 @@
       }
 
       @if (user?.bucket_quota) {
-        <section class="cds-mb-6">
+        <section class="cds-mb-5">
           <h2
             class="cds--type-heading-03"
             i18n

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-resource-page/smb-cluster-resource-page.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-resource-page/smb-cluster-resource-page.component.html
@@ -9,7 +9,7 @@
       >
       </cd-resource-overview-card>
 
-      <section class="cds-mt-6">
+      <section class="cds-mt-5">
         <cd-smb-share-list [clusterId]="selection.cluster_id"></cd-smb-share-list>
       </section>
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/resource-overview-card/resource-overview-card.component.ts
@@ -19,6 +19,7 @@ export interface OverviewField {
   emptyText?: string;
 }
 
+/* This component doesn't add its own outer spacing; apply spacing utility classes (e.g. `cds-mb-5`) where it's used. */
 @Component({
   selector: 'cd-resource-overview-card',
   templateUrl: './resource-overview-card.component.html',


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/79336


<img width="1361" height="608" alt="Screenshot From 2026-08-30 14-14-35" src="https://github.com/user-attachments/assets/b833db4e-4f00-4422-b295-964a6d90dda1" />



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
