### PR TITLE
rgw/s3vectors: support purging and remove the s3 backend

### DIFF
--- a/doc/radosgw/s3vectors.rst
+++ b/doc/radosgw/s3vectors.rst
@@ -34,25 +34,11 @@ with:
 
 .. confval:: rgw_s3vector_backend
 
-Three backends are supported:
+Two backends are supported:
 
 - ``rgw`` (the default): LanceDB files are stored in the same Ceph cluster,
   through the RGW storage abstraction layer. No external service and no extra
   configuration are needed.
-- ``s3``: LanceDB files are stored in an S3-compatible object store.
-  The endpoint is configured centrally, while the credentials used to access it
-  are the credentials of the user that issued the S3 Vectors request.
-  The endpoint must be reachable from the RGW process, and the user must have
-  access to it with its credentials. Using this option may give better visibility
-  to the data being stored, allow for quota management, rate-limiting etc.
-
-  .. tip:: Using ``http://localhost:<port>`` (where ``<port>`` is the port
-     configured for the RGW's frontend) lets the RGW send the S3 requests to
-     itself. Make sure to set: ``rgw_s3vector_s3_allow_http = true`` in this case.
-
-  .. tip:: Setting the endpoint to be the RGW's load balancer (if one exists)
-     may achieve better load distribution.
-
 - ``local``: LanceDB files are stored on the local filesystem of the RGW
   process. This backend is intended for testing and single RGW setups only:
   vector buckets created on one RGW will not be usable from another one.
@@ -61,29 +47,18 @@ The ``local`` backend is configured with:
 
 .. confval:: rgw_s3vector_local_path
 
-The ``s3`` backend is configured with:
-
-.. confval:: rgw_s3vector_s3_endpoint
-.. confval:: rgw_s3vector_s3_region
-.. confval:: rgw_s3vector_s3_allow_http
-
-.. warning:: ``rgw_s3vector_s3_allow_http`` should only be enabled when the
-   configured endpoint is reachable over a trusted network, since the user
-   credentials would otherwise be sent in cleartext.
-
 
 Backing Buckets
 ~~~~~~~~~~~~~~~
 
-With the ``rgw`` and the ``s3`` backends, LanceDB stores its files inside a
-regular S3 bucket. The name of that bucket is identical to the name of the
-vector bucket. **This bucket is not created automatically**: it must be created
-before ``CreateVectorBucket`` is called.
+With the ``rgw`` backend, LanceDB stores its files inside a regular S3 bucket.
+The name of that bucket is identical to the name of the vector bucket.
+**This bucket is not created automatically**: it must be created before
+``CreateVectorBucket`` is called.
 
 For example, to create a vector bucket named ``my-vectors``, first create a
-regular S3 bucket named ``my-vectors`` (at the RGW endpoint for the ``rgw``
-backend, or at the endpoint configured in ``rgw_s3vector_s3_endpoint`` for the
-``s3`` backend), and only then call ``CreateVectorBucket``.
+regular S3 bucket named ``my-vectors`` at the RGW endpoint, and only then call
+``CreateVectorBucket``.
 
 .. note:: S3 buckets are kept in separate namespaces, and a name may be used by both
    at the same time. Listing S3 buckets does not show vector buckets,
@@ -139,9 +114,6 @@ more than one zone, holding different indexes and vectors.
 The backing bucket of a vector bucket is a regular S3 bucket, and its own sync
 configuration applies to it. It should not be synced. See:
 `Recommended Bucket Configuration`_.
-
-.. note:: When an ``s3`` backend is used, all endpoints must belong to the same
-   zone/site.
 
 Metadata Filtering
 ------------------
@@ -455,8 +427,8 @@ Create Vector Bucket
 ````````````````````
 
 Creates a new vector bucket. The bucket name must be between 3 and 63
-characters long. With the ``rgw`` and ``s3`` backends, a regular S3 bucket with
-the same name must already exist. See: `Backing Buckets`_.
+characters long. With the ``rgw`` backend, a regular S3 bucket with the same
+name must already exist. See: `Backing Buckets`_.
 
 ::
 

--- a/qa/suites/rgw/s3vectors/cluster/single-zone.yaml
+++ b/qa/suites/rgw/s3vectors/cluster/single-zone.yaml
@@ -12,7 +12,7 @@ tasks:
       rgw_server: client.0
       # the tests are run once per backend. the backend is set on the RGW by the
       # tests, and does not require a restart
-      backends: [rgw, s3, local]
+      backends: [rgw, local]
 
 overrides:
   ceph:

--- a/qa/suites/rgw/s3vectors/cluster/two-zones.yaml
+++ b/qa/suites/rgw/s3vectors/cluster/two-zones.yaml
@@ -21,13 +21,13 @@ tasks:
       extra_attr: [multisite_test]
       # the tests are run once per backend. the backend is set on the RGWs by the
       # tests, and does not require a restart
-      backends: [rgw, s3, local]
+      backends: [rgw, local]
     c2.client.0:
       rgw_server: c2.client.0
       # the vector bucket lifecycle is tested on the non-master zone as well,
       # since vector buckets are created there and not on the master zone
       extra_attr: [vector_bucket_test]
-      backends: [rgw, s3, local]
+      backends: [rgw, local]
 
 overrides:
   ceph:

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -5066,12 +5066,11 @@ options:
   level: advanced
   desc: S3 Vector backend type
   long_desc: Specifies the storage backend for S3 Vector (LanceDB). Use "local" for
-    local filesystem storage, "s3" for external S3-compatible object storage, or
-    "rgw" for RGW's internal Storage Abstraction Layer (same Ceph cluster).
+    local filesystem storage, or "rgw" for RGW's internal Storage Abstraction Layer
+    (same Ceph cluster).
   default: rgw
   enum_values:
   - local
-  - s3
   - rgw
   services:
   - rgw
@@ -5085,40 +5084,6 @@ options:
   long_desc: The local filesystem path where LanceDB databases will be stored when
     using the "local" backend. Each vector bucket will be created as a subdirectory.
   default: /var/lib/ceph/radosgw/$cluster-$id/s3vector-lancedb
-  services:
-  - rgw
-  flags:
-  - runtime
-  with_legacy: true
-- name: rgw_s3vector_s3_endpoint
-  type: str
-  level: advanced
-  desc: S3 endpoint URL for S3 Vector backend
-  long_desc: The S3-compatible endpoint URL (e.g., http://localhost:9000) to use
-    when rgw_s3vector_backend is set to "s3".
-  services:
-  - rgw
-  flags:
-  - runtime
-  with_legacy: true
-- name: rgw_s3vector_s3_region
-  type: str
-  level: advanced
-  desc: AWS region for S3 Vector backend
-  long_desc: The AWS region to use for S3 storage when rgw_s3vector_backend is set to "s3".
-  default:
-  services:
-  - rgw
-  flags:
-  - runtime
-  with_legacy: true
-- name: rgw_s3vector_s3_allow_http
-  type: bool
-  level: advanced
-  desc: Allow HTTP (non-HTTPS) S3 endpoints
-  long_desc: When set to true, allows connecting to S3 endpoints using HTTP instead of HTTPS.
-    This is useful for using a local S3-compatible services (e.g. point to the same RGW).
-  default: false
   services:
   - rgw
   flags:

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -61,6 +61,10 @@
 #include "rgw_rest_user.h"
 #include "rgw_sal.h"
 #include "rgw_sal_rados.h"
+#ifdef WITH_RADOSGW_LANCEDB
+#include "rgw_s3vector.h"
+#include "rgw_s3vector_background.h"
+#endif
 #include "rgw_service.h"
 #include "rgw_tools.h"
 #include "rgw_tracer.h"
@@ -663,6 +667,22 @@ int RadosVectorBucket::remove(const DoutPrefixProvider* dpp,
 			optional_yield y)
 {
   ldpp_dout(dpp, 20) << "s3vector --- RadosVectorBucket::remove called" << dendl;
+
+#ifdef WITH_RADOSGW_LANCEDB
+  {
+    // the indexes hold the data of a vector bucket, like the objects of an ordinary
+    // one: they are removed only when the caller asks for it, and prevent the removal
+    // of the vector bucket otherwise
+    const int r = rgw::s3vector::remove_indexes(dpp, store, &info.bucket.tenant,
+                                                info.bucket.name, delete_children, y);
+    if (r < 0) {
+      return r;
+    }
+    // the data of the vector bucket is gone, and so should be its cached session
+    rgw::s3vector::notify_session_delete(dpp, info.bucket.name);
+  }
+#endif
+
   RGWObjVersionTracker ot;
 
   int ret = store->getRados()->delete_vector_bucket(info, ot, y, dpp);

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -1899,6 +1899,37 @@ int RGWUser::execute_remove(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
 
   size_t max_buckets = dpp->get_cct()->_conf->rgw_list_buckets_max_chunk;
 
+  rgw::sal::BucketList vector_listing;
+  do {
+    ret = driver->list_vector_buckets(dpp, user->get_id(), user->get_tenant(),
+                                      vector_listing.next_marker, string(),
+                                      max_buckets, vector_listing, y);
+    if (ret < 0) {
+      set_err_msg(err_msg, "unable to list user vector buckets");
+      return ret;
+    }
+
+    if (!vector_listing.buckets.empty() && !purge_data) {
+      set_err_msg(err_msg, "must specify purge data to remove user with vector buckets");
+      return -EEXIST; // change to code that maps to 409: conflict
+    }
+
+    for (const auto& ent : vector_listing.buckets) {
+      std::unique_ptr<rgw::sal::VectorBucket> vector_bucket;
+      ret = driver->load_vector_bucket(dpp, ent.bucket, &vector_bucket, y);
+      if (ret < 0) {
+        set_err_msg(err_msg, "unable to load vector bucket " + ent.bucket.name);
+        return ret;
+      }
+
+      ret = vector_bucket->remove(dpp, true, y);
+      if (ret < 0) {
+        set_err_msg(err_msg, "unable to delete user vector bucket data");
+        return ret;
+      }
+    }
+  } while (!vector_listing.next_marker.empty());
+
   rgw::sal::BucketList listing;
   do {
     ret = driver->list_buckets(dpp, user->get_id(), user->get_tenant(),

--- a/src/rgw/rgw_account.cc
+++ b/src/rgw/rgw_account.cc
@@ -305,6 +305,40 @@ int remove(const DoutPrefixProvider* dpp,
   constexpr std::string_view path_prefix; // empty
   constexpr uint32_t max_items = 100;
 
+  rgw::sal::BucketList vector_buckets;
+  do {
+    ret = driver->list_vector_buckets(dpp, info.id, info.tenant,
+                                      vector_buckets.next_marker, "",
+                                      max_items, vector_buckets, y);
+    if (ret < 0) {
+      err_msg = "Unable to list account vector buckets";
+      return ret;
+    }
+
+    if (!vector_buckets.buckets.empty() && !op_state.purge_data) {
+      err_msg = "The account cannot be deleted until all vector buckets are removed.";
+      return -EEXIST; // change to code that maps to 409: conflict
+    }
+
+    for (const auto& ent : vector_buckets.buckets) {
+      std::unique_ptr<rgw::sal::VectorBucket> vector_bucket;
+      ret = driver->load_vector_bucket(dpp, ent.bucket, &vector_bucket, y);
+      if (ret < 0) {
+        err_msg = fmt::format("unable to load vector bucket {}", ent.bucket.name);
+        return ret;
+      }
+
+      // the indexes hold the data of the vector bucket, and are purged with it
+      constexpr bool delete_indexes = true;
+      ret = vector_bucket->remove(dpp, delete_indexes, y);
+      if (ret < 0) {
+        err_msg = fmt::format("unable to delete vector bucket {}", ent.bucket.name);
+        return ret;
+      }
+      ldpp_dout_fmt(dpp, 1, "Deleted account vector bucket {}", ent.bucket.name);
+    }
+  } while (!vector_buckets.next_marker.empty());
+
   rgw::sal::UserList users;
   do {
     ret = driver->list_account_users(dpp, y, info.id, info.tenant, path_prefix,

--- a/src/rgw/rgw_rest_s3vector.cc
+++ b/src/rgw/rgw_rest_s3vector.cc
@@ -47,9 +47,15 @@ protected:
 
   // check that the authenticated user has permission to access the
   // backing S3 bucket. only needed for the RGW backend, which writes
-  // through SAL and bypasses S3 API permission checks
+  // through SAL and bypasses S3 API permission checks.
+  // an object operation is verified against any object of the bucket, since
+  // LanceDB spreads the data of a vector bucket over objects whose names are not
+  // known here. the operations needed by each request were taken from the SAL
+  // calls that it makes: note that "s3:GetObject" covers the head of an object as
+  // well, and that removing vectors writes deletion files, and deletes nothing
   int verify_s3_bucket_permission(const std::string& bucket_name,
-                                  uint64_t s3_op, optional_yield y) {
+                                  std::initializer_list<uint64_t> s3_ops,
+                                  optional_yield y) {
     CephContext* cct = s->cct;
     const auto& conf = cct->_conf;
     const std::string backend_str = conf.get_val<std::string>("rgw_s3vector_backend");
@@ -87,11 +93,14 @@ protected:
     auto bucket_policy = get_iam_policy_from_attr(
         cct, s3_bucket->get_attrs(), s->bucket_tenant);
 
-    if (!verify_bucket_permission(this, s,
-        rgw::ARN(s3_bucket->get_key()),
-        s->user_acl, bucket_acl, bucket_policy,
-        s->iam_identity_policies, s->session_policies, s3_op)) {
-      return -EACCES;
+    for (const uint64_t s3_op : s3_ops) {
+      const rgw::ARN arn = (s3_op == rgw::IAM::s3ListBucket) ?
+          rgw::ARN(s3_bucket->get_key()) : rgw::ARN(s3_bucket->get_key(), "*");
+      if (!verify_bucket_permission(this, s, arn,
+          s->user_acl, bucket_acl, bucket_policy,
+          s->iam_identity_policies, s->session_policies, s3_op)) {
+        return -EACCES;
+      }
     }
     return 0;
   }
@@ -136,7 +145,7 @@ private:
       return -EACCES;
     }*/
     return verify_s3_bucket_permission(
-        configuration.vector_bucket_name, rgw::IAM::s3All, y);
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3GetObject, rgw::IAM::s3PutObject}, y);
   }
 
   const char* name() const override { return "s3vector_create_index"; }
@@ -159,7 +168,7 @@ private:
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
     }
-    op_ret = rgw::s3vector::create_index(configuration, driver, s->user.get(), &s->bucket_tenant, this, y, validation_errors);
+    op_ret = rgw::s3vector::create_index(configuration, driver, &s->bucket_tenant, this, y, validation_errors);
   }
 
   void send_response() override {
@@ -217,7 +226,8 @@ private:
       }
     }
 
-    return 0;
+    return verify_s3_bucket_permission(
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3PutObject}, y);
   }
 
   const char* name() const override { return "s3vector_create_vector_bucket"; }
