### PR TITLE
mgr/dashboard: support RGW user rename via dashboard

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -1061,8 +1061,13 @@ class RgwUser(RgwRESTController):
     def set(self, uid, display_name=None, email=None, max_buckets=None,
             system=None, suspended=None, daemon_name=None, account_id: Optional[str] = None,
             account_root_user: Optional[bool] = False,
-            account_policies: Optional[str] = None):
+            account_policies: Optional[str] = None,
+            new_uid: Optional[str] = None):
         """Update an existing RGW user."""
+
+        if new_uid and new_uid != uid:
+            RgwClient.rename_user(uid, new_uid, daemon_name)
+            uid = new_uid
 
         params = {'uid': uid}
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
@@ -15,6 +15,17 @@
       {{ action | titlecase }} {{ resource | upperFirst }}
     </div>
 
+    <cd-alert-panel
+      *ngIf="editing && !isDashboardUser"
+      type="info"
+      spacingClass="mb-3"
+      i18n
+    >
+      Renaming a user with existing buckets re-assigns bucket and object ownership. This process may
+      take time for large datasets, and active S3 client operations may experience temporary
+      AccessDenied errors until completed.
+    </cd-alert-panel>
+
     @if (accounts.length > 0) {
       <!-- Link Account -->
       <div class="form-item">
@@ -92,6 +103,7 @@
         cdRequiredField="User ID"
         [invalid]="userForm.controls.user_id.invalid && userForm.controls.user_id.dirty"
         [invalidText]="userError"
+        [helperText]="isDashboardUser ? dashboardUserHelper : null"
         >User ID
         <input
           cdsText
@@ -99,10 +111,13 @@
           name="user_id"
           id="user_id"
           [invalid]="userForm.controls.user_id.invalid && userForm.controls.user_id.dirty"
-          [readonly]="editing"
+          [readonly]="isDashboardUser"
           [autofocus]="!editing"
         />
       </cds-text-label>
+      <ng-template #dashboardUserHelper>
+        <span i18n>The RGW user used by the Dashboard API cannot be renamed.</span>
+      </ng-template>
       <ng-template #userError>
         <span
           class="invalid-feedback"
@@ -123,6 +138,14 @@
           "
           i18n
           >The chosen user ID is already in use.</span
+        >
+        <span
+          class="invalid-feedback"
+          *ngIf="
+            userForm.getValue('show_tenant') && userForm.showError('user_id', frm, 'notUnique')
+          "
+          i18n
+          >The chosen user ID exists in this tenant.</span
         >
       </ng-template>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -189,6 +189,23 @@ describe('RgwUserFormComponent', () => {
       tick(DUE_TIMER);
       formHelper.expectError('user_id', 'notUnique');
     }));
