### PR TITLE
cephadm: retry image pulls that fail on transient blob fetch errors

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2144,6 +2144,7 @@ def _pull_image(ctx, image, insecure=False):
         'error creating read-write layer with ID',
         'net/http: TLS handshake timeout',
         'Digest did not match, expected',
+        'failed to copy: httpReadSeeker: failed open: failed to do request',
     ]
 
     cmd = pull_command(ctx, image, insecure=insecure)

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -2822,6 +2822,16 @@ class TestPull:
             _cephadm.command_pull(ctx)
         assert err in str(e.value)
 
+        _call.return_value = (
+            '',
+            'failed to copy: httpReadSeeker: failed open: failed to do request: '
+            'Get "https://cdn01.quay.io/quayio-production-s3/sha256/f8/f8a4970c": EOF',
+            1,
+        )
+        with pytest.raises(_cephadm.Error) as e:
+            _cephadm.command_pull(ctx)
+        assert err in str(e.value)
+
     @mock.patch('cephadm.get_image_info_from_inspect', return_value={})
     @mock.patch('cephadm.infer_local_ceph_image', return_value='last_local_ceph_image')
     def test_image(self, _infer_local_ceph_image, _get_image_info_from_inspect):


### PR DESCRIPTION
docker/containerd can fail a pull with

```
failed to copy: httpReadSeeker: failed open: failed to do request:
Get "https://cdn01.quay.io/...": EOF
```

when the registry's CDN drops a blob request mid-flight. `_pull_image()` only retries errors matching its ignorelist, so this transient failure killed cluster bootstrap on the first attempt — even though a concurrent pull of the same image on another host in the same job succeeded, and the 1s/4s/25s retry schedule would almost certainly have recovered.

Seen twice in one teuthology upgrade run (jobs 520609 and 520628, different hosts, ~15 minutes apart), so it's a recurring flake class, not a one-off.

Adds the `httpReadSeeker` request-failure signature to the retry ignorelist and extends the existing `TestPull::test_pull_retries` case to cover it.

Fixes: https://tracker.ceph.com/issues/80077

## Contribution Guidelines
- [x] To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).
- [x] If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/main/SubmittingPatches-backports.rst) for the proper workflow.
- [x] When filling out the below checklist, you may click boxes directly in the GitHub web UI. When entering or editing the entire PR message in the text box, you may also select a checkbox via typing an `x` between the brackets.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests