### PR TITLE
mgr/dashboard: fix missing synced RGW roles in UI

### DIFF
--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -1034,7 +1034,7 @@ class RgwClient(RestClient):
         except RequestException as e:
             raise DashboardException(msg=str(e), component='rgw')
 
-    def list_roles(self, account_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    def _fetch_roles_raw(self, account_id: Optional[str] = None) -> List[Dict[str, Any]]:
         rgw_list_roles_command = ['role', 'list']
         if account_id:
             rgw_list_roles_command += ['--account-id', account_id]
@@ -1045,6 +1045,29 @@ class RgwClient(RestClient):
 
         if isinstance(roles, dict):
             roles = roles.get('Roles', [])
+        return roles if isinstance(roles, list) else []
+
+    def list_roles(self, account_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        roles = self._fetch_roles_raw(account_id)
+        if account_id:
+            all_roles = self._fetch_roles_raw(None)
+            existing_names = set()
+            for role_entry in roles:
+                role_dict = (role_entry.get('member', role_entry)
+                             if isinstance(role_entry, dict) and 'member' in role_entry
+                             else role_entry)
+                if isinstance(role_dict, dict) and 'RoleName' in role_dict:
+                    existing_names.add(role_dict['RoleName'])
+            for role_entry in all_roles:
+                role_dict = (role_entry.get('member', role_entry)
+                             if isinstance(role_entry, dict) and 'member' in role_entry
+                             else role_entry)
+                if isinstance(role_dict, dict):
+                    role_account_id = role_dict.get('AccountId', '')
+                    # Include matching account roles or unassigned/global roles (empty AccountId)
+                    if ((not role_account_id or role_account_id == account_id) and
+                            role_dict.get('RoleName') not in existing_names):
+                        roles.append(role_entry)
 
         result = []
         for role in roles:
@@ -1117,6 +1140,9 @@ class RgwClient(RestClient):
         if account_id:
             rgw_get_role_command += ['--account-id', account_id]
         code, role, _err = mgr.send_rgwadmin_command(rgw_get_role_command)
+        if code != 0 and account_id:
+            rgw_get_role_command = ['role', 'get', '--role-name', role_name]
+            code, role, _err = mgr.send_rgwadmin_command(rgw_get_role_command)
         if code != 0:
             raise DashboardException(msg=f'Error getting role with code {code}: {_err}',
                                      component='rgw')
@@ -1132,6 +1158,11 @@ class RgwClient(RestClient):
             rgw_update_role_command += ['--account-id', account_id]
         code, _, _err = mgr.send_rgwadmin_command(rgw_update_role_command,
                                                   stdout_as_json=False)
+        if code != 0 and account_id:
+            rgw_update_role_command = ['role', 'update', '--role-name',
+                                       role_name, '--max_session_duration', max_session_duration]
+            code, _, _err = mgr.send_rgwadmin_command(rgw_update_role_command,
+                                                      stdout_as_json=False)
         if code != 0:
             raise DashboardException(msg=f'Error updating role with code {code}: {_err}',
                                      component='rgw')
@@ -1142,6 +1173,10 @@ class RgwClient(RestClient):
             rgw_delete_role_command += ['--account-id', account_id]
         code, _, _err = mgr.send_rgwadmin_command(rgw_delete_role_command,
                                                   stdout_as_json=False)
+        if code != 0 and account_id:
+            rgw_delete_role_command = ['role', 'delete', '--role-name', role_name]
+            code, _, _err = mgr.send_rgwadmin_command(rgw_delete_role_command,
+                                                      stdout_as_json=False)
         if code != 0:
             raise DashboardException(msg=f'Error deleting role with code {code}: {_err}',
                                      component='rgw')


### PR DESCRIPTION
mgr/dashboard: fix missing synced RGW roles in UI

Fixes: https://tracker.ceph.com/issues/80100

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

PR Description :  

This PR fixes an issue where RGW IAM roles synced across multisite or created without explicit account-id bindings were missing from the Ceph Dashboard UI.
Previously, querying account roles executed `radosgw-admin role list --account-id <id>`, which filtered out unassigned and global roles with empty `AccountId`.
The `list_roles` helper in `rgw_client.py` has been updated to query both account-scoped and global unassigned roles, merging and deduplicating the results.
All replicated and global RGW roles are now consistently rendered in the Dashboard UI table.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
