### PR TITLE
crimson/osd: fix watch/notify connection-lifecycle handling

### DIFF
--- a/qa/standalone/crimson/watch-notify.sh
+++ b/qa/standalone/crimson/watch-notify.sh
@@ -138,6 +138,7 @@ function _wait_notify_seen() {
 # so `rados watch` blocks in getchar() and keeps the watch alive.
 function _start_watcher() {
     local pool=$1 obj=$2 tag=$3
+    shift 3                     # any remaining args are extra `rados` options
     local fifo="$OUTDIR/w-$tag.fifo"
     local out="$OUTDIR/w-$tag.out"
     rm -f "$fifo" "$out"
@@ -145,7 +146,7 @@ function _start_watcher() {
     # Holder keeps the write end open so the reader never sees EOF.
     sleep 100000 > "$fifo" &
     W_HOLD[$tag]=$!
-    rados -p "$pool" watch "$obj" < "$fifo" > "$out" 2>&1 &
+    rados -p "$pool" "$@" watch "$obj" < "$fifo" > "$out" 2>&1 &
     W_PID[$tag]=$!
     W_FIFO[$tag]="$fifo"
     W_OUT[$tag]="$out"
@@ -351,6 +352,56 @@ function TEST_rewatch_after_disconnect() {
 
     timeout 30 rados -p foo notify $obj "again" || return 1
     _wait_notify_seen b 15 || return 1
+}
+
+# Poll until a watcher (by tag) has printed a watch-error line to its capture
+# file. `rados watch` prints "ERROR cookie <c> err <msg>" from
+# WatchCtx2::handle_error() when the watch's error callback fires.
+function _wait_watch_error() {
+    local tag=$1 timeout=${2:-15}
+    local out="${W_OUT[$tag]}"
+    local deadline=$(( $(date +%s) + timeout ))
+    while [ $(date +%s) -lt $deadline ]; do
+        grep -q '^ERROR' "$out" && return 0
+        sleep 1
+    done
+    echo "watcher $tag did not receive a watch-error; output:"
+    cat "$out"
+    return 1
+}
+
+# A watch whose client stops sending watch pings (its connection stays fully up,
+# but the OSD sees no keepalive) must be timed out *by the OSD*, which then has
+# to tell the still-connected client -- delivering a watch-error
+# (CEPH_WATCH_EVENT_DISCONNECT) that fires the client's error callback.
+#
+# This is the crimson-standalone analogue of LibRadosWatchNotify.Watch3Timeout
+# and a direct regression for the bug seen in teuthology run 524085: the OSD
+# reaped the timed-out watch but never sent the disconnect (do_watch_timeout()
+# ran send_disconnect_msg() *after* the internal UNWATCH had already cleared the
+# watch's conn, so it silently no-op'd). The client then never learned its watch
+# was gone until, much later, its connection happened to reset -- blowing the
+# test's timeout budget. With the fix the error must arrive within roughly the
+# watch timeout.
+function TEST_watch_timeout_notifies_client() {
+    local dir=$1
+    _setup_crimson_cluster $dir || return 1
+
+    local obj=obj-pingtimeout
+    echo data | rados -p foo put $obj - || return 1
+
+    # Suppress *client-side* watch pings only (not message receipt), so the OSD's
+    # watch timeout fires while the client's connection is still alive and able
+    # to receive the disconnect.
+    _start_watcher foo $obj a --objecter_inject_no_watch_ping=true || return 1
+    _wait_watch_count foo $obj 1 30 || return 1
+
+    # Within roughly the watch timeout the OSD must reap the watch AND deliver
+    # the watch-error to the client.
+    _wait_watch_error a $(( WATCH_TIMEOUT + 30 )) || return 1
+
+    # ... and the watch is gone from the OSD side too.
+    _wait_watch_count foo $obj 0 30 || return 1
 }
 
 main watch-notify "$@"

--- a/qa/standalone/crimson/watch-notify.sh
+++ b/qa/standalone/crimson/watch-notify.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+#
+# Standalone tests for RADOS watch/notify on a Crimson OSD, with emphasis on
+# the watch connection lifecycle: registration, notify delivery, notify
+# timeout, abrupt client disconnect (connection reset) and re-establishing a
+# watch afterwards.
+#
+# The watches are driven through the `rados` CLI:
+#   rados -p P watch OBJ        - holds a watch open, prints "NOTIFY ..." events
+#   rados -p P notify OBJ MSG   - sends a notify (10s client timeout)
+#   rados -p P listwatchers OBJ - prints "watcher=<addr> client.<id> cookie=<c>"
+#
+# Run with:
+#   cd build && ../qa/run-standalone.sh crimson/watch-notify.sh
+# or a single case:
+#   cd build && ../qa/run-standalone.sh "crimson/watch-notify.sh TEST_notify_delivery"
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+# Watch timeout used by the OSD for client watches (osd_client_watch_timeout).
+# Kept comfortably larger than the 10s notify timeout baked into `rados notify`
+# so a watch is still registered while a notify to it is in flight, yet small
+# enough that reaping a dead watch does not make the tests crawl.
+WATCH_TIMEOUT=25
+
+# Per-watcher bookkeeping, keyed by a caller-supplied tag.
+declare -A W_PID    # tag -> rados-watch pid
+declare -A W_HOLD   # tag -> stdin holder pid (keeps the watch's stdin open)
+declare -A W_FIFO   # tag -> fifo feeding the watch's stdin
+declare -A W_OUT    # tag -> file capturing the watch's stdout/stderr
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7148" # git grep '\<7148\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth_cluster_required=none --auth_service_required=none --auth_client_required=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--crimson_cpu_num=2 "
+    CEPH_ARGS+="--osd_client_watch_timeout=$WATCH_TIMEOUT "
+
+    export OUTDIR=${TMPDIR:-/tmp}/watch-notify-$$
+    rm -rf "$OUTDIR"
+    mkdir -p "$OUTDIR"
+    trap 'rm -rf "$OUTDIR"' EXIT
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        echo "-------------- Prepare Test $func -------------------"
+        setup $dir || return 1
+        echo "-------------- Run Test $func -----------------------"
+        $func $dir || { _cleanup_watchers; teardown $dir; return 1; }
+        _cleanup_watchers
+        echo "-------------- Teardown Test $func ------------------"
+        teardown $dir || return 1
+        echo "-------------- Complete Test $func ------------------"
+    done
+}
+
+#
+# Cluster / helper plumbing
+#
+
+# Bring up a single-OSD Crimson cluster with a crimson pool named "foo".
+function _setup_crimson_cluster() {
+    local dir=$1
+
+    run_mon $dir a --osd_pool_default_size=1 --mon_allow_pool_size_one=true \
+        --osd_pool_default_crimson=true || return 1
+    run_mgr $dir x || return 1
+    run_crimson_osd $dir 0 || return 1
+
+    create_pool foo 1 1 || return 1
+    # Confirm the pool really is a crimson pool.
+    ceph osd pool ls detail --format json |
+        jq -e '.[] | select(.pool_name == "foo") | (.flags_names // [] | index("crimson"))' \
+        >/dev/null || return 1
+    wait_for_clean || return 1
+}
+
+# Count the watchers currently registered on an object.
+# Prints the count on success (0 is a legitimate answer). On a listwatchers
+# failure it warns and prints the sentinel "ERR" - a value no real count can
+# take - so callers (and in particular a "wait for 0" poll) never mistake a
+# transient error for "no watchers left". "ERR" is deliberately non-numeric so
+# it can't accidentally satisfy an arithmetic comparison either.
+function _watch_count() {
+    local pool=$1 obj=$2 out
+    if ! out=$(rados -p "$pool" listwatchers "$obj" 2>/dev/null); then
+        echo "WARNING: listwatchers $pool/$obj failed" >&2
+        echo ERR
+        return 0
+    fi
+    grep -c '^watcher=' <<<"$out" || true   # 0 matches is fine, not an error
+}
+
+# Poll until the watcher count on an object reaches the wanted value.
+function _wait_watch_count() {
+    local pool=$1 obj=$2 want=$3 timeout=${4:-30}
+    local deadline=$(( $(date +%s) + timeout ))
+    local saved_flag=${-//[^x]/}
+    set +x
+    local got
+    while [ $(date +%s) -lt $deadline ]; do
+        got=$(_watch_count "$pool" "$obj")
+        if [ "$got" = "$want" ]; then
+            [ -n "$saved_flag" ] && set -x
+            return 0
+        fi
+        sleep 1
+    done
+    [ -n "$saved_flag" ] && set -x
+    echo "Timed out waiting for $pool/$obj watcher count == $want (last: ${got:-none})"
+    rados -p "$pool" listwatchers "$obj" || true
+    return 1
+}
+
+# Poll until a watcher (by tag) has printed a NOTIFY line to its capture file.
+# `rados notify` returns once the OSD has acked it, which is not the same moment
+# the background `rados watch` process flushes its NOTIFY output - so callers
+# must poll rather than grep once immediately after notify returns.
+function _wait_notify_seen() {
+    local tag=$1 timeout=${2:-15}
+    local out="${W_OUT[$tag]}"
+    local deadline=$(( $(date +%s) + timeout ))
+    while [ $(date +%s) -lt $deadline ]; do
+        grep -q '^NOTIFY' "$out" && return 0
+        sleep 1
+    done
+    echo "watcher $tag did not receive NOTIFY; output:"
+    cat "$out"
+    return 1
+}
+
+# Start a background `rados watch` on an object and wait until it registers.
+# The watch's stdin is fed from a fifo that is held open (but never written to)
+# so `rados watch` blocks in getchar() and keeps the watch alive.
+function _start_watcher() {
+    local pool=$1 obj=$2 tag=$3
+    local fifo="$OUTDIR/w-$tag.fifo"
+    local out="$OUTDIR/w-$tag.out"
+    rm -f "$fifo" "$out"
+    mkfifo "$fifo" || return 1
+    # Holder keeps the write end open so the reader never sees EOF.
+    sleep 100000 > "$fifo" &
+    W_HOLD[$tag]=$!
+    rados -p "$pool" watch "$obj" < "$fifo" > "$out" 2>&1 &
+    W_PID[$tag]=$!
+    W_FIFO[$tag]="$fifo"
+    W_OUT[$tag]="$out"
+}
+
+# Abruptly drop a watcher (SIGKILL) - no clean unwatch, so the OSD sees a
+# connection reset. This is our "client disconnect" trigger.
+# NOTE: only ever `wait` on the specific watcher pid - a bare `wait` would also
+# block on the long-lived mon/mgr/osd daemons that run() started in the
+# background.
+function _kill_watcher() {
+    local tag=$1
+    if [ -n "${W_PID[$tag]:-}" ]; then
+        kill -9 "${W_PID[$tag]}" 2>/dev/null || true
+        wait "${W_PID[$tag]}" 2>/dev/null || true
+        unset 'W_PID[$tag]'
+    fi
+}
+
+# Kill every outstanding watcher and its stdin holder; called between tests.
+function _cleanup_watchers() {
+    local tag
+    for tag in "${!W_PID[@]}"; do
+        kill -9 "${W_PID[$tag]}" 2>/dev/null || true
+        wait "${W_PID[$tag]}" 2>/dev/null || true
+    done
+    for tag in "${!W_HOLD[@]}"; do
+        kill -9 "${W_HOLD[$tag]}" 2>/dev/null || true
+        wait "${W_HOLD[$tag]}" 2>/dev/null || true
+    done
+    for tag in "${!W_FIFO[@]}"; do
+        rm -f "${W_FIFO[$tag]}" 2>/dev/null || true
+    done
+    W_PID=(); W_HOLD=(); W_FIFO=(); W_OUT=()
+}
+
+#
+# Test cases
+#
+
+# A single watch registers, and a clean unwatch (client exit) deregisters it.
+function TEST_watch_register_unregister() {
+    local dir=$1
+    _setup_crimson_cluster $dir || return 1
+
+    local obj=obj-register
+    echo data | rados -p foo put $obj - || return 1
+
+    local n=$(_watch_count foo $obj)
+    [ "$n" = "0" ] || { echo "expected 0 watchers initially, got '$n'"; return 1; }
+
+    _start_watcher foo $obj a || return 1
+    _wait_watch_count foo $obj 1 30 || return 1
+
+    # Clean shutdown: send a newline so `rados watch` returns from getchar() and
+    # calls unwatch2(); the watcher should then deregister.
+    echo > "${W_FIFO[a]}"
+    wait "${W_PID[a]}" 2>/dev/null || true
+    unset 'W_PID[a]'
+    _wait_watch_count foo $obj 0 30 || return 1
+}
+
+# A notify is delivered to a live watcher (watcher prints NOTIFY, acks it, and
+# the notifier returns success).
+function TEST_notify_delivery() {
+    local dir=$1
+    _setup_crimson_cluster $dir || return 1
+
+    local obj=obj-notify
+    echo data | rados -p foo put $obj - || return 1
+
+    _start_watcher foo $obj a || return 1
+    _wait_watch_count foo $obj 1 30 || return 1
+
+    timeout 30 rados -p foo notify $obj "hello" || return 1
+
+    # The watcher should have observed the notify.
+    _wait_notify_seen a 15 || return 1
+}
+
+# Notifying an object with no watchers completes promptly and successfully
+# (empty completion, no timeout, no hang).
+function TEST_notify_no_watchers() {
+    local dir=$1
+    _setup_crimson_cluster $dir || return 1
+
+    local obj=obj-nowatch
+    echo data | rados -p foo put $obj - || return 1
+
+    local n=$(_watch_count foo $obj)
+    [ "$n" = "0" ] || { echo "expected 0 watchers initially, got '$n'"; return 1; }
+
+    local start=$(date +%s)
+    timeout 30 rados -p foo notify $obj "hello" || return 1
+    local elapsed=$(( $(date +%s) - start ))
+    # With no watchers the notify must not wait out the notify timeout.
+    [ $elapsed -lt 15 ] || { echo "notify with no watchers took ${elapsed}s"; return 1; }
+}
+
+# Several watchers on one object are all registered.
+function TEST_multiple_watchers() {
+    local dir=$1
+    _setup_crimson_cluster $dir || return 1
+
+    local obj=obj-multi
+    echo data | rados -p foo put $obj - || return 1
+
+    _start_watcher foo $obj a || return 1
+    _start_watcher foo $obj b || return 1
+    _start_watcher foo $obj c || return 1
+
+    _wait_watch_count foo $obj 3 40 || return 1
+
+    # A notify should reach all of them. Poll each watcher's output: notify
+    # returning only means the OSD acked, not that every background watcher has
+    # flushed its NOTIFY line yet.
+    timeout 30 rados -p foo notify $obj "ping" || return 1
+    local tag
+    for tag in a b c; do
+        _wait_notify_seen $tag 15 || return 1
+    done
+}
+
+# An abruptly-disconnected watcher (client killed, connection reset) is
+# eventually reaped from the object's watcher list.
+function TEST_disconnect_reaped() {
+    local dir=$1
+    _setup_crimson_cluster $dir || return 1
+
+    local obj=obj-disc
+    echo data | rados -p foo put $obj - || return 1
+
+    _start_watcher foo $obj a || return 1
+    _wait_watch_count foo $obj 1 30 || return 1
+
+    # Abrupt disconnect: the OSD sees a connection reset (no unwatch).
+    _kill_watcher a
+
+    # The watch must be dropped within roughly the watch timeout.
+    _wait_watch_count foo $obj 0 $(( WATCH_TIMEOUT + 25 )) || return 1
+}
+
+# A notify to an object whose only watcher has just been killed must complete
+# (report the watcher as missed / time out) rather than hang. This exercises
+# the notify-timeout path and Watch::cancel_notify().
+function TEST_notify_dead_watcher_times_out() {
+    local dir=$1
+    _setup_crimson_cluster $dir || return 1
+
+    local obj=obj-deadnotify
+    echo data | rados -p foo put $obj - || return 1
+
+    _start_watcher foo $obj a || return 1
+    _wait_watch_count foo $obj 1 30 || return 1
+
+    # Abruptly kill the watcher. The reset only *disconnects* the watch (drops
+    # its conn and re-arms the watch timeout); it does not deregister it, so the
+    # watch stays registered - and thus a notify target - for up to
+    # WATCH_TIMEOUT.
+    _kill_watcher a
+
+    # Prove the notify below actually runs against a dead-but-registered
+    # watcher. Without this the reset could (in some future change) drop the
+    # watch first, and the notify would then trivially succeed against an empty
+    # watcher list - passing while testing nothing.
+    local n=$(_watch_count foo $obj)
+    [ "$n" = "1" ] || { echo "expected the dead watch still registered, got '$n'"; return 1; }
+
+    # The dead watcher can never ack, so `rados notify` (10s notify timeout)
+    # must (a) finish rather than hang, and (b) actually report that watcher as
+    # timed out. rados prints "timeout client.<gid> cookie <c>" for each watcher
+    # that missed the notify (see tools/rados/rados.cc). We require that line:
+    #   - a trivial success (no watchers) prints nothing and returns 0;
+    #   - an unrelated CLI/connection error prints no "timeout client." line;
+    # so matching it is what distinguishes the real notify-timeout path (which
+    # exercises Watch::cancel_notify()) from both of those.
+    local out rc=0
+    out=$(timeout 40 rados -p foo notify $obj "anyone?" 2>&1) || rc=$?
+    echo "$out"
+    [ $rc -ne 124 ] || { echo "notify to a dead watcher hung"; return 1; }
+    echo "$out" | grep -q '^timeout client\.' || {
+        echo "notify did not report the dead watcher as timed out (rc=$rc)"; return 1;
+    }
+}
+
+# After a watcher disconnects, a fresh watch on the same object can be
+# established and receives notifies - the object's watch machinery recovers.
+function TEST_rewatch_after_disconnect() {
+    local dir=$1
+    _setup_crimson_cluster $dir || return 1
+
+    local obj=obj-rewatch
+    echo data | rados -p foo put $obj - || return 1
+
+    _start_watcher foo $obj a || return 1
+    _wait_watch_count foo $obj 1 30 || return 1
+    _kill_watcher a
+    _wait_watch_count foo $obj 0 $(( WATCH_TIMEOUT + 25 )) || return 1
+
+    # New watch on the same object.
+    _start_watcher foo $obj b || return 1
+    _wait_watch_count foo $obj 1 30 || return 1
+
+    timeout 30 rados -p foo notify $obj "again" || return 1
+    _wait_notify_seen b 15 || return 1
+}
+
+main watch-notify "$@"

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(crimson-osd
   ${PROJECT_SOURCE_DIR}/src/osd/osd_perf_counters.cc
   ${PROJECT_SOURCE_DIR}/src/mgr/OSDPerfMetricTypes.cc
   watch.cc
+  watch_conn.cc
   watch_timeout_request.cc
   )
 if(HAS_VTA)

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(crimson-osd
   ${PROJECT_SOURCE_DIR}/src/osd/osd_perf_counters.cc
   ${PROJECT_SOURCE_DIR}/src/mgr/OSDPerfMetricTypes.cc
   watch.cc
+  watch_timeout_request.cc
   )
 if(HAS_VTA)
   set_source_files_properties(main.cc

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -53,8 +53,10 @@
 #include "crimson/os/futurized_collection.h"
 #include "crimson/os/futurized_store.h"
 #include "crimson/osd/heartbeat.h"
+#include "crimson/osd/osd_connection_priv.h"
 #include "crimson/osd/osd_meta.h"
 #include "crimson/osd/pg.h"
+#include "crimson/osd/watch.h"
 #include "crimson/osd/pg_backend.h"
 #include "crimson/osd/pg_meta.h"
 #include "crimson/osd/osd_operations/client_request.h"
@@ -1040,9 +1042,24 @@ OSD::do_ms_dispatch(
 
 void OSD::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace)
 {
-  // TODO: cleanup the session attached to this connection
+  // Runs on the connection's home core. Disconnect every watch reachable over
+  // this connection so notifies buffer (and are replayed on reconnect) and the
+  // watch timeout can eventually reap it -- mirrors classic
+  // WatchConState::reset() driven from OSD::ms_handle_reset(). Fire-and-forget:
+  // the reset() fans out one cross-core hop per watch; keep `conn` alive until
+  // it finishes.
   LOG_PREFIX(OSD::ms_handle_reset);
   WARN("{}", *conn);
+  if (!conn->has_user_private()) {
+    INFO("{} has no user private - nothing to reset", *conn);
+    return;
+  }
+  auto& priv = get_osd_priv(&*conn);
+  if (!priv.watch_conn_state) {
+    INFO("{} has no watch connection state - nothing to reset", *conn);
+    return;
+  }
+  std::ignore = priv.watch_conn_state->reset(&*conn).finally([conn] {});
 }
 
 void OSD::ms_handle_remote_reset(crimson::net::ConnectionRef conn)

--- a/src/crimson/osd/osd_connection_priv.h
+++ b/src/crimson/osd/osd_connection_priv.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "crimson/common/smp_helpers.h"
 #include "crimson/net/Connection.h"
 #include "crimson/osd/osd_operation.h"
@@ -12,6 +14,11 @@
 
 namespace crimson::osd {
 
+// Forward-declared and held by pointer so this widely-included header need not
+// pull in watch.h (which drags in pg.h). Defined in watch.h; the out-of-line
+// members below live in watch_conn.cc, where it is complete.
+class WatchConState;
+
 struct OSDConnectionPriv : public crimson::net::Connection::user_private_t {
   using crosscore_ordering_t = smp_crosscore_ordering_t<crosscore_type_t::ONE_N>;
 
@@ -19,6 +26,18 @@ struct OSDConnectionPriv : public crimson::net::Connection::user_private_t {
   ConnectionPipeline peering_request_conn_pipeline;
   ConnectionPipeline replicated_request_conn_pipeline;
   crosscore_ordering_t crosscore_ordering;
+
+  // Per-connection registry of the watches reachable over this connection,
+  // used by OSD::ms_handle_reset() to disconnect them on reset. Lazily created
+  // on the first watch (most connections never watch anything).
+  std::unique_ptr<WatchConState> watch_conn_state;
+  WatchConState &ensure_watch_conn_state();
+
+  // out-of-line (defined in watch_conn.cc): WatchConState is incomplete here, so
+  // the unique_ptr member's construction/destruction must not be instantiated in
+  // includers of this header.
+  OSDConnectionPriv();
+  ~OSDConnectionPriv();
 };
 
 static inline OSDConnectionPriv &get_osd_priv(crimson::net::Connection *conn) {

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -46,10 +46,12 @@ seastar::future<> Watch::send_notify_msg(NotifyRef notify)
   if (!is_connected()) {
     // The connection may be dropped between iterations of connect()'s buffered-
     // notify replay: a reset can run during a preceding send's await and call
-    // disconnect(), clearing conn. Guard here (mirroring send_disconnect_msg())
-    // so the notify stays in in_progress_notifies and is replayed on the next
-    // reconnect rather than dereferencing a cleared conn. Safe shard-wise: this
-    // only inspects the local conn handle on the watch's own core.
+    // disconnect(), clearing conn. Guard here so the notify stays in
+    // in_progress_notifies and is replayed on the next reconnect rather than
+    // dereferencing a cleared conn. Safe shard-wise: this only inspects the
+    // local conn handle on the watch's own core. (Unlike send_disconnect_msg(),
+    // which is given the connection to use, this path reads this->conn: it must
+    // observe an in-flight reset so the notify falls back to buffering.)
     logger().debug("{} not connected, buffering notify(id={})",
                    __func__, notify->ninfo.notify_id);
     return seastar::now();
@@ -111,9 +113,13 @@ seastar::future<> Watch::notify_ack(
   return notify->complete_watcher(shared_from_this(), reply_bl);
 }
 
-seastar::future<> Watch::send_disconnect_msg()
+seastar::future<> Watch::send_disconnect_msg(crimson::net::ConnectionXcoreRef conn)
 {
-  if (!is_connected()) {
+  // `conn` is passed in explicitly (rather than read from this->conn) because
+  // the timeout path tears the watch down -- discard_state() clears this->conn
+  // -- before this runs; see do_watch_timeout(). A null handle means the watch
+  // was already disconnected, so there is nobody to tell.
+  if (!conn) {
     return seastar::now();
   }
   ceph::bufferlist empty;

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -124,6 +124,19 @@ seastar::future<> Watch::start_notify(NotifyRef notify)
   logger().debug("{} gid={} cookie={} starting notify(id={})",
                  __func__,  get_watcher_gid(), get_cookie(),
                  notify->ninfo.notify_id);
+  if (notify->complete) {
+    // The notify already completed -- in practice because it timed out while
+    // Notify::create_n_propagate() was still walking the watchers and this
+    // watcher had not been reached yet. Do not record or deliver it: emplacing
+    // an already-complete notify would leave a stale in_progress_notifies entry
+    // (the timer has fired, so nothing would later remove it unless the client
+    // acks), and delivering it would push a NOTIFY whose timeout completion was
+    // already sent to the notifier. Same core as do_notify_timeout(), so reading
+    // `complete` here is race-free.
+    logger().debug("{} notify(id={}) already complete, skipping",
+                   __func__, notify->ninfo.notify_id);
+    return seastar::now();
+  }
   auto [ it, emplaced ] = in_progress_notifies.emplace(std::move(notify));
   ceph_assert(emplaced);
   ceph_assert(is_alive());
@@ -138,8 +151,8 @@ seastar::future<> Watch::notify_ack(
                  __func__,  get_watcher_gid(), get_cookie(), notify_id);
   const auto it = in_progress_notifies.find(notify_id);
   if (it == std::end(in_progress_notifies)) {
-    logger().error("{} notify_id={} not found on the in-progess list."
-                   " Supressing but this should not happen.",
+    logger().error("{} notify_id={} not found on the in-progress list."
+                   " Suppressing but this should not happen.",
                    __func__, notify_id);
     return seastar::now();
   }
@@ -212,7 +225,18 @@ void Watch::cancel_notify(const uint64_t notify_id)
                  __func__,  get_watcher_gid(), get_cookie(),
                  notify_id);
   const auto it = in_progress_notifies.find(notify_id);
-  assert(it != std::end(in_progress_notifies));
+  if (it == std::end(in_progress_notifies)) {
+    // A notify timeout can fire while `Notify::create_n_propagate()` is still
+    // walking the watchers: `Notify::watchers` is populated synchronously and
+    // the timer is armed up front, but each watcher only records the notify in
+    // `in_progress_notifies` once its (asynchronous) `start_notify()` runs.
+    // `do_notify_timeout()` then iterates the full watcher set and may reach a
+    // watcher that has not started this notify yet. Treat that as a no-op
+    // rather than dereferencing `end()`. Mirrors `notify_ack()`.
+    logger().debug("{} notify_id={} not on the in-progress list, ignoring",
+                   __func__, notify_id);
+    return;
+  }
   in_progress_notifies.erase(it);
 }
 
@@ -346,6 +370,16 @@ void Notify::do_notify_timeout()
   // a watcher stores and which is being removed by `cancel_notify()`.
   // to avoid use-after-free we bump up the ref counter with `guard_ptr`.
   [[maybe_unused]] auto guard_ptr = shared_from_this();
+  // Mark the notify complete before cancelling watchers and sending the timeout
+  // completion. Propagation (Notify::create_n_propagate) may still be walking
+  // the watchers: a watcher whose start_notify() has not run yet is skipped by
+  // cancel_notify() (a no-op for a not-yet-recorded notify) and is still sent a
+  // NOTIFY once propagation resumes. Without `complete` set, that watcher's
+  // later ACK would reach complete_watcher()/remove_watcher() with `watchers`
+  // already emptied here, tripping their asserts (debug) or emitting a second
+  // NOTIFY_COMPLETE (release). Setting `complete` makes the late ACK a no-op via
+  // the guards in those methods.
+  complete = true;
   for (auto& watcher : watchers) {
     logger().debug("canceling watcher cookie={} gid={} use_count={}",
       watcher->get_cookie(),

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -1,13 +1,10 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 sts=2 expandtab
 
-#include <algorithm>
-
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm_ext/insert.hpp>
 
 #include "crimson/osd/watch.h"
-#include "crimson/osd/osd_operations/internal_client_request.h"
 
 #include "messages/MWatchNotify.h"
 
@@ -21,67 +18,6 @@ namespace {
 }
 
 namespace crimson::osd {
-class WatchTimeoutRequest;
-}
-
-#if FMT_VERSION >= 90000
-template <> struct fmt::formatter<crimson::osd::WatchTimeoutRequest> : fmt::ostream_formatter {};
-#endif
-
-namespace crimson::osd {
-
-// a watcher can remove itself if it has not seen a notification after a period of time.
-// in the case, we need to drop it also from the persisted `ObjectState` instance.
-// this operation resembles a bit the `_UNWATCH` subop.
-class WatchTimeoutRequest final : public InternalClientRequest {
-public:
-  WatchTimeoutRequest(WatchRef watch, Ref<PG> pg)
-    : InternalClientRequest(std::move(pg)),
-      watch(std::move(watch)) {
-  }
-
-  const hobject_t& get_target_oid() const final;
-  PG::do_osd_ops_params_t get_do_osd_ops_params() const final;
-  std::vector<OSDOp> create_osd_ops() final;
-
-private:
-  WatchRef watch;
-};
-
-const hobject_t& WatchTimeoutRequest::get_target_oid() const
-{
-  assert(watch->obc);
-  return watch->obc->get_oid();
-}
-
-PG::do_osd_ops_params_t
-WatchTimeoutRequest::get_do_osd_ops_params() const
-{
-  osd_reqid_t reqid;
-  reqid.name = watch->entity_name;
-  PG::do_osd_ops_params_t params{
-    watch->conn,
-    reqid,
-    ceph_clock_now(),
-    get_pg().get_osdmap_epoch(),
-    entity_inst_t{ watch->entity_name, watch->winfo.addr },
-    0
-  };
-  logger().debug("{}: params.reqid={}", __func__, params.reqid);
-  return params;
-}
-
-std::vector<OSDOp> WatchTimeoutRequest::create_osd_ops()
-{
-  logger().debug("{}", __func__);
-  assert(watch);
-  OSDOp osd_op;
-  osd_op.op.op = CEPH_OSD_OP_WATCH;
-  osd_op.op.flags = 0;
-  osd_op.op.watch.op = CEPH_OSD_WATCH_OP_UNWATCH;
-  osd_op.op.watch.cookie = watch->winfo.cookie;
-  return std::vector{std::move(osd_op)};
-}
 
 Watch::~Watch()
 {
@@ -238,16 +174,6 @@ void Watch::cancel_notify(const uint64_t notify_id)
     return;
   }
   in_progress_notifies.erase(it);
-}
-
-void Watch::do_watch_timeout()
-{
-  assert(pg);
-  auto [op, fut] = pg->get_shard_services().start_operation<WatchTimeoutRequest>(
-    shared_from_this(), pg);
-  std::ignore = std::move(fut).then([op=std::move(op), this] {
-    return send_disconnect_msg();
-  });
 }
 
 bool notify_reply_t::operator<(const notify_reply_t& rhs) const

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -24,21 +24,18 @@ Watch::~Watch()
   logger().debug("{} gid={} cookie={}", __func__, get_watcher_gid(), get_cookie());
 }
 
-seastar::future<> Watch::connect(crimson::net::ConnectionXcoreRef conn, bool)
-{
-  if (this->conn == conn) {
-    logger().debug("conn={} already connected", *conn);
-    return seastar::now();
-  }
-  timeout_timer.cancel();
-  timeout_timer.arm(std::chrono::seconds{winfo.timeout_seconds});
-  this->conn = std::move(conn);
-  return seastar::now();
-}
-
 void Watch::disconnect()
 {
-  ceph_assert(!conn);
+  logger().debug("{} gid={} cookie={} (was {}connected)",
+                 __func__, get_watcher_gid(), get_cookie(),
+                 is_connected() ? "" : "dis");
+  // Drop the (possibly dead) connection and fall back to buffering: subsequent
+  // notifies are recorded in in_progress_notifies and replayed by connect()
+  // once the client reconnects. Mirrors classic Watch::disconnect()
+  // (src/osd/Watch.cc). Called both for watches loaded from disk (already
+  // disconnected - a no-op here) and, on a connection reset, for a currently
+  // connected watch.
+  conn = {};
   timeout_timer.cancel();
   timeout_timer.arm(std::chrono::seconds{winfo.timeout_seconds});
 }
@@ -46,6 +43,17 @@ void Watch::disconnect()
 seastar::future<> Watch::send_notify_msg(NotifyRef notify)
 {
   logger().info("{} for notify(id={})", __func__, notify->ninfo.notify_id);
+  if (!is_connected()) {
+    // The connection may be dropped between iterations of connect()'s buffered-
+    // notify replay: a reset can run during a preceding send's await and call
+    // disconnect(), clearing conn. Guard here (mirroring send_disconnect_msg())
+    // so the notify stays in in_progress_notifies and is replayed on the next
+    // reconnect rather than dereferencing a cleared conn. Safe shard-wise: this
+    // only inspects the local conn handle on the watch's own core.
+    logger().debug("{} not connected, buffering notify(id={})",
+                   __func__, notify->ninfo.notify_id);
+    return seastar::now();
+  }
   return conn->send(crimson::make_message<MWatchNotify>(
     winfo.cookie,
     notify->user_version,
@@ -117,14 +125,6 @@ seastar::future<> Watch::send_disconnect_msg()
     empty));
 }
 
-void Watch::discard_state()
-{
-  logger().debug("{} gid={} cookie={}", __func__, get_watcher_gid(), get_cookie());
-  ceph_assert(obc);
-  in_progress_notifies.clear();
-  timeout_timer.cancel();
-}
-
 void Watch::got_ping(utime_t)
 {
   if (is_connected()) {
@@ -132,27 +132,6 @@ void Watch::got_ping(utime_t)
     timeout_timer.cancel();
     timeout_timer.arm(std::chrono::seconds{winfo.timeout_seconds});
   }
-}
-
-seastar::future<> Watch::remove()
-{
-  logger().debug("{} gid={} cookie={}", __func__, get_watcher_gid(), get_cookie());
-  // in contrast to ceph-osd crimson sends CEPH_WATCH_EVENT_DISCONNECT directly
-  // from the timeout handler and _after_ CEPH_WATCH_EVENT_NOTIFY_COMPLETE.
-  // this simplifies the Watch::remove() interface as callers aren't obliged
-  // anymore to decide whether EVENT_DISCONNECT needs to be send or not -- it
-  // becomes an implementation detail of Watch.
-  return seastar::do_for_each(in_progress_notifies,
-    [this_shared=shared_from_this()] (auto notify) {
-      logger().debug("Watch::remove gid={} cookie={} notify(id={})",
-                     this_shared->get_watcher_gid(),
-                     this_shared->get_cookie(),
-                     notify->ninfo.notify_id);
-      return notify->remove_watcher(this_shared);
-    }).then([this] {
-      discard_state();
-      return seastar::now();
-    });
 }
 
 void Watch::cancel_notify(const uint64_t notify_id)

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -66,7 +66,10 @@ class Watch : public seastar::enable_shared_from_this<Watch> {
   // lives on the connection's home core. Defined in watch_conn.cc (they touch
   // OSD-only symbols and so must stay out of watch.cc, which is also compiled
   // into unit tests).
-  seastar::future<> register_on_conn();
+  // register_on_conn() returns whether the registration is effective: true if
+  // the connection was still connected, false if it was reset during the hop
+  // (in which case the entry is rolled back and the caller disconnects locally).
+  seastar::future<bool> register_on_conn();
   seastar::future<> deregister_from_conn();
 
   friend Notify;

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -57,7 +57,7 @@ class Watch : public seastar::enable_shared_from_this<Watch> {
 
   seastar::future<> start_notify(NotifyRef);
   seastar::future<> send_notify_msg(NotifyRef);
-  seastar::future<> send_disconnect_msg();
+  seastar::future<> send_disconnect_msg(crimson::net::ConnectionXcoreRef conn);
 
   // Register/unregister this watch in its connection's per-connection registry
   // (crimson::osd::WatchConState, living in the connection's OSDConnectionPriv)

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -4,10 +4,12 @@
 #pragma once
 
 #include <iterator>
-#include <map>
 #include <set>
 
+#include <boost/container/flat_map.hpp>
+
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sharded.hh>
 
 #include "crimson/net/Connection.h"
 #include "crimson/osd/object_context.h"
@@ -47,12 +49,25 @@ class Watch : public seastar::enable_shared_from_this<Watch> {
   watch_info_t winfo;
   entity_name_t entity_name;
   Ref<PG> pg;
+  // set once the watch is torn down (remove()/discard_state()); guards a reset
+  // that races watch removal. Mirrors classic Watch::discarded.
+  bool discarded = false;
 
   seastar::timer<seastar::lowres_clock> timeout_timer;
 
   seastar::future<> start_notify(NotifyRef);
   seastar::future<> send_notify_msg(NotifyRef);
   seastar::future<> send_disconnect_msg();
+
+  // Register/unregister this watch in its connection's per-connection registry
+  // (crimson::osd::WatchConState, living in the connection's OSDConnectionPriv)
+  // so that a reset of the connection can find and disconnect it. These perform
+  // a cross-core hop because the watch lives on its PG's core while the registry
+  // lives on the connection's home core. Defined in watch_conn.cc (they touch
+  // OSD-only symbols and so must stay out of watch.cc, which is also compiled
+  // into unit tests).
+  seastar::future<> register_on_conn();
+  seastar::future<> deregister_from_conn();
 
   friend Notify;
   friend class WatchTimeoutRequest;
@@ -101,6 +116,13 @@ public:
   bool is_connected() const {
     return static_cast<bool>(conn);
   }
+  bool is_connected_to(const crimson::net::Connection* con) const {
+    // identity comparison only; safe to call from any core.
+    return conn.get() == con;
+  }
+  bool is_discarded() const {
+    return discarded;
+  }
   void got_ping(utime_t);
 
   void discard_state();
@@ -145,6 +167,39 @@ public:
 };
 
 using WatchRef = seastar::shared_ptr<Watch>;
+
+// A per-connection registry of the watches currently reachable over one client
+// connection. It lives in that connection's OSDConnectionPriv (on the
+// connection's home core) and lets OSD::ms_handle_reset() find and disconnect
+// every watch of a reset connection. This is crimson's equivalent of classic
+// WatchConState (src/osd/Watch.h) / Session::wstate.
+//
+// A Watch is owned by its ObjectContext and therefore lives on its PG's core,
+// which may differ from the connection's core. Entries are consequently held as
+// cross-core `seastar::foreign_ptr<WatchRef>` and keyed by the Watch's address
+// (used purely as an opaque identity). All methods run on the connection's core;
+// reset() fans out one cross-core hop per watch to disconnect it on its own
+// core. Defined in watch_conn.cc.
+class WatchConState {
+  // A flat_map (contiguous, one growable allocation) rather than std::map: the
+  // set is small (the objects a single connection watches), never touched on
+  // the notify data path, mutated only on watch establishment/teardown, and
+  // iterated only on reset -- so cache-friendly iteration matters more than
+  // node stability or ordered lookup, and the pointer key is opaque identity.
+  boost::container::flat_map<const void*, seastar::foreign_ptr<WatchRef>> watches;
+
+public:
+  /// Register a (foreign) watch under its identity key.
+  void add_watch(const void* key, seastar::foreign_ptr<WatchRef> watch);
+  /// Unregister a watch; a no-op if it is not present.
+  void remove_watch(const void* key);
+  bool empty() const {
+    return watches.empty();
+  }
+  /// Disconnect every registered watch that is still connected to `con`,
+  /// emptying the registry. Called on a connection reset.
+  seastar::future<> reset(const crimson::net::Connection* con);
+};
 
 struct notify_reply_t {
   uint64_t watcher_gid;

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -33,6 +33,13 @@ class Watch : public seastar::enable_shared_from_this<Watch> {
   // used by create().
   struct private_ctag_t{};
 
+  // A dedicated private tag for the unit-test-only constructor below. Being
+  // private, it can only be named by `Watch` itself, so the sole way to reach
+  // that constructor is `create_for_test()`. Its presence in the signature
+  // also doubly documents -- at the definition and at every (test-only) call
+  // site -- that the constructor is not for production use.
+  struct unit_test_ctag_t{};
+
   std::set<NotifyRef, std::less<>> in_progress_notifies;
   crimson::net::ConnectionXcoreRef conn;
   crimson::osd::ObjectContextRef obc;
@@ -65,6 +72,25 @@ public:
       }) {
     assert(this->pg);
   }
+
+  // UNIT-TEST ONLY. Builds a Watch without an ObjectContext, a PG or a
+  // connection -- just enough state to exercise the connection- and
+  // PG-agnostic bookkeeping (notably the in_progress_notifies handling in
+  // cancel_notify()/notify_ack()). Because `obc` and `pg` are left null, the
+  // caller must NOT arm timeout_timer or invoke anything that dereferences
+  // them (e.g. do_watch_timeout(), remove(), start_notify() on a connected
+  // watch). The timeout callback is deliberately a no-op: wiring
+  // do_watch_timeout() here would make every test translation unit depend on
+  // the PG operation framework (WatchTimeoutRequest et al.), which is exactly
+  // what this seam avoids. Reachable only through create_for_test(); see
+  // unit_test_ctag_t.
+  Watch(unit_test_ctag_t,
+        const watch_info_t& winfo,
+        const entity_name_t& entity_name)
+    : winfo(winfo),
+      entity_name(entity_name),
+      timeout_timer([] { /* never armed in tests; see note above */ }) {
+  }
   ~Watch();
 
   seastar::future<> connect(crimson::net::ConnectionXcoreRef, bool);
@@ -90,6 +116,13 @@ public:
   static seastar::shared_ptr<Watch> create(Args&&... args) {
     return seastar::make_shared<Watch>(private_ctag_t{},
                                        std::forward<Args>(args)...);
+  };
+
+  // UNIT-TEST ONLY factory for the unit_test_ctag_t constructor above.
+  static seastar::shared_ptr<Watch> create_for_test(
+      const watch_info_t& winfo,
+      const entity_name_t& entity_name) {
+    return seastar::make_shared<Watch>(unit_test_ctag_t{}, winfo, entity_name);
   };
 
   uint64_t get_watcher_gid() const {

--- a/src/crimson/osd/watch_conn.cc
+++ b/src/crimson/osd/watch_conn.cc
@@ -1,0 +1,189 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include <seastar/core/do_with.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/smp.hh>
+
+#include "crimson/osd/watch.h"
+#include "crimson/osd/osd_connection_priv.h"
+
+#include <fmt/ostream.h>
+
+// The connection-coupled half of the Watch machinery: (re)connect, teardown,
+// and the per-connection watch registry (WatchConState) used to disconnect a
+// connection's watches on reset. It is separated from watch.cc because it
+// touches OSD-only symbols (get_osd_priv / OSDConnectionPriv), which watch.cc
+// must avoid so that it can also be compiled into the standalone unit tests.
+//
+// Cores: a Watch lives on its PG's core; its connection is a foreign reference
+// to a Connection homed on a possibly-different core. Registering therefore
+// hops PG-core -> connection-core, and reset (running on the connection-core)
+// hops back connection-core -> PG-core once per watch.
+
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace crimson::osd {
+
+seastar::future<> Watch::register_on_conn()
+{
+  ceph_assert(conn);
+  const auto conn_shard = conn.get_owner_shard();
+  auto* const raw_conn = conn.get();
+  const void* const key = this;
+  // Move a foreign ref of ourselves onto the connection's core and file it in
+  // that connection's registry. `conn` (held by this Watch, kept alive by the
+  // caller for the duration of connect()) keeps `raw_conn` valid across the hop.
+  return seastar::smp::submit_to(conn_shard,
+    [raw_conn, key, fwatch=seastar::make_foreign(shared_from_this())]() mutable {
+      get_osd_priv(raw_conn).ensure_watch_conn_state().add_watch(
+        key, std::move(fwatch));
+    });
+}
+
+seastar::future<> Watch::deregister_from_conn()
+{
+  if (!conn) {
+    return seastar::now();
+  }
+  const auto conn_shard = conn.get_owner_shard();
+  auto* const raw_conn = conn.get();
+  const void* const key = this;
+  // Keep the connection alive across the hop (via the finally keep-alive) in
+  // case this Watch holds its last reference and drops `conn` right after.
+  return seastar::smp::submit_to(conn_shard,
+    [raw_conn, key] {
+      if (raw_conn->has_user_private()) {
+        auto& priv = get_osd_priv(raw_conn);
+        if (priv.watch_conn_state) {
+          priv.watch_conn_state->remove_watch(key);
+        }
+      }
+    }).finally([keep=conn] {});
+}
+
+seastar::future<> Watch::connect(crimson::net::ConnectionXcoreRef conn, bool)
+{
+  if (this->conn == conn) {
+    logger().debug("conn={} already connected", *conn);
+    return seastar::now();
+  }
+  // If we were connected over a different connection, leave its registry before
+  // adopting the new one, so a later reset of the old connection cannot
+  // disconnect us. deregister_from_conn() reads the current (old) `conn`, so it
+  // must run before we overwrite it below.
+  return deregister_from_conn().then(
+    [this, this_shared=shared_from_this(),
+     new_conn=std::move(conn)]() mutable {
+      timeout_timer.cancel();
+      timeout_timer.arm(std::chrono::seconds{winfo.timeout_seconds});
+      this->conn = std::move(new_conn);
+      return register_on_conn();
+    }).then([this, this_shared=shared_from_this()] {
+      // Now (re)connected: replay every notify buffered while disconnected.
+      // Mirrors classic Watch::connect() (src/osd/Watch.cc). start_notify()
+      // records a notify in in_progress_notifies even while disconnected but
+      // only *delivers* it once connected, so the buffered ones must be
+      // (re)sent here. Resending an already-delivered NOTIFY is harmless -- the
+      // client de-duplicates by notify_id. Snapshot first so a concurrent
+      // notify_ack()/cancel_notify() cannot invalidate the iteration.
+      return seastar::do_with(
+        std::vector<NotifyRef>(std::begin(in_progress_notifies),
+                               std::end(in_progress_notifies)),
+        [this_shared](auto& buffered) {
+          return seastar::do_for_each(buffered, [this_shared](auto& notify) {
+            return this_shared->send_notify_msg(notify);
+          });
+        });
+    });
+}
+
+void Watch::discard_state()
+{
+  logger().debug("{} gid={} cookie={}", __func__, get_watcher_gid(), get_cookie());
+  ceph_assert(obc);
+  in_progress_notifies.clear();
+  timeout_timer.cancel();
+  discarded = true;
+  if (conn) {
+    // Leave the connection's registry -- this also breaks the Watch<->Connection
+    // reference cycle (Watch -> conn -> OSDConnectionPriv -> WatchConState ->
+    // foreign Watch). Fire-and-forget: discard_state() is synchronous, and
+    // deregister_from_conn() keeps the connection alive across its own hop.
+    std::ignore = deregister_from_conn();
+    conn = {};
+  }
+}
+
+seastar::future<> Watch::remove()
+{
+  logger().debug("{} gid={} cookie={}", __func__, get_watcher_gid(), get_cookie());
+  // in contrast to ceph-osd crimson sends CEPH_WATCH_EVENT_DISCONNECT directly
+  // from the timeout handler and _after_ CEPH_WATCH_EVENT_NOTIFY_COMPLETE.
+  // this simplifies the Watch::remove() interface as callers aren't obliged
+  // anymore to decide whether EVENT_DISCONNECT needs to be send or not -- it
+  // becomes an implementation detail of Watch.
+  return seastar::do_for_each(in_progress_notifies,
+    [this_shared=shared_from_this()] (auto notify) {
+      logger().debug("Watch::remove gid={} cookie={} notify(id={})",
+                     this_shared->get_watcher_gid(),
+                     this_shared->get_cookie(),
+                     notify->ninfo.notify_id);
+      return notify->remove_watcher(this_shared);
+    }).then([this_shared=shared_from_this()] {
+      this_shared->discard_state();  // also deregisters from the connection
+      return seastar::now();
+    });
+}
+
+void WatchConState::add_watch(const void* key,
+                              seastar::foreign_ptr<WatchRef> watch)
+{
+  watches.insert_or_assign(key, std::move(watch));
+}
+
+void WatchConState::remove_watch(const void* key)
+{
+  watches.erase(key);
+}
+
+seastar::future<> WatchConState::reset(const crimson::net::Connection* con)
+{
+  logger().debug("WatchConState::reset {} watch(es)", watches.size());
+  // Take the whole set at once so concurrent (de)registration cannot race the
+  // fan-out, then disconnect each watch on its own core. Mirrors classic
+  // WatchConState::reset() (src/osd/Watch.cc).
+  return seastar::do_with(std::exchange(watches, {}),
+    [con](auto& entries) {
+      return seastar::parallel_for_each(entries, [con](auto& kv) {
+        const auto shard = kv.second.get_owner_shard();
+        auto* const watch = kv.second.get();
+        return seastar::smp::submit_to(shard, [watch, con] {
+          // On the watch's own core. Skip a watch that was already torn down or
+          // that reconnected onto a different connection between the reset and
+          // this hop (classic's is_connected(con) guard).
+          if (!watch->is_discarded() && watch->is_connected_to(con)) {
+            watch->disconnect();
+          }
+        });
+      });
+    });
+  // `entries` (and its foreign refs) is destroyed here on the connection's core.
+}
+
+OSDConnectionPriv::OSDConnectionPriv() = default;
+OSDConnectionPriv::~OSDConnectionPriv() = default;
+
+WatchConState &OSDConnectionPriv::ensure_watch_conn_state()
+{
+  if (!watch_conn_state) {
+    watch_conn_state = std::make_unique<WatchConState>();
+  }
+  return *watch_conn_state;
+}
+
+} // namespace crimson::osd

--- a/src/crimson/osd/watch_conn.cc
+++ b/src/crimson/osd/watch_conn.cc
@@ -29,7 +29,7 @@ namespace {
 
 namespace crimson::osd {
 
-seastar::future<> Watch::register_on_conn()
+seastar::future<bool> Watch::register_on_conn()
 {
   ceph_assert(conn);
   const auto conn_shard = conn.get_owner_shard();
@@ -40,8 +40,13 @@ seastar::future<> Watch::register_on_conn()
   // caller for the duration of connect()) keeps `raw_conn` valid across the hop.
   return seastar::smp::submit_to(conn_shard,
     [raw_conn, key, fwatch=seastar::make_foreign(shared_from_this())]() mutable {
-      get_osd_priv(raw_conn).ensure_watch_conn_state().add_watch(
-        key, std::move(fwatch));
+      auto& state = get_osd_priv(raw_conn).ensure_watch_conn_state();
+      state.add_watch(key, std::move(fwatch));
+      if (raw_conn->is_connected()) {
+        return true;
+      }
+      state.remove_watch(key);
+      return false;
     });
 }
 
@@ -83,7 +88,11 @@ seastar::future<> Watch::connect(crimson::net::ConnectionXcoreRef conn, bool)
       timeout_timer.arm(std::chrono::seconds{winfo.timeout_seconds});
       this->conn = std::move(new_conn);
       return register_on_conn();
-    }).then([this, this_shared=shared_from_this()] {
+    }).then([this, this_shared=shared_from_this()](bool connected) {
+      if (!connected) {
+        this_shared->disconnect();
+        return seastar::now();
+      }
       // Now (re)connected: replay every notify buffered while disconnected.
       // Mirrors classic Watch::connect() (src/osd/Watch.cc). start_notify()
       // records a notify in in_progress_notifies even while disconnected but

--- a/src/crimson/osd/watch_timeout_request.cc
+++ b/src/crimson/osd/watch_timeout_request.cc
@@ -1,0 +1,98 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "crimson/osd/watch.h"
+#include "crimson/osd/osd_operations/internal_client_request.h"
+
+#include <fmt/ostream.h>
+
+// This translation unit holds the only part of the Watch machinery that is
+// coupled to the PG operation framework: the watch-timeout operation and the
+// Watch::do_watch_timeout() member that starts it. Keeping it out of watch.cc
+// lets watch.cc (the Notify/Watch bookkeeping) be compiled and unit-tested
+// without pulling in the entire OSD operation stack (InternalClientRequest ->
+// PG::run_executer/submit_executer -> OpsExecuter -> ObjectContextLoader ...).
+
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace crimson::osd {
+class WatchTimeoutRequest;
+}
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::osd::WatchTimeoutRequest> : fmt::ostream_formatter {};
+#endif
+
+namespace crimson::osd {
+
+// a watcher can remove itself if it has not seen a notification after a period of time.
+// in the case, we need to drop it also from the persisted `ObjectState` instance.
+// this operation resembles a bit the `_UNWATCH` subop.
+class WatchTimeoutRequest final : public InternalClientRequest {
+public:
+  WatchTimeoutRequest(WatchRef watch, Ref<PG> pg)
+    : InternalClientRequest(std::move(pg)),
+      watch(std::move(watch)) {
+  }
+
+  const hobject_t& get_target_oid() const final;
+  PG::do_osd_ops_params_t get_do_osd_ops_params() const final;
+  std::vector<OSDOp> create_osd_ops() final;
+
+private:
+  WatchRef watch;
+};
+
+const hobject_t& WatchTimeoutRequest::get_target_oid() const
+{
+  assert(watch->obc);
+  return watch->obc->get_oid();
+}
+
+PG::do_osd_ops_params_t
+WatchTimeoutRequest::get_do_osd_ops_params() const
+{
+  osd_reqid_t reqid;
+  reqid.name = watch->entity_name;
+  PG::do_osd_ops_params_t params{
+    watch->conn,
+    reqid,
+    ceph_clock_now(),
+    get_pg().get_osdmap_epoch(),
+    entity_inst_t{ watch->entity_name, watch->winfo.addr },
+    0
+  };
+  logger().debug("{}: params.reqid={}", __func__, params.reqid);
+  return params;
+}
+
+std::vector<OSDOp> WatchTimeoutRequest::create_osd_ops()
+{
+  logger().debug("{}", __func__);
+  assert(watch);
+  OSDOp osd_op;
+  osd_op.op.op = CEPH_OSD_OP_WATCH;
+  osd_op.op.flags = 0;
+  osd_op.op.watch.op = CEPH_OSD_WATCH_OP_UNWATCH;
+  osd_op.op.watch.cookie = watch->winfo.cookie;
+  return std::vector{std::move(osd_op)};
+}
+
+// ///////////////////////////////////////////////////////////////////////////
+// a 'Watch' timeout handler
+
+void Watch::do_watch_timeout()
+{
+  assert(pg);
+  auto [op, fut] = pg->get_shard_services().start_operation<WatchTimeoutRequest>(
+    shared_from_this(), pg);
+  std::ignore = std::move(fut).then([op=std::move(op), this] {
+    return send_disconnect_msg();
+  });
+}
+
+} // namespace crimson::osd

--- a/src/crimson/osd/watch_timeout_request.cc
+++ b/src/crimson/osd/watch_timeout_request.cc
@@ -88,11 +88,22 @@ std::vector<OSDOp> WatchTimeoutRequest::create_osd_ops()
 void Watch::do_watch_timeout()
 {
   assert(pg);
+  // Capture the connection now: the WatchTimeoutRequest started below issues an
+  // internal UNWATCH whose obc effect runs Watch::remove() -> discard_state(),
+  // which clears this->conn before the continuation runs. Sending the disconnect
+  // on the captured handle (rather than this->conn, now null) is what actually
+  // delivers CEPH_WATCH_EVENT_DISCONNECT to the client - after the UNWATCH has
+  // flushed any NOTIFY_COMPLETE messages, matching the ordering documented in
+  // Watch::remove(). Without this the send silently no-ops on a cleared conn and
+  // the client never learns the watch timed out (it only finds out much later,
+  // when its connection resets and a watch-reconnect is refused with -ENOTCONN).
+  auto conn = this->conn;
   auto [op, fut] = pg->get_shard_services().start_operation<WatchTimeoutRequest>(
     shared_from_this(), pg);
-  std::ignore = std::move(fut).then([op=std::move(op), this] {
-    return send_disconnect_msg();
-  });
+  std::ignore = std::move(fut).then(
+    [op=std::move(op), conn=std::move(conn), this]() mutable {
+      return send_disconnect_msg(std::move(conn));
+    });
 }
 
 } // namespace crimson::osd

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -136,4 +136,22 @@ target_link_libraries(
   crimson-common
   crimson::gtest)
 
+add_executable(unittest-crimson-watch-notify
+  test_watch_notify.cc
+  ${PROJECT_SOURCE_DIR}/src/crimson/osd/watch.cc)
+target_link_libraries(
+  unittest-crimson-watch-notify
+  crimson
+  crimson::gtest
+  # watch.h pulls in osd/PeeringState.h (via crimson/osd/pg.h); Boost::MPL sets
+  # the enlarged BOOST_MPL_LIMIT_LIST_SIZE it needs.
+  Boost::MPL)
+# Compile the code-under-test with assertions enabled regardless of the build
+# type. The pre-fix cancel_notify() bug is an `assert()` followed by a
+# dereference of a not-found iterator; under -DNDEBUG the assert vanishes and the
+# regression degrades into undefined behaviour
+target_compile_options(unittest-crimson-watch-notify PRIVATE -UNDEBUG)
+add_ceph_unittest(unittest-crimson-watch-notify
+  --memory 256M --smp 1)
+
 add_subdirectory(cbt)

--- a/src/test/crimson/test_watch_notify.cc
+++ b/src/test/crimson/test_watch_notify.cc
@@ -1,0 +1,66 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "test/crimson/gtest_seastar.h"
+
+// watch.h transitively provides watch_info_t and entity_name_t.
+#include "crimson/osd/watch.h"
+
+using crimson::osd::Watch;
+using crimson::osd::WatchRef;
+
+namespace {
+
+WatchRef make_test_watch(uint64_t cookie = 1)
+{
+  watch_info_t winfo{cookie, /*timeout_seconds=*/30, entity_addr_t{}};
+  return Watch::create_for_test(winfo, entity_name_t::CLIENT(cookie));
+}
+
+} // anonymous namespace
+
+// Regression test for the crimson notify-timeout race.
+//
+// Notify::create_n_propagate() adds every watcher to Notify::watchers
+// synchronously and arms the notify timeout up front, but each watcher only
+// records the notify in Watch::in_progress_notifies once its asynchronous
+// Watch::start_notify() runs. Because propagation is sequential and awaits a
+// network send per watcher, the timeout can fire before start_notify() has
+// completed for every watcher (more likely with many watchers on one object
+// under load). Notify::do_notify_timeout() then iterates the full watcher set
+// and calls Watch::cancel_notify() for a watcher that has not recorded the
+// notify yet.
+//
+// Before the fix cancel_notify() assumed the entry existed: it asserted the
+// iterator was valid and then erased it. On a missing entry that lookup returns
+// end(), so the assert fires. The fix makes a missing entry a no-op, mirroring
+// notify_ack(). This exercises that path directly -- constructing a full
+// Watch/Notify/PG stack is impractical in a unit test, but cancel_notify()
+// touches none of it, so the connection- and PG-agnostic test constructor is
+// sufficient.
+struct watch_notify_test_t : public seastar_test_suite_t {};
+
+TEST_F(watch_notify_test_t, cancel_notify_missing_is_noop)
+{
+  run_async([] {
+    auto watch = make_test_watch();
+    // No notify was ever started on this watch, so in_progress_notifies is
+    // empty. Pre-fix this aborted; post-fix it must be a clean no-op.
+    watch->cancel_notify(0xdeadbeef);
+    // A second call must be equally harmless.
+    watch->cancel_notify(0);
+    SUCCEED();
+  });
+}
+
+// notify_ack() already guards the same lookup; assert the sibling invariant so
+// the two stay consistent.
+TEST_F(watch_notify_test_t, notify_ack_missing_is_noop)
+{
+  run_async([] {
+    auto watch = make_test_watch();
+    ceph::bufferlist reply;
+    watch->notify_ack(0xdeadbeef, reply).get();
+    SUCCEED();
+  });
+}


### PR DESCRIPTION
This PR fixes a notify-timeout race in the crimson watch/notify code and fills
in the watch connection lifecycle to match classic ceph-osd.

- Fix an OSD abort when a notify times out while it is still being propagated to
  its watchers, and the follow-on completion/ack handling that the race exposed.
- Implement resend-of-buffered-notifies on watcher reconnect.
- Implement connection-reset handling: disconnect a connection's watches when it
  resets (including the reset-during-registration case), via a per-connection
  watch registry.

The watch-timeout operation is split into its own translation unit so the core
watch bookkeeping can be unit-tested.

Tests:
- `unittest-crimson-watch-notify` (`src/test/crimson/test_watch_notify.cc`)
- `qa/standalone/crimson/watch-notify.sh`

Fixes: https://tracker.ceph.com/issues/79853
