### PR TITLE
common: ignore unknown config options given as command line arguments

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,13 @@
+* A configuration option given on the command line that the daemon does not
+  recognize is now ignored with a warning instead of causing the daemon to
+  exit. A config option may be renamed, retyped or removed between releases,
+  and a deployed daemon that was given one should still start; this also
+  matches how an unknown option is already treated when it comes from a
+  configuration file or from the mon config database. Both the
+  ``--name=value`` and the ``--name value`` forms are covered. An unrecognized
+  argument that takes no value, such as a mistyped flag, is still an error.
+  The warning naming each ignored option is written to the daemon log.
+
 * ``src/script/ceph-backport.sh`` now runs on macOS in addition to Linux: it
   re-execs under GNU bash >= 4 when the system bash is too old, and honors a
   ``$GETOPT`` environment override so GNU getopt can be selected

--- a/doc/man/8/ceph-mds.rst
+++ b/doc/man/8/ceph-mds.rst
@@ -74,6 +74,29 @@ Options
    Set the MDS name of the format TYPE.ID. The TYPE is obviously 'mds'.
    The ID should not start with a numeric digit.
 
+Configuration Options
+=====================
+
+Any Ceph configuration option may be given on the command line, in either the
+``--name=value`` or the ``--name value`` form.
+
+An option that is not recognized is ignored with a warning rather than treated
+as an error, because a configuration option may have been renamed, retyped or
+removed since the daemon was deployed, and such a daemon should still start.
+The warning naming each ignored option is written to the daemon log. This
+matches how an unknown option is treated when it is read from a configuration
+file or from the Monitor configuration database.
+
+Note that this applies only to options carrying a value. An unrecognized
+argument that takes no value is far more likely to be a mistyped command
+argument than a configuration option, so it is still an error.
+
+Which options are recognized is decided by the version of this daemon's own
+package: the set of known options is compiled in, not retrieved from the
+cluster. In a cluster whose packages are at mixed revisions, as during a
+staggered upgrade, the same option may therefore be applied by one daemon and
+ignored with a warning by another.
+
 Availability
 ============
 

--- a/doc/man/8/ceph-mon.rst
+++ b/doc/man/8/ceph-mon.rst
@@ -88,6 +88,29 @@ Options
     or the default, to run the daemon.  This will entail providing all
     necessary options to the daemon as arguments.
 
+Configuration Options
+=====================
+
+Any Ceph configuration option may be given on the command line, in either the
+``--name=value`` or the ``--name value`` form.
+
+An option that is not recognized is ignored with a warning rather than treated
+as an error, because a configuration option may have been renamed, retyped or
+removed since the daemon was deployed, and such a daemon should still start.
+The warning naming each ignored option is written to the daemon log. This
+matches how an unknown option is treated when it is read from a configuration
+file or from the Monitor configuration database.
+
+Note that this applies only to options carrying a value. An unrecognized
+argument that takes no value is far more likely to be a mistyped command
+argument than a configuration option, so it is still an error.
+
+Which options are recognized is decided by the version of this daemon's own
+package: the set of known options is compiled in, not retrieved from the
+cluster. In a cluster whose packages are at mixed revisions, as during a
+staggered upgrade, the same option may therefore be applied by one daemon and
+ignored with a warning by another.
+
 Availability
 ============
 

--- a/doc/man/8/ceph-osd.rst
+++ b/doc/man/8/ceph-osd.rst
@@ -127,6 +127,29 @@ Options
    Set an affinity to a certain OSDSpec.
    This option can only be used in conjunction with --mkfs.
 
+Configuration Options
+=====================
+
+Any Ceph configuration option may be given on the command line, in either the
+``--name=value`` or the ``--name value`` form.
+
+An option that is not recognized is ignored with a warning rather than treated
+as an error, because a configuration option may have been renamed, retyped or
+removed since the daemon was deployed, and such a daemon should still start.
+The warning naming each ignored option is written to the daemon log. This
+matches how an unknown option is treated when it is read from a configuration
+file or from the Monitor configuration database.
+
+Note that this applies only to options carrying a value. An unrecognized
+argument that takes no value is far more likely to be a mistyped command
+argument than a configuration option, so it is still an error.
+
+Which options are recognized is decided by the version of this daemon's own
+package: the set of known options is compiled in, not retrieved from the
+cluster. In a cluster whose packages are at mixed revisions, as during a
+staggered upgrade, the same option may therefore be applied by one daemon and
+ignored with a warning by another.
+
 Availability
 ============
 

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -66,6 +66,38 @@ cluster to retrieve centrally-stored configuration for the entire cluster.
 After a complete set of configuration options is available, the startup of the
 daemon or process will commence.
 
