### PR TITLE
osd/PeeringState: Record the departing primary's rebuild segment on handover & survive a PG split.

### DIFF
--- a/qa/standalone/osd/osd-recovery-stats.sh
+++ b/qa/standalone/osd/osd-recovery-stats.sh
@@ -1153,6 +1153,311 @@ function TEST_rebuild_perf_empty_pg_not_counted() {
     kill_daemons $dir || return 1
 }
 
+# A PG split (ceph osd pool set ... pg_num N, triggering
+# PeeringState::split_into()/finish_split_stats()) occurring while the parent PG
+# is already latched as vulnerable. The test Forces a PG degraded (noup + down
+# one replica, size=3/ min_size=2), lets a first recovery cycle complete so
+# num_objects_recovered is genuinely nonzero, then re-degrades the same PG,
+# holds it vulnerable for a deliberate 8 secs, and grows pg_num from 1 to 2 to
+# split it while still degraded. The test finally verifies the following:
+#  1. The parent PG's own recorded duration - printed and asserted positive.
+#  2. The child must show NO "latched failure start" line of its own anywhere
+#     -- the most direct check of all, since it actually inherits the latch.
+#  3. The child's recorded duration is also parsed and printed, and asserted
+#     >= 5s. Reason: The second-cycle degrade-then-sleep-8-then-split sequence
+#     above means an inherited latch's recorded duration must be at least ~8s
+#     (it spans that sleep), while a fresh arm at the split moment would show
+#     a duration of a few seconds at most.
+function TEST_rebuild_perf_pg_split_inherits_latch() {
+    local dir=$1
+    local OSDS=4
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd --osd-mclock-skip-benchmark=true --debug-osd=15 || return 1
+    done
+
+    create_pool $poolname 1 1 replicated || return 1
+    ceph osd pool set $poolname size 3 || return 1
+    ceph osd pool set $poolname min_size 2 || return 1
+    # Deterministic pg_num control for this test -- don't let the
+    # autoscaler race the manual pg_num bump below.
+    ceph osd pool set $poolname pg_autoscale_mode off || return 1
+    wait_for_clean || return 1
+
+    rados -p $poolname bench 5 write -b 4096 --no-cleanup || return 1
+    wait_for_clean || return 1
+
+    local primary
+    primary=$(get_primary $poolname dummyname)
+    local PG
+    PG=$(get_pg $poolname dummyname)
+    local poolid=${PG%.*}
+    local child_pg="${poolid}.1"
+    local otherosd
+    otherosd=$(get_not_primary $poolname dummyname)
+    local log=$dir/osd.${primary}.log
+
+    # --- Priming cycle: force a real, *completed* recovery so
+    # num_objects_recovered is genuinely nonzero before the PG is ever
+    # re-degraded and split -- see header comment for why this matters.
+    ceph osd set noup || return 1
+    ceph osd down osd.${otherosd} || return 1
+    for i in $(seq 1 10)
+    do
+      flush_pg_stats || return 1
+      sleep 1
+    done
+    grep -q "rebuild-stats: latched failure start for ${PG} " $log || {
+      echo "FAIL: the priming latch never armed -- test setup didn't" \
+           "actually make the PG degraded"
+      return 1
+    }
+    # More writes while degraded, so the down OSD has real missing
+    # objects to actually recover once it returns (not a no-op catch-up).
+    rados -p $poolname bench 5 write -b 4096 --no-cleanup || return 1
+    ceph osd unset noup || return 1
+    wait_for_clean || return 1
+    flush_pg_stats || return 1
+    grep -q "rebuild-stats: recorded rebuild for ${PG} " $log || {
+      echo "FAIL: the priming cycle's recovery was never recorded --" \
+           "num_objects_recovered won't be primed, the real test below" \
+           "would be vacuous"
+      return 1
+    }
+
+    # --- Real test: re-degrade the same PG (now with a large, nonzero
+    # rebuild_base_recovered baseline once this second latch arms), hold
+    # it degraded for a bit, then split while still vulnerable.
+    ceph osd set noup || return 1
+    ceph osd down osd.${otherosd} || return 1
+
+    local second_armed=false
+    for i in $(seq 1 10)
+    do
+      flush_pg_stats || return 1
+      if test "$(grep -c "rebuild-stats: latched failure start for ${PG} " $log)" -ge 2
+      then
+        second_armed=true
+        break
+      fi
+      sleep 1
+    done
+    $second_armed || {
+      echo "FAIL: the second latch never armed before the split -- test" \
+           "setup didn't actually re-degrade the PG"
+      return 1
+    }
+    # Hold the degraded window open for long enough that an inherited
+    # duration (spanning this whole sleep) and a freshly-armed one
+    # (starting at the split below) are unambiguously distinguishable
+    # afterward.
+    sleep 8
+
+    # Split the still-degraded parent PG in two
+    local before_numpg
+    before_numpg=$(CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${primary}) \
+      perf dump | jq '.osd.numpg')
+    ceph osd pool set $poolname pg_num 2 || return 1
+
+    local split_done=false
+    for i in $(seq 1 60)
+    do
+      local numpg
+      numpg=$(CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${primary}) \
+        perf dump | jq '.osd.numpg')
+      if test "$numpg" -gt "$before_numpg"
+      then
+        split_done=true
+        break
+      fi
+      sleep 1
+    done
+    $split_done || {
+      echo "FAIL: split never completed on osd.${primary} (numpg stayed" \
+           "at $before_numpg after 60s) -- either the split stalled while" \
+           "the PG was degraded (a real, previously unconfirmed risk --" \
+           "see this test's header comment), or ${child_pg} isn't where" \
+           "expected; check osd logs directly"
+      return 1
+    }
+
+    ceph osd unset noup || return 1
+    wait_for_clean || return 1
+    flush_pg_stats || return 1
+
+    # Both the parent and the split-created child must eventually record a
+    # genuine, non-discarded rebuild segment with a sane (non-negative)
+    # delta_recovered -- checked across all four OSDs since either PG's
+    # primary could have landed anywhere post-split.
+    for pg in ${PG} ${child_pg}
+    do
+      local recorded=false
+      local discarded=false
+      for osd in $(seq 0 $(expr $OSDS - 1))
+      do
+        grep -q "rebuild-stats: recorded rebuild for ${pg} " $dir/osd.${osd}.log \
+          && recorded=true
+        grep -q "rebuild-stats: discarded rebuild for ${pg} " $dir/osd.${osd}.log \
+          && discarded=true
+      done
+
+      $recorded || {
+        echo "FAIL: no 'recorded rebuild' line found anywhere for ${pg} --" \
+             "the split-inherited latch was lost or never resolved"
+        return 1
+      }
+      ! $discarded || {
+        echo "FAIL: a 'discarded rebuild' line was found for ${pg} -- likely" \
+             "delta_recovered went negative after the split, discarding a" \
+             "genuine rebuild instead of recording it"
+        return 1
+      }
+
+      # Directly confirm delta_recovered isn't negative in the recorded line
+      # itself, not just that it recorded instead of being discarded -- the
+      # two filters overlap but aren't identical.
+      grep -h "rebuild-stats: recorded rebuild for ${pg} " $dir/osd.*.log \
+        | grep -q "delta_recovered=-" && {
+        echo "FAIL: ${pg} recorded a NEGATIVE delta_recovered -- the" \
+             "split-time num_objects_recovered redistribution bug is" \
+             "present"
+        return 1
+      }
+    done
+
+    # Sharpest, most direct check of all: the child pg must not emit its
+    # own "latched failure start" line BEFORE its first recorded resolution.
+    # A correctly inheriting child must produce no "latched" line before the
+    # inherited rebuild resolves.
+    #
+    # The check is deliberately scoped to "before the first recorded line",
+    # not "anywhere in the log": growing pg_num can also auto-bump
+    # pgp_num_target, and pgp_num's own gradual catch-up is a genuine, unrelated
+    # CRUSH remap that can cause the child to legitimately re-latch on its own,
+    # later, due to a real misplacement. Therefore, this tests the actual
+    # inheritance mechanism directly rather than through inference.
+    local child_first_recorded_ts
+   child_first_recorded_ts=$(grep -h "rebuild-stats: recorded rebuild for ${child_pg} " \
+      $dir/osd.*.log | sort | head -1 | awk '{print $1}')
+    test -n "$child_first_recorded_ts" || {
+      echo "FAIL: could not determine ${child_pg}'s first recorded timestamp"
+      return 1
+    }
+    local child_earliest_latched_ts
+    child_earliest_latched_ts=$(grep -h "rebuild-stats: latched failure start for ${child_pg} " \
+      $dir/osd.*.log | sort | head -1 | awk '{print $1}')
+    if [ -n "$child_earliest_latched_ts" ] \
+      && [[ "$child_earliest_latched_ts" < "$child_first_recorded_ts" ]]
+    then
+      echo "FAIL: ${child_pg} shows its own 'latched failure start' line" \
+           "(at $child_earliest_latched_ts) BEFORE its first recorded" \
+           "resolution (at $child_first_recorded_ts) -- it independently" \
+           "armed a fresh latch instead of inheriting the parent's" \
+           "already-armed one at split time"
+      return 1
+    fi
+
+    # Parent PG sanity check complementing the non-negative delta_recovered
+    # check above: its recorded duration from the real (second, post-
+    # priming) cycle must be positive. Uses $log specifically (not a glob
+    # across all four OSDs) because the primary never changes for this PG
+    # throughout the test (only otherosd goes up/down), so both the
+    # priming cycle's and the real test's "recorded rebuild for ${PG}"
+    # lines land in this single file in true chronological order --
+    # `tail -1` reliably picks the real (second) one, not the priming
+    # cycle's first one, without relying on cross-file ordering.
+    local parent_duration
+    parent_duration=$(grep "rebuild-stats: recorded rebuild for ${PG} " $log \
+      | tail -1 | grep -o "duration=[0-9.]*" | cut -d= -f2)
+    test -n "$parent_duration" || {
+      echo "FAIL: could not extract ${PG}'s (parent) recorded duration"
+      return 1
+    }
+    echo "INFO: ${PG} (parent) recorded duration=${parent_duration}s"
+    awk -v d="$parent_duration" 'BEGIN { exit !(d > 0) }' || {
+      echo "FAIL: ${PG}'s (parent) recorded duration (${parent_duration}s)" \
+           "is not positive"
+      return 1
+    }
+
+    # The child PG's  inherited latch's recorded duration must be
+    # at least ~8s (it spans that sleep), while a fresh arm at the split
+    # moment would show a duration of a few seconds at most (just the
+    # post-split recovery time, none of the pre-split sleep). Use >=5 as
+    # the threshold -- comfortably below the true ~8s+ floor for a correct
+    # inheritance, comfortably above what a fresh split-time arm could
+    # plausibly accumulate before this test's own wait_for_clean returns.
+    local child_duration
+    child_duration=$(grep -h "rebuild-stats: recorded rebuild for ${child_pg} " \
+      $dir/osd.*.log | grep -o "duration=[0-9.]*" | head -1 | cut -d= -f2)
+    test -n "$child_duration" || {
+      echo "FAIL: could not extract ${child_pg}'s recorded duration"
+      return 1
+    }
+    echo "INFO: ${child_pg} (child) recorded duration=${child_duration}s"
+    awk -v d="$child_duration" 'BEGIN { exit !(d >= 5) }' || {
+      echo "FAIL: ${child_pg}'s recorded duration ($child_duration s) is" \
+           "too short to have inherited the pre-split latch -- looks like" \
+           "the child started a fresh arm at the split moment instead of" \
+           "parent-to-child copy taking effect"
+      return 1
+    }
+
+    # Global reconciliation: pg_vulnerability_duration is an OSD-wide
+    # aggregate, not per-PG, so the only meaningful level to verify it at
+    # is a TOTAL across all four OSDs. Retries briefly since perf dump can
+    # momentarily race a just-written log line's disk flush.
+    local total_log_recorded total_log_duration total_avgcount total_sum
+    for i in $(seq 1 10)
+    do
+      total_log_recorded=$(grep -h "rebuild-stats: recorded rebuild for " \
+        $dir/osd.*.log | wc -l)
+      total_avgcount=0
+      total_sum=0
+      for osd in $(seq 0 $(expr $OSDS - 1))
+      do
+        local dump
+        dump=$(CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${osd}) \
+          perf dump) || return 1
+        total_avgcount=$(awk -v a="$total_avgcount" \
+          -v b="$(jq '.recoverystate_perf.pg_vulnerability_duration.avgcount' <<< "$dump")" \
+          'BEGIN{print a+b}')
+        total_sum=$(awk -v a="$total_sum" \
+          -v b="$(jq '.recoverystate_perf.pg_vulnerability_duration.sum' <<< "$dump")" \
+          'BEGIN{print a+b}')
+      done
+      test "$total_avgcount" = "$total_log_recorded" && break
+      sleep 1
+    done
+    total_log_duration=$(grep -h "rebuild-stats: recorded rebuild for " $dir/osd.*.log \
+      | grep -o "duration=[0-9.]*" | cut -d= -f2 | awk '{s+=$1} END {print s+0}')
+
+    echo "INFO: total recorded (logs)=${total_log_recorded}," \
+         "total avgcount (perf dump)=${total_avgcount}"
+    echo "INFO: total duration (logs)=${total_log_duration}s," \
+         "total sum (perf dump)=${total_sum}s"
+
+    test "$total_avgcount" = "$total_log_recorded" || {
+      echo "FAIL: perf dump's total avgcount (${total_avgcount}) across" \
+           "all four OSDs doesn't match the total 'recorded rebuild' line" \
+           "count from the logs (${total_log_recorded})"
+      return 1
+    }
+    awk -v a="$total_sum" -v b="$total_log_duration" \
+      'BEGIN { d=a-b; if (d<0) d=-d; exit !(d < 0.01) }' || {
+      echo "FAIL: perf dump's total sum (${total_sum}s) across all four" \
+           "OSDs doesn't match the total recorded duration from the logs" \
+           "(${total_log_duration}s)"
+      return 1
+    }
+
+    delete_pool $poolname
+    kill_daemons $dir || return 1
+}
+
 main osd-recovery-stats "$@"
 
 # Local Variables:

--- a/qa/standalone/osd/osd-recovery-stats.sh
+++ b/qa/standalone/osd/osd-recovery-stats.sh
@@ -853,18 +853,21 @@ function TEST_rebuild_perf_ec_increments() {
            perf dump) || return 1
 
     local rebuild_avgcount
-    rebuild_avgcount=$(jq '.recoverystate_perf.pg_rebuild_duration.avgcount' \
-      <<< "$dump")
+    rebuild_avgcount=$(\
+      jq '.recoverystate_perf.pg_vulnerability_duration.avgcount' <<< "$dump")
     test "$rebuild_avgcount" -ge 1 || {
-      echo "FAIL: expected pg_rebuild_duration.avgcount>=1, got $rebuild_avgcount"
+      echo "FAIL: expected pg_vulnerability_duration.avgcount>=1," \
+           "got $rebuild_avgcount"
       return 1
     }
 
     local rebuild_sum
-    rebuild_sum=$(jq '.recoverystate_perf.pg_rebuild_duration.sum' <<< "$dump")
+    rebuild_sum=$(\
+      jq '.recoverystate_perf.pg_vulnerability_duration.sum' <<< "$dump")
     echo "$dump" | \
-      jq -e '.recoverystate_perf.pg_rebuild_duration.sum > 0' > /dev/null || {
-      echo "FAIL: expected pg_rebuild_duration.sum>0, got $rebuild_sum"
+      jq -e '.recoverystate_perf.pg_vulnerability_duration.sum > 0' \
+      > /dev/null || {
+      echo "FAIL: expected pg_vulnerability_duration.sum>0, got $rebuild_sum"
       return 1
     }
 
@@ -878,18 +881,275 @@ function TEST_rebuild_perf_ec_increments() {
     }
 
     # The recorded duration must cover at least the deliberate gap held
-    # before the second restart i.e., $gap_secs. pg_rebuild_duration.sum is
+    # before the second restart i.e., $gap_secs. pg_vulnerability_duration.sum is
     # reported in fractional seconds.
     echo "$dump" | \
-      jq -e ".recoverystate_perf.pg_rebuild_duration.sum >= ${gap_secs}" \
+      jq -e ".recoverystate_perf.pg_vulnerability_duration.sum >= ${gap_secs}" \
       > /dev/null || {
-      echo "FAIL: expected pg_rebuild_duration.sum >= ${gap_secs}s" \
+      echo "FAIL: expected pg_vulnerability_duration.sum >= ${gap_secs}s" \
            "(the ${gap_secs}s gap held before the second interval restart)," \
            "got ${rebuild_sum}s -- duration looks truncated"
       return 1
     }
 
     delete_pool $ecpoolname
+    kill_daemons $dir || return 1
+}
+
+# Test to verify the following:
+# 1. A forced, deterministic two primary handover chain within ONE continuous
+#    vulnerability episode, confirming the departing primary's own segment is
+#    recorded on each handover and that this holds across a genuine multi-hop
+#    chain, not just a single one.
+# 2. The test also observes (without asserting either way) whether the
+#    returning OSDs show any activity of their own once brought back.
+function TEST_rebuild_perf_multihop_handover() {
+    local dir=$1
+    local OSDS=4
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd --osd-mclock-skip-benchmark=true --debug-osd=15 || return 1
+    done
+
+    create_pool $poolname 1 1 replicated || return 1
+    ceph osd pool set $poolname size 4 || return 1
+    ceph osd pool set $poolname min_size 2 || return 1
+    wait_for_clean || return 1
+
+    for i in $(seq 1 5)
+    do
+      rados -p $poolname put obj$i /etc/hostname || return 1
+    done
+    wait_for_clean || return 1
+
+    local PG
+    PG=$(get_pg $poolname obj1)
+    local primary_a
+    primary_a=$(get_primary $poolname obj1)
+
+    # --- Hop 0: kill the original primary A. Primary hands to a survivor B.
+    ceph osd set noup || return 1
+    ceph osd down osd.${primary_a} || return 1
+
+    local primary_b=""
+    for i in $(seq 1 30)
+    do
+      primary_b=$(get_primary $poolname obj1)
+      test "$primary_b" != "$primary_a" && break
+      sleep 1
+    done
+    test "$primary_b" != "$primary_a" -a -n "$primary_b" || {
+      echo "FAIL: primary never changed after osd.${primary_a} went down"
+      return 1
+    }
+    local log_b=$dir/osd.${primary_b}.log
+
+    local latched_b=0
+    for i in $(seq 1 30)
+    do
+      flush_pg_stats || return 1
+      grep -q "rebuild-stats: latched failure start for ${PG} " $log_b && {
+        latched_b=1
+        break
+      }
+      sleep 1
+    done
+    test "$latched_b" = 1 || {
+      echo "FAIL: osd.${primary_b} never latched after taking over primary"
+      return 1
+    }
+
+    for i in $(seq 6 10)
+    do
+      rados -p $poolname put obj$i /etc/hostname || return 1
+    done
+
+    # --- Hop 1: kill B too, before anything has a chance to recover.
+    # osd.${primary_a} is still merely down (not out); so nothing has backfilled
+    ceph osd down osd.${primary_b} || return 1
+
+    local primary_c=""
+    for i in $(seq 1 30)
+    do
+      primary_c=$(get_primary $poolname obj1)
+      test "$primary_c" != "$primary_a" -a "$primary_c" != "$primary_b" && break
+      sleep 1
+    done
+    test -n "$primary_c" -a "$primary_c" != "$primary_a" -a "$primary_c" != "$primary_b" || {
+      echo "FAIL: primary never changed to a third OSD after osd.${primary_b} went down"
+      return 1
+    }
+    local log_c=$dir/osd.${primary_c}.log
+
+    local recorded_b=0
+    for i in $(seq 1 30)
+    do
+      flush_pg_stats || return 1
+      grep -q "rebuild-stats: recorded rebuild for ${PG} .*reason=handover-away" $log_b && {
+        recorded_b=1
+        break
+      }
+      sleep 1
+    done
+    test "$recorded_b" = 1 || {
+      echo "FAIL: osd.${primary_b}'s segment was not recorded on its own handover-away"
+      return 1
+    }
+
+    local latched_c=0
+    for i in $(seq 1 30)
+    do
+      grep -q "rebuild-stats: latched failure start for ${PG} " $log_c && {
+        latched_c=1
+        break
+      }
+      sleep 1
+    done
+    test "$latched_c" = 1 || {
+      echo "FAIL: osd.${primary_c} never latched after taking over primary" \
+           "(the multi-hop chain, requires a fresh arming of the latch here)"
+      return 1
+    }
+
+    # --- Bring both A and B back and let the episode resolve. Which OSD
+    # ends up recording the eventual "reached-clean" segment, and how many
+    # more handovers happen in between, is deliberately not predicted here.
+    ceph osd unset noup || return 1
+    wait_for_clean || return 1
+    flush_pg_stats || return 1
+
+    local final_primary
+    final_primary=$(get_primary $poolname obj1)
+    local log_final=$dir/osd.${final_primary}.log
+    grep -q "rebuild-stats: recorded rebuild for ${PG} .*reason=reached-clean" $log_final || {
+      echo "FAIL: no OSD recorded a reached-clean segment once the PG went clean" \
+           "(checked the final primary, osd.${final_primary})"
+      return 1
+    }
+
+    # Soft observation (not asserted either way): did osd.a or osd.b show any
+    # of their own rebuild-stats activity after coming back up? Either outcome
+    # is informative and is just logged here. A genuinely open, likely
+    # timing-dependent question with no settled answer (whether the
+    # async-recovery quick-promotion ever arms a spurious segment that gets
+    # recorded or discarded before being demoted again). The following 2 checks
+    # will confirm this observation:
+    #
+    # 1. A "discarded rebuild" line for this PG on ANY of the four OSDs is
+    #    unambiguous: A discarded line can only be residue of an UNPLANNED
+    #    arm-then-filtered-out cycle, exactly the quick-promotion signature,
+    #    regardless of which OSD ends up primary or how many real handovers occur.
+    for osd in 0 1 2 3
+    do
+      if grep -q "rebuild-stats: discarded rebuild for ${PG} " $dir/osd.${osd}.log
+      then
+        echo "OBSERVATION: osd.${osd} shows a DISCARDED rebuild-stats segment" \
+             "for ${PG}; likely evidence of the async-recovery quick-promotion" \
+             "arming and then being filtered out at record time"
+      fi
+    done
+
+    # 2. Total "latched failure start" lines for this PG, across all four
+    # OSDs, as a coarser but still useful signal: exactly 2 are
+    # structurally guaranteed by this test's design (primary_b's and
+    # primary_c's own arms), plus one more if whichever OSD ends up as
+    # final_primary needed a fresh arm of its own (i.e. a third real
+    # handover happened beyond the two this test forces). A count higher than
+    # that baseline would mean an extra, unplanned arm occurred somewhere --
+    # whether or not it went on to be recorded or discarded.
+    local total_latches
+    total_latches=$(grep -h "rebuild-stats: latched failure start for ${PG} " \
+      $dir/osd.*.log | wc -l)
+    echo "OBSERVATION: ${total_latches} total 'latched' lines for ${PG} across" \
+         "all four OSDs this run (2 expected structurally, 3 if the final" \
+         "primary needed its own fresh arm; more than that would mean an" \
+         "extra, unplanned arm occurred)"
+
+    delete_pool $poolname
+    kill_daemons $dir || return 1
+}
+
+# Test that verifies that an empty PG (no objects ever written) going
+# undersized+degraded and back to active+clean must not be recorded at all --
+# the interim solution's documented, deliberately-unfixed limitation.
+function TEST_rebuild_perf_empty_pg_not_counted() {
+    local dir=$1
+    local OSDS=4
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd --osd-mclock-skip-benchmark=true --debug-osd=15 || return 1
+    done
+
+    create_pool $poolname 1 1 replicated || return 1
+    ceph osd pool set $poolname size 3 || return 1
+    ceph osd pool set $poolname min_size 2 || return 1
+    wait_for_clean || return 1
+    # Deliberately no rados put here -- this PG must stay empty throughout.
+
+    local primary
+    primary=$(get_primary $poolname dummyname)
+    local PG
+    PG=$(get_pg $poolname dummyname)
+    local otherosd
+    otherosd=$(get_not_primary $poolname dummyname)
+    local log=$dir/osd.${primary}.log
+
+    ceph osd set noup || return 1
+    ceph osd down osd.${otherosd} || return 1
+
+    for i in $(seq 1 10)
+    do
+      flush_pg_stats || return 1
+      sleep 1
+    done
+
+    # Confirm the latch actually armed (state genuinely went
+    # undersized) before checking it was correctly discarded -- a test
+    # that just sees "nothing recorded" without this is equally
+    # consistent with the mechanism never engaging at all.
+    grep -q "rebuild-stats: latched failure start for ${PG} " $log || {
+      echo "FAIL: the latch never armed at all -- test setup didn't" \
+           "actually make the PG undersized, this isn't testing what" \
+           "it claims to"
+      return 1
+    }
+
+    ceph osd unset noup || return 1
+    wait_for_clean || return 1
+    flush_pg_stats || return 1
+
+    if grep -q "rebuild-stats: recorded rebuild for ${PG} " $log
+    then
+      echo "FAIL: an empty PG's undersized/degraded window was recorded --" \
+           "this is supposed to remain a known, unfixed limitation"
+      return 1
+    fi
+
+    grep -q "rebuild-stats: discarded rebuild for ${PG} .*delta_recovered=0 had_redundancy_loss=0" $log || {
+      echo "FAIL: expected a 'discarded' line confirming the filter" \
+           "correctly rejected this empty-PG episode, found none"
+      return 1
+    }
+
+    local dump
+    dump=$(CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${primary}) \
+           perf dump) || return 1
+    local avgcount
+    avgcount=$(jq '.recoverystate_perf.pg_vulnerability_duration.avgcount' \
+      <<< "$dump")
+    test "$avgcount" = "0" || {
+      echo "FAIL: expected pg_vulnerability_duration.avgcount=0 for an" \
+           "empty-PG episode, got $avgcount"
+      return 1
+    }
+
+    delete_pool $poolname
     kill_daemons $dir || return 1
 }
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -839,6 +839,18 @@ void PeeringState::start_peering_interval(
     pl->clear_want_pg_temp();
   }
 
+  // if this OSD specifically is *losing* the primary role (as opposed to
+  // gaining it) while the latch is still armed, close out and record this
+  // OSD's own segment of the vulnerability window before discarding the
+  // latch fields below -- otherwise a primary handover mid-rebuild
+  // silently drops the whole in-progress duration with no trace on any OSD.
+  // This does not recover the true total across a multi-handover chain --
+  // see try_record_rebuild_segment()'s doc comment.
+  const bool losing_primary = was_old_primary && !is_primary();
+  if (losing_primary && rebuild_start_time != utime_t()) {
+    try_record_rebuild_segment(ceph_clock_now(), "handover-away");
+  }
+
   // Only reset the rebuild-time latch when the primary role actually
   // changes across this interval transition. Routine peering restarts
   // (e.g. acting-set churn from backfill peers being added/removed)
@@ -1077,6 +1089,35 @@ void PeeringState::clear_primary_state()
   pg_committed_to = eversion_t();
   missing_loc.clear();
   pl->clear_primary_state();
+}
+
+void PeeringState::try_record_rebuild_segment(
+  utime_t end_time,
+  std::string_view reason)
+{
+  // Caller (prepare_stats_for_publish()'s "reached clean" branch, or
+  // start_peering_interval()'s "handover-away" check) is responsible for
+  // guarding rebuild_start_time != utime_t() before calling this, and for
+  // resetting the three latch fields immediately afterward -- this method
+  // only computes, filters, records, and logs; it does not reset state.
+  const int64_t num_recovered = info.stats.stats.sum.num_objects_recovered;
+  const int64_t delta_recovered = num_recovered - rebuild_base_recovered;
+  const utime_t rebuild_dur = end_time - rebuild_start_time;
+
+  if (rebuild_dur.to_msec() > 0 &&
+      (delta_recovered > 0 || rebuild_had_redundancy_loss)) {
+    pl->get_peering_perf().tinc(rs_pg_rebuild_duration, rebuild_dur);
+    psdout(15) << "rebuild-stats: recorded rebuild for " << info.pgid
+              << " duration=" << rebuild_dur
+              << " delta_recovered=" << delta_recovered
+              << " reason=" << reason << dendl;
+  } else {
+    psdout(15) << "rebuild-stats: discarded rebuild for " << info.pgid
+              << " duration=" << rebuild_dur
+              << " delta_recovered=" << delta_recovered
+              << " had_redundancy_loss=" << rebuild_had_redundancy_loss
+              << " reason=" << reason << dendl;
+  }
 }
 
 /// return [start,end) bounds for required past_intervals