@@ -241,7 +251,9 @@ private:
     const auto& zonegroup = s->penv.site->get_zonegroup();
 
     rgw::sal::VectorBucket::CreateParams createparams;
-    createparams.owner = s->user->get_id();
+    // as with ordinary buckets, a vector bucket belongs to the account of the user
+    // creating it, when it has one, and to the user itself otherwise
+    createparams.owner = s->owner.id;
     createparams.zonegroup_id = zonegroup.id;
     // vector buckets are indexless
     createparams.index_type = rgw::BucketIndexType::Indexless;
@@ -252,7 +264,7 @@ private:
       ldpp_dout(this, 1) << "ERROR: failed to create s3vector bucket " << bucket_id << ". error: " << ret << dendl;
       return;
     }
-    op_ret = rgw::s3vector::create_vector_bucket(configuration, driver, s->user.get(), &s->bucket_tenant, this, y);
+    op_ret = rgw::s3vector::create_vector_bucket(configuration, driver, &s->bucket_tenant, this, y);
     if (op_ret < 0) {
       ldpp_dout(this, 1) << "ERROR: failed to initialize s3vector bucket " << bucket_id << ". error: " << ret << dendl;
       return;
@@ -318,7 +330,7 @@ private:
       return -EACCES;
     }*/
     return verify_s3_bucket_permission(
-        configuration.vector_bucket_name, rgw::IAM::s3All, y);
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3GetObject, rgw::IAM::s3DeleteObject}, y);
   }
 
   const char* name() const override { return "s3vector_delete_index"; }
@@ -341,7 +353,7 @@ private:
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
     }
-    op_ret = rgw::s3vector::delete_index(configuration, driver, s->user.get(), &s->bucket_tenant, this, y);
+    op_ret = rgw::s3vector::delete_index(configuration, driver, &s->bucket_tenant, this, y);
   }
 };
 
@@ -355,9 +367,9 @@ private:
     if (!verify_bucket_permission(this, s, configuration.vector_bucket_arn.get(), rgw::IAM::s3vectorsDeleteVectorBucket)) {
       // policy TODO: ignore failure for now "evaluate_iam_policies: implicit deny from identity-based policy"
       // return -EACCES;
-      return 0;
     }
-    return 0;
+    return verify_s3_bucket_permission(
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3GetObject}, y);
   }
 
   const char* name() const override { return "s3vector_delete_vector_bucket"; }
@@ -399,10 +411,6 @@ private:
         rgw::s3vector::notify_session_delete(this, bucket_id.name);
       }
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
-      return;
-    }
-    op_ret = rgw::s3vector::delete_vector_bucket(configuration, driver, s->user.get(), &s->bucket_tenant, this, y);
-    if (op_ret < 0) {
       return;
     }
     op_ret = bucket->remove(this, false, y);
@@ -462,7 +470,7 @@ private:
       return -EACCES;
     }*/
     return verify_s3_bucket_permission(
-        configuration.vector_bucket_name, rgw::IAM::s3All, y);
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3GetObject, rgw::IAM::s3PutObject}, y);
   }
 
   const char* name() const override { return "s3vector_put_vectors"; }
@@ -485,7 +493,7 @@ private:
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
     }
-    op_ret = rgw::s3vector::put_vectors(configuration, driver, s->user.get(), &s->bucket_tenant, this, y, validation_errors);
+    op_ret = rgw::s3vector::put_vectors(configuration, driver, &s->bucket_tenant, this, y, validation_errors);
   }
 
   void send_response() override {
@@ -514,7 +522,7 @@ private:
       return -EACCES;
     }*/
     return verify_s3_bucket_permission(
-        configuration.vector_bucket_name, rgw::IAM::s3All, y);
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3GetObject}, y);
   }
 
   const char* name() const override { return "s3vector_get_vectors"; }
@@ -537,7 +545,7 @@ private:
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
     }
-    op_ret = rgw::s3vector::get_vectors(configuration, driver, s->user.get(), &s->bucket_tenant, this, y, reply);
+    op_ret = rgw::s3vector::get_vectors(configuration, driver, &s->bucket_tenant, this, y, reply);
   }
 
   void send_response() override {
@@ -572,7 +580,7 @@ private:
       return -EACCES;
     }*/
     return verify_s3_bucket_permission(
-        configuration.vector_bucket_name, rgw::IAM::s3All, y);
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3GetObject}, y);
   }
 
   const char* name() const override { return "s3vector_list_vectors"; }
@@ -595,7 +603,7 @@ private:
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
     }
-    op_ret = rgw::s3vector::list_vectors(configuration, driver, s->user.get(), &s->bucket_tenant, this, y, reply);
+    op_ret = rgw::s3vector::list_vectors(configuration, driver, &s->bucket_tenant, this, y, reply);
   }
 
   void send_response() override {
@@ -843,11 +851,12 @@ public:
 private:
   int verify_permission(optional_yield y) override {
     ldpp_dout(this, 10) << "INFO: verifying permission for s3vector GetIndex" << dendl;
-    // policy TODO: implement permission check
+    // policy TODO: implement vector bucket permission check
     /*if (!verify_bucket_permission(this, s, rgw::IAM::s3vectorsGetIndex)) {
       return -EACCES;
     }*/
-    return 0;
+    return verify_s3_bucket_permission(
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3GetObject}, y);
   }
 
   const char* name() const override { return "s3vector_get_index"; }
@@ -870,7 +879,7 @@ private:
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
     }
-    op_ret = rgw::s3vector::get_index(configuration, s->zonegroup_name, s->account_name, driver, s->user.get(), &s->bucket_tenant, this, y, reply);
+    op_ret = rgw::s3vector::get_index(configuration, s->zonegroup_name, s->account_name, driver, &s->bucket_tenant, this, y, reply);
   }
 
   void send_response() override {
@@ -900,11 +909,12 @@ public:
 private:
   int verify_permission(optional_yield y) override {
     ldpp_dout(this, 10) << "INFO: verifying permission for s3vector ListIndexes" << dendl;
-    // policy TODO: implement permission check
+    // policy TODO: implement vector bucket permission check
     /*if (!verify_bucket_permission(this, s, rgw::IAM::s3vectorsListIndexes)) {
       return -EACCES;
     }*/
-    return 0;
+    return verify_s3_bucket_permission(
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3GetObject}, y);
   }
 
   const char* name() const override { return "s3vector_list_indexes"; }
@@ -934,7 +944,7 @@ private:
         configuration.vector_bucket_name
       );
     }