+Unknown Options
+---------------
+
+A configuration option may be renamed, retyped or removed between Ceph
+releases, so a daemon or client may be given an option that no longer exists.
+Each source treats that case differently:
+
+- In a configuration file, an unknown option is ignored silently.
+- In the central configuration database, an unknown option is retained but has
+  no effect.
+- On the command line, an unknown option is ignored with a warning, which is
+  written to the daemon log. This applies to both the ``--name=value`` and the
+  ``--name value`` form. An unrecognized argument that takes no value is still
+  an error, because it is far more likely to be a mistyped command argument
+  than a configuration option.
+- In the ``CEPH_ARGS`` environment variable, which is parsed exactly as the
+  command line is, an unknown option is ignored silently.
+
+Whether an option is recognized at all is decided by the version of the
+binary that parses it, because the set of known options is compiled into each
+package rather than retrieved from the cluster. On a host whose packages are
+at a different revision, or during a staggered upgrade, the same option may
+therefore be applied by one process and ignored by another. An option that a
+newer Monitor accepts from ``ceph config set`` may likewise be unknown to an
+older daemon, which will ignore it.
+
+.. warning:: Because a misspelled option is ignored rather than rejected, a
+   typo in an option name will not prevent a daemon from starting, and outside
+   of the command line it produces no warning at all. After setting an option,
+   confirm that it took effect, for example with ``ceph config show`` for a
+   running daemon or with ``--show-config-value <option>``.
+
 .. _bootstrap-options:
 
 Bootstrap Options

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -119,15 +119,30 @@ int main(int argc, const char **argv)
     dout(1) << __func__ << " not setting numa affinity" << dendl;
   }
   std::string val, action;
+  bool double_dash = false;
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
+      double_dash = true;
       break;
     }
     else if (ceph_argparse_witharg(args, i, &val, "--hot-standby", (char*)NULL)) {
       dout(0) << "--hot-standby is obsolete and has no effect" << dendl;
     }
     else {
-      derr << "Error: can't understand argument: " << *i << "\n" << dendl;
+      ++i;
+    }
+  }
+
+  // Anything left is unknown to both the config schema and to us. Drop the
+  // ones that were given as a config, so that a config which has since been
+  // renamed or removed does not stop the daemon from starting, and reject
+  // the rest as before.
+  if (!double_dash) {
+    for (const auto& opt : ceph_argparse_drop_unknown_conf_opts(args)) {
+      derr << "WARNING: ignoring unknown config option: " << opt << dendl;
+    }
+    if (!args.empty()) {
+      derr << "Error: can't understand argument: " << args.front() << "\n" << dendl;
       exit(1);
     }
   }

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -369,6 +369,10 @@ int main(int argc, const char **argv)
       ++i;
     }
   }
+  for (const auto& opt : ceph_argparse_drop_unknown_conf_opts(args)) {
+    derr << "WARNING: ignoring unknown config option: " << opt << dendl;
+  }
+
   if (!args.empty()) {
     cerr << "too many arguments: " << args << std::endl;
     exit(1);

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -201,6 +201,10 @@ int main(int argc, const char **argv)
       ++i;
     }
   }
+  for (const auto& opt : ceph_argparse_drop_unknown_conf_opts(args)) {
+    derr << "WARNING: ignoring unknown config option: " << opt << dendl;
+  }
+
   if (!args.empty()) {
     cerr << "unrecognized arg " << args[0] << std::endl;
     exit(1);

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -577,6 +577,41 @@ static void generic_usage(bool is_server)
   std::cout.flush();
 }
 