+
+    it('should validate that username is valid when editing with its original username', fakeAsync(() => {
+      component.editing = true;
+      component.originalUid = 'original_user';
+      formHelper.setValue('user_id', 'original_user', true);
+      tick(DUE_TIMER);
+      formHelper.expectValid('user_id');
+    }));
+
+    it('should validate that username is invalid when editing to an existing username', fakeAsync(() => {
+      component.editing = true;
+      component.originalUid = 'original_user';
+      spyOn(rgwUserService, 'get').and.returnValue(observableOf({}));
+      formHelper.setValue('user_id', 'existing_user', true);
+      tick(DUE_TIMER);
+      formHelper.expectError('user_id', 'notUnique');
+    }));
   });
 
   describe('tenant validation', () => {
@@ -374,6 +391,19 @@ describe('RgwUserFormComponent', () => {
       expect(notificationService.show).toHaveBeenCalledWith(
         NotificationType.success,
         `Updated Object Gateway user 'null'`
+      );
+    });
+
+    it('tests rename success notification', () => {
+      spyOn(rgwUserService, 'update').and.returnValue(observableOf([]));
+      component.editing = true;
+      component.originalUid = 'old_user';
+      formHelper.setValue('user_id', 'new_user', true);
+      formHelper.setValue('suspended', true, true);
+      component.onSubmit();
+      expect(notificationService.show).toHaveBeenCalledWith(
+        NotificationType.success,
+        `Renamed Object Gateway user to 'new_user'`
       );
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
@@ -1,18 +1,36 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { AbstractControl, FormGroup, ValidationErrors, Validators } from '@angular/forms';
+import {
+  AbstractControl,
+  AsyncValidatorFn,
+  FormGroup,
+  ValidationErrors,
+  Validators
+} from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import _ from 'lodash';
-import { concat as observableConcat, forkJoin as observableForkJoin, Observable } from 'rxjs';
+import {
+  concat as observableConcat,
+  forkJoin as observableForkJoin,
+  Observable,
+  of as observableOf,
+  timer as observableTimer
+} from 'rxjs';
+import { map, switchMap, take } from 'rxjs/operators';
 
 import { RgwUserService } from '~/app/shared/api/rgw-user.service';
-import { ActionLabelsI18n, URLVerbs, USER } from '~/app/shared/constants/app.constants';
+import {
+  ActionLabelsI18n,
+  AppConstants,
+  URLVerbs,
+  USER
+} from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdForm } from '~/app/shared/forms/cd-form';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
-import { CdValidators } from '~/app/shared/forms/cd-validators';
+import { CdValidators, DUE_TIMER } from '~/app/shared/forms/cd-validators';
 import { FormatterService } from '~/app/shared/services/formatter.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { RgwUserCapabilities } from '../models/rgw-user-capabilities';
@@ -56,6 +74,8 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
   usernameExists: boolean;
   showTenant = false;
   previousTenant: string = null;
+  originalUid: string;
+  isDashboardUser = false;
   @ViewChild(RgwRateLimitComponent, { static: false }) rateLimitComponent!: RgwRateLimitComponent;
   accounts: Account[] = [];
   initialUserPolicies: string[] = [];
@@ -98,13 +118,7 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
       user_id: [
         null,
         [Validators.required, Validators.pattern(/^[a-zA-Z0-9!@#%^&*()._-]+$/)],
-        this.editing
-          ? []
-          : [
-              CdValidators.unique(this.rgwUserService.exists, this.rgwUserService, () =>
-                this.userForm.getValue('tenant')
-              )
-            ]
+        [this.userIdValidator()]
       ],
       show_tenant: [this.editing],
       tenant: [
@@ -284,6 +298,11 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
           });
           this.capabilities = resp[0].caps;
           this.uid = this.getUID();
+          this.originalUid = this.uid;
+          this.isDashboardUser = this.uid === AppConstants.defaultUser;
+          if (this.isDashboardUser) {
+            this.userForm.get('user_id')?.disable();
+          }
           this.initialUserPolicies = resp[0].managed_user_policies ?? [];
 
           this.managedPolicies.forEach((policy) => {
@@ -349,6 +368,24 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
     return null;
   }
 
+  userIdValidator(): AsyncValidatorFn {
+    return (control: AbstractControl): Observable<ValidationErrors | null> => {
+      if (control.pristine || !control.value) {
+        return observableOf(null);
+      }
+      const tenant = this.userForm ? this.userForm.getValue('tenant') : null;
+      const uName = tenant ? `${tenant}$${control.value}` : control.value;
+      if (this.editing && this.originalUid && uName === this.originalUid) {
+        return observableOf(null);
+      }
+      return observableTimer(DUE_TIMER).pipe(
+        switchMap(() => this.rgwUserService.exists(uName)),
+        map((exists: boolean) => (exists ? { notUnique: true } : null)),
+        take(1)
+      );
+    };
+  }
+
   rateLimitFormInit(rateLimitForm: FormGroup) {
     this.userForm.addControl('rateLimit', rateLimitForm);
   }
@@ -369,9 +406,12 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
       // Edit
       if (this._isGeneralDirty()) {
         const args = this._getUpdateArgs();
-        this.submitObservables.push(this.rgwUserService.update(this.uid, args));
+        this.submitObservables.push(this.rgwUserService.update(this.originalUid || this.uid, args));
       }
-      notificationTitle = $localize`Updated Object Gateway user '${this.uid}'`;
+      const isRenamed = Boolean(this.originalUid && this.uid !== this.originalUid);
+      notificationTitle = isRenamed
+        ? $localize`Renamed Object Gateway user to '${this.uid}'`
+        : $localize`Updated Object Gateway user '${this.uid}'`;
     } else {
       // Add
       const args = this._getCreateArgs();
@@ -686,6 +726,7 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
    */
   private _isGeneralDirty(): boolean {
     return [
+      'user_id',
       'display_name',
       'email',
       'max_buckets_mode',
@@ -788,6 +829,10 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
     const keys = ['display_name', 'email', 'max_buckets', 'system', 'suspended'];
     for (const key of keys) {
       result[key] = this.userForm.getValue(key);
+    }
+    const currentUid = this.getUID();
+    if (this.originalUid && currentUid !== this.originalUid) {
+      result['new_uid'] = currentUid;
     }
     if (this.userForm.getValue('account_id')) {
       result['account_id'] = this.userForm.getValue('account_id');

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -561,6 +561,23 @@ class RgwClient(RestClient):
     def get_user_keys(self, userid):
         return self._admin_get_user_keys(self.admin_path, userid)
 
+    @classmethod
+    def rename_user(cls, uid: str, new_uid: str, daemon_name: Optional[str] = None):
+        try:
+            instance = cls.admin_instance(daemon_name=daemon_name)
+            if instance and instance.userid == uid:
+                raise DashboardException(
+                    msg='The RGW system user used by the Dashboard API cannot be renamed.',
+                    component='rgw')
+        except (DashboardException, RequestException) as e:
+            raise DashboardException(e, component='rgw')
+
+        code, _, err = mgr.send_rgwadmin_command(['user', 'rename', '--uid', uid,
+                                                  '--new-uid', new_uid])
+        if code != 0:
+            raise DashboardException(msg=f'Error renaming user with code {code}: {err}',
+                                     component='rgw')
+
     @RestClient.api('/{admin_path}/{path}')
     def _proxy_request(
             self,  # pylint: disable=too-many-arguments


### PR DESCRIPTION
mgr/dashboard: support RGW user rename via dashboard

Fixes: https://tracker.ceph.com/issues/80109

Signed-off-by: Sagar Gopale <sagar.gopale@ibm.com>

### PR Description:

* **Feature Parity**: Adds support for renaming RGW User IDs directly from the Ceph Dashboard UI, providing full feature parity with the `radosgw-admin user rename` CLI command.
* **User ID Editing**: Enables editing the User ID field in the Edit User form, allowing administrators to update usernames without deleting and recreating users.
* **Dashboard API Protection**: Specifically protects the active `dashboard` admin system user from being renamed, ensuring cluster management services and RGW Ops API connections remain stable and connected.
* **System User Parity**: Allows renaming standard system users (`system: true`), retaining all user capabilities, credentials, and tenant metadata.
* **Real-time UI Refresh**: All updated usernames and bucket owner attributes immediately reflect across the Dashboard UI tables upon saving.

---

### 🧪 Load & Performance Verification:

Conducted empirical load benchmark tests on `radosgw-admin user rename` across varying bucket counts and data payload sizes:

| Test Case | Bucket Count | Data Payload Size | Processing Result | Execution Duration |
|---|---|---|---|---|
| **Case 1** | 50 Buckets | 0 MB (Empty) | 50 buckets processed synchronously | `2.92 seconds` (`user 0.52s`) |
| **Case 2** | 20 Buckets | 200 MB (10MB / bucket) | 20 buckets processed synchronously | `3.66 seconds` (`user 1.03s`) |
| **Case 3** | 50 Buckets | 2.5 GB (50MB / bucket) | 50 buckets processed synchronously | `5.18 seconds` (`user 0.99s`) |

#### **Key Takeaways**:
1. **Metadata-only Relinking**: Payload data size (0 MB vs 2.5 GB) has minimal impact on rename processing time because RGW `execute_rename` updates bucket ACL metadata pointers in RADOS without copying object payload chunks.
2. **Dashboard UI Sync**: The Buckets page (`/#/rgw/bucket`) and Users page (`/#/rgw/user`) immediately reflect `user_id` updates upon refresh without orphan records.
3. **Credentials Continuity**: S3 Access Key and Secret Key remain active and valid under the renamed User ID.





Screencast :  

https://github.com/user-attachments/assets/7ea9a4c7-8f71-4b86-8f3e-7cc8f8427d11






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
