### PR TITLE
mgr/cephadm: validate NVMe-oF gateways per service in ok_to_stop

### DIFF
--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -261,25 +261,29 @@ class NvmeofService(CephService):
                    daemon_ids: List[str],
                    force: bool = False,
                    known: Optional[List[str]] = None) -> HandleCommandResult:
-        # if only 1 nvmeof, alert user (this is not passable with --force)
-        warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'Nvmeof', 1, True)
-        if warn:
-            return HandleCommandResult(-errno.EBUSY, '', warn_message)
-
-        # if reached here, there is > 1 nvmeof daemon. make sure none are down
-        if not force:
-            warn_message = ('WARNING: Only one nvmeof daemon is running. Please bring another nvmeof daemon up before stopping the current one.')
-            unreachable_hosts = [h.hostname for h in self.mgr.cache.get_unreachable_hosts()]
-            running_nvmeof_daemons = [
-                d for d in self.mgr.cache.get_daemons_by_type(self.TYPE)
-                if d.status == DaemonDescriptionStatus.running and d.hostname not in unreachable_hosts
-            ]
-            if len(running_nvmeof_daemons) < 2:
-                return HandleCommandResult(-errno.EBUSY, '', warn_message)
-
         names = [f'{self.TYPE}.{d_id}' for d_id in daemon_ids]