+std::vector<std::string> ceph_argparse_drop_unknown_conf_opts(
+  std::vector<const char*>& args)
+{
+  std::vector<std::string> dropped;
+  for (auto i = args.begin(); i != args.end(); ) {
+    const char *arg = *i;
+    if (strcmp(arg, "--") == 0) {
+      // everything past a double dash is for the caller to deal with
+      break;
+    }
+    // "--=bar" has no option name, so it is not one of ours either
+    if (arg[0] != '-' || arg[1] != '-' || arg[2] == '\0' || arg[2] == '=') {
+      ++i;
+      continue;
+    }
+    if (const char *eq = strchr(arg + 2, '='); eq != NULL) {
+      // --foo=bar
+      dropped.emplace_back(arg + 2, eq);
+      i = args.erase(i);
+      continue;
+    }
+    // --foo bar, where the value is a separate argument. Take the next one
+    // only if it is not an option itself, so that a bare flag stays a bare
+    // flag and is left for the caller to reject.
+    auto value = std::next(i);
+    if (value == args.end() || (*value)[0] == '-') {
+      ++i;
+      continue;
+    }
+    dropped.emplace_back(arg + 2);
+    i = args.erase(i, std::next(value));
+  }
+  return dropped;
+}
+
 bool ceph_argparse_need_usage(const std::vector<const char*>& args)
 {
   if (args.empty()) {

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -90,6 +90,31 @@ bool ceph_argparse_binary_flag(std::vector<const char*> &args,
 extern CephInitParameters ceph_argparse_early_args
 	    (std::vector<const char*>& args, uint32_t module_type,
 	     std::string *cluster, std::string *conf_file_list);
+/*
+ * Remove from args any unrecognized argument that was given as a config
+ * option, in either the "--foo=bar" or the "--foo bar" form, and return the
+ * names of the options removed.
+ *
+ * Config options are routinely renamed, retyped or dropped altogether, so a
+ * deployed daemon should not refuse to start just because it was handed one
+ * that no longer exists.  This matches how the same option is treated when it
+ * comes from ceph.conf or from the mon config database, where an unknown
+ * option is ignored.  Callers are expected to warn about what was removed.
+ *
+ * Only options carrying a value are removed.  A bare "--flag" is left in
+ * place, as is everything following a "--", because a flag that takes no
+ * value is far more likely to be a mistyped command argument than a config,
+ * and quietly dropping it would turn the typo into a flag that silently does
+ * nothing.  For the same reason the argument after "--foo" is only taken as
+ * its value if it does not itself begin with a '-'.
+ *
+ * Call this only where any remaining argument would otherwise be rejected as
+ * unrecognized, and after the caller has parsed the arguments it knows about:
+ * consuming the value of a "--foo bar" pair is safe precisely because that
+ * pair would have been an error anyway.
+ */
+extern std::vector<std::string> ceph_argparse_drop_unknown_conf_opts(
+	std::vector<const char*>& args);
 extern bool ceph_argparse_need_usage(const std::vector<const char*>& args);
 extern void generic_server_usage();
 extern void generic_client_usage();

--- a/src/test/common/test_config.cc
+++ b/src/test/common/test_config.cc
@@ -23,6 +23,7 @@
 
 #include <iostream> // for std::cout
 
+#include "common/ceph_argparse.h"
 #include "common/config_proxy.h"
 #include "common/errno.h"
 #include "gtest/gtest.h"
@@ -303,6 +304,93 @@ TEST(Option, validation)
   input = "one";  // A value that has a magic conversion
   EXPECT_EQ(0, opt_validator.pre_validate(&input, &msg));
   EXPECT_EQ(input, "1");
+}
+
+TEST(daemon_config, drop_unknown_conf_opts)
+{
+  // compare by value: the arguments are pointers, and comparing those would
+  // only be testing whether the compiler happened to pool the literals
+  auto as_strings = [](const std::vector<const char*>& args) {
+    return std::vector<std::string>(args.begin(), args.end());
+  };
+  // an unknown config given as an argument is dropped and reported, so that
+  // the caller does not treat it as a fatal unrecognized argument
+  {
+    std::vector<const char*> args{"--debug_foijdf=1"};
+    EXPECT_EQ(std::vector<std::string>{"debug_foijdf"},
+	      ceph_argparse_drop_unknown_conf_opts(args));
+    EXPECT_TRUE(args.empty());
+  }
+  // a bare flag may be a command argument, so it is left for the caller
+  {
+    std::vector<const char*> args{"--hot-standby"};
+    EXPECT_TRUE(ceph_argparse_drop_unknown_conf_opts(args).empty());
+    EXPECT_EQ(1u, args.size());
+  }
+  // so is anything that is not an option at all
+  {
+    std::vector<const char*> args{"a", "-i", "-"};
+    EXPECT_TRUE(ceph_argparse_drop_unknown_conf_opts(args).empty());
+    EXPECT_EQ(3u, args.size());
+  }
+  // an option name is required
+  {
+    std::vector<const char*> args{"--=1"};
+    EXPECT_TRUE(ceph_argparse_drop_unknown_conf_opts(args).empty());
+    EXPECT_EQ(1u, args.size());
+  }
+  // only the offending options are removed, order is otherwise preserved
+  {
+    std::vector<const char*> args{"-i", "a", "--debug_a=1", "-f",
+				  "--debug_b=2", "--hot-standby"};
+    std::vector<std::string> expected{"debug_a", "debug_b"};
+    EXPECT_EQ(expected, ceph_argparse_drop_unknown_conf_opts(args));
+    std::vector<std::string> remaining{"-i", "a", "-f", "--hot-standby"};
+    EXPECT_EQ(remaining, as_strings(args));
+  }
+  // the value may be a separate argument: both are dropped
+  {
+    std::vector<const char*> args{"--debug_ms", "1"};
+    EXPECT_EQ(std::vector<std::string>{"debug_ms"},
+	      ceph_argparse_drop_unknown_conf_opts(args));
+    EXPECT_TRUE(args.empty());
+  }
+  // ... but only when there is something that can be a value
+  {
+    std::vector<const char*> args{"--debug_ms"};
+    EXPECT_TRUE(ceph_argparse_drop_unknown_conf_opts(args).empty());
+    EXPECT_EQ(1u, args.size());
+  }
+  // an option is not the value of the option before it
+  {
+    std::vector<const char*> args{"--debug_ms", "--debug_mds=1"};
+    EXPECT_EQ(std::vector<std::string>{"debug_mds"},
+	      ceph_argparse_drop_unknown_conf_opts(args));
+    std::vector<std::string> remaining{"--debug_ms"};
+    EXPECT_EQ(remaining, as_strings(args));
+  }
+  // a value that looks like an option is left alone, so that a bare flag is
+  // still rejected rather than silently swallowing the next argument
+  {
+    std::vector<const char*> args{"--mds_numa_nod", "-1"};
+    EXPECT_TRUE(ceph_argparse_drop_unknown_conf_opts(args).empty());
+    EXPECT_EQ(2u, args.size());
+  }
+  // a value may itself contain an '=', and may be empty
+  {
+    std::vector<const char*> args{"--debug_a=b=c", "--debug_b="};
+    std::vector<std::string> expected{"debug_a", "debug_b"};
+    EXPECT_EQ(expected, ceph_argparse_drop_unknown_conf_opts(args));
+    EXPECT_TRUE(args.empty());
+  }
+  // everything past a double dash belongs to the caller
+  {
+    std::vector<const char*> args{"--debug_a=1", "--", "--debug_b=2"};
+    EXPECT_EQ(std::vector<std::string>{"debug_a"},
+	      ceph_argparse_drop_unknown_conf_opts(args));
+    std::vector<std::string> remaining{"--", "--debug_b=2"};
+    EXPECT_EQ(remaining, as_strings(args));
+  }
 }
 
 /*


### PR DESCRIPTION
A config that no longer exists is treated differently depending on how it was supplied. From `ceph.conf` it is ignored, from the mon config database it is kept but has no effect, and from the command line it is fatal — so a daemon deployed with a config that has since been renamed or removed refuses to start.

Worth flagging: the config parser is not what rejects these. `md_config_t::parse_option` already skips an option that is not in the schema and leaves it in `args`, returning success. The `exit(1)` comes from each daemon's own check for arguments it did not recognize — `can't understand argument` in `ceph_mds.cc`, `unrecognized arg` in `ceph_osd.cc`, `too many arguments` in `ceph_mon.cc`. So the fix is not in `common/` alone. The `ceph.conf` side is not a deliberate ignore either: `parse_buffer` walks the schema and looks each known option up in the file, so an unknown key is never examined at all.

This adds `ceph_argparse_drop_unknown_conf_opts()`, which removes leftover arguments that were given as a config and returns their names, and calls it from the three daemons that have such a check.

On the concern raised in the tracker about daemons running with undiscovered misconfigurations, three things keep that narrow:

Only arguments carrying a value (`--foo=bar`) are ignored. A bare `--foo` is still fatal, so a mistyped flag like `--hot-standbi` does not silently become a no-op. A config supplied as an argument always has a value; a mistyped command flag usually does not.

The daemon is not silent about it. Each ignored option is logged with `derr` rather than written to stderr, so it is still recorded for a daemon that has forked into the background.

It runs after each daemon has parsed its own arguments, not in `parse_option`. This matters: `parse_argv` runs first, and daemons have value-taking arguments of their own that are not config options — `--get-device-fsid`, `--restore-backup`, `--backup-version`. Dropping unknown `--x=y` centrally would swallow those before the daemon saw them. An earlier version of this patch ate `--hot-standby=1` that way.

Known gap: `--debug_foijdf 1` written with a space is still fatal. There the flag and its value are separate tokens, and pairing them would risk consuming a positional argument. Only the `=` form is handled.

Checked against built `ceph-mds`, `ceph-mon` and `ceph-osd`: an unknown `--x=y` warns and startup continues, an unknown bare `--x` is still fatal, a daemon's own `--x=y` argument still reaches the daemon, a known config still applies with no warning, and arguments after `--` are untouched. The new `daemon_config.drop_unknown_conf_opts` unit test covers the argument filtering, and `unittest_config` passes.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
