### PR TITLE
ceph-volume: zfs plugin: fix invalid escape sequences in geom_disk_parser regexes

### DIFF
--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/disk.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/disk.py
@@ -39,10 +39,10 @@ def geom_disk_parser(block):
         except ValueError:
             continue
         # fixup
-        column = re.sub("\s+", "", column)
-        column= re.sub("^[0-9]+\.", "", column)
+        column = re.sub(r"\s+", "", column)
+        column = re.sub(r"^[0-9]+\.", "", column)
         value = value.strip()
-        value = re.sub('\([0-9A-Z]+\)', '', value)
+        value = re.sub(r"\([0-9A-Z]+\)", '', value)
         parsed[column.lower()] = value
     return parsed
 


### PR DESCRIPTION
ceph-volume: zfs plugin: fix invalid escape sequences in geom_disk_parser regexes

Picking up up some of my FreeeBSD stuff, Python now complains about regexes that needs/prefers a raw-string

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

