### PR TITLE
cephadm: probe the cluster before handing out new cap profiles

### DIFF
--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -464,6 +464,12 @@ Note too that each entry has a ``key: <value>`` entry, and also has one or more
 
 To save the output of ``ceph auth ls`` to a file, use the ``-o {filename}`` option.
 
+A user named ``client.cap-profile-probe-*`` may appear briefly: the manager
+creates and removes it to check that the monitor accepts a new capability
+profile. A leftover one is safe to remove. Once every monitor, manager, and
+active OSD has the profile, the manager records that under ``config-key
+mgr/cap_profiles/<profile>`` and uses the profile from then on.
+
 
 Getting a User
 --------------

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -53,9 +53,6 @@ logger = logging.getLogger(__name__)
 ServiceSpecs = TypeVar('ServiceSpecs', bound=ServiceSpec)
 AuthEntity = NewType('AuthEntity', str)
 
-# the release that added 'profile rgw'
-RGW_PROFILE_RELEASE = utils.ceph_release_to_major('umbrella')
-
 
 def get_auth_entity(daemon_type: str, daemon_id: str, host: str = "") -> AuthEntity:
     """
@@ -1758,19 +1755,10 @@ class RgwService(CephService):
         updated, verify whether the same changes are required for these
         services as well.
         """
-        # a mon or osd from before the profile reads it as granting nothing.
-        # require_osd_release only moves up once all of them are upgraded
-        osdmap = self.mgr.get('osd_map')
-        release = osdmap.get('require_osd_release', 'argonaut')
-        if utils.ceph_release_to_major(release) >= RGW_PROFILE_RELEASE:
-            caps = ['mon', 'profile rgw',
-                    'mgr', 'profile rgw',
-                    'osd', 'profile rgw']
-        else:
-            caps = ['mon', 'allow *',
-                    'mgr', 'allow rw',
-                    'osd', 'allow rwx tag rgw *=*']
-        return self.get_keyring_with_caps(self.get_auth_entity(rgw_id), caps)
+        return self.get_keyring_with_caps(self.get_auth_entity(rgw_id),
+                                          ['mon', 'profile rgw',
+                                           'mgr', 'profile rgw',
+                                           'osd', 'profile rgw'])
 
     def purge(self, service_name: str) -> None:
         self.mgr.check_mon_command({

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -24,7 +24,7 @@ from ceph.deployment.service_spec import (
     RequiresCertificatesEntry
 )
 from ceph.deployment.utils import is_ipv6, unwrap_ipv6, wrap_ipv6
-from mgr_util import build_url, merge_dicts
+from mgr_util import CapProfiles, build_url, merge_dicts
 from orchestrator import (
     OrchestratorError,
     DaemonDescription,
@@ -365,6 +365,7 @@ class CephadmService(metaclass=ABCMeta):
 
     def __init__(self, mgr: "CephadmOrchestrator"):
         self.mgr: "CephadmOrchestrator" = mgr
+        self._cap_profiles = CapProfiles(mgr)
 
     def get_self_signed_certificates_with_label(self, svc_spec: ServiceSpec, daemon_spec: CephadmDaemonDeploySpec, label: str, ip_addr: Optional[str] = None) -> TLSCredentials:
         svc_name = svc_spec.service_name()
@@ -678,6 +679,7 @@ class CephadmService(metaclass=ABCMeta):
         return DaemonDescription()
 
     def get_keyring_with_caps(self, entity: AuthEntity, caps: List[str]) -> str:
+        caps = self._cap_profiles.resolve(caps)
         # try with newer cipher first, it's possible this isn't supported
         # early in an upgrade
         ret, keyring, err = self.mgr.mon_command({

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -17,8 +17,7 @@ from ceph.utils import with_units_to_int
 from .service_registry import register_cephadm_service
 
 from orchestrator import DaemonDescription, OrchestratorError
-from cephadm.services.cephadmservice import AuthEntity, CephadmDaemonDeploySpec, CephService, \
-    RGW_PROFILE_RELEASE
+from cephadm.services.cephadmservice import AuthEntity, CephadmDaemonDeploySpec, CephService
 from cephadm.schedule import get_placement_hosts
 if TYPE_CHECKING:
     from ..module import CephadmOrchestrator
@@ -476,16 +475,9 @@ class NFSService(CephService):
         entity: AuthEntity = self.get_auth_entity(f'{daemon_id}-rgw')
 
         logger.info('Creating key for %s' % entity)
-        # the profile grants nothing on a mon or osd that predates it
-        osdmap = self.mgr.get('osd_map')
-        release = osdmap.get('require_osd_release', 'argonaut')
-        if utils.ceph_release_to_major(release) >= RGW_PROFILE_RELEASE:
-            osd_caps = 'profile rgw'
-        else:
-            osd_caps = 'allow rwx tag rgw *=*'
         keyring = self.get_keyring_with_caps(entity,
                                              ['mon', 'allow r',
-                                              'osd', osd_caps])
+                                              'osd', 'profile rgw'])
 
         return keyring
 

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -129,6 +129,10 @@ def with_cephadm_module(module_options=None, store=None):
                 'osds': [],
                 'require_osd_release': 'umbrella',
             })
+        # a cluster that says nothing about its versions: cap profiles
+        # resolve to their fallbacks without probing
+        for prefix in ('mon metadata', 'mgr metadata', 'osd info', 'osd metadata'):
+            setattr(m, '_mon_command_mock_' + prefix.replace(' ', '_'), lambda cmd: '[]')
         for k, v in store.items():
             m._ceph_set_store(k, v)
 

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -124,11 +124,6 @@ def with_cephadm_module(module_options=None, store=None):
                 },
                 'modules': ['dashboard', 'prometheus'],
             })
-        if '_ceph_get/osd_map' not in store:
-            m.mock_store_set('_ceph_get', 'osd_map', {
-                'osds': [],
-                'require_osd_release': 'umbrella',
-            })
         # a cluster that says nothing about its versions: cap profiles
         # resolve to their fallbacks without probing
         for prefix in ('mon metadata', 'mgr metadata', 'osd info', 'osd metadata'):

--- a/src/pybind/mgr/cephadm/tests/services/test_rgw.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_rgw.py
@@ -1,8 +1,10 @@
 
+import errno
 import pytest
 from unittest.mock import patch, MagicMock
 
 from cephadm.services.service_registry import service_registry
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.module import CephadmOrchestrator
 from ceph.deployment.service_spec import RGWSpec, CertificateSource
 from cephadm.tests.fixtures import with_host, with_service, _run_cephadm
@@ -103,24 +105,44 @@ class TestRGWService:
 
         return cm, svc_name, spec, daemon, mock_spec_store
 
-    @patch("cephadm.services.cephadmservice.CephadmService.get_keyring_with_caps")
-    def test_rgw_keyring_caps(self, get_keyring_with_caps, cephadm_module: CephadmOrchestrator):
-        get_keyring_with_caps.return_value = ''
+    def test_rgw_keyring_caps(self, cephadm_module: CephadmOrchestrator):
         rgw_svc = service_registry.get_service('rgw')
+        nfs_svc = service_registry.get_service('nfs')
 
-        rgw_svc.get_keyring('foo.bar')
-        assert get_keyring_with_caps.call_args[0][1] == ['mon', 'profile rgw',
-                                                         'mgr', 'profile rgw',
-                                                         'osd', 'profile rgw']
+        def created_caps():
+            return [c['caps'] for c in cephadm_module._mon_commands_sent
+                    if c['prefix'] == 'auth get-or-create']
 