-    op_ret = rgw::s3vector::list_indexes(configuration, driver, s->user.get(), &s->bucket_tenant, this, y, reply);
+    op_ret = rgw::s3vector::list_indexes(configuration, driver, &s->bucket_tenant, this, y, reply);
   }
 
   void send_response() override {
@@ -1044,7 +1054,7 @@ private:
       return -EACCES;
     }*/
     return verify_s3_bucket_permission(
-        configuration.vector_bucket_name, rgw::IAM::s3All, y);
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3GetObject, rgw::IAM::s3PutObject}, y);
   }
 
   const char* name() const override { return "s3vector_delete_vectors"; }
@@ -1067,7 +1077,7 @@ private:
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
     }
-    op_ret = rgw::s3vector::delete_vectors(configuration, driver, s->user.get(), &s->bucket_tenant, this, y);
+    op_ret = rgw::s3vector::delete_vectors(configuration, driver, &s->bucket_tenant, this, y);
   }
 };
 
@@ -1085,7 +1095,7 @@ private:
       return -EACCES;
     }*/
     return verify_s3_bucket_permission(
-        configuration.vector_bucket_name, rgw::IAM::s3All, y);
+        configuration.vector_bucket_name, {rgw::IAM::s3ListBucket, rgw::IAM::s3GetObject}, y);
   }
 
   const char* name() const override { return "s3vector_query_vectors"; }
@@ -1119,7 +1129,7 @@ private:
       ldpp_dout(this, 1) << "ERROR: failed to load s3vector bucket " << bucket_id << ". error: " << op_ret << dendl;
       return;
     }