-        warn_message = f'It is presumed safe to stop {names}'
-        return HandleCommandResult(0, warn_message, '')
+
+        if not force:
+            all_nvmeof = self.mgr.cache.get_daemons_by_type(self.TYPE)
+            unreachable = {h.hostname for h in self.mgr.cache.get_unreachable_hosts()}
+            group_by_daemon = {d.daemon_id: d.service_name()
+                               for d in all_nvmeof if d.daemon_id in daemon_ids}
+
+            for gateway_group in set(group_by_daemon.values()):
+                ids_to_stop_in_group = {did for did, s in group_by_daemon.items() if s == gateway_group}
+                remaining = [
+                    d for d in self.mgr.cache.get_daemons_by_service(gateway_group)
+                    if d.status == DaemonDescriptionStatus.running
+                    and d.hostname not in unreachable
+                    and d.daemon_id not in ids_to_stop_in_group
+                ]
+                if not remaining:
+                    warn = (f'WARNING: Stopping {[f"{self.TYPE}.{d}" for d in ids_to_stop_in_group]} '
+                            f'would leave no running nvmeof daemons in {gateway_group}. '
+                            f'Please bring another nvmeof daemon up before stopping the current one.')
+                    return HandleCommandResult(-errno.EBUSY, '', warn)
+
+        return HandleCommandResult(0, f'It is presumed safe to stop {names}', '')
 
     def ignore_possible_stray(
         self, service_type: str, daemon_id: str, name: str

--- a/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nvmeof.py
@@ -8,7 +8,7 @@ from cephadm.services.nvmeof import NvmeofService, NVMEOF_CLIENT_CERT_LABEL
 from cephadm.module import CephadmOrchestrator
 from ceph.deployment.service_spec import NvmeofServiceSpec
 from cephadm.tests.fixtures import with_host, with_service, _run_cephadm, async_side_effect
-from orchestrator import OrchestratorError
+from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus
 from cephadm.tlsobject_types import TLSCredentials
 
 cephadm_root_ca = """-----BEGIN CERTIFICATE-----\nMIIE7DCCAtSgAwIBAgIUE8b2zZ64geu2ns3Zfn3/4L+Cf6MwDQYJKoZIhvcNAQEL\nBQAwFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MB4XDTI0MDYyNjE0NDA1M1oXDTM0\nMDYyNzE0NDA1M1owFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEAsZRJsdtTr9GLG1lWFql5SGc46ldFanNJd1Gl\nqXq5vgZVKRDTmNgAb/XFuNEEmbDAXYIRZolZeYKMHfn0pouPRSel0OsC6/02ZUOW\nIuN89Wgo3IYleCFpkVIumD8URP3hwdu85plRxYZTtlruBaTRH38lssyCqxaOdEt7\nAUhvYhcMPJThB17eOSQ73mb8JEC83vB47fosI7IhZuvXvRSuZwUW30rJanWNhyZq\neS2B8qw2RSO0+77H6gA4ftBnitfsE1Y8/F9Z/f92JOZuSMQXUB07msznPbRJia3f\nueO8gOc32vxd1A1/Qzp14uX34yEGY9ko2lW226cZO29IVUtXOX+LueQttwtdlpz8\ne6Npm09pXhXAHxV/OW3M28MdXmobIqT/m9MfkeAErt5guUeC5y8doz6/3VQRjFEn\nRpN0WkblgnNAQ3DONPc+Qd9Fi/wZV2X7bXoYpNdoWDsEOiE/eLmhG1A2GqU/mneP\nzQ6u79nbdwTYpwqHpa+PvusXeLfKauzI8lLUJotdXy9EK8iHUofibB61OljYye6B\nG3b8C4QfGsw8cDb4APZd/6AZYyMx/V3cGZ+GcOV7WvsC8k7yx5Uqasm/kiGQ3EZo\nuNenNEYoGYrjb8D/8QzqNUTwlEh27/ps80tO7l2GGTvWVZL0PRZbmLDvO77amtOf\nOiRXMoUCAwEAAaMwMC4wGwYDVR0RBBQwEocQAAAAAAAAAAAAAAAAAAAAATAPBgNV\nHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQAxwzX5AhYEWhTV4VUwUj5+\nqPdl4Q2tIxRokqyE+cDxoSd+6JfGUefUbNyBxDt0HaBq8obDqqrbcytxnn7mpnDu\nhtiauY+I4Amt7hqFOiFA4cCLi2mfok6g2vL53tvhd9IrsfflAU2wy7hL76Ejm5El\nA+nXlkJwps01Whl9pBkUvIbOn3pXX50LT4hb5zN0PSu957rjd2xb4HdfuySm6nW4\n4GxtVWfmGA6zbC4XMEwvkuhZ7kD2qjkAguGDF01uMglkrkCJT3OROlNBuSTSBGqt\ntntp5VytHvb7KTF7GttM3ha8/EU2KYaHM6WImQQTrOfiImAktOk4B3lzUZX3HYIx\n+sByO4P4dCvAoGz1nlWYB2AvCOGbKf0Tgrh4t4jkiF8FHTXGdfvWmjgi1pddCNAy\nn65WOCmVmLZPERAHOk1oBwqyReSvgoCFo8FxbZcNxJdlhM0Z6hzKggm3O3Dl88Xl\n5euqJjh2STkBW8Xuowkg1TOs5XyWvKoDFAUzyzeLOL8YSG+gXV22gPTUaPSVAqdb\nwd0Fx2kjConuC5bgTzQHs8XWA930U3XWZraj21Vaa8UxlBLH4fUro8H5lMSYlZNE\nJHRNW8BkznAClaFSDG3dybLsrzrBFAu/Qb5zVkT1xyq0YkepGB7leXwq6vjWA5Pw\nmZbKSphWfh0qipoqxqhfkw==\n-----END CERTIFICATE-----\n"""
@@ -25,6 +25,26 @@ class FakeInventory:
         return '1.2.3.4'
 
 
+class FakeHostSpec:
+    def __init__(self, hostname: str):
+        self.hostname = hostname
+
+
+class FakeCache:
+    def __init__(self):
+        self._daemons: List[DaemonDescription] = []
+        self._unreachable_hosts: List[FakeHostSpec] = []
+
+    def get_daemons_by_type(self, daemon_type: str) -> List[DaemonDescription]:
+        return [d for d in self._daemons if d.daemon_type == daemon_type]
+
+    def get_daemons_by_service(self, service_name: str) -> List[DaemonDescription]:
+        return [d for d in self._daemons if d.service_name() == service_name]
+
+    def get_unreachable_hosts(self) -> List[FakeHostSpec]:
+        return self._unreachable_hosts
+
+
 class FakeMgr:
     def __init__(self):
         self.config = ''
@@ -35,6 +55,7 @@ class FakeMgr:
         self.log = MagicMock()
         self.cert_mgr = MagicMock()
         self.inventory = FakeInventory()
+        self.cache = FakeCache()
 
     def _check_mon_command(self, cmd_dict, inbuf=None):
         prefix = cmd_dict.get('prefix')
@@ -81,6 +102,90 @@ class TestNVMEOFService:
     @patch('cephadm.utils.resolve_ip')
     def test_nvmeof_dashboard_config(self, mock_resolve_ip):
         pass
+
+    def _make_daemon(self, daemon_id, hostname, service_name, status=DaemonDescriptionStatus.running):
+        return DaemonDescription(
+            daemon_type='nvmeof',
+            daemon_id=daemon_id,
+            hostname=hostname,
+            service_name=service_name,
+            status=status,
+        )
+
+    def test_ok_to_stop_last_daemon_in_group_warns(self):
+        """Stopping the last running daemon in a gateway group should warn."""
+        self.mgr.cache._daemons = [
+            self._make_daemon('pool.grp1.node0.aaa', 'node0', 'nvmeof.pool.grp1',
+                              status=DaemonDescriptionStatus.stopped),
+            self._make_daemon('pool.grp1.node1.bbb', 'node1', 'nvmeof.pool.grp1',
+                              status=DaemonDescriptionStatus.running),
+            self._make_daemon('pool.grp2.node2.ccc', 'node2', 'nvmeof.pool.grp2',
+                              status=DaemonDescriptionStatus.running),
+            self._make_daemon('pool.grp2.node3.ddd', 'node3', 'nvmeof.pool.grp2',
+                              status=DaemonDescriptionStatus.running),
+        ]
+        self.mgr.cache._unreachable_hosts = []
+
+        result = self.nvmeof_service.ok_to_stop(['pool.grp1.node1.bbb'])
+        assert result.retval != 0
+        assert 'nvmeof.pool.grp1' in result.stderr
+
+    def test_ok_to_stop_safe_when_group_has_remaining(self):
+        """Stopping one daemon when the group still has another running should be safe."""
+        self.mgr.cache._daemons = [
+            self._make_daemon('pool.grp1.node0.aaa', 'node0', 'nvmeof.pool.grp1',
+                              status=DaemonDescriptionStatus.running),
+            self._make_daemon('pool.grp1.node1.bbb', 'node1', 'nvmeof.pool.grp1',
+                              status=DaemonDescriptionStatus.running),
+            self._make_daemon('pool.grp2.node2.ccc', 'node2', 'nvmeof.pool.grp2',
+                              status=DaemonDescriptionStatus.running),
+        ]
+        self.mgr.cache._unreachable_hosts = []
+
+        result = self.nvmeof_service.ok_to_stop(['pool.grp1.node0.aaa'])
+        assert result.retval == 0
+
+    def test_ok_to_stop_force_bypasses_warning(self):
+        """The --force flag should bypass per-group warnings."""
+        self.mgr.cache._daemons = [
+            self._make_daemon('pool.grp1.node0.aaa', 'node0', 'nvmeof.pool.grp1',
+                              status=DaemonDescriptionStatus.stopped),
+            self._make_daemon('pool.grp1.node1.bbb', 'node1', 'nvmeof.pool.grp1',
+                              status=DaemonDescriptionStatus.running),
+        ]
+        self.mgr.cache._unreachable_hosts = []
+
+        result = self.nvmeof_service.ok_to_stop(['pool.grp1.node1.bbb'], force=True)
+        assert result.retval == 0
+
+    def test_ok_to_stop_multiple_groups_warns_per_group(self):
+        """Stopping last daemons in multiple groups should warn about the affected group."""
+        self.mgr.cache._daemons = [
+            self._make_daemon('pool.grp1.node0.aaa', 'node0', 'nvmeof.pool.grp1',
+                              status=DaemonDescriptionStatus.running),
+            self._make_daemon('pool.grp2.node2.ccc', 'node2', 'nvmeof.pool.grp2',
+                              status=DaemonDescriptionStatus.running),
+        ]
+        self.mgr.cache._unreachable_hosts = []
+
+        result = self.nvmeof_service.ok_to_stop(
+            ['pool.grp1.node0.aaa', 'pool.grp2.node2.ccc'])
+        assert result.retval != 0
+        assert 'nvmeof.pool.grp' in result.stderr
+
+    def test_ok_to_stop_unreachable_host_not_counted(self):
+        """Daemons on unreachable hosts should not count as running."""
+        self.mgr.cache._daemons = [
+            self._make_daemon('pool.grp1.node0.aaa', 'node0', 'nvmeof.pool.grp1',
+                              status=DaemonDescriptionStatus.running),
+            self._make_daemon('pool.grp1.node1.bbb', 'node1', 'nvmeof.pool.grp1',
+                              status=DaemonDescriptionStatus.running),
+        ]
+        self.mgr.cache._unreachable_hosts = [FakeHostSpec('node0')]
+
+        result = self.nvmeof_service.ok_to_stop(['pool.grp1.node1.bbb'])
+        assert result.retval != 0
+        assert 'nvmeof.pool.grp1' in result.stderr
 
     @patch("cephadm.inventory.Inventory.get_addr", lambda _, __: '192.168.100.100')
     @patch("cephadm.serve.CephadmServe._run_cephadm")


### PR DESCRIPTION
**Summary**

ok_to_stop() currently validates NVMe-oF daemon availability using the global daemon count (get_daemons_by_type()).

In multi-gateway-group deployments, this can incorrectly allow the last running gateway in a specific group to be stopped as long as other groups still have running gateways, causing IO interruption for namespaces served by that group.

This change updates the validation to use get_daemons_by_service() and perform checks per gateway group.

Fixes: https://tracker.ceph.com/issues/80096
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]

**Before**

```
Gateway state:

grp1: 1 running
grp2: 2 running

Stopping the last gateway in grp1 was allowed because the global NVMe-oF daemon count was greater than one.

$ ceph orch host maintenance enter ceph-node-00

Daemons for Ceph cluster <fsid> stopped on host ceph-node-00.
Host ceph-node-00 moved to maintenance mode
```
**After**

```
Gateway state:

grp1: 1 running
grp2: 2 running

Attempting to stop the last running gateway in grp1 is now blocked.

$ ceph orch host ok-to-stop ceph-node-00

[ceph: root@ceph-node-00 /]# ceph orch host ok-to-stop ceph-node-00
Error EBUSY: It is NOT safe to stop mon.ceph-node-00 at this time: not enough monitors would be available (ceph-node-02,ceph-node-03) after stopping mons [ceph-node-00]
WARNING: Stopping 1 out of 1 daemons in Alertmanager service. Service will not be operational with no daemons left. At least 1 daemon must be running to guarantee service. 
WARNING: Stopping 1 out of 1 daemons in Grafana service. Service will not be operational with no daemons left. At least 1 daemon must be running to guarantee service. 
WARNING: Stopping 1 out of 1 daemons in Prometheus service. Service will not be operational with no daemons left. At least 1 daemon must be running to guarantee service. 
unsafe to stop osd(s) at this time (7 PGs are or would become offline)
WARNING: Stopping ['nvmeof.nvmeof.grp1.ceph-node-00.miiblx'] would leave no running nvmeof daemons in nvmeof.nvmeof.grp1. Please bring another nvmeof daemon up before stopping the current one.
[ceph: root@ceph-node-00 /]# ceph orch host maintenance enter ceph-node-00
Error EBUSY: It is NOT safe to stop mon.ceph-node-00 at this time: not enough monitors would be available (ceph-node-02,ceph-node-03) after stopping mons [ceph-node-00]
WARNING: Stopping 1 out of 1 daemons in Alertmanager service. Service will not be operational with no daemons left. At least 1 daemon must be running to guarantee service. 
WARNING: Stopping 1 out of 1 daemons in Grafana service. Service will not be operational with no daemons left. At least 1 daemon must be running to guarantee service. 
WARNING: Stopping 1 out of 1 daemons in Prometheus service. Service will not be operational with no daemons left. At least 1 daemon must be running to guarantee service. 
unsafe to stop osd(s) at this time (7 PGs are or would become offline)
WARNING: Stopping ['nvmeof.nvmeof.grp1.ceph-node-00.miiblx'] would leave no running nvmeof daemons in nvmeof.nvmeof.grp1. Please bring another nvmeof daemon up before stopping the current one.
Note: Warnings can be bypassed with the --force flag

```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
