### PR TITLE
tentacle: doc/cephadm: fix spec webhook key name in services/monitoring.rst

### DIFF
--- a/doc/cephadm/services/monitoring.rst
+++ b/doc/cephadm/services/monitoring.rst
@@ -602,7 +602,7 @@ webhook urls like so:
         - "https://foo"
         - "https://bar"
 
-Where ``default_webhook_urls`` is a list of additional URLs that are
+Where ``webhook_urls`` is a list of additional URLs that are
 added to the default receivers' ``<webhook_configs>`` configuration.
 
 Run ``reconfig`` on the service to update its configuration:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79347
backport of https://github.com/ceph/ceph/pull/70907 (generated with ceph-backport-doc.sh)


---

a8498ddad536305cdeda4699932dc4de7a93f540 changed the config key in spec file example but missed the same key name in the following text.



parent tracker: https://tracker.ceph.com/issues/79139