-    op_ret = rgw::s3vector::query_vectors(configuration, filter_parser, driver, s->user.get(), &s->bucket_tenant, this, y, reply, validation_errors);
+    op_ret = rgw::s3vector::query_vectors(configuration, filter_parser, driver, &s->bucket_tenant, this, y, reply, validation_errors);
   }
 
   void send_response() override {

--- a/src/rgw/rgw_s3vector.cc
+++ b/src/rgw/rgw_s3vector.cc
@@ -145,68 +145,10 @@ namespace rgw::s3vector {
     return fmt::format("{}://{}/?tenant={}", RGW_PROVIDER_SCHEME, bucket, *tenant);
   }
 
-  // Set S3 storage options (endpoint, region, credentials, allow_http) on a
-  // connection builder. Returns true on success, false on failure (builder is
-  // freed on error).
-  bool set_s3_storage_options(const DoutPrefixProvider* dpp,
-      const rgw::sal::User* user, CephContext* cct,
-      LanceDBConnectBuilder*& builder) {
-    const auto& conf = cct->_conf;
-    const std::string s3_endpoint = conf.get_val<std::string>("rgw_s3vector_s3_endpoint");
-    const std::string s3_region = conf.get_val<std::string>("rgw_s3vector_s3_region");
-    const bool s3_allow_http = conf.get_val<bool>("rgw_s3vector_s3_allow_http");
-
-    auto set_option = [&](const char* key, const char* value) -> bool {
-      LanceDBConnectBuilder* new_builder = lancedb_connect_builder_storage_option(builder, key, value);
-      if (!new_builder) {
-        ldpp_dout(dpp, 1) << "ERROR: s3vector failed to set storage option: " << key << dendl;
-        lancedb_connect_builder_free(builder);
-        builder = nullptr;
-        return false;
-      }
-      builder = new_builder;
-      return true;
-    };
-
-    if (!s3_endpoint.empty()) {
-      if (!set_option("endpoint", s3_endpoint.c_str())) return false;
-    }
-    if (!s3_region.empty()) {
-      if (!set_option("aws_region", s3_region.c_str())) return false;
-    }
-
-    if (!user) {
-      ldpp_dout(dpp, 1) << "ERROR: s3vector S3 backend requires user credentials" << dendl;
-      lancedb_connect_builder_free(builder);
-      builder = nullptr;
-      return false;
-    }
-    const auto& keys = user->get_info().access_keys;
-    if (keys.empty()) {
-      ldpp_dout(dpp, 1) << "ERROR: s3vector S3 backend: user has no access keys" << dendl;
-      lancedb_connect_builder_free(builder);
-      builder = nullptr;
-      return false;
-    }
-    for (const auto& [id, ak] : keys) {
-      if (ak.active) {
-        if (!set_option("aws_access_key_id", ak.id.c_str())) return false;
-        if (!set_option("aws_secret_access_key", ak.key.c_str())) return false;
-        break;
-      }
-    }
-
-    if (s3_allow_http) {
-      if (!set_option("allow_http", "true")) return false;
-    }
-
-    return true;
-  }
-
   // utility functions for connection creation and opening table
 
   LanceDBConnection* connect(const DoutPrefixProvider* dpp, rgw::sal::Driver* driver,
-      const rgw::sal::User* user, const std::string* tenant,
+      const std::string* tenant,
       const std::string& vector_bucket_name) {
     CephContext* cct = dpp->get_cct();
     const auto& conf = cct->_conf;
@@ -244,23 +186,6 @@ namespace rgw::s3vector {
       }
 
       ldpp_dout(dpp, 10) << "INFO: s3vector connecting to RGW backend: " << uri << dendl;
-    } else { // S3 backend
-
-      // S3 endpoint/region are set as storage options, not embedded in the URI.
-      // A regular S3 bucket with the same name as the vector bucket must exist
-      // at the backend.
-      uri = fmt::format("s3://{}/", vector_bucket_name);
-      builder = lancedb_connect(uri.c_str());
-      if (!builder) {
-        ldpp_dout(dpp, 1) << "ERROR: s3vector failed to create connection builder for: " << uri << dendl;
-        return nullptr;
-      }
-
-      if (!set_s3_storage_options(dpp, user, cct, builder)) {
-        return nullptr;
-      }
-
-      ldpp_dout(dpp, 10) << "INFO: s3vector connecting to S3 backend: " << uri << dendl;
     }
 
     // connect() is used for vector bucket and index operations and therfore is using a short-lived session
@@ -299,7 +224,7 @@ namespace rgw::s3vector {
   }
 
   LanceDBSessionConnHandle connect_with_session_handle(const DoutPrefixProvider* dpp,
-      rgw::sal::Driver* driver, const rgw::sal::User* user,
+      rgw::sal::Driver* driver,
       const std::string* tenant, const std::string& vector_bucket_name) {
     CephContext* cct = dpp->get_cct();
     const auto& conf = cct->_conf;
@@ -315,7 +240,7 @@ namespace rgw::s3vector {
       // No cached session — create a short-lived connection using caller's driver/dpp
       rgw::s3vector::notify_session_create(dpp, vector_bucket_name);
       return LanceDBSessionConnHandle{
-        .conn = connect(dpp, driver, user, tenant, vector_bucket_name)
+        .conn = connect(dpp, driver, tenant, vector_bucket_name)
       };
     }
 
@@ -323,26 +248,16 @@ namespace rgw::s3vector {
     if (is_local_backend(backend_type)) {
       const std::string local_path = conf.get_val<std::string>("rgw_s3vector_local_path");
       uri = fmt::format("{}/{}", local_path, vector_bucket_name);
-    } else if (is_rgw_backend(backend_type)) {
-      uri = make_rgw_uri(vector_bucket_name, tenant);
     } else {
-      uri = fmt::format("s3://{}/", vector_bucket_name);
+      uri = make_rgw_uri(vector_bucket_name, tenant);
     }
 
     LanceDBConnectBuilder* builder = lancedb_connect(uri.c_str());
     if (!builder) {
       ldpp_dout(dpp, 1) << "ERROR: s3vector failed to create connection builder for: " << uri << dendl;
       return LanceDBSessionConnHandle{
-        .conn = connect(dpp, driver, user, tenant, vector_bucket_name)
+        .conn = connect(dpp, driver, tenant, vector_bucket_name)
       };
-    }
-
-    if (is_s3_backend(backend_type)) {
-      if (!set_s3_storage_options(dpp, user, cct, builder)) {
-        return LanceDBSessionConnHandle{
-          .conn = connect(dpp, driver, user, tenant, vector_bucket_name)
-        };
-      }
     }
 
     // Cached session exists — attach it to the builder
@@ -356,7 +271,7 @@ namespace rgw::s3vector {
         << " falling back to connect without session" << dendl;
       lancedb_free_string(error_message);
       return LanceDBSessionConnHandle{
-        .conn = connect(dpp, driver, user, tenant, vector_bucket_name)
+        .conn = connect(dpp, driver, tenant, vector_bucket_name)
       };
     }
 
@@ -367,9 +282,9 @@ namespace rgw::s3vector {
   }
 
   LanceDBTable* open_table(const DoutPrefixProvider* dpp, rgw::sal::Driver* driver,
-      const rgw::sal::User* user, const std::string* tenant,
+      const std::string* tenant,
       const std::string& vector_bucket_name, const std::string& index_name) {
-    LanceDBConnection* conn = connect(dpp, driver, user, tenant, vector_bucket_name);
+    LanceDBConnection* conn = connect(dpp, driver, tenant, vector_bucket_name);
     if (!conn) {
       return nullptr;
     }
@@ -383,10 +298,10 @@ namespace rgw::s3vector {
   }
 
   LanceDBSessionTableHandle open_table_with_session_handle(const DoutPrefixProvider* dpp,
-      rgw::sal::Driver* driver, const rgw::sal::User* user,
+      rgw::sal::Driver* driver,
       const std::string* tenant, const std::string& vector_bucket_name,
       const std::string& index_name) {
-    auto conn_handle = connect_with_session_handle(dpp, driver, user, tenant, vector_bucket_name);
+    auto conn_handle = connect_with_session_handle(dpp, driver, tenant, vector_bucket_name);
     if (!conn_handle) {
       return {};
     }
@@ -889,7 +804,6 @@ namespace rgw::s3vector {
   struct CreateIndexCtx {
     const create_index_t* configuration;
     rgw::sal::Driver* driver;
-    const rgw::sal::User* user;
     const std::string* tenant;
     DoutPrefixProvider* dpp;
     std::vector<validation_error_t>* errors;
@@ -900,12 +814,11 @@ namespace rgw::s3vector {
     auto* ctx = static_cast<CreateIndexCtx*>(user_data);
     auto* dpp = ctx->dpp;
     auto* driver = ctx->driver;
-    auto* user = ctx->user;
     const auto& tenant = ctx->tenant;
     const auto& configuration = *ctx->configuration;
     auto& errors = *ctx->errors;
 
-    LanceDBConnection* conn = connect(dpp, driver, user, tenant, configuration.vector_bucket_name);
+    LanceDBConnection* conn = connect(dpp, driver, tenant, configuration.vector_bucket_name);
     if (!conn) {
       ctx->result = -EIO;
       return;
@@ -1046,9 +959,9 @@ namespace rgw::s3vector {
     return;
   }
 
-  int create_index(const create_index_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, std::vector<validation_error_t>& errors) {
+  int create_index(const create_index_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, std::vector<validation_error_t>& errors) {
     log_configuration(dpp, "CreateIndex", configuration);
-    CreateIndexCtx ctx{&configuration, driver, user, tenant, dpp, &errors, 0};
+    CreateIndexCtx ctx{&configuration, driver, tenant, dpp, &errors, 0};
     lancedb_run_on_stack(create_index_impl, &ctx, 256*1024, 1024*1024);
     return ctx.result;
   }
@@ -1070,9 +983,9 @@ namespace rgw::s3vector {
     decode_index_name(vector_bucket_name, index_name, obj);
   }
 
-  int delete_index(const delete_index_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y) {
+  int delete_index(const delete_index_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y) {
     log_configuration(dpp, "DeleteIndex", configuration);
-    LanceDBConnection* conn = connect(dpp, driver, user, tenant, configuration.vector_bucket_name);
+    LanceDBConnection* conn = connect(dpp, driver, tenant, configuration.vector_bucket_name);
     if (!conn) {
       return -EIO;
     }
@@ -1131,9 +1044,9 @@ namespace rgw::s3vector {
   }
 
 
-  int get_index(const get_index_t& configuration, const std::string& region, const std::string& account, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, get_index_reply_t& reply) {
+  int get_index(const get_index_t& configuration, const std::string& region, const std::string& account, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, get_index_reply_t& reply) {
     log_configuration(dpp, "GetIndex", configuration);
-    LanceDBConnection* conn = connect(dpp, driver, user, tenant, configuration.vector_bucket_name);
+    LanceDBConnection* conn = connect(dpp, driver, tenant, configuration.vector_bucket_name);
     if (!conn) {
       return -EIO;
     }
@@ -1248,9 +1161,9 @@ namespace rgw::s3vector {
     f->close_section();
   }
 
-  int list_indexes(const list_indexes_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, list_indexes_reply_t& reply) {
+  int list_indexes(const list_indexes_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, list_indexes_reply_t& reply) {
     log_configuration(dpp, "ListIndexes", configuration);
-    LanceDBConnection* conn = connect(dpp, driver, user, tenant, configuration.vector_bucket_name);
+    LanceDBConnection* conn = connect(dpp, driver, tenant, configuration.vector_bucket_name);
     if (!conn) {
       return -EIO;
     }
@@ -1339,29 +1252,25 @@ namespace rgw::s3vector {
     decode_vector_bucket_name(vector_bucket_name, vector_bucket_arn, obj);
   }
 
-  struct DeleteVectorBucketCtx {
-    const delete_vector_bucket_t* configuration;
+  struct RemoveIndexesCtx {
+    const std::string* vector_bucket_name;
     rgw::sal::Driver* driver;
-    const rgw::sal::User* user;
     const std::string* tenant;
-    DoutPrefixProvider* dpp;
+    const DoutPrefixProvider* dpp;
+    bool delete_indexes;
     int result;
   };
 
-  static void delete_vector_bucket_impl(void* user_data) {
-    auto* ctx = static_cast<DeleteVectorBucketCtx*>(user_data);
-    auto* dpp = ctx->dpp;
-    auto* driver = ctx->driver;
-    auto* user = ctx->user;
-    const auto& tenant = ctx->tenant;
-    const auto& bucket_name = ctx->configuration->vector_bucket_name;
+  static void remove_indexes_impl(void* user_data) {
+    auto* ctx = static_cast<RemoveIndexesCtx*>(user_data);
+    const auto* dpp = ctx->dpp;
+    const auto& bucket_name = *ctx->vector_bucket_name;
 
-    LanceDBConnection* conn = connect(dpp, driver, user, tenant, bucket_name);
+    LanceDBConnection* conn = connect(dpp, ctx->driver, ctx->tenant, bucket_name);
     if (!conn) {
       ctx->result = -EIO;
       return;
     }
-    // a vector bucket that still has indexes cannot be deleted
     char** table_names;
     size_t name_count;
     char* error_message;
@@ -1372,7 +1281,7 @@ namespace rgw::s3vector {
       ctx->result = lancedb_error_to_errno(err);
       return;
     }
-    if (name_count > 0) {
+    if (name_count > 0 && !ctx->delete_indexes) {
       ldpp_dout(dpp, 1) << "ERROR: s3vector bucket: " << bucket_name << " cannot be deleted, it still has " <<
         name_count << " indexes" << dendl;
       lancedb_free_table_names(table_names, name_count);
@@ -1380,17 +1289,33 @@ namespace rgw::s3vector {
       ctx->result = -ENOTEMPTY;
       return;
     }
+    for (size_t i = 0; i < name_count; ++i) {
+      if (const LanceDBError err = lancedb_connection_drop_table(conn, table_names[i], nullptr, &error_message);
+          err == LANCEDB_TABLE_NOT_FOUND) {
+        ldpp_dout(dpp, 10) << "INFO: s3vector index: " << table_names[i] << " does not exist" << dendl;
+        lancedb_free_string(error_message);
+      } else if (err != LANCEDB_SUCCESS) {
+        ldpp_dout(dpp, 1) << "ERROR: failed to delete index: " << table_names[i] << " of s3vector bucket: " <<
+          bucket_name << ". error: " << error_message << dendl;
+        lancedb_free_string(error_message);
+        lancedb_free_table_names(table_names, name_count);
+        lancedb_connection_free(conn);
+        ctx->result = lancedb_error_to_errno(err);
+        return;
+      } else { // successfully deleted the index
+        // we are not failing the operation if we cannot notify the background process on index removal
+        notify_index_remove(dpp, bucket_name, table_names[i]);
+      }
+    }
     lancedb_free_table_names(table_names, name_count);
-    ldpp_dout(dpp, 20) << "INFO: deleting in-memory session (if it exists) for bucket: " << bucket_name << dendl;
-    rgw::s3vector::notify_session_delete(dpp, bucket_name);
     lancedb_connection_free(conn);
     ctx->result = 0;
   }
 
-  int delete_vector_bucket(const delete_vector_bucket_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y) {
-    log_configuration(dpp, "DeleteVectorBucket", configuration);
-    DeleteVectorBucketCtx ctx{&configuration, driver, user, tenant, dpp, 0};
-    lancedb_run_on_stack(delete_vector_bucket_impl, &ctx, 256*1024, 1024*1024);
+  int remove_indexes(const DoutPrefixProvider* dpp, rgw::sal::Driver* driver,
+      const std::string* tenant, const std::string& vector_bucket_name, bool delete_indexes, optional_yield y) {
+    RemoveIndexesCtx ctx{&vector_bucket_name, driver, tenant, dpp, delete_indexes, 0};
+    lancedb_run_on_stack(remove_indexes_impl, &ctx, 256*1024, 1024*1024);
     return ctx.result;
   }
 
@@ -1438,7 +1363,6 @@ namespace rgw::s3vector {
   struct CreateVectorBucketCtx {
     const create_vector_bucket_t* configuration;
     rgw::sal::Driver* driver;
-    const rgw::sal::User* user;
     const std::string* tenant;
     DoutPrefixProvider* dpp;
     int result;
@@ -1448,11 +1372,10 @@ namespace rgw::s3vector {
     auto* ctx = static_cast<CreateVectorBucketCtx*>(user_data);
     auto* dpp = ctx->dpp;
     auto* driver = ctx->driver;
-    auto* user = ctx->user;
     const auto& tenant = ctx->tenant;
     const auto& bucket_name = ctx->configuration->vector_bucket_name;
 
-    auto conn_handle = connect_with_session_handle(dpp, driver, user, tenant, bucket_name);
+    auto conn_handle = connect_with_session_handle(dpp, driver, tenant, bucket_name);
     if (!conn_handle) {
       ctx->result = -EIO;
       return;
@@ -1473,9 +1396,9 @@ namespace rgw::s3vector {
     ctx->result = 0;
   }
 
-  int create_vector_bucket(const create_vector_bucket_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y) {
+  int create_vector_bucket(const create_vector_bucket_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y) {
     log_configuration(dpp, "CreateVectorBucket", configuration);
-    CreateVectorBucketCtx ctx{&configuration, driver, user, tenant, dpp, 0};
+    CreateVectorBucketCtx ctx{&configuration, driver, tenant, dpp, 0};
     lancedb_run_on_stack(create_vector_bucket_impl, &ctx, 256*1024, 1024*1024);
     return ctx.result;
   }
@@ -1626,7 +1549,6 @@ namespace rgw::s3vector {
   struct PutVectorsCtx {
     const put_vectors_t* configuration;
     rgw::sal::Driver* driver;
-    const rgw::sal::User* user;
     const std::string* tenant;
     DoutPrefixProvider* dpp;
     std::vector<validation_error_t>* errors;
@@ -1637,12 +1559,11 @@ namespace rgw::s3vector {
     auto* ctx = static_cast<PutVectorsCtx*>(user_data);
     auto* dpp = ctx->dpp;
     auto* driver = ctx->driver;
-    auto* user = ctx->user;
     const auto& tenant = ctx->tenant;
     const auto& configuration = *ctx->configuration;
     auto& errors = *ctx->errors;
 
-    auto table_handle = open_table_with_session_handle(dpp, driver, user, tenant, configuration.vector_bucket_name, configuration.index_name);
+    auto table_handle = open_table_with_session_handle(dpp, driver, tenant, configuration.vector_bucket_name, configuration.index_name);
     if (!table_handle) {
       ctx->result = -EIO;
       return;
@@ -2025,9 +1946,9 @@ namespace rgw::s3vector {
     ctx->result = 0;
   }
 
-  int put_vectors(const put_vectors_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, std::vector<validation_error_t>& errors) {
+  int put_vectors(const put_vectors_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, std::vector<validation_error_t>& errors) {
     log_configuration(dpp, "PutVectors", configuration);
-    PutVectorsCtx ctx{&configuration, driver, user, tenant, dpp, &errors, 0};
+    PutVectorsCtx ctx{&configuration, driver, tenant, dpp, &errors, 0};
     lancedb_run_on_stack(put_vectors_impl, &ctx, 256*1024, 1024*1024);
     return ctx.result;
   }
@@ -2190,9 +2111,9 @@ namespace rgw::s3vector {
     return populate_vectors_from_arrow(dpp, c_arrays_ptr, c_schema_ptr, vectors, index_name, use_data, use_distance, vector_query, use_metadata);
   }
 
-  int get_vectors(const get_vectors_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, get_vectors_reply_t& reply) {
+  int get_vectors(const get_vectors_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, get_vectors_reply_t& reply) {
     log_configuration(dpp, "GetVectors", configuration);
-    auto table_handle = open_table_with_session_handle(dpp, driver, user, tenant, configuration.vector_bucket_name, configuration.index_name);
+    auto table_handle = open_table_with_session_handle(dpp, driver, tenant, configuration.vector_bucket_name, configuration.index_name);
     if (!table_handle) {
       return -EIO;
     }
@@ -2337,9 +2258,9 @@ namespace rgw::s3vector {
     f->close_section();
   }
 
-  int list_vectors(const list_vectors_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, list_vectors_reply_t& reply) {
+  int list_vectors(const list_vectors_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, list_vectors_reply_t& reply) {
     log_configuration(dpp, "ListVectors", configuration);
-    LanceDBTable* table = open_table(dpp, driver, user, tenant, configuration.vector_bucket_name, configuration.index_name);
+    LanceDBTable* table = open_table(dpp, driver, tenant, configuration.vector_bucket_name, configuration.index_name);
     if (!table) {
       return -EIO;
     }
@@ -2430,9 +2351,9 @@ namespace rgw::s3vector {
     }
   }
 
-  int delete_vectors(const delete_vectors_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y) {
+  int delete_vectors(const delete_vectors_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y) {
     log_configuration(dpp, "DeleteVectors", configuration);
-    auto table_handle = open_table_with_session_handle(dpp, driver, user, tenant, configuration.vector_bucket_name, configuration.index_name);
+    auto table_handle = open_table_with_session_handle(dpp, driver, tenant, configuration.vector_bucket_name, configuration.index_name);
     if (!table_handle) {
       return -EIO;
     }
@@ -2527,9 +2448,9 @@ namespace rgw::s3vector {
     f->close_section();
   }
 
-  int query_vectors(const query_vectors_t& configuration, std::optional<JSONParser>& filter, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, query_vectors_reply_t& reply, std::vector<validation_error_t>& errors) {
+  int query_vectors(const query_vectors_t& configuration, std::optional<JSONParser>& filter, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, query_vectors_reply_t& reply, std::vector<validation_error_t>& errors) {
     log_configuration(dpp, "QueryVectors", configuration);
-    auto table_handle = open_table_with_session_handle(dpp, driver, user, tenant, configuration.vector_bucket_name, configuration.index_name);
+    auto table_handle = open_table_with_session_handle(dpp, driver, tenant, configuration.vector_bucket_name, configuration.index_name);
     if (!table_handle) {
       return -EIO;
     }

--- a/src/rgw/rgw_s3vector.h
+++ b/src/rgw/rgw_s3vector.h
@@ -54,8 +54,7 @@ struct filterable_metadata_key_t {
 // Backend type for S3 Vector storage
 enum class BackendType {
   LOCAL, // Local filesystem storage (default)
-  RGW,   // RGW Storage Abstraction Layer (internal)
-  S3     // External S3-compatible object storage
+  RGW    // RGW Storage Abstraction Layer (internal)
 };
 
 // Convert string to backend type (case-insensitive)
@@ -69,10 +68,6 @@ inline int get_backend_type(const std::string& str, BackendType& type) {
     type = BackendType::RGW;
     return 0;
   }
-  if (boost::iequals(str, "s3")) {
-    type = BackendType::S3;
-    return 0;
-  }
   return -EINVAL;
 }
 
@@ -83,10 +78,6 @@ inline bool is_local_backend(BackendType type) {
 
 inline bool is_rgw_backend(BackendType type) {
   return type == BackendType::RGW;
-}
-
-inline bool is_s3_backend(BackendType type) {
-  return type == BackendType::S3;
 }
 
 // Create a LanceDB session with RGW provider
@@ -550,20 +541,20 @@ struct validation_error_t {
   std::string message;
 };
 
-int create_index(const create_index_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, std::vector<validation_error_t>& errors);
-int create_vector_bucket(const create_vector_bucket_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y);
-int delete_index(const delete_index_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y);
-int delete_vector_bucket(const delete_vector_bucket_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y);
+int create_index(const create_index_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, std::vector<validation_error_t>& errors);
+int create_vector_bucket(const create_vector_bucket_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y);
+int delete_index(const delete_index_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y);
+int remove_indexes(const DoutPrefixProvider* dpp, rgw::sal::Driver* driver, const std::string* tenant, const std::string& vector_bucket_name, bool delete_indexes, optional_yield y);
 int delete_vector_bucket_policy(const delete_vector_bucket_policy_t& configuration, DoutPrefixProvider* dpp, optional_yield y);
-int put_vectors(const put_vectors_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, std::vector<validation_error_t>& errors);
-int get_vectors(const get_vectors_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, get_vectors_reply_t& reply);
-int list_vectors(const list_vectors_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, list_vectors_reply_t& reply);
-int get_index(const get_index_t& configuration, const std::string& region, const std::string& account, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, get_index_reply_t& reply);
-int list_indexes(const list_indexes_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, list_indexes_reply_t& reply);
+int put_vectors(const put_vectors_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, std::vector<validation_error_t>& errors);
+int get_vectors(const get_vectors_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, get_vectors_reply_t& reply);
+int list_vectors(const list_vectors_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, list_vectors_reply_t& reply);
+int get_index(const get_index_t& configuration, const std::string& region, const std::string& account, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, get_index_reply_t& reply);
+int list_indexes(const list_indexes_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, list_indexes_reply_t& reply);
 int put_vector_bucket_policy(const put_vector_bucket_policy_t& configuration, DoutPrefixProvider* dpp, optional_yield y);
 int get_vector_bucket_policy(const get_vector_bucket_policy_t& configuration, DoutPrefixProvider* dpp, optional_yield y);
-int delete_vectors(const delete_vectors_t& configuration, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y);
-int query_vectors(const query_vectors_t& configuration, std::optional<JSONParser>& filter, rgw::sal::Driver* driver, const rgw::sal::User* user, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, query_vectors_reply_t& reply, std::vector<validation_error_t>& errors);
+int delete_vectors(const delete_vectors_t& configuration, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y);
+int query_vectors(const query_vectors_t& configuration, std::optional<JSONParser>& filter, rgw::sal::Driver* driver, const std::string* tenant, DoutPrefixProvider* dpp, optional_yield y, query_vectors_reply_t& reply, std::vector<validation_error_t>& errors);
 
 }
 

--- a/src/rgw/rgw_sal_wrapper.cc
+++ b/src/rgw/rgw_sal_wrapper.cc
@@ -120,6 +120,9 @@ int rgw_put_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     return -EINVAL;
   }
 
+  ldpp_dout(dpp, 10) << "rgw_put_object: bucket=" << bucket_id->name
+                     << " obj=" << obj_id->key << dendl;
+
   std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = load_bucket(driver, dpp, bucket_id, bucket, y);
   if (ret < 0) {
@@ -216,6 +219,9 @@ int rgw_put_object_conditional( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dp
     return -EINVAL;
   }
 
+  ldpp_dout(dpp, 10) << "rgw_put_object_conditional: bucket=" << bucket_id->name
+                     << " obj=" << obj_id->key << dendl;
+
   std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = load_bucket(driver, dpp, bucket_id, bucket, y);
   if (ret < 0) {
@@ -311,6 +317,9 @@ int rgw_get_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     return -EINVAL;
   }
 
+  ldpp_dout(dpp, 10) << "rgw_get_object: bucket=" << bucket_id->name
+                     << " obj=" << obj_id->key << dendl;
+
   buffer->data = nullptr;
   buffer->len = 0;
 
@@ -397,6 +406,9 @@ int rgw_delete_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     return -EINVAL;
   }
 
+  ldpp_dout(dpp, 10) << "rgw_delete_object: bucket=" << bucket_id->name
+                     << " obj=" << obj_id->key << dendl;
+
   std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = load_bucket(driver, dpp, bucket_id, bucket, y);
   if (ret < 0) {
@@ -430,6 +442,9 @@ int rgw_head_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     ldpp_dout(dpp, 1) << "ERROR: sal_wrapper: rgw_head_object: invalid args" << dendl;
     return -EINVAL;
   }
+
+  ldpp_dout(dpp, 10) << "rgw_head_object: bucket=" << bucket_id->name
+                     << " obj=" << obj_id->key << dendl;
 
   meta->size = 0;
   meta->etag = nullptr;
@@ -498,6 +513,12 @@ int rgw_list_objects( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     return -EINVAL;
   }
 
+  ldpp_dout(dpp, 10) << "rgw_list_objects: bucket=" << bucket_id->name
+                     << " prefix='" << (prefix ? prefix : "") << "'"
+                     << " delimiter='" << (delimiter ? delimiter : "") << "'"
+                     << " marker='" << (marker ? marker : "") << "'"
+                     << " max_keys=" << max_keys << dendl;
+
   result->entries = nullptr;
   result->count = 0;
   result->is_truncated = 0;
@@ -515,12 +536,6 @@ int rgw_list_objects( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
   params.marker = rgw_obj_key(marker ? marker : "");
   params.list_versions = false;
   params.allow_unordered = false;
-
-  ldpp_dout(dpp, 10) << "rgw_list_objects: bucket=" << bucket_id->name
-           << " prefix='" << params.prefix << "'"
-           << " delimiter='" << params.delim << "'"
-           << " marker='" << params.marker.name << "'"
-           << " max_keys=" << max_keys << dendl;
 
   rgw::sal::Bucket::ListResults results;
 
@@ -605,6 +620,11 @@ int rgw_copy_object( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     return -EINVAL;
   }
 
+  ldpp_dout(dpp, 10) << "rgw_copy_object: src_bucket=" << src_bucket_id->name
+                     << " src_obj=" << src_obj_id->key
+                     << " dst_bucket=" << dst_bucket_id->name
+                     << " dst_obj=" << dst_obj_id->key << dendl;
+
   std::unique_ptr<rgw::sal::Bucket> src_bucket;
   int ret = load_bucket(driver, dpp, src_bucket_id, src_bucket, y);
   if (ret < 0) {
@@ -683,6 +703,11 @@ int rgw_copy_object_conditional( CRgwDriver* driver_ptr, const CRgwDoutPrefix* d
     ldpp_dout(dpp, 1) << "ERROR: sal_wrapper: rgw_copy_object_conditional: invalid args" << dendl;
     return -EINVAL;
   }
+
+  ldpp_dout(dpp, 10) << "rgw_copy_object_conditional: src_bucket=" << src_bucket_id->name
+                     << " src_obj=" << src_obj_id->key
+                     << " dst_bucket=" << dst_bucket_id->name
+                     << " dst_obj=" << dst_obj_id->key << dendl;
 
   if (if_nomatch && std::string(if_nomatch) == "*") {
     std::unique_ptr<rgw::sal::Bucket> check_bucket;
@@ -777,6 +802,9 @@ int rgw_delete_objects( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     return -EINVAL;
   }
 
+  ldpp_dout(dpp, 10) << "rgw_delete_objects: bucket=" << bucket_id->name
+                     << " count=" << count << dendl;
+
   if (count == 0) {
     return 0;
   }
@@ -837,6 +865,9 @@ int rgw_init_multipart( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     return -EINVAL;
   }
 
+  ldpp_dout(dpp, 10) << "rgw_init_multipart: bucket=" << bucket_id->name
+                     << " obj=" << obj_id->key << dendl;
+
   *upload_id = nullptr;
 
   std::unique_ptr<rgw::sal::Bucket> bucket;
@@ -884,6 +915,9 @@ int rgw_multipart_put_part( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_pt
     ldpp_dout(dpp, 1) << "ERROR: sal_wrapper: rgw_multipart_put_part: invalid args" << dendl;
     return -EINVAL;
   }
+
+  ldpp_dout(dpp, 10) << "rgw_multipart_put_part: bucket=" << bucket_id->name
+                     << " obj=" << obj_id->key << dendl;
 
   *etag = nullptr;
 
@@ -984,6 +1018,9 @@ int rgw_multipart_complete( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_pt
     return -EINVAL;
   }
 
+  ldpp_dout(dpp, 10) << "rgw_multipart_complete: bucket=" << bucket_id->name
+                     << " obj=" << obj_id->key << dendl;
+
   std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = load_bucket(driver, dpp, bucket_id, bucket, y);
   if (ret < 0) {
@@ -1034,6 +1071,9 @@ int rgw_multipart_abort( CRgwDriver* driver_ptr, const CRgwDoutPrefix* dpp_ptr,
     ldpp_dout(dpp, 1) << "ERROR: sal_wrapper: rgw_multipart_abort: invalid args" << dendl;
     return -EINVAL;
   }
+
+  ldpp_dout(dpp, 10) << "rgw_multipart_abort: bucket=" << bucket_id->name
+                     << " obj=" << obj_id->key << dendl;
 
   std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = load_bucket(driver, dpp, bucket_id, bucket, y);

--- a/src/rgw/services/svc_user_rados.cc
+++ b/src/rgw/services/svc_user_rados.cc
@@ -579,7 +579,15 @@ int RGWSI_User_RADOS::remove_user_info(const RGWUserInfo& info,
       ldpp_dout(dpp, 0) << "ERROR: could not remove " << info.user_id << ":" << uid_bucks << ", should be fixed (err=" << ret << ")" << dendl;
       return ret;
     }
-    // TODO: remove vector buckets
+
+    rgw_raw_obj uid_vector_bucks = get_vector_buckets_obj(info.user_id);
+    ldpp_dout(dpp, 10) << "removing user vector buckets index" << dendl;
+    auto vector_sysobj = svc.sysobj->get_obj(uid_vector_bucks);
+    ret = vector_sysobj.wop().remove(dpp, y);
+    if (ret < 0 && ret != -ENOENT) {
+      ldpp_dout(dpp, 0) << "ERROR: could not remove " << info.user_id << ":" << uid_vector_bucks << ", should be fixed (err=" << ret << ")" << dendl;
+      return ret;
+    }
   } else if (info.type != TYPE_ROOT) {
     // unlink the name from its account
     const RGWZoneParams& zone = svc.zone->get_zone_params();

--- a/src/test/rgw/s3vectors/README.rst
+++ b/src/test/rgw/s3vectors/README.rst
@@ -19,21 +19,16 @@ backend the tests exercise. It must match the ``rgw_s3vector_backend`` value
 in ``ceph.conf``:
 
 * ``local`` — LanceDB stores data on the local filesystem (no S3 bucket needed)
-* ``s3`` — LanceDB stores data in an S3 bucket
 * ``rgw`` — LanceDB stores data via RGW's SAL layer
 
-When set to ``s3`` or ``rgw``, the tests automatically create and clean up a
-regular S3 bucket with the same name as each vector bucket.
+When set to ``rgw``, the tests automatically create and clean up a regular S3
+bucket with the same name as each vector bucket.
 
 Starting the cluster for each backend:
 
 For ``rgw`` (default)::
 
   ../src/vstart.sh -n -d
-
-For ``s3``::
-
-  ../src/vstart.sh -n -d -o "rgw_s3vector_backend=s3" -o "rgw_s3vector_s3_endpoint=http://localhost:8000" -o "rgw_s3vector_s3_allow_http=true" -o "rgw_s3vector_s3_region=default"
 
 For ``local``::
 

--- a/src/test/rgw/s3vectors/__init__.py
+++ b/src/test/rgw/s3vectors/__init__.py
@@ -76,14 +76,6 @@ def setup():
     global s3vector_local_path
     s3vector_local_path = defaults.get("s3vector_local_path")
 
-    global s3vector_s3_endpoint
-    s3vector_s3_endpoint = defaults.get("s3vector_s3_endpoint")
-
-    global s3vector_s3_region
-    s3vector_s3_region = defaults.get("s3vector_s3_region")
-
-    global s3vector_s3_allow_http
-    s3vector_s3_allow_http = defaults.get("s3vector_s3_allow_http", "true")
 
 
 def get_config_host():
@@ -151,23 +143,9 @@ def get_s3vector_local_path():
     return s3vector_local_path
 
 
-def get_s3vector_s3_endpoint():
-    global s3vector_s3_endpoint
-    return s3vector_s3_endpoint
-
-
-def get_s3vector_s3_region():
-    global s3vector_s3_region
-    return s3vector_s3_region
-
-
-def get_s3vector_s3_allow_http():
-    global s3vector_s3_allow_http
-    return s3vector_s3_allow_http
-
-
-def is_s3_backend():
-    return get_s3vector_backend() in ("s3", "rgw")
+def has_backing_bucket():
+    """ whether the tested backend keeps the vector data in an ordinary bucket """
+    return get_s3vector_backend() == "rgw"
 
 
 @pytest.fixture(autouse=True, scope="package")

--- a/src/test/rgw/s3vectors/s3vector_test.py
+++ b/src/test/rgw/s3vectors/s3vector_test.py
@@ -23,12 +23,9 @@ from . import(
     get_config_cluster2,
     get_config_rgw_client,
     get_config_master_cluster,
-    is_s3_backend,
+    has_backing_bucket,
     get_s3vector_backend,
-    get_s3vector_local_path,
-    get_s3vector_s3_endpoint,
-    get_s3vector_s3_region,
-    get_s3vector_s3_allow_http
+    get_s3vector_local_path
     )
 
 
@@ -109,9 +106,8 @@ def set_rgw_config_option(option, value, port=None, cluster=None):
     return out, ret
 
 
-def _configure_backend(host, port, cluster):
-    """ set the s3vector backend options on an RGW, so that it does not have to
-    be started with them """
+def _backend_options(host, port, cluster):
+    """ the s3vector backend options that fit the given zone """
     backend = get_s3vector_backend()
     options = {'rgw_s3vector_backend': backend}
     if backend == 'local':
@@ -120,14 +116,28 @@ def _configure_backend(host, port, cluster):
         local_path = get_s3vector_local_path() or '/tmp/rgw-s3vector-<cluster>-<port>'
         options['rgw_s3vector_local_path'] = local_path.replace(
             '<cluster>', cluster).replace('<port>', str(port))
-    elif backend == 's3':
-        allow_http = get_s3vector_s3_allow_http()
-        # by default, the RGW is sending the S3 requests to itself
-        scheme = 'http' if allow_http in ('true', 'True', '1') else 'https'
-        options['rgw_s3vector_s3_endpoint'] = get_s3vector_s3_endpoint() or \
-            f'{scheme}://{host}:{port}'
-        options['rgw_s3vector_s3_region'] = get_s3vector_s3_region() or get_config_zonegroup()
-        options['rgw_s3vector_s3_allow_http'] = allow_http
+    return options
+
+
+def backend_admin_args():
+    """
+    the s3vector backend options, as command line arguments of "radosgw-admin".
+    the options are set on the RGWs of the tested zones, and radosgw-admin does not
+    read them from there, so they have to be given to it explicitly whenever it has
+    to reach the vector data itself (e.g. when purging the data of a user)
+    """
+    options = _backend_options(get_config_host(), get_config_port(), get_config_cluster())
+    args = []
+    for option, value in options.items():
+        args += ['--' + option.replace('_', '-'), str(value)]
+    return args
+
+
+def _configure_backend(host, port, cluster):
+    """ set the s3vector backend options on an RGW, so that it does not have to
+    be started with them """
+    backend = get_s3vector_backend()
+    options = _backend_options(host, port, cluster)
 
     # the tests must run against the backend they were configured with: if it
     # cannot be set, the run is failed, and not done against another backend
@@ -159,7 +169,7 @@ def forbid_data_sync(configfile):
     bucket, so that there is no window in which a bucket is created but its data
     may still be synced. note that the metadata of the entities is still synced.
     """
-    if not get_config_host2() or not is_s3_backend():
+    if not get_config_host2() or not has_backing_bucket():
         # not a multisite configuration, or a backend that does not store the
         # vector data in S3 buckets, so there is nothing that may be synced
         yield
@@ -239,6 +249,22 @@ def connection2(service_name='s3vectors'):
     return client
 
 
+def service_connection(service_name, access_key, secret_key):
+    """ a connection to the tested zone with the given credentials """
+    hostname = get_config_host()
+    port_no = get_config_port()
+    if port_no == 443 or port_no == 8443:
+        scheme = 'https://'
+    else:
+        scheme = 'http://'
+
+    return boto3.client(service_name,
+            endpoint_url=scheme+hostname+':'+str(port_no),
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            region_name=get_config_zonegroup())
+
+
 def _wait_for_user(uid, tenant=None, retries=12, delay=5):
     """ wait for a user of the master zone to be synced to the tested zone """
     if get_config_cluster() == (get_config_master_cluster() or get_config_cluster()):
@@ -281,13 +307,55 @@ def another_user(tenant=None):
     else:
         scheme = 'http://'
 
-    client = boto3.client('s3vectors',
-            endpoint_url=scheme+hostname+':'+str(port_no),
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-            region_name=get_config_zonegroup())
-
+    client = service_connection('s3vectors', access_key, secret_key)
     client.uid = uid
+    # the "s3" connection of the same user, to create the backing buckets
+    client.s3 = service_connection('s3', access_key, secret_key)
+    return client
+
+
+num_accounts = 0
+
+
+def another_account_user(account_id=None):
+    """
+    a root user of an account, in an account of its own when no account is given.
+    the buckets of an account, vector buckets included, belong to the account and
+    not to the user that created them
+    """
+    # accounts and users may be created only on the master zone, and are synced
+    # from there
+    master_cluster = get_config_master_cluster()
+    if master_cluster and master_cluster != get_config_cluster():
+        pytest.skip(f"cannot create a user: the master zone is in cluster "
+                    f"'{master_cluster}', and the tested zone is in '{get_config_cluster()}'")
+
+    global num_accounts
+    num_accounts += 1
+    if not account_id:
+        name = 'account' + run_prefix + str(num_accounts)
+        out, result = admin(['account', 'create', '--account-name', name,
+                             '--email', name + '@ceph.com'], cluster=master_cluster)
+        assert result == 0, f"failed to create account '{name}': {out}"
+        # the output of the command may be prefixed with warnings of the cluster
+        account_id = json.loads(out[out.index('{'):])['id']
+
+    access_key = str(time.time())
+    secret_key = str(time.time())
+    # the display name of an account user is its IAM user name, which allows no spaces
+    uid = 'accountman' + run_prefix + str(num_accounts)
+    out, result = admin(['user', 'create', '--uid', uid, '--display-name', uid,
+                         '--account-id', account_id, '--account-root',
+                         '--access-key', access_key, '--secret-key', secret_key],
+                        cluster=master_cluster)
+    assert result == 0, f"failed to create user '{uid}' of account '{account_id}': {out}"
+    _wait_for_user(uid)
+
+    client = service_connection('s3vectors', access_key, secret_key)
+    client.uid = uid
+    client.account_id = account_id
+    # the "s3" connection of the same user, to create the backing buckets
+    client.s3 = service_connection('s3', access_key, secret_key)
     return client
 
 
@@ -297,8 +365,8 @@ def another_user(tenant=None):
 
 def _ensure_s3_bucket_for_vector_bucket(bucket_name, s3conn=None, retries=12, delay=5):
     """
-    When using S3/SAL backend, create a regular S3 bucket with the same name
-    as the vector bucket. Required because these backends store LanceDB data
+    When using the RGW backend, create a regular S3 bucket with the same name
+    as the vector bucket. Required because that backend stores LanceDB data
     directly in an S3 bucket with the vector bucket name.
     In a multisite configuration, the connection of the second zone should be
     used to create the bucket there as well, since a vector bucket cannot be
@@ -306,7 +374,7 @@ def _ensure_s3_bucket_for_vector_bucket(bucket_name, s3conn=None, retries=12, de
     request in a zone that is not the master zone is forwarded to the master,
     and the bucket is created locally afterwards.
     """
-    if not is_s3_backend():
+    if not has_backing_bucket():
         return
     if not s3conn:
         s3conn = connection('s3')
@@ -334,14 +402,16 @@ def _ensure_s3_bucket_for_vector_bucket(bucket_name, s3conn=None, retries=12, de
         f"{retries * delay} seconds")
 
 
-def _delete_s3_bucket_for_vector_bucket(bucket_name):
+def _delete_s3_bucket_for_vector_bucket(bucket_name, s3conn=None):
     """
-    When using S3/SAL backend, delete the regular S3 bucket that was created
-    for the vector bucket.
+    When using the RGW backend, delete the regular S3 bucket that was created
+    for the vector bucket. The connection of the owner must be given when the
+    bucket is not owned by the main user, since it is not visible to it.
     """
-    if not is_s3_backend():
+    if not has_backing_bucket():
         return
-    s3conn = connection('s3')
+    if not s3conn:
+        s3conn = connection('s3')
     try:
         paginator = s3conn.get_paginator('list_objects_v2')
         for page in paginator.paginate(Bucket=bucket_name):
@@ -356,22 +426,6 @@ def _delete_s3_bucket_for_vector_bucket(bucket_name):
             log.info("S3 bucket '%s' does not exist, nothing to delete", bucket_name)
         else:
             log.warning("Failed to delete S3 bucket '%s': %s", bucket_name, str(err))
-
-
-def _purge_all_versions(s3conn, bucket_name):
-    """
-    Remove every version and delete marker from a versioned S3 bucket, so that
-    it is actually empty and can be deleted.
-    """
-    paginator = s3conn.get_paginator('list_object_versions')
-    for page in paginator.paginate(Bucket=bucket_name):
-        objects = []
-        for v in page.get('Versions', []):
-            objects.append({'Key': v['Key'], 'VersionId': v['VersionId']})
-        for dm in page.get('DeleteMarkers', []):
-            objects.append({'Key': dm['Key'], 'VersionId': dm['VersionId']})
-        if objects:
-            s3conn.delete_objects(Bucket=bucket_name, Delete={'Objects': objects})
 
 
 def _delete_all_indexes(conn, bucket_name):
@@ -776,7 +830,7 @@ def test_vector_buckets_deletion_with_buckets():
     _create_s3bucket(s3conn, bucket_name2)
     # delete the s3 bucket: for S3/SAL backends, empty it first (LanceDB data files);
     # for local backend, the bucket is empty since LanceDB uses local filesystem.
-    if is_s3_backend():
+    if has_backing_bucket():
         paginator = s3conn.get_paginator('list_objects_v2')
         for page in paginator.paginate(Bucket=bucket_name2):
             if 'Contents' in page:
@@ -3336,7 +3390,7 @@ def test_sal_error_propagation():
     underlying storage is gone. This validates the error chain:
     rgw_sal_wrapper -> store.rs -> LanceDB -> lancedb-c -> rgw_s3vector.cc
     """
-    if not is_s3_backend():
+    if not has_backing_bucket():
         pytest.skip("error propagation test only applies to S3/SAL backends")
 
     conn = connection()
@@ -3379,28 +3433,20 @@ def test_sal_error_propagation():
 def test_cross_owner_vector_bucket():
     """When the S3 bucket owner differs from the vector bucket owner,
     operations should fail without a bucket policy and succeed with one."""
-    if not is_s3_backend():
-        pytest.skip("cross-owner test only applies to S3/SAL backends")
+    if not has_backing_bucket():
+        pytest.skip("cross-owner test only applies to backends with a backing bucket")
 
     # user A (config user) creates the S3 bucket
     s3conn = connection('s3')
     bucket_name = gen_bucket_name()
     _create_s3bucket(s3conn, bucket_name)
 
-    # user B creates a vector bucket with the same name
+    # every operation reaching the backend is verified against the backing bucket,
+    # so user B cannot even create the vector bucket over the bucket of user A
     other = another_user()
-    result = other.create_vector_bucket(vectorBucketName=bucket_name)
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
-
-    # without a bucket policy, user B should fail to create an index
-    index_name = 'cross-owner-idx'
-    try:
-        other.create_index(vectorBucketName=bucket_name, indexName=index_name,
-                           dataType='float32', dimension=4, distanceMetric='cosine')
-        assert False, "create_index should have failed without bucket policy"
-    except other.exceptions.ClientError as err:
-        log.info("create_index correctly failed without bucket policy: %s", err)
-        assert err.response['ResponseMetadata']['HTTPStatusCode'] >= 400
+    with pytest.raises(other.exceptions.ClientError) as exc_info:
+        other.create_vector_bucket(vectorBucketName=bucket_name)
+    assert exc_info.value.response['ResponseMetadata']['HTTPStatusCode'] >= 400
 
     # user A sets a bucket policy granting user B full access
     policy = json.dumps({
@@ -3417,7 +3463,12 @@ def test_cross_owner_vector_bucket():
     })
     s3conn.put_bucket_policy(Bucket=bucket_name, Policy=policy)
 
-    # now user B should be able to create an index and write/query vectors
+    # now user B should be able to create the vector bucket, an index, and
+    # write/query vectors
+    index_name = 'cross-owner-idx'
+    result = other.create_vector_bucket(vectorBucketName=bucket_name)
+    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+
     result = other.create_index(vectorBucketName=bucket_name, indexName=index_name,
                                 dataType='float32', dimension=4, distanceMetric='cosine')
     assert result['ResponseMetadata']['HTTPStatusCode'] == 200
@@ -3437,73 +3488,211 @@ def test_cross_owner_vector_bucket():
 
 
 @pytest.mark.vector_bucket_test
-def test_versioned_s3_bucket():
-    """Vector bucket backed by an S3 bucket with versioning enabled."""
-    if not is_s3_backend():
-        pytest.skip("versioned bucket test only applies to S3/SAL backends")
-    if get_s3vector_backend() == 'rgw':
-        pytest.skip("versioned buckets not supported with RGW backend (null version IDs)")
-
-    conn = connection()
+def test_delete_user_with_vector_buckets():
+    """
+    A user owning vector buckets cannot be deleted unless its data is purged, and
+    purging it removes the vector buckets together with their indexes. Note that
+    the backing bucket belongs to the main user: it is an ordinary bucket, and
+    would have refused the deletion of the user by itself, hiding the check on the
+    vector buckets
+    """
+    dimension = 4
+    index_name = 'index-of-the-deleted-user'
+    main_conn = connection()
     s3conn = connection('s3')
+    conn = another_user()
+    uid = conn.uid
     bucket_name = gen_bucket_name()
+    try:
+        _ensure_s3_bucket_for_vector_bucket(bucket_name, s3conn)
+        if has_backing_bucket():
+            # the backing bucket belongs to the main user, so the user under test
+            # needs a policy on it to create indexes
+            policy = json.dumps({
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Principal": {"AWS": [f"arn:aws:iam:::user/{uid}"]},
+                    "Action": "s3:*",
+                    "Resource": [
+                        f"arn:aws:s3:::{bucket_name}",
+                        f"arn:aws:s3:::{bucket_name}/*"
+                    ]
+                }]
+            })
+            s3conn.put_bucket_policy(Bucket=bucket_name, Policy=policy)
 
-    # create an S3 bucket and enable versioning
-    _create_s3bucket(s3conn, bucket_name)
-    s3conn.put_bucket_versioning(Bucket=bucket_name,
-                                 VersioningConfiguration={'Status': 'Enabled'})
-
-    # create a vector bucket, index, and write/query vectors
-    result = conn.create_vector_bucket(vectorBucketName=bucket_name)
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
-
-    index_name = 'versioned-idx'
-    result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
-                               dataType='float32', dimension=4, distanceMetric='cosine')
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
-
-    vectors = generate_vectors(3, 4)
-    # upsert the same vectors multiple times to exercise overwrites with versioning
-    for i in range(3):
-        result = conn.put_vectors(vectorBucketName=bucket_name, indexName=index_name, vectors=vectors)
+        result = conn.create_vector_bucket(vectorBucketName=bucket_name)
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
+                                   dataType='float32', dimension=dimension,
+                                   distanceMetric='euclidean')
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        result = conn.put_vectors(vectorBucketName=bucket_name, indexName=index_name,
+                                  vectors=generate_vectors(2, dimension))
         assert result['ResponseMetadata']['HTTPStatusCode'] == 200
 
-    # get vectors
-    vector_keys = [v['key'] for v in vectors]
-    result = conn.get_vectors(vectorBucketName=bucket_name, indexName=index_name,
-                              keys=vector_keys, returnData=True)
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
-    assert len(result['vectors']) == 3
+        # the user cannot be deleted while it owns a vector bucket
+        out, result = admin(['user', 'rm', '--uid', uid])
+        assert result != 0, f"user '{uid}' was deleted while it owns a vector bucket"
+        assert 'vector bucket' in out, f"unexpected error when deleting user '{uid}': {out}"
 
-    # query vectors
-    query_vector = generate_data(4, 0)
-    result = conn.query_vectors(vectorBucketName=bucket_name, indexName=index_name,
-                                queryVector=query_vector, topK=3)
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
-    assert len(result['vectors']) == 3
+        # purging the data of the user removes its vector buckets. note that
+        # radosgw-admin reaches the vector data itself, so it needs the backend
+        # options of the RGWs
+        out, result = admin(['user', 'rm', '--uid', uid, '--purge-data'] + backend_admin_args())
+        assert result == 0, f"failed to delete user '{uid}' with its data: {out}"
+        out, result = admin(['user', 'info', '--uid', uid])
+        assert result != 0, f"user '{uid}' still exists after it was deleted: {out}"
 
-    # delete vectors
-    result = conn.delete_vectors(vectorBucketName=bucket_name, indexName=index_name,
-                                 keys=vector_keys)
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        # the indexes were purged together with the vector bucket: a vector bucket
+        # created again over the same storage holds none of them
+        result = main_conn.create_vector_bucket(vectorBucketName=bucket_name)
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        result = main_conn.list_indexes(vectorBucketName=bucket_name)
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        assert result['indexes'] == [], \
+            f"the indexes of the deleted user were not purged: {result['indexes']}"
+    finally:
+        # best effort cleanup, in case the user was not deleted by the test
+        admin(['user', 'rm', '--uid', uid, '--purge-data'] + backend_admin_args())
+        try:
+            _delete_vector_bucket(main_conn, bucket_name)
+        except main_conn.exceptions.ClientError as err:
+            log.warning("failed to delete vector bucket '%s': %s", bucket_name, str(err))
+        _delete_s3_bucket_for_vector_bucket(bucket_name)
 
-    # verify they are gone
-    result = conn.get_vectors(vectorBucketName=bucket_name, indexName=index_name,
-                              keys=vector_keys)
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
-    assert len(result['vectors']) == 0
 
-    # cleanup - delete the indexes, and then purge all versions and delete markers.
-    # the files that LanceDB removes are kept as noncurrent versions of the objects,
-    # so the vector bucket would still look like it holds indexes if the versions
-    # are not purged before it is deleted
-    _delete_all_indexes(conn, bucket_name)
-    _purge_all_versions(s3conn, bucket_name)
-    result = conn.delete_vector_bucket(vectorBucketName=bucket_name)
-    assert result['ResponseMetadata']['HTTPStatusCode'] == 200
-    # deleting the vector bucket removes the LanceDB files again, which leaves
-    # a new set of delete markers behind, so purge once more before the bucket
-    # itself can be deleted
-    _purge_all_versions(s3conn, bucket_name)
-    s3conn.delete_bucket(Bucket=bucket_name)
+@pytest.mark.vector_bucket_test
+def test_account_vector_buckets():
+    """
+    The vector buckets created by a user of an account belong to the account, like
+    its ordinary buckets: they are listed by every user of the account, and they
+    outlive the user that created them
+    """
+    dimension = 4
+    index_name = 'index-of-the-account'
+    conn = another_account_user()
+    other = another_account_user(account_id=conn.account_id)
+    bucket_name = gen_bucket_name()
+    try:
+        _ensure_s3_bucket_for_vector_bucket(bucket_name, conn.s3)
+        result = conn.create_vector_bucket(vectorBucketName=bucket_name)
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
+                                   dataType='float32', dimension=dimension,
+                                   distanceMetric='euclidean')
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
 
+        # the vector bucket belongs to the account, so it is listed by the user that
+        # created it, and by any other user of the same account
+        for account_conn in (conn, other):
+            result = account_conn.list_vector_buckets()
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+            bucket_names = [b['vectorBucketName'] for b in result['vectorBuckets']]
+            assert bucket_names == [bucket_name], \
+                f"user '{account_conn.uid}' of the account sees the vector buckets: {bucket_names}"
+            result = account_conn.get_vector_bucket(vectorBucketName=bucket_name)
+            assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+
+        # the vector bucket is not owned by the user that created it, so it is not
+        # part of the data of that user: the user is deleted with its data purged,
+        # and the vector bucket, with its indexes, remains with the account
+        out, result = admin(['user', 'rm', '--uid', conn.uid, '--purge-data'])
+        assert result == 0, f"failed to delete account user '{conn.uid}': {out}"
+        result = other.list_vector_buckets()
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        bucket_names = [b['vectorBucketName'] for b in result['vectorBuckets']]
+        assert bucket_names == [bucket_name], \
+            f"the vector bucket of the account did not outlive the user that created it: {bucket_names}"
+        result = other.list_indexes(vectorBucketName=bucket_name)
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        assert [i['indexName'] for i in result['indexes']] == [index_name]
+    finally:
+        # best effort cleanup. the account and its users are left behind, as done
+        # for the users created by another_user()
+        try:
+            _delete_vector_bucket(other, bucket_name)
+        except other.exceptions.ClientError as err:
+            log.warning("failed to delete vector bucket '%s': %s", bucket_name, str(err))
+        _delete_s3_bucket_for_vector_bucket(bucket_name, other.s3)
+
+
+@pytest.mark.vector_bucket_test
+def test_delete_account_with_vector_buckets():
+    """
+    An account holding vector buckets cannot be deleted unless its data is purged,
+    and purging it removes them together with their indexes. The data is reached
+    with the credentials of the root user of the account
+    """
+    dimension = 4
+    index_name = 'index-of-the-account'
+    conn = another_account_user()
+    account_id = conn.account_id
+    bucket_name = gen_bucket_name()
+    try:
+        _ensure_s3_bucket_for_vector_bucket(bucket_name, conn.s3)
+        result = conn.create_vector_bucket(vectorBucketName=bucket_name)
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
+                                   dataType='float32', dimension=dimension,
+                                   distanceMetric='euclidean')
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+
+        # the account is not deleted while it holds a vector bucket. note that its
+        # users are still there afterwards: the vector buckets are handled before
+        # anything else is removed
+        out, result = admin(['account', 'rm', '--account-id', account_id])
+        assert result != 0, f"account '{account_id}' was deleted while it holds a vector bucket"
+        assert 'vector bucket' in out, \
+            f"unexpected error when deleting account '{account_id}': {out}"
+        out, result = admin(['user', 'info', '--uid', conn.uid])
+        assert result == 0, f"user '{conn.uid}' of the account was removed by the failed deletion: {out}"
+
+        # purging the data of the account removes its vector buckets. note that
+        # radosgw-admin reaches the vector data itself, so it needs the backend
+        # options of the RGWs
+        out, result = admin(['account', 'rm', '--account-id', account_id, '--purge-data'] +
+                            backend_admin_args())
+        assert result == 0, f"failed to delete account '{account_id}' with its data: {out}"
+        out, result = admin(['account', 'get', '--account-id', account_id])
+        assert result != 0, f"account '{account_id}' still exists after it was deleted: {out}"
+    finally:
+        # best effort cleanup, in case the account was not deleted by the test
+        admin(['account', 'rm', '--account-id', account_id, '--purge-data'] + backend_admin_args())
+
+
+@pytest.mark.vector_bucket_test
+def test_delete_user_owning_the_backing_bucket():
+    """
+    The data of a vector bucket is held in an ordinary bucket, which may belong to
+    the same user. Purging the data of that user must remove the vector bucket
+    before the bucket holding its data, or the indexes can no longer be reached
+    """
+    dimension = 4
+    index_name = 'index-over-an-owned-bucket'
+    conn = another_user()
+    uid = conn.uid
+    s3conn = conn.s3
+    bucket_name = gen_bucket_name()
+    try:
+        # unlike the other tests, the backing bucket belongs to the user under test
+        _ensure_s3_bucket_for_vector_bucket(bucket_name, s3conn)
+        result = conn.create_vector_bucket(vectorBucketName=bucket_name)
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        result = conn.create_index(vectorBucketName=bucket_name, indexName=index_name,
+                                   dataType='float32', dimension=dimension,
+                                   distanceMetric='euclidean')
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+        result = conn.put_vectors(vectorBucketName=bucket_name, indexName=index_name,
+                                  vectors=generate_vectors(2, dimension))
+        assert result['ResponseMetadata']['HTTPStatusCode'] == 200
+
+        out, result = admin(['user', 'rm', '--uid', uid, '--purge-data'] + backend_admin_args())
+        assert result == 0, f"failed to delete user '{uid}' with its data: {out}"
+        out, result = admin(['user', 'info', '--uid', uid])
+        assert result != 0, f"user '{uid}' still exists after it was deleted: {out}"
+    finally:
+        # best effort cleanup, in case the user was not deleted by the test. the
+        # backing bucket belongs to the user, and is purged together with it
+        admin(['user', 'rm', '--uid', uid, '--purge-data'] + backend_admin_args())

--- a/src/test/rgw/s3vectors/s3vtests.conf.SAMPLE
+++ b/src/test/rgw/s3vectors/s3vtests.conf.SAMPLE
@@ -3,24 +3,17 @@ port = 8000
 host = localhost
 zonegroup = default
 cluster = noname
-# s3vector_backend: Storage backend for s3vector data. Options: local, s3, or rgw (default)
-# When set to 's3' or 'rgw', tests will create a regular S3 bucket with the same name
+# s3vector_backend: Storage backend for s3vector data. Options: local or rgw (default)
+# When set to 'rgw', tests will create a regular S3 bucket with the same name
 # as the vector bucket before vector operations.
-# s3vector_backend = s3
+# s3vector_backend = loca
 #
 # backend options.
 # when not set, a value that fits the tested zone is used:
 # - s3vector_local_path: /tmp/rgw-s3vector-<cluster>-<port>
-# - s3vector_s3_endpoint: http://<host>:<port>, so that the RGW sends the S3 requests
-#   to itself. must be a URL, including the scheme
-# - s3vector_s3_region: the zonegroup
-# - s3vector_s3_allow_http: true
 # in s3vector_local_path, "<cluster>" and "<port>" are replaced with the values of
 # the tested zone, so that the RGWs of different zones do not share a directory
 # s3vector_local_path = /tmp/rgw-s3vector-<cluster>-<port>
-# s3vector_s3_endpoint = http://localhost:8000
-# s3vector_s3_region = default
-# s3vector_s3_allow_http = true
 
 [s3 main]
 access_key = 0555b35654ad1656d804


### PR DESCRIPTION
* making sure that user is not deleted when it has vector buckets
* allow purging vector buckets with users's data
* make sure that this works for accounts as well. for s3 backend where user credentials are needed, we take the credentials of the accoun't root user


Assisted-by: claude-code:claude-opus-5





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