@@ -4515,7 +4556,7 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
 
     /**
      * The following block is an interim solution to aggregate PG rebuild stats
-     * into a set of perf counters. The counterss are set based on the following
+     * into a perf counter. The counter is set based on the following
      * existing pg_stat_t fields:
      *  - last_clean, last_change
      *  - num_objects_degraded, num_objects_misplaced, num_objects_recovered
@@ -4549,6 +4590,17 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
      *     set while PEERING) filters out that transient situation so it can't
      *     prematurely record a truncated duration and reset the latch out
      *     from under an in-progress rebuild.
+     *  5. A primary handover mid-vulnerability window closes out and records
+     *     the departing OSD's own segment instead of silently discarding it.
+     *     This means a PG that changes primary N times while continuously
+     *     vulnerable is recorded as N separate rebuild_duration samples
+     *     (whose durations sum to roughly, not exactly, the true total episode
+     *     length) rather than one -- a real, understood, and accepted
+     *     trade-off for this interim solution: avgcount can overcount the true
+     *     number of distinct redundancy-loss incidents whenever a handover
+     *     occurs mid-episode, though avgtime/the summed exposure duration stay
+     *     roughly accurate. A PG whose primary never changes is entirely
+     *     unaffected and continues to produce exactly one sample.
      *
      * last_degraded is intentionally not used in the interim solution to
      * retain compatibility with older Ceph releases where this field doesn't
@@ -4589,16 +4641,7 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
         // window (see point 4 above) where the degraded/misplaced counts
         // can momentarily read as zero before peering has finished
         // repopulating them for the new interval.
-        const int64_t delta_recovered = num_recovered - rebuild_base_recovered;
-        const utime_t rebuild_dur  = now - rebuild_start_time;
-
-        if (rebuild_dur.to_msec() > 0 &&
-            (delta_recovered > 0 || rebuild_had_redundancy_loss)) {
-          pl->get_peering_perf().tinc(rs_pg_rebuild_duration, rebuild_dur);
-          psdout(15) << "rebuild-stats: recorded rebuild for " << info.pgid
-                     << " duration=" << rebuild_dur
-                     << " delta_recovered=" << delta_recovered << dendl;
-        }
+        try_record_rebuild_segment(now, "reached-clean");
         // reset for the next event
         rebuild_start_time = utime_t();
         rebuild_base_recovered = 0;

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3885,6 +3885,13 @@ void PeeringState::split_into(
   child->info.last_epoch_started = info.last_epoch_started;
   child->info.last_interval_started = info.last_interval_started;
 
+  // rebuild-stats: Make the child inherit the parent's latch. Otherwise the
+  // child's share of a pre-split, still-ongoing failure would understate its
+  // true duration (or vanish from delta_recovered's filter entirely) once it
+  // independently detects its own degradation post-split.
+  child->rebuild_start_time = rebuild_start_time;
+  child->rebuild_had_redundancy_loss = rebuild_had_redundancy_loss;
+
   increment_stats_invalidations_counter(rs_pg_split_parent_stats_invalidated,
                                         info.stats.stats_invalid);
   increment_stats_invalidations_counter(rs_pg_split_child_stats_invalidated,
@@ -4119,6 +4126,21 @@ void PeeringState::finish_split_stats(
   const object_stat_sum_t& stats, ObjectStore::Transaction &t)
 {
   info.stats.stats.sum = stats;
+
+  // rebuild-stats: object_stat_sum_t::split() (see its SPLIT(num_objects_
+  // recovered) macro) divides num_objects_recovered evenly across the
+  // parent and every child -- so info.stats.stats.sum.num_objects_recovered
+  // just dropped to a fraction of whatever it was when rebuild_base_
+  // recovered was last snapshotted, on BOTH the parent and the child. Without
+  // the redistributed value (via split()), try_record_rebuild_segment()'s
+  // delta_recovered = num_recovered - rebuild_base_recovered can go negative
+  // can reflect inaccurate value and result in discarding a genuine rebuild.
+  // Therefore, re-anchor the baseline to the just-applied, already
+  // redistributed value and make the child's inheritance numerically correct.
+  if (rebuild_start_time != utime_t()) {
+    rebuild_base_recovered = info.stats.stats.sum.num_objects_recovered;
+  }
+
   write_if_dirty(t);
 }
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1650,6 +1650,17 @@ public:
   void on_new_interval();
   void clear_recovery_state();
   void clear_primary_state();
+  /**
+   * This is used by:
+   * a) start_peering_interval(): If this OSD is losing the primary role
+   *    while rebuild_start_time is still armed -- close out and record this
+   *    OSD's own segment of the vulnerability window instead of discarding it.
+   * b) prepare_stats_for_publish(): The case where this OSD is the primary
+   *   and completes a rebuild and records the OSD's vulnerability window.
+   *
+   * So both paths use identical filter/record/log logic.
+   */
+  void try_record_rebuild_segment(utime_t end_time, std::string_view reason);
   void check_past_interval_bounds() const;
   bool set_force_recovery(bool b);
   bool set_force_backfill(bool b);

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -542,8 +542,16 @@ PerfCounters *build_recoverystate_perf(CephContext *cct) {
   rs_perf.add_u64_counter(rs_update_stats_invalidated, "update_stats_invalidated", "Number of times pg stats received invalidations during stats updates");
   rs_perf.add_u64_counter(rs_append_log_stats_invalidated, "append_log_stats_invalidated", "Number of times pg stats received invalidations when appending new log entries");
   rs_perf.add_u64_counter(rs_merge_log_stats_invalidated, "merge_log_stats_invalidated", "Number of times pg stats received invalidations during merging of log entries");
-  rs_perf.add_time_avg(rs_pg_rebuild_duration, "pg_rebuild_duration",
-    "Average PG rebuild duration on this OSD (primary role only)",
+  rs_perf.add_time_avg(rs_pg_rebuild_duration, "pg_vulnerability_duration",
+    "Average PG vulnerability duration on this OSD (primary role only), "
+    "i.e. time exposed to redundancy loss -- not literal rebuild/"
+    "data-movement time, which this interim counter does not separately "
+    "track; also counts misplacement-only episodes (e.g. benign CRUSH "
+    "rebalancing) indistinguishable from genuine failures, and excludes "
+    "windows where the PG never had data recovered or lost (e.g. an "
+    "empty PG); a primary handover mid-window is recorded as a separate "
+    "sample per OSD segment, so avgcount can exceed the true number of "
+    "distinct redundancy-loss incidents",
     NULL, PerfCountersBuilder::PRIO_USEFUL);
 
   return rs_perf.create_perf_counters();

--- a/src/test/osd/TestPeeringState.cc
+++ b/src/test/osd/TestPeeringState.cc
@@ -2446,14 +2446,15 @@ TEST_F(PeeringStateTest, RebuildStatsCountAccumulates) {
 
 // ============================================================================
 // Test 5: Latch is discarded when the OSD loses its primary role mid-rebuild.
+// But the departing primary's own in-progress segment is now recorded rather
+// than silently discarded.
 //
-// If a new interval begins while rebuild_start_time is set and the OSD
-// transitions from primary to stray, clear_primary_state() must discard the
-// stale latch so no spurious rebuild event is emitted for a recovery that the
-// OSD no longer owns.
+// The original interim design discarded the stale latch during the
+// primary -> stray transition with no recording. This discarded real rebuild
+// episodes whenever the failed OSD was held primary for the affected PG.
 // ============================================================================
-TEST_F(PeeringStateTest, RebuildStatsLatchClearedOnRoleChange) {
-  dout(0) << "== RebuildStatsLatchClearedOnRoleChange ==" << dendl;
+TEST_F(PeeringStateTest, RebuildStatsRecordsSegmentOnRoleChange) {
+  dout(0) << "== RebuildStatsRecordsSegmentOnRoleChange ==" << dendl;
   test_create_peering_state();
   test_init();
   test_event_initialize();
@@ -2481,6 +2482,11 @@ TEST_F(PeeringStateTest, RebuildStatsLatchClearedOnRoleChange) {
   ASSERT_NE(get_ps(0)->get_rebuild_start_time(), utime_t())
       << "latch must be set before role change";
 
+  // Sleep so the departing primary's segment has a real, nonzero duration
+  // to record -- mirrors the sleep pattern used by the other RebuildStats*
+  // tests for the same reason.
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
   // --- Phase 2: change the primary before recovery completes. ---
   // Swap acting[0] from OSD 0 to OSD 7. OSD 0 leaves the acting set
   // entirely and becomes a stray; OSD 7 takes over as primary.
@@ -2491,22 +2497,25 @@ TEST_F(PeeringStateTest, RebuildStatsLatchClearedOnRoleChange) {
   test_init(7);
   test_event_initialize(7);
 
-  // advance_map on OSD 0: the new acting set excludes OSD 0, so
-  // should_restart_peering()->start_peering_interval() resets the
-  // three latch variables since the role of OSD 0 is now changed.
+  // should_restart_peering()->start_peering_interval() now closes out and
+  // records OSD 0's own segment before resetting the three latch variables.
   test_event_advance_map();
 
-  // --- Phase 3: verify latch is cleared on the old primary. ---
+  // --- Phase 3: latch fields still reset on the departing primary. ---
+  // This part of the behavior is unchanged from before: a stale
+  // start time/baseline must never be reused across a role change.
   EXPECT_EQ(get_ps(0)->get_rebuild_start_time(), utime_t());
   EXPECT_EQ(get_ps(0)->get_rebuild_base_recovered(), 0);
   EXPECT_FALSE(get_ps(0)->get_rebuild_had_redundancy_loss());
 
-  // No rebuild record must have been emitted: the latch was discarded, not
-  // fired. A spurious emission here would record a duration spanning a
-  // recovery that OSD 0 did not complete.
+  // --- Phase 4: the segment IS now recorded, not silently dropped. ---
+  // OSD 0 had real degraded objects at latch time (rebuild_had_redundancy_
+  // loss == true), so the genuine-event filter passes even though no
+  // recovery I/O had completed yet (delta_recovered == 0 at handover time).
   auto [sum_ns, count] = perf_osd0->get_tavg_ns(rs_pg_rebuild_duration);
-  EXPECT_EQ(count, 0u);
-  EXPECT_EQ(sum_ns,  0u);
+  EXPECT_EQ(count, 1u)
+    << "the departing primary's segment must be recorded, not discarded";
+  EXPECT_GT(sum_ns,  0u);
 }
 
 // ============================================================================
@@ -2568,6 +2577,128 @@ TEST_F(PeeringStateTest, RebuildStatsLatchSurvivesSamePrimaryIntervalRestart) {
   PerfCounters *perf_osd0 = get_listener(0)->recoverystate_perf;
   auto [sum_ns, count] = perf_osd0->get_tavg_ns(rs_pg_rebuild_duration);
   EXPECT_EQ(count, 0u);
+}
+
+// ============================================================================
+// Test 7: A PG that changes primary TWICE while continuously vulnerable
+// records a SEPARATE partial segment on each departing primary, instead of
+// losing the whole episode, and demonstrates its accepted trade-off concretely:
+// one true, continuous vulnerability episode is recorded as THREE separate
+// avgcount samples, not one.
+//
+// The test chains two primary handovers back to back (0 -> 7 -> 8) while
+// up_acting keeps accumulating every historical OSD (modify_up_acting() only
+// ever pushes; see osd_down() for the only helper that erases).
+// test_event_advance_map() with no target therefore re-processes
+// already-departed OSDs on the second handover too; this is expected to be
+// harmless because try_record_rebuild_segment() is only invoked when
+// rebuild_start_time != utime_t(), and the departing OSD's latch is
+// unconditionally reset to utime_t() immediately after its segment is recorded
+// on the first handover -- so a redundant advance_map on an already-departed
+// OSD cannot re-fire or double-record.
+// ============================================================================
+TEST_F(PeeringStateTest, RebuildStatsMultiHopHandoverRecordsEachSegment) {
+  dout(0) << "== RebuildStatsMultiHopHandoverRecordsEachSegment ==" << dendl;
+  test_create_peering_state();
+  test_init();
+  test_event_initialize();
+  eversion_t v = test_append_log_entry();
+  test_peering();
+  verify_all_active_clean(v, eversion_t());
+
+  // Stamp last_clean so the new_failure guard is satisfied for OSD 0.
+  call_prepare_stats(acting_primary);        // acting_primary = OSD 0
+
+  // --- Degrade the PG while OSD 0 is primary. ---
+  // Replace acting[1] (OSD 1) with OSD 9; OSD 9 needs recovery. This keeps
+  // the PG degraded (rebuild_had_redundancy_loss latches true at every
+  // hop) all the way through both handovers below, without needing to
+  // actually complete the recovery until the very end.
+  modify_up_acting(1, 9);
+  test_create_peering_state(9, 1);
+  test_init(9);
+  test_event_initialize(9);
+  test_peering();
+  // PG is now active+recovering+degraded; OSD 0 remains primary.
+
+  PerfCounters *perf_osd0 = get_listener(0)->recoverystate_perf;
+
+  // Latch fires on OSD 0.
+  call_prepare_stats(acting_primary);
+  ASSERT_NE(get_ps(0)->get_rebuild_start_time(), utime_t())
+      << "latch must be set before the first handover";
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  // --- Hop 1: OSD 0 -> OSD 7. OSD 0 leaves the acting set entirely. ---
+  modify_up_acting(0, 7);
+  acting_primary = 7;
+  up_primary = 7;
+  test_create_peering_state(7, 0);
+  test_init(7);
+  test_event_initialize(7);
+  test_event_advance_map();   // closes out and records OSD 0's segment
+  test_peering();
+
+  // OSD 0's segment must be recorded now, not silently discarded.
+  {
+    auto [sum_ns, count] = perf_osd0->get_tavg_ns(rs_pg_rebuild_duration);
+    EXPECT_EQ(count, 1u)
+        << "OSD 0's segment must be recorded on the first handover";
+    EXPECT_GT(sum_ns, 0u);
+  }
+  EXPECT_EQ(get_ps(0)->get_rebuild_start_time(), utime_t())
+      << "OSD 0's latch fields must still reset after recording";
+
+  PerfCounters *perf_osd7 = get_listener(7)->recoverystate_perf;
+
+  // OSD 7 must reliably re-arm its own fresh latch: the PG is still
+  // degraded (OSD 9 still needs recovery), and last_change was just
+  // bumped by this interval restart while last_clean is still the old,
+  // pre-failure value -- confirmed reliable in the pg-state-machine skill.
+  call_prepare_stats(acting_primary);
+  ASSERT_NE(get_ps(7)->get_rebuild_start_time(), utime_t())
+      << "a fresh primary must reliably re-arm mid-vulnerability";
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  // --- Hop 2: OSD 7 -> OSD 8. OSD 7 leaves the acting set entirely. ---
+  modify_up_acting(0, 8);
+  acting_primary = 8;
+  up_primary = 8;
+  test_create_peering_state(8, 0);
+  test_init(8);
+  test_event_initialize(8);
+  test_event_advance_map();   // closes out and records OSD 7's segment
+  test_peering();
+
+  // OSD 7's segment must ALSO be recorded, independently of OSD 0's.
+  {
+    auto [sum_ns, count] = perf_osd7->get_tavg_ns(rs_pg_rebuild_duration);
+    EXPECT_EQ(count, 1u)
+        << "OSD 7's segment must be recorded on the second handover";
+    EXPECT_GT(sum_ns, 0u);
+  }
+
+  PerfCounters *perf_osd8 = get_listener(8)->recoverystate_perf;
+
+  // OSD 8 arms its own fresh latch the same way OSD 7 did.
+  call_prepare_stats(acting_primary);
+  ASSERT_NE(get_ps(8)->get_rebuild_start_time(), utime_t());
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  // --- Finally: drive the recovery to completion under OSD 8. ---
+  test_recover_got(8, v);
+  test_begin_peer_recover(9, 1);
+  test_on_peer_recover(9, 1, v);
+  test_recover_got(9, v);
+  test_object_recovered();
+  test_event_all_replicas_recovered();
+  verify_all_active_clean(v, eversion_t());
+  call_prepare_stats(acting_primary);   // "reached-clean" record fires on OSD 8
+
+  auto [sum_ns, count] = perf_osd8->get_tavg_ns(rs_pg_rebuild_duration);
+  EXPECT_EQ(count, 1u)
+      << "OSD 8's own segment must be recorded once it reaches clean";
+  EXPECT_GT(sum_ns, 0u);
 }
 
 // ============================================================================


### PR DESCRIPTION
Changes:

1. Whenever a PG's primary changes hands while it is vulnerable, the in-memory
    rebuild-time latch was discarded incorrectly by start_peering_interval()'s
    reset with no recording step at all. Every OSD that touched a multi-handover
    PG ended up with pg_rebuild_duration avgcount=0 despite real, confirmed
    recovery activity, while the one PG whose primary never changed hands recorded
    the correct full duration.  This is not a rare corner case: it reproduces
    whenever the failed OSD was a primary for the affected PG, which is the common
    case for any OSD restart, not the exception.
    
    This is a scoped mitigation, for the interim solution where the departing
    primary's rebuild segment is now recorded on handover.

2. ` osd_perf_counters.cc`: Rename the exposed `pg_rebuild_duration` perf counter
     to `pg_vulnerability_duration` and extend the description string. This only
     changes the externally-visible Prometheus/perf-schema facing name and its
     description.
    
     _Rationale_: The counter has always measured a vulnerability window (onset
     of redundancy loss to resolution), not literal rebuild/data-movement time.
     This accounts for the case where a recorded duration includes several
     minutes of a PG sitting undersized+degraded with zero recovery activity
     possible (no spare OSD) before any data moved at all. However, note that in
     this scenario if no data was moved at all and the PG returns to active+clean,
     the window is excluded and not recorded (see caveats below).

3. A PG split (`split_into()`), triggered by a pg_num increase during map advance
    should not leave a child PG's rebuild-stats latch fields (`rebuild_start_time`,
    `rebuild_base_recovered`, `rebuild_had_redundancy_loss`) at their default, unarmed
    values regardless of whether the parent was already latched as vulnerable at
    split time. Leaving it at default would cause it to understate its true
    duration or vanish from `delta_recovered`'s filter.

Fixes: https://tracker.ceph.com/issues/80117
Signed-off-by: Sridhar Seshasayee <sridhar.seshasayee@ibm.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