-        cephadm_module.mock_store_set('_ceph_get', 'osd_map', {
-            'osds': [],
-            'require_osd_release': 'tentacle',
-        })
-        rgw_svc.get_keyring('foo.bar')
-        assert get_keyring_with_caps.call_args[0][1] == ['mon', 'allow *',
-                                                         'mgr', 'allow rw',
-                                                         'osd', 'allow rwx tag rgw *=*']
+        with patch('mgr_util.CapProfiles.supported', return_value=False):
+            rgw_svc.get_keyring('foo.bar')
+            assert created_caps()[-1] == ['mon', 'allow *',
+                                          'mgr', 'allow rw',
+                                          'osd', 'allow rwx tag rgw *=*']
+            nfs_svc.create_rgw_keyring(CephadmDaemonDeploySpec('host1', 'foo.mixed', 'nfs'))
+            assert created_caps()[-1] == ['mon', 'allow r', 'osd', 'allow rwx tag rgw *=*']
+
+        with patch('mgr_util.CapProfiles.supported', return_value=True):
+            rgw_svc.get_keyring('foo.bar')
+            nfs_svc.create_rgw_keyring(CephadmDaemonDeploySpec('host1', 'foo.qux', 'nfs'))
+            assert created_caps()[-2:] == [['mon', 'profile rgw',
+                                            'mgr', 'profile rgw',
+                                            'osd', 'profile rgw'],
+                                           ['mon', 'allow r', 'osd', 'profile rgw']]
+
+            # a key made with the old caps is moved to the profile
+            def exists(cmd):
+                return (-errno.EINVAL, '',
+                        'key for client.rgw.foo.bar exists but cap mon does not match')
+            cephadm_module._mon_command_mock_auth_get = \
+                lambda cmd: (0, f"[{cmd['entity']}]\n\tkey = AQ==\n", '')
+            setattr(cephadm_module, '_mon_command_mock_auth_get-or-create', exists)
+            assert rgw_svc.get_keyring('foo.bar') == '[client.rgw.foo.bar]\nkey = AQ==\n'
+            recapped = [c for c in cephadm_module._mon_commands_sent
+                        if c['prefix'] == 'auth caps']
+            assert recapped[-1]['caps'] == ['mon', 'profile rgw',
+                                            'mgr', 'profile rgw',
+                                            'osd', 'profile rgw']
+            delattr(cephadm_module, '_mon_command_mock_auth_get-or-create')
 
     @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_post_remove_no_op_when_requires_certificates_is_false(

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -1028,7 +1028,13 @@ MARKER_PREFIX = 'mgr/cap_profiles/'
 
 # caps to use in place of 'profile <name>' on a cluster that cannot use it,
 # keyed by profile name, then by cap type
-PROFILE_FALLBACKS: Dict[str, Dict[str, str]] = {}
+PROFILE_FALLBACKS: Dict[str, Dict[str, str]] = {
+    'rgw': {
+        'mon': 'allow *',
+        'mgr': 'allow rw',
+        'osd': 'allow rwx tag rgw *=*',
+    },
+}
 
 
 class CapProfileError(RuntimeError):

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -14,8 +14,10 @@ import cephfs
 import contextlib
 import datetime
 import errno
+import json
 import socket
 import time
+import uuid
 import logging
 import re
 import sys
@@ -30,7 +32,7 @@ if sys.version_info >= (3, 3):
 else:
     from threading import _Timer as Timer
 
-from typing import Tuple, Any, Callable, Optional, Dict, TYPE_CHECKING, TypeVar, List, Iterable, Generator, Generic, Iterator
+from typing import Tuple, Any, Callable, Optional, Dict, TYPE_CHECKING, TypeVar, List, Iterable, Generator, Generic, Iterator, Set
 
 from ceph.deployment.utils import wrap_ipv6
 from ceph.cryptotools.select import get_crypto_caller
@@ -1019,3 +1021,112 @@ def password_hash(password: Optional[str], salt_password: Optional[str] = None) 
 
     cc = get_crypto_caller()
     return cc.password_hash(password, salt_password)
+
+
+PROBE_ENTITY_PREFIX = 'client.cap-profile-probe-'
+MARKER_PREFIX = 'mgr/cap_profiles/'
+
+# caps to use in place of 'profile <name>' on a cluster that cannot use it,
+# keyed by profile name, then by cap type
+PROFILE_FALLBACKS: Dict[str, Dict[str, str]] = {}
+
+
+class CapProfileError(RuntimeError):
+    """the cluster could not be asked; fail and retry rather than guess"""
+
+
+class CapProfiles:
+    """
+    Says whether a cap profile can be handed out. Mons and osds silently
+    accept a profile they do not know and grant it nothing, so one is only
+    used once every member of the mon, mgr and osd maps runs the same
+    version and the mon, which alone rejects an unknown mgr profile, takes
+    it on a throwaway key while refusing a made-up one. That is recorded
+    in config-key for good: a daemon from before the profile must not be
+    brought in afterwards.
+    """
+
+    def __init__(self, mgr: Any) -> None:
+        self.mgr = mgr
+        self._enabled: Set[str] = set()
+
+    def _cmd(self, **cmd: Any) -> Tuple[int, str, str]:
+        return self.mgr.mon_command(cmd)
+
+    def _json(self, prefix: str) -> Any:
+        ret, out, err = self._cmd(prefix=prefix, format='json')
+        if ret:
+            raise CapProfileError(f"'{prefix}' failed [{ret}]: {err}")
+        try:
+            return json.loads(out)
+        except ValueError:
+            raise CapProfileError(f"'{prefix}' did not answer in json")
+
+    def _marked(self, profile: str) -> bool:
+        if profile not in self._enabled:
+            ret, out, err = self._cmd(prefix='config-key get', key=MARKER_PREFIX + profile)
+            if ret not in (0, -errno.ENOENT):
+                raise CapProfileError(f'cannot read the cap profile marker for {profile} [{ret}]: {err}')
+            if ret == 0 and out.strip():
+                self._enabled.add(profile)
+        return profile in self._enabled
+
+    def _version(self) -> Optional[str]:
+        """the one version every mon, mgr and osd runs, if there is one"""
+        destroyed = {o['osd'] for o in self._json('osd info') if 'destroyed' in o.get('state', [])}
+        osds = [o for o in self._json('osd metadata') if o.get('id') not in destroyed]
+        rows = osds + self._json('mon metadata') + self._json('mgr metadata')
+        # a member that never booted has no version and could be anything,
+        # and no osd at all says nothing about the ones to come
+        versions = {r.get('ceph_version_short', 'unknown') for r in rows} | ({'unknown'} if not osds else set())
+        return versions.pop() if len(versions) == 1 and 'unknown' not in versions else None
+
+    def _probe(self, profile: str) -> bool:
+        """whether the mon takes 'mgr profile <profile>'"""
+        # a fresh entity each time: an existing one answers with the same
+        # EINVAL a bad profile gets
+        entity = f'{PROBE_ENTITY_PREFIX}{profile}-{uuid.uuid4().hex}'
+        ret, out, err = self._cmd(prefix='auth get-or-create-key', entity=entity,
+                                  caps=['mgr', f'profile {profile}'])
+        if ret == -errno.EINVAL:
+            return False
+        if ret == 0:
+            ret, out, err = self._cmd(prefix='auth rm', entity=entity)
+        if ret:
+            raise CapProfileError(f'cap profile probe for {profile} failed [{ret}], {entity} '
+                                  f'may be left behind: {err}')
+        return True
+
+    def supported(self, profile: str) -> bool:
+        """raises CapProfileError when the cluster could not be asked"""
+        if self._marked(profile):
+            return True
+        version = self._version()
+        if not version or self._probe('nosuch') or not self._probe(profile):
+            return False
+        ret, out, err = self._cmd(prefix='config-key set', key=MARKER_PREFIX + profile, val=version)
+        if ret:
+            logger.warning(f'recording that cap profile {profile} is usable failed: {err}')
+            return self._marked(profile)  # the mon may have kept it anyway
+        logger.info(f'cap profile {profile} is usable on this cluster as of {version}; '
+                    'daemons from before it are no longer supported')
+        self._enabled.add(profile)
+        return True
+
+    def resolve(self, caps: List[str]) -> List[str]:
+        """
+        Swap each 'profile <name>' the cluster cannot use for its entry in
+        PROFILE_FALLBACKS. caps is the flat [type, cap, ...] auth list.
+        Raises CapProfileError when the cluster could not be asked.
+        """
+        out = list(caps)
+        decided: Dict[str, bool] = {}
+        for i in range(1, len(out), 2):
+            words = out[i].split()
+            if len(words) == 2 and words[0] == 'profile' and words[1] in PROFILE_FALLBACKS:
+                name = words[1]
+                if name not in decided:
+                    decided[name] = self.supported(name)
+                if not decided[name]:
+                    out[i] = PROFILE_FALLBACKS[name][out[i - 1]]
+        return out

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -15,6 +15,7 @@ from typing import (
 
 import contextlib
 import dataclasses
+import errno
 import fnmatch
 import logging
 import time
@@ -192,6 +193,11 @@ class _FakeMonCommandIssuer:
     def mon_command(
         self, cmd_dict: dict, inbuf: Optional[str] = None
     ) -> Tuple[int, str, str]:
+        # a cluster that knows nothing about what its daemons run
+        if cmd_dict['prefix'] == 'config-key get':
+            return (-errno.ENOENT, '', 'no such key')
+        if cmd_dict['prefix'].endswith((' metadata', ' info')):
+            return (0, '[]', '')
         return (0, '', '')
 
 
@@ -348,7 +354,7 @@ class ClusterConfigHandler:
         self._authorizer: AccessAuthorizer = authorizer
         if mon_cmd_issuer is None:
             mon_cmd_issuer = _FakeMonCommandIssuer()
-        self._mon_cmd_issuer: MonCommandIssuer = mon_cmd_issuer
+        self._rgw_authorizer = RGWAuthorizer(mon_cmd_issuer)
         self._orch = orch  # if None, disables updating the spec via orch
         if earmark_resolver is None:
             earmark_resolver = cast(EarmarkResolver, _FakeEarmarkResolver())
@@ -711,13 +717,11 @@ class ClusterConfigHandler:
         _save_pending_join_auths(self.priv_store, change_group)
         _save_pending_users_and_groups(self.priv_store, change_group)
         _save_pending_tls_credentials(self.priv_store, change_group)
-        # Create RGW authorizer for this cluster configuration
-        rgw_authorizer = RGWAuthorizer(self._mon_cmd_issuer)
         cluster_conf = _ClusterConf.assemble(
             change_group,
             self._path_resolver,
             self._authorizer,
-            rgw_authorizer,
+            self._rgw_authorizer,
         )
         _save_pending_config(self.public_store, cluster_conf)
         _save_pending_rgw_config(self.priv_store, cluster_conf)

--- a/src/pybind/mgr/smb/rgw_auth.py
+++ b/src/pybind/mgr/smb/rgw_auth.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 
 import logging
 
+from mgr_util import CapProfiles
+
 from .proto import MonCommandIssuer
 
 log = logging.getLogger(__name__)
@@ -20,6 +22,7 @@ class RGWAuthorizer:
 
     def __init__(self, mc: MonCommandIssuer) -> None:
         self._mc = mc
+        self._cap_profiles = CapProfiles(mc)
 
     def authorize_entity(
         self, entity: str, caps: Optional[List[str]] = None
@@ -37,6 +40,7 @@ class RGWAuthorizer:
                 'osd',
                 'profile rgw',
             ]
+        caps = self._cap_profiles.resolve(caps)
 
         cmd = {
             'prefix': 'auth get-or-create',

--- a/src/pybind/mgr/smb/tests/test_rgw_shares.py
+++ b/src/pybind/mgr/smb/tests/test_rgw_shares.py
@@ -1,4 +1,6 @@
+import errno
 import json
+from unittest import mock
 
 import pytest
 
@@ -863,3 +865,70 @@ def test_external_cluster_no_user_validation(thandler):
             fsid='12345678-1234-1234-1234-123456789abc',
             mon_host='10.0.1.10:6789',
         )
+
+
+class _RecordingMon:
+    def __init__(self):
+        self.sent = []
+
+    def mon_command(self, cmd, inbuf=None):
+        self.sent.append(cmd)
+        if cmd['prefix'] == 'auth get-or-create':
+            return self.get_or_create(cmd)
+        return 0, '', ''
+
+    def get_or_create(self, cmd):
+        return 0, '', ''
+
+    def created(self):
+        return [c for c in self.sent if c['prefix'] == 'auth get-or-create']
+
+
+@pytest.mark.parametrize("supported", [True, False])
+def test_rgw_authorizer_caps(supported):
+    from smb.rgw_auth import RGWAuthorizer
+
+    mon = _RecordingMon()
+    authorizer = RGWAuthorizer(mon)
+    with mock.patch.object(
+        authorizer._cap_profiles, 'supported', return_value=supported
+    ):
+        authorizer.authorize_entity('client.smb.rgw.foo')
+    expected = (
+        ['mon', 'profile rgw', 'osd', 'profile rgw']
+        if supported
+        else ['mon', 'allow *', 'osd', 'allow rwx tag rgw *=*']
+    )
+    assert mon.created() == [
+        {
+            'prefix': 'auth get-or-create',
+            'entity': 'client.smb.rgw.foo',
+            'caps': expected,
+        }
+    ]
+
+
+def test_rgw_authorizer_moves_old_key_to_profile():
+    from smb.rgw_auth import RGWAuthorizer
+
+    class Mon(_RecordingMon):
+        def get_or_create(self, cmd):
+            return (
+                -errno.EINVAL,
+                '',
+                'key for client.smb.rgw.foo exists but cap mon does not match',
+            )
+
+    mon = Mon()
+    authorizer = RGWAuthorizer(mon)
+    with mock.patch.object(
+        authorizer._cap_profiles, 'supported', return_value=True
+    ):
+        authorizer.authorize_entity('client.smb.rgw.foo')
+    assert [c for c in mon.sent if c['prefix'] == 'auth caps'] == [
+        {
+            'prefix': 'auth caps',
+            'entity': 'client.smb.rgw.foo',
+            'caps': ['mon', 'profile rgw', 'osd', 'profile rgw'],
+        }
+    ]

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -146,6 +146,9 @@ if 'UNITTEST' in os.environ:
             elif hasattr(self, '_mon_command_mock_' + cmd['prefix'].replace(' ', '_')):
                 a = getattr(self, '_mon_command_mock_' + cmd['prefix'].replace(' ', '_'))
                 outb = a(cmd)
+                if isinstance(outb, tuple):
+                    res.complete(*outb)
+                    return
 
             res.complete(0, outb, '')
 

--- a/src/pybind/mgr/tests/test_cap_profiles.py
+++ b/src/pybind/mgr/tests/test_cap_profiles.py
@@ -1,0 +1,125 @@
+import errno
+import json
+from unittest.mock import patch
+
+import pytest
+
+from mgr_util import CapProfiles, CapProfileError, MARKER_PREFIX, PROFILE_FALLBACKS
+
+FALLBACKS = {'foo': {'mon': 'allow r', 'osd': 'allow rw pool=foo'}}
+CAPS = ['mon', 'allow *', 'mgr', 'profile bar', 'osd', 'profile foo', 'mon', 'profile foo']
+
+
+class FakeMon:
+    def __init__(self, mons=('a',), mgrs=('a',), osds=('a',), known=('foo',), validate=True,
+                 destroyed=(), broken=None):
+        self.rows = {'mon metadata': [{'name': 'a', 'ceph_version_short': v} for v in mons],
+                     'mgr metadata': [{'name': 'a', 'ceph_version_short': v} for v in mgrs],
+                     'osd metadata': [{'id': i, 'ceph_version_short': v} for i, v in enumerate(osds)],
+                     'osd info': [{'osd': i, 'state': ['destroyed'] if i in destroyed else []}
+                                  for i in range(len(osds))]}
+        for row in (r for rows in self.rows.values() for r in rows):
+            if row.get('ceph_version_short') is None:  # never booted
+                row.pop('ceph_version_short', None)
+        self.known = set(known)
+        self.validate = validate
+        self.broken = broken
+        self.keys = {}
+        self.entities = set()
+        self.sent = []
+
+    def mon_command(self, cmd, inbuf=None):
+        self.sent.append(cmd)
+        prefix = cmd['prefix']
+        if prefix == self.broken:
+            return -errno.ETIMEDOUT, '', 'timed out'
+        if prefix in self.rows:
+            # like the mon, answer in text unless asked for json
+            return 0, json.dumps(self.rows[prefix]) if cmd.get('format') == 'json' else 'text', ''
+        if prefix == 'config-key get':
+            if cmd['key'] in self.keys:
+                return 0, self.keys[cmd['key']], ''
+            return -errno.ENOENT, '', 'no such key'
+        if prefix == 'config-key set':
+            self.keys[cmd['key']] = cmd['val']
+            return 0, '', ''
+        if prefix == 'auth get-or-create-key':
+            profile = cmd['caps'][1].split()[1]
+            if self.validate and profile not in self.known:
+                return -errno.EINVAL, '', f"unrecognized profile '{profile}'"
+            self.entities.add(cmd['entity'])
+            return 0, 'AQ==', ''
+        if prefix == 'auth rm':
+            # the mon says yes whether or not the entity exists
+            self.entities.discard(cmd['entity'])
+            return 0, '', ''
+        raise AssertionError(cmd)
+
+    def probes(self, profile):
+        return [c for c in self.sent
+                if c['prefix'] == 'auth get-or-create-key' and c['caps'][1] == f'profile {profile}']
+
+
+@pytest.mark.parametrize(
+    "mon,expected",
+    [
+        (FakeMon(), True),
+        (FakeMon(known=()), False),
+        (FakeMon(osds=('a', 'b')), False),
+        # a daemon that never booted could be anything, unless it was destroyed
+        (FakeMon(mons=('a', None)), False),
+        (FakeMon(osds=('a', 'b'), destroyed=(1,)), True),
+        # no osd yet says nothing about the ones to come
+        (FakeMon(osds=()), False),
+        # the mon takes any profile: it is not validating caps
+        (FakeMon(validate=False), False),
+    ])
+def test_supported(mon, expected):
+    assert CapProfiles(mon).supported('foo') is expected
+    assert mon.entities == set()
+    assert (MARKER_PREFIX + 'foo' in mon.keys) is expected
+
+
+def test_marker_is_one_way_and_shared():
+    mon = FakeMon()
+    assert CapProfiles(mon).supported('foo')
+    assert mon.keys == {MARKER_PREFIX + 'foo': 'a'}
+    # another instance on a later mixed cluster: the decision stands
+    mon.rows['osd metadata'].append({'id': 9, 'ceph_version_short': 'old'})
+    before = len(mon.sent)
+    assert CapProfiles(mon).supported('foo')
+    assert [c['prefix'] for c in mon.sent[before:]] == ['config-key get']
+
+
+@pytest.mark.parametrize("broken", ['config-key get', 'osd metadata', 'auth rm'])
+def test_uncertainty_is_not_a_fallback(broken):
+    mon = FakeMon(broken=broken)
+    with patch.dict(PROFILE_FALLBACKS, FALLBACKS, clear=True), pytest.raises(CapProfileError):
+        CapProfiles(mon).resolve(['osd', 'profile foo'])
+    assert mon.keys == {}
+
+
+def test_probe_never_reuses_an_entity():
+    mon = FakeMon()
+    mon.entities.add('client.cap-profile-probe-foo')  # a probe whose answer never came
+    assert CapProfiles(mon).supported('foo')
+    assert mon.entities == {'client.cap-profile-probe-foo'}
+
+
+def test_profile_waits_for_the_marker():
+    mon = FakeMon(broken='config-key set')
+    cp = CapProfiles(mon)
+    assert not cp.supported('foo')
+    mon.keys[MARKER_PREFIX + 'foo'] = 'a'  # the set may have gone through regardless
+    assert cp.supported('foo')
+
+
+@pytest.mark.parametrize("known", [('foo',), ()])
+def test_resolve(known):
+    mon = FakeMon(known=known)
+    with patch.dict(PROFILE_FALLBACKS, FALLBACKS, clear=True):
+        resolved = CapProfiles(mon).resolve(CAPS)
+    # only caps with a fallback are swapped; the rest pass through
+    assert resolved == (CAPS if known else ['mon', 'allow *', 'mgr', 'profile bar',
+                                            'osd', 'allow rw pool=foo', 'mon', 'allow r'])
+    assert len(mon.probes('foo')) == 1  # named twice, probed once


### PR DESCRIPTION
PR https://github.com/ceph/ceph/pull/70538 added profile rgw, but supporting it in Squid (PR https://github.com/ceph/ceph/pull/71362) and Tentacle (PR https://github.com/ceph/ceph/pull/71361) backports means cephadm and mgr/smb cannot simply start using the profile based on the Ceph release. A cluster may be running Squid or Tentacle without the backport, and older mons, mgrs, or OSDs can accept an unknown profile while granting no permissions. require_osd_release therefore is not enough to determine whether profile rgw is safe to use.

This PR adds a `CapProfiles` helper that verifies the entire cluster is on the same Ceph version and confirms that the monitor actually supports profile rgw using a temporary key. Once verified, support is recorded in config-key and new keys use the profile. Until then, cephadm and SMB continue using the existing cap strings. Existing keys are updated the next time they are recreated.

Fixes: https://tracker.ceph.com/issues/80089

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [X] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [X] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
