### PR TITLE
os/bluestore: enforce tail data caching for appends

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1707,7 +1707,7 @@ void BlueStore::BufferSpace::_add_buffer(BufferCacheShard* cache,
                                          uint16_t cache_private, int level,
                                          Buffer *near)
 {
-  ldout(cache->cct, 20) << __func__ << "? " << b << dendl;
+  ldout(cache->cct, 20) << __func__ << "? " << *b << dendl;
   cache->_audit("_add_buffer start");
   ceph_assert(!b->set_item.is_linked());
   // illegal to provide both near and cache_private
@@ -1738,7 +1738,7 @@ void BlueStore::BufferSpace::_add_buffer(BufferCacheShard* cache,
     }
   }
   if (add_to_map) {
-    ldout(cache->cct, 20) << __func__ << " added " << b << dendl;
+    ldout(cache->cct, 20) << __func__ << " added " << *b << dendl;
     b->data.reassign_to_mempool(mempool::mempool_bluestore_cache_data);
     b->cache_private = cache_private;
     buffer_map.insert(*b);
@@ -1754,10 +1754,10 @@ void BlueStore::BufferSpace::__rm_buffer(BufferCacheShard* cache,
 {
   ceph_assert(b);
   cache->_audit("_rm_buffer start");
+  ldout(cache->cct, 20) << __func__ << " " << *b << dendl;
   if (!b->is_writing()) {
     cache->_rm(b);
   }
-  ldout(cache->cct, 20) << __func__ << " erasing " << b << dendl;
   __erase_from_map(b);
   cache->_audit("_rm_buffer end");
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -664,10 +664,9 @@ ostream& operator<<(ostream& out, const BlueStore::Buffer& b)
 {
   out << "buffer(" << &b << " space " << b.space << " 0x" << std::hex
       << b.offset << "~" << b.length << std::dec
-      << " " << BlueStore::Buffer::get_state_name(b.state);
-  if (b.flags)
-    out << " " << BlueStore::Buffer::get_flag_name(b.flags);
-  return out << ")";
+      << " " << BlueStore::Buffer::get_state_name(b.state)
+      << BlueStore::Buffer::get_flag_name(" ", b.flags)
+      << ")";
 }
 
 //pool_fsck_stats_t

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -667,6 +667,7 @@ ostream& operator<<(ostream& out, const BlueStore::Buffer& b)
       << " " << BlueStore::Buffer::get_state_name(b.state)
       << BlueStore::Buffer::get_flag_name(" ", b.flags)
       << ")";
+  return out;
 }
 
 //pool_fsck_stats_t

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -17836,7 +17836,7 @@ void BlueStore::_do_write_data(
 	_do_write_big(txc, c, o, write_offset, segment_end - write_offset, p, wctx);
 	write_offset = segment_end;
       }
-    } else {
+    } else if (middle_length > 0) {
       _do_write_big(txc, c, o, middle_offset, middle_length, p, wctx);
     }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16908,7 +16908,8 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 	  if (head_read) {
 	    bufferlist head_bl;
 	    int r = _do_read(c.get(), o, offset - head_pad - head_read, head_read,
-			     head_bl, 0);
+			     head_bl,
+			     CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
 	    ceph_assert(r >= 0 && r <= (int)head_read);
 	    size_t zlen = head_read - r;
 	    if (zlen) {
@@ -16922,7 +16923,8 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 	  if (tail_read) {
 	    bufferlist tail_bl;
 	    int r = _do_read(c.get(), o, offset + length + tail_pad, tail_read,
-			     tail_bl, 0);
+			     tail_bl,
+			     CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
 	    ceph_assert(r >= 0 && r <= (int)tail_read);
 	    size_t zlen = tail_read - r;
 	    if (zlen) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5144,7 +5144,8 @@ bool BlueStore::WriteContext::has_conflict(
   for (auto w : writes) {
     if (b == w.b) {
       auto loffs2 = p2align(w.logical_offset, min_alloc_size);
-      auto loffs2_end = p2roundup(w.logical_offset + w.length0, min_alloc_size);
+      auto loffs2_end = p2roundup(w.logical_offset + w.get_original_length(),
+        min_alloc_size);
       if ((loffs <= loffs2 && loffs_end > loffs2) ||
           (loffs >= loffs2 && loffs < loffs2_end)) {
         return true;
@@ -13414,9 +13415,10 @@ void inline BlueStore::_do_read_and_pad(
   OnodeRef& o,
   uint32_t offset,
   uint32_t length,
-  ceph::buffer::list& bl)
+  ceph::buffer::list& bl,
+  uint32_t op_flags)
 {
-  int r = _do_read(c, o, offset, length, bl, 0);
+  int r = _do_read(c, o, offset, length, bl, op_flags);
   ceph_assert(r >= 0 && r <= (int)length);
   size_t zlen = length - r;
   if (zlen > 0) {
@@ -16628,7 +16630,7 @@ int BlueStore::_touch(TransContext *txc,
   return r;
 }
 
-void BlueStore::_pad_zeros(
+size_t BlueStore::_pad_zeros(
   bufferlist *bl, uint64_t *offset,
   uint64_t chunk_size)
 {
@@ -16688,6 +16690,7 @@ void BlueStore::_pad_zeros(
   if (pad_count)
     logger->inc(l_bluestore_write_pad_bytes, pad_count);
   ceph_assert(bl->length() == length);
+  return pad_count;
 }
 
 void BlueStore::_do_write_small(
@@ -16701,74 +16704,24 @@ void BlueStore::_do_write_small(
   dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   << std::dec << dendl;
   ceph_assert(length < min_alloc_size);
-
   logger->inc(l_bluestore_write_small);
   logger->inc(l_bluestore_write_small_bytes, length);
 
-  bufferlist bl;
-  blp.copy(length, bl);
+  const uint64_t end_offs = offset + length;
+  const auto max_bsize = std::max(wctx->target_blob_size, min_alloc_size);
+  const auto max_off = offset + max_bsize;
+  const auto min_off = offset >= max_bsize ? offset - max_bsize : 0;
 
-  uint32_t alloc_len = min_alloc_size;
-
-  auto max_bsize = std::max(wctx->target_blob_size, min_alloc_size);
-  auto min_off = offset >= max_bsize ? offset - max_bsize : 0;
-
-  // search suitable extent in both forward and reverse direction in
+  // We'll search suitable extent in both forward and reverse direction in
   // [offset - target_max_blob_size, offset + target_max_blob_size] range
   // then check if blob can be reused via can_reuse_blob func or apply
   // direct/deferred write (the latter for extents including or higher
   // than 'offset' only).
-  o->extent_map.fault_range(db, min_off, offset + max_bsize - min_off);
+  o->extent_map.fault_range(db, min_off, max_off - min_off);
 
-  if (!wctx->full_write) {
-    alloc_len = _do_write_small_with_maybe_blob_reuse(txc,
-      c, o, offset, length, bl, wctx);
-  }
-  if (alloc_len) {
-    // we still need new blob allocation
-    uint64_t b_off = p2phase<uint64_t>(offset, alloc_len);
-    uint64_t b_off0 = b_off;
-    o->extent_map.punch_hole(c, offset, length, &wctx->old_extents);
-
-    // Zero detection -- small block
-    if (!cct->_conf->bluestore_zero_block_detection || !bl.is_zero()) {
-      // new blob.
-      BlobRef b = c->new_blob();
-      _pad_zeros(&bl, &b_off0, block_size);
-      wctx->write(offset, b, alloc_len, b_off0, bl, b_off, length,
-	  min_alloc_size != block_size, // use 'unused' bitmap when alloc granularity
-					// doesn't match disk one only
-	  true);
-    } else { // if (bl.is_zero())
-      dout(20) << __func__ << " skip small zero block " << std::hex
-	<< " (0x" << b_off0 << "~" << bl.length() << ")"
-	<< " (0x" << b_off << "~" << length << ")"
-	<< std::dec << dendl;
-      logger->inc(l_bluestore_write_small_skipped);
-      logger->inc(l_bluestore_write_small_skipped_bytes, length);
-    }
-  }
-}
-
-uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
-      TransContext* txc,
-      CollectionRef& c,
-      OnodeRef& o,
-      uint64_t offset, uint64_t length,
-      bufferlist& bl,
-      WriteContext* wctx)
-{
-  uint32_t alloc_len = min_alloc_size;
-  auto offset0 = p2align<uint64_t>(offset, alloc_len);
-
-  auto max_bsize = std::max(wctx->target_blob_size, min_alloc_size);
-  auto min_off = offset >= max_bsize ? offset - max_bsize : 0;
-
-  uint64_t end_offs = offset + length;
-
-  // Look for an existing mutable blob we can use.
-  auto begin = o->extent_map.extent_map.begin();
-  auto end = o->extent_map.extent_map.end();
+  // Prepare for looking for an existing mutable blob we can use.
+  const auto begin = o->extent_map.extent_map.begin();
+  const auto end = o->extent_map.extent_map.end();
   auto ep = o->extent_map.seek_lextent(offset);
   if (ep != begin) {
     --ep;
@@ -16782,29 +16735,60 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
     --prev_ep;
   }
 
+  // Stuff to notice observed extent map bounds and inspected blobs
+  // to determine if we want to do garbase collection
+  auto start_ep = ep;
+  auto end_ep = ep; // exclusively
+  uint64_t min_seen_off = offset;
+  uint64_t max_seen_off = offset;
   boost::container::flat_set<const bluestore_blob_t*> inspected_blobs;
   // We don't want to have more blobs than min alloc units fit
   // into 2 max blobs
   size_t blob_threshold = max_blob_size / min_alloc_size * 2 + 1;
   bool above_blob_threshold = false;
-
   inspected_blobs.reserve(blob_threshold);
 
-  uint64_t max_off = 0;
-  auto start_ep = ep;
-  auto end_ep = ep; // exclusively
-  bool any_change;
-  do {
+  // Stuff to determine and notice blob one can reuse.
+  BlobRef candidate_blob;
+  uint64_t candidate_blob_off = 0;
+  auto can_reuse_blob = [&](BlobRef b, uint32_t bstart) {
+    const auto alloc_aligned_offset = p2align<uint64_t>(offset, min_alloc_size);
+    // try to reuse blob if we can
+    uint32_t alloc_len = min_alloc_size;
+    if (b->can_reuse_blob(min_alloc_size,
+                          max_bsize,
+			  alloc_aligned_offset - bstart,
+			  &alloc_len)) {
+      // expecting data always fit into reused blob
+      ceph_assert(alloc_len == min_alloc_size);
+      // Need to check for pending writes desiring to
+      // reuse the same pextent. The rationale is that during GC two chunks
+      // from garbage blobs(compressed?) can share logical space within the same
+      // AU. That's in turn might be caused by unaligned len in clone_range2.
+      // Hence the second write will fail in an attempt to reuse blob at
+      // do_alloc_write().
+      if (!wctx->has_conflict(b,
+			      alloc_aligned_offset,
+			      alloc_aligned_offset + alloc_len,
+			      min_alloc_size)) {
+	candidate_blob = b;
+	candidate_blob_off = offset - bstart;
+	return true;
+      }
+    }
+    return false;
+  };
+
+  bufferlist bl;
+  blp.copy(length, bl);
+
+  bool any_change = !wctx->full_write; // skip blob lookup in full_write
+  while(any_change) {
     any_change = false;
 
-    if (ep != end && ep->logical_offset < offset + max_bsize) {
+    if (ep != end && ep->logical_offset < max_off) {
       BlobRef b = ep->blob;
-      if (!above_blob_threshold) {
-	inspected_blobs.insert(&b->get_blob());
-	above_blob_threshold = inspected_blobs.size() >= blob_threshold;
-      }
-      max_off = ep->logical_end();
-      auto bstart = ep->blob_start();
+      uint32_t bstart = ep->blob_start();
 
       dout(20) << __func__ << " considering " << *b
 	       << " bstart 0x" << std::hex << bstart << std::dec << dendl;
@@ -16817,263 +16801,122 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 	dout(20) << __func__ << " ignoring offset-skewed " << *b << dendl;
       } else {
 	uint64_t chunk_size = b->get_blob().get_chunk_size(block_size);
-	// can we pad our head/tail out with zeros?
-	uint64_t head_pad, tail_pad;
-	head_pad = p2phase(offset, chunk_size);
-	tail_pad = p2nphase(end_offs, chunk_size);
-	if (head_pad || tail_pad) {
-	  o->extent_map.fault_range(db, offset - head_pad,
-				    end_offs - offset + head_pad + tail_pad);
-	}
-	if (head_pad &&
-	    o->extent_map.has_any_lextents(offset - head_pad, head_pad)) {
-	  head_pad = 0;
-	}
-	if (tail_pad && o->extent_map.has_any_lextents(end_offs, tail_pad)) {
-	  tail_pad = 0;
-	}
+	// Should we pad our head/tail with zeros or existing data
+	uint64_t head_pad0 = p2phase(offset - bstart, chunk_size);
+	uint64_t tail_pad0 = p2nphase(end_offs - bstart, chunk_size);
 
-	uint64_t b_off = offset - head_pad - bstart;
-	uint64_t b_len = length + head_pad + tail_pad;
+	// Aligned offset within blob
+	uint64_t b_off0 = offset - bstart - head_pad0;
+	// Aligned length within blob
+	uint64_t b_len = length + head_pad0 + tail_pad0;
+	if(b_off0 % chunk_size == 0 && b_len % chunk_size == 0 &&
+           head_pad0 + tail_pad0 < min_alloc_size &&
+	   b->get_blob().is_allocated(b_off0, b_len)) {
+	  auto head_pad = head_pad0;
+	  auto tail_pad = tail_pad0;
+	  bool unused = true;
+	  if (head_pad &&
+	      o->extent_map.has_any_lextents(offset - head_pad, head_pad)) {
+	    // read and pad the head
+	    bufferlist head_bl;
+	    _do_read_and_pad(c.get(), o, offset - head_pad, head_pad,
+	      head_bl,
+	      CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
+	    head_bl.claim_append(bl);
+	    bl.swap(head_bl);
+	    head_pad = 0;
+	    unused = false;
+	  }
+	  if (tail_pad &&
+	      o->extent_map.has_any_lextents(end_offs, tail_pad)) {
+	    // read and pad the tail
+	    bufferlist tail_bl;
+	    _do_read_and_pad(c.get(), o, end_offs, tail_pad,
+	      tail_bl,
+	      CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
+	    bl.claim_append(tail_bl);
+	    tail_pad = 0;
+	    unused = false;
+	  }
+	  // pad head or tail or both if not yet padded
+	  _apply_padding(head_pad, tail_pad, bl);
+	  unused = unused && b->get_blob().is_unused(b_off0, b_len);
 
-        // direct write into unused blocks of an existing mutable blob?
-        if ((b_off % chunk_size == 0 && b_len % chunk_size == 0) &&
-            b->get_blob().get_ondisk_capacity() >= b_off + b_len &&
-            b->get_blob().is_unused(b_off, b_len) &&
-            b->get_blob().is_allocated(b_off, b_len)) {
-          _buffer_cache_write(txc, o, offset, bl,
-                              wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
-          _apply_padding(head_pad, tail_pad, bl);
+	  dout(20) << __func__
+	           << (unused ? " to unused 0x" : " overwrite 0x")
+	           << std::hex << b_off0 << "~" << b_len
+		   << " pad 0x" << head_pad0 << " + 0x" << tail_pad0
+		   << " go deferred " << bool(b_len < prefer_deferred_size || !unused)
+		   << std::dec << " of mutable " << *b
+		   << dendl;
+	  _buffer_cache_write(txc, o, bstart + b_off0, bl,
+	    _get_write_caching(o, offset, length, wctx->fadv_flags));
 
-          dout(20) << __func__ << "  write to unused 0x" << std::hex << b_off
-                   << "~" << b_len << " pad 0x" << head_pad << " + 0x"
-                   << tail_pad << std::dec << " of mutable " << *b << dendl;
+	  b->dirty_blob().calc_csum(b_off0, bl);
 
           if (!g_conf()->bluestore_debug_omit_block_device_write) {
-            if (b_len < prefer_deferred_size) {
-              dout(20) << __func__ << " deferring small 0x" << std::hex
-                       << b_len << std::dec << " unused write via deferred" << dendl;
-              bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
-              op->op = bluestore_deferred_op_t::OP_WRITE;
-              b->get_blob().map(
-                b_off, b_len,
-                [&](uint64_t offset, uint64_t length) {
-                  op->extents.emplace_back(bluestore_pextent_t(offset, length));
-                  return 0;
-                });
-              op->data = bl;
-            } else {
-              b->get_blob().map_bl(
-                b_off, bl,
-                [&](uint64_t offset, bufferlist& t) {
-                  bdev->aio_write(offset, t, &txc->ioc, wctx->buffered);
-              });
-            }
+	    if (b_len < prefer_deferred_size || !unused) {
+		bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
+		op->op = bluestore_deferred_op_t::OP_WRITE;
+		op->data = bl;
+		int r = b->get_blob().map(
+		  b_off0, b_len,
+		    [&](uint64_t offset, uint64_t length) {
+		      op->extents.emplace_back(bluestore_pextent_t(offset, length));
+		      return 0;
+		    });
+		ceph_assert(r == 0);
+	    } else {
+		b->get_blob().map_bl(
+		    b_off0, bl,
+		  [&](uint64_t offset, bufferlist& t) {
+		      bdev->aio_write(offset, t,
+				    &txc->ioc, false);
+		   });
+	    }
           }
-          b->dirty_blob().calc_csum(b_off, bl);
           dout(20) << __func__ << "  lex old " << *ep << dendl;
-          Extent *le = o->extent_map.set_lextent(c, offset, b_off + head_pad, length,
+          Extent *le = o->extent_map.set_lextent(c, offset, offset - bstart, length,
 						 b,
 						 &wctx->old_extents);
 	  b->dirty_blob().mark_used(le->blob_offset, le->length);
-
 	  txc->statfs_delta.stored() += le->length;
 	  dout(20) << __func__ << "  lex " << *le << dendl;
-	  logger->inc(l_bluestore_write_small_unused);
-	  return 0;
+	  logger->inc(unused ?
+	    l_bluestore_write_small_unused :
+	    l_bluestore_write_small_pre_read);
+	  return;
 	}
-	// read some data to fill out the chunk?
-	uint64_t head_read = p2phase(b_off, chunk_size);
-	uint64_t tail_read = p2nphase(b_off + b_len, chunk_size);
-	if ((head_read || tail_read) &&
-	    (b->get_blob().get_ondisk_capacity() >= b_off + b_len + tail_read) &&
-	    head_read + tail_read < min_alloc_size) {
-	  b_off -= head_read;
-	  b_len += head_read + tail_read;
-
-	} else {
-	  head_read = tail_read = 0;
-	}
-
-	// chunk-aligned deferred overwrite?
-	if (b->get_blob().get_ondisk_capacity() >= b_off + b_len &&
-	    b_off % chunk_size == 0 &&
-	    b_len % chunk_size == 0 &&
-	    b->get_blob().is_allocated(b_off, b_len)) {
-
-	  _apply_padding(head_pad, tail_pad, bl);
-
-	  dout(20) << __func__ << "  reading head 0x" << std::hex << head_read
-		   << " and tail 0x" << tail_read << std::dec << dendl;
-	  if (head_read) {
-	    bufferlist head_bl;
-	    int r = _do_read(c.get(), o, offset - head_pad - head_read, head_read,
-			     head_bl,
-			     CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
-	    ceph_assert(r >= 0 && r <= (int)head_read);
-	    size_t zlen = head_read - r;
-	    if (zlen) {
-	      head_bl.append_zero(zlen);
-	      logger->inc(l_bluestore_write_pad_bytes, zlen);
-	    }
-	    head_bl.claim_append(bl);
-	    bl.swap(head_bl);
-	    logger->inc(l_bluestore_write_penalty_read_ops);
-	  }
-	  if (tail_read) {
-	    bufferlist tail_bl;
-	    int r = _do_read(c.get(), o, offset + length + tail_pad, tail_read,
-			     tail_bl,
-			     CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
-	    ceph_assert(r >= 0 && r <= (int)tail_read);
-	    size_t zlen = tail_read - r;
-	    if (zlen) {
-	      tail_bl.append_zero(zlen);
-	      logger->inc(l_bluestore_write_pad_bytes, zlen);
-	    }
-	    bl.claim_append(tail_bl);
-	    logger->inc(l_bluestore_write_penalty_read_ops);
-	  }
-          logger->inc(l_bluestore_write_small_pre_read);
-
-          _buffer_cache_write(txc, o, offset - head_read - head_pad, bl,
-                              wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
-
-          b->dirty_blob().calc_csum(b_off, bl);
-
-          if (!g_conf()->bluestore_debug_omit_block_device_write) {
-            bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
-            op->op = bluestore_deferred_op_t::OP_WRITE;
-            int r = b->get_blob().map(
-              b_off, b_len,
-              [&](uint64_t offset, uint64_t length) {
-                op->extents.emplace_back(bluestore_pextent_t(offset, length));
-                return 0;
-              });
-            ceph_assert(r == 0);
-            op->data = std::move(bl);
-            dout(20) << __func__ << "  deferred write 0x" << std::hex << b_off
-                     << "~" << b_len << std::dec << " of mutable " << *b << " at "
-                     << op->extents << dendl;
-          }
-
-          Extent *le = o->extent_map.set_lextent(c, offset, offset - bstart, length,
-						 b, &wctx->old_extents);
-          b->dirty_blob().mark_used(le->blob_offset, le->length);
-          txc->statfs_delta.stored() += le->length;
-          dout(20) << __func__ << "  lex " << *le << dendl;
-          return 0;
-        }
-        // try to reuse blob if we can
-        if (b->can_reuse_blob(min_alloc_size,
-			      max_bsize,
-			      offset0 - bstart,
-			      &alloc_len)) {
-	  ceph_assert(alloc_len == min_alloc_size); // expecting data always
-                                                    // fit into reused blob
-	  // Need to check for pending writes desiring to
-	  // reuse the same pextent. The rationale is that during GC two chunks
-	  // from garbage blobs(compressed?) can share logical space within the same
-	  // AU. That's in turn might be caused by unaligned len in clone_range2.
-	  // Hence the second write will fail in an attempt to reuse blob at
-	  // do_alloc_write().
-	  if (!wctx->has_conflict(b,
-				  offset0,
-				  offset0 + alloc_len, 
-				  min_alloc_size)) {
-
-	    // we can't reuse pad_head/pad_tail since they might be truncated 
-	    // due to existent extents
-	    uint64_t b_off = offset - bstart;
-	    uint64_t b_off0 = b_off;
-	    o->extent_map.punch_hole(c, offset, length, &wctx->old_extents);
-
-	    // Zero detection -- small block
-	    if (!cct->_conf->bluestore_zero_block_detection || !bl.is_zero()) {
-	      _pad_zeros(&bl, &b_off0, chunk_size);
-
-	      dout(20) << __func__ << " reuse blob " << *b << std::hex
-		       << " (0x" << b_off0 << "~" << bl.length() << ")"
-		       << " (0x" << b_off << "~" << length << ")"
-		       << std::dec << dendl;
-
-	      wctx->write(offset, b, alloc_len, b_off0, bl, b_off, length,
-		  false, false);
-	      logger->inc(l_bluestore_write_small_unused);
-	    } else { // if (bl.is_zero())
-	      dout(20) << __func__ << " skip small zero block " << std::hex
-                << " (0x" << b_off0 << "~" << bl.length() << ")"
-                << " (0x" << b_off << "~" << length << ")"
-                << std::dec << dendl;
-	      logger->inc(l_bluestore_write_small_skipped);
-	      logger->inc(l_bluestore_write_small_skipped_bytes, length);
-	    }
-	    return 0;
-	  }
+	if (can_reuse_blob(b, bstart)) {
+	  break;
 	}
       }
+
+      if (!above_blob_threshold) {
+	inspected_blobs.insert(&b->get_blob());
+	above_blob_threshold = inspected_blobs.size() >= blob_threshold;
+      }
+      max_seen_off = ep->logical_end();
       ++ep;
       end_ep = ep;
       any_change = true;
-    } // if (ep != end && ep->logical_offset < offset + max_bsize)
+    } // if (ep != end && ep->logical_offset < max_off)
 
     // check extent for reuse in reverse order
     if (prev_ep != end && prev_ep->logical_offset >= min_off) {
       BlobRef b = prev_ep->blob;
+      uint32_t bstart = prev_ep->blob_start();
+      dout(20) << __func__ << " considering " << *b
+	       << " bstart 0x" << std::hex << bstart << std::dec << dendl;
+      if (can_reuse_blob(b, bstart)) {
+	break;
+      }
       if (!above_blob_threshold) {
 	inspected_blobs.insert(&b->get_blob());
 	above_blob_threshold = inspected_blobs.size() >= blob_threshold;
       }
       start_ep = prev_ep;
-      auto bstart = prev_ep->blob_start();
-      dout(20) << __func__ << " considering " << *b
-	       << " bstart 0x" << std::hex << bstart << std::dec << dendl;
-      if (b->can_reuse_blob(min_alloc_size,
-			    max_bsize,
-                            offset0 - bstart,
-                            &alloc_len)) {
-	ceph_assert(alloc_len == min_alloc_size); // expecting data always
-						  // fit into reused blob
-	// Need to check for pending writes desiring to
-	// reuse the same pextent. The rationale is that during GC two chunks
-	// from garbage blobs(compressed?) can share logical space within the same
-	// AU. That's in turn might be caused by unaligned len in clone_range2.
-	// Hence the second write will fail in an attempt to reuse blob at
-	// do_alloc_write().
-	if (!wctx->has_conflict(b,
-				offset0,
-				offset0 + alloc_len, 
-				min_alloc_size)) {
-
-	  uint64_t b_off = offset - bstart;
-	  uint64_t b_off0 = b_off;
-	  o->extent_map.punch_hole(c, offset, length, &wctx->old_extents);
-
-	  // Zero detection -- small block
-	  if (!cct->_conf->bluestore_zero_block_detection || !bl.is_zero()) {
-	    uint64_t chunk_size = b->get_blob().get_chunk_size(block_size);
-	    _pad_zeros(&bl, &b_off0, chunk_size);
-
-	    dout(20) << __func__ << " reuse blob " << *b << std::hex
-	      << " (0x" << b_off0 << "~" << bl.length() << ")"
-	      << " (0x" << b_off << "~" << length << ")"
-	      << std::dec << dendl;
-
-	    wctx->write(offset, b, alloc_len, b_off0, bl, b_off, length,
-		false, false);
-	    logger->inc(l_bluestore_write_small_unused);
-	  } else { // if (bl.is_zero())
-	    dout(20) << __func__ << " skip small zero block " << std::hex
-	      << " (0x" << b_off0 << "~" << bl.length() << ")"
-	      << " (0x" << b_off << "~" << length << ")"
-	      << std::dec << dendl;
-	    logger->inc(l_bluestore_write_small_skipped);
-	    logger->inc(l_bluestore_write_small_skipped_bytes, length);
-	  }
-
-	  return 0;
-	}
-      } 
+      min_seen_off = start_ep->logical_offset;
       if (prev_ep != begin) {
 	--prev_ep;
 	any_change = true;
@@ -17081,11 +16924,11 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 	prev_ep = end; // to avoid useless first extent re-check
       }
     } // if (prev_ep != end && prev_ep->logical_offset >= min_off) 
-  } while (any_change);
+  };
 
   if (above_blob_threshold) {
     dout(10) << __func__ << " request GC, blobs >= " << inspected_blobs.size()
-            << " " << std::hex << min_off << "~" << max_off << std::dec
+            << " " << std::hex << min_seen_off << "~" << max_seen_off << std::dec
 	    << dendl;
     ceph_assert(start_ep != end_ep);
     for (auto ep = start_ep; ep != end_ep; ++ep) {
@@ -17101,7 +16944,35 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
               << std::hex << offset << "~" << length
 	      << std::dec << dendl;
   }
-  return alloc_len;
+
+  // Zero detection -- small block
+  if (!cct->_conf->bluestore_zero_block_detection || !bl.is_zero()) {
+    bool new_blob = false;
+    bool mark_unused = false;
+    if (!candidate_blob) {
+      candidate_blob = c->new_blob();
+      candidate_blob_off = p2phase<uint64_t>(offset, min_alloc_size);
+      // use 'unused' bitmap when alloc granularity
+      // doesn't match disk one only
+      mark_unused = min_alloc_size != block_size;
+      new_blob = true;
+    }
+    o->extent_map.punch_hole(c, offset, length, &wctx->old_extents);
+
+    wctx->write(offset, candidate_blob,
+      candidate_blob_off, bl,
+      mark_unused, new_blob);
+    if (!new_blob) {
+      logger->inc(l_bluestore_write_small_unused);
+    }
+  } else { // if (bl.is_zero())
+    dout(20) << __func__ << " skip small zero block " << std::hex
+      << " (0x" << offset << "~" << length << ")"
+      << std::dec << dendl;
+    logger->inc(l_bluestore_write_small_skipped);
+    logger->inc(l_bluestore_write_small_skipped_bytes, length);
+  }
+  return;
 }
 
 bool BlueStore::BigDeferredWriteContext::can_defer(
@@ -17202,7 +17073,7 @@ void BlueStore::_do_write_big_apply_deferred(
   }
   auto& b0 = dctx.blob_ref;
   _buffer_cache_write(txc, o, dctx.off - dctx.head_read, bl,
-    wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
+    _get_write_caching(o, dctx.off, dctx.used, wctx->fadv_flags));
 
   b0->dirty_blob().calc_csum(dctx.b_off, bl);
 
@@ -17413,7 +17284,7 @@ void BlueStore::_do_write_big(
 
     // Zero detection -- big block
     if (!cct->_conf->bluestore_zero_block_detection || !t.is_zero()) {
-      wctx->write(offset, b, l, b_off, t, b_off, l, false, new_blob);
+      wctx->write(offset, b, b_off, t, false, new_blob);
 
       dout(20) << __func__ << " schedule write big: 0x"
       << std::hex << offset << "~" << l << std::dec
@@ -17455,10 +17326,11 @@ int BlueStore::_do_alloc_write(
   uint64_t need = 0;
   uint64_t data_size = 0;
   // 'need' is amount of space that must be provided by allocator.
-  // 'data_size' is a size of data that will be transferred to disk.
+  // 'data_size' is a size of data that will be transferred to disk
+  // (disk block padded).
   // Note that data_size is always <= need. This comes from:
-  // - write to blob was unaligned, and there is free space
-  // - data has been compressed
+  // - write to blob could be unaligned with min_alloc_size,
+  //   hence adjusting required size
   //
   // We make one decision and apply it to all blobs.
   // All blobs will be deferred or none will.
@@ -17467,70 +17339,74 @@ int BlueStore::_do_alloc_write(
 
   auto max_bsize = std::max(wctx->target_blob_size, min_alloc_size);
   for (auto& wi : wctx->writes) {
-    if (wctx->compressor && wi.blob_length > min_alloc_size) {
+    bool compress_applied = false;
+    bluestore_blob_t& dblob = wi.b->dirty_blob();
+    uint64_t csum_length = 0;
+    unsigned csum_order = 0;
+
+    if (wctx->compressor && wi.get_original_length() > min_alloc_size) {
       auto start = mono_clock::now();
 
       // compress
-      ceph_assert(wi.b_off == 0);
-      ceph_assert(wi.blob_length == wi.bl.length());
+      ceph_assert(wi.b_off_orig == 0);
+      // initialize newly created blob only
+      ceph_assert(wi.new_blob);
+      ceph_assert(dblob.is_mutable()); // paranoic but let's make sure it is.
 
       // FIXME: memory alignment here is bad
       bufferlist t;
       std::optional<int32_t> compressor_message;
-      int r = wctx->compressor->compress(wi.bl, t, compressor_message);
-      uint64_t want_len_raw = wi.blob_length * wctx->crr;
+      int r = wctx->compressor->compress(wi.get_original_data(), t, compressor_message);
+      uint64_t want_len_raw = wi.get_original_length() * wctx->crr;
       uint64_t want_len = p2roundup(want_len_raw, min_alloc_size);
-      bool rejected = false;
       uint64_t compressed_len = t.length();
       // do an approximate (fast) estimation for resulting blob size
       // that doesn't take header overhead  into account
       uint64_t result_len = p2roundup(compressed_len, min_alloc_size);
-      if (r == 0 && result_len <= want_len && result_len < wi.blob_length) {
+      if (r == 0 && result_len <= want_len && result_len < wi.get_original_length()) {
 	bluestore_compression_header_t chdr;
+	bufferlist compressed_bl;
 	chdr.type = wctx->compressor->get_type();
 	chdr.length = t.length();
 	chdr.compressor_message = compressor_message;
-	encode(chdr, wi.compressed_bl);
-	wi.compressed_bl.claim_append(t);
+	encode(chdr, compressed_bl);
+	compressed_bl.claim_append(t);
 
-	compressed_len = wi.compressed_bl.length();
+	compressed_len = compressed_bl.length();
 	result_len = p2roundup(compressed_len, min_alloc_size);
-	if (result_len <= want_len && result_len < wi.blob_length) {
+	if (result_len <= want_len && result_len < wi.get_original_length()) {
 	  // Cool. We compressed at least as much as we were hoping to.
-	  // pad out to min_alloc_size
-	  wi.compressed_bl.append_zero(result_len - compressed_len);
-	  wi.compressed_len = compressed_len;
-	  wi.compressed = true;
+	  // Pad out to min_alloc_size
+	  compressed_bl.append_zero(result_len - compressed_len);
+	  wi.set_compressed_data(compressed_len, std::move(compressed_bl));
 	  logger->inc(l_bluestore_write_pad_bytes, result_len - compressed_len);
-	  dout(20) << __func__ << std::hex << "  compressed 0x" << wi.blob_length
+	  dout(20) << __func__ << std::hex << "  compressed 0x" << wi.get_original_length()
 		   << " -> 0x" << compressed_len << " => 0x" << result_len
 		   << " with " << wctx->compressor->get_type()
 		   << std::dec << dendl;
 	  txc->statfs_delta.compressed() += compressed_len;
-	  txc->statfs_delta.compressed_original() += wi.blob_length;
+	  txc->statfs_delta.compressed_original() += wi.get_original_length();
 	  txc->statfs_delta.compressed_allocated() += result_len;
 	  logger->inc(l_bluestore_compress_success_count);
 	  need += result_len;
 	  data_size += result_len;
-	} else {
-	  rejected = true;
+	  // use the obtained length as a block size for csum
+	  csum_length = wi.get_ondisk_length();
+	  csum_order = std::countr_zero(csum_length);
+	  dblob.set_compressed(wi.get_original_length(), wi.compressed_len);
+	  compress_applied = true;
 	}
       } else if (r != 0) {
-	dout(5) << __func__ << std::hex << "  0x" << wi.blob_length
+	dout(5) << __func__ << std::hex << "  0x" << wi.get_original_length()
 		 << " bytes compressed using " << wctx->compressor->get_type_name()
 		 << std::dec
 		 << " failed with errcode = " << r
 		 << ", leaving uncompressed"
 		 << dendl;
 	logger->inc(l_bluestore_compress_rejected_count);
-	need += wi.blob_length;
-	data_size += wi.bl.length();
-      } else {
-	rejected = true;
       }
-
-      if (rejected) {
-	dout(20) << __func__ << std::hex << "  0x" << wi.blob_length
+      if (r == 0 && !compress_applied) {
+	dout(20) << __func__ << std::hex << "  0x" << wi.get_original_length()
 		 << " compressed to 0x" << compressed_len << " -> 0x" << result_len
 		 << " with " << wctx->compressor->get_type()
 		 << ", which is more than required 0x" << want_len_raw
@@ -17538,16 +17414,67 @@ int BlueStore::_do_alloc_write(
 		 << ", leaving uncompressed"
 		 << std::dec << dendl;
 	logger->inc(l_bluestore_compress_rejected_count);
-	need += wi.blob_length;
-	data_size += wi.bl.length();
       }
       log_latency("compress@_do_alloc_write",
 	l_bluestore_compress_lat,
         mono_clock::now() - start,
 	cct->_conf->bluestore_log_op_age );
-    } else {
-      need += wi.blob_length;
-      data_size += wi.bl.length();
+    }
+    if (!compress_applied) {
+      uint64_t chunk_size = wi.b->get_blob().get_chunk_size(block_size);
+      bufferlist ondisk_data(wi.get_original_data());
+      auto b_off = wi.b_off_orig;
+      if (_pad_zeros(&ondisk_data, &b_off, chunk_size) > 0) {
+        wi.set_padded_data(b_off, std::move(ondisk_data));
+      }
+      need += p2roundup(wi.get_ondisk_length(), min_alloc_size);
+      data_size += wi.get_ondisk_length();
+      if (wi.new_blob) {
+	ceph_assert(dblob.is_mutable()); // paranoic but let's make sure it is.
+	uint64_t alloc_length = p2roundup(wi.get_ondisk_length(), min_alloc_size);
+	// use allocator size aligned block size as csum length
+	csum_length = alloc_length;
+	if (p2phase(wi.get_ondisk_length(), min_alloc_size) != 0) {
+	  // hrm, maybe we could do better here, but let's not bother.
+	  dout(20) << __func__ << " forcing csum_order to block_size_order "
+		   << block_size_order << dendl;
+	  csum_order = block_size_order;
+	} else {
+	  csum_order =
+	    std::min<unsigned>(wctx->csum_order, std::countr_zero(wi.get_ondisk_length()));
+	}
+	// try to align blob with max_blob_size to improve
+	// its reuse ratio, e.g. in case of reverse write
+	ceph_assert(wi.b_off_orig >= wi.b_off);
+	uint32_t new_boff =
+	 (wi.logical_offset - (wi.b_off_orig - wi.b_off)) % max_bsize;
+	if ((new_boff % (1 << csum_order)) == 0 &&
+	     new_boff + alloc_length <= max_bsize &&
+	     new_boff > wi.b_off) {
+	  size_t delta = new_boff - wi.b_off;
+	  dout(20) << __func__ << std::hex
+	           << " forcing blob_offset to 0x"
+		   << b_off << " -> 0x" << new_boff
+		   << " original 0x"
+		   << wi.b_off_orig << " -> 0x" << wi.b_off_orig + delta
+		   << std::dec << dendl;
+	  csum_length += delta;
+	  wi.b_off_orig += delta;
+	  wi.b_off = new_boff;
+	}
+      }
+      if (csum != Checksummer::CSUM_NONE && wi.new_blob) {
+	dout(20) << __func__
+	  << " initialize csum setting for blob " << *wi.b
+	  << " csum_type " << Checksummer::get_csum_type_string(csum)
+	  << " csum_order " << csum_order
+	  << " csum_length 0x" << std::hex << csum_length
+	  << dendl;
+	dblob.init_csum(csum, csum_order, csum_length);
+      }
+    }
+    if (dblob.has_csum()) {
+      dblob.calc_csum(wi.b_off, wi.get_ondisk_data());
     }
   }
   PExtentVector prealloc;
@@ -17582,66 +17509,10 @@ int BlueStore::_do_alloc_write(
 
   for (auto& wi : wctx->writes) {
     bluestore_blob_t& dblob = wi.b->dirty_blob();
-    uint64_t b_off = wi.b_off;
-    bufferlist *l = &wi.bl;
-    uint64_t final_length = wi.blob_length;
-    uint64_t csum_length = wi.blob_length;
-    if (wi.compressed) {
-      final_length = wi.compressed_bl.length();
-      csum_length = final_length;
-      unsigned csum_order = std::countr_zero(csum_length);
-      l = &wi.compressed_bl;
-      dblob.set_compressed(wi.blob_length, wi.compressed_len);
-      if (csum != Checksummer::CSUM_NONE) {
-        dout(20) << __func__
-		 << " initialize csum setting for compressed blob " << *wi.b
-                 << " csum_type " << Checksummer::get_csum_type_string(csum)
-                 << " csum_order " << csum_order
-                 << " csum_length 0x" << std::hex << csum_length
-                 << " blob_length 0x" << wi.blob_length
-                 << " compressed_length 0x" << wi.compressed_len << std::dec
-                 << dendl;
-        dblob.init_csum(csum, csum_order, csum_length);
-      }
-    } else if (wi.new_blob) {
-      unsigned csum_order;
-      // initialize newly created blob only
-      ceph_assert(dblob.is_mutable());
-      if (l->length() != wi.blob_length) {
-        // hrm, maybe we could do better here, but let's not bother.
-        dout(20) << __func__ << " forcing csum_order to block_size_order "
-                << block_size_order << dendl;
-	csum_order = block_size_order;
-      } else {
-        csum_order = std::min<unsigned>(wctx->csum_order, std::countr_zero(l->length()));
-      }
-      // try to align blob with max_blob_size to improve
-      // its reuse ratio, e.g. in case of reverse write
-      uint32_t suggested_boff =
-       (wi.logical_offset - (wi.b_off0 - wi.b_off)) % max_bsize;
-      if ((suggested_boff % (1 << csum_order)) == 0 &&
-           suggested_boff + final_length <= max_bsize &&
-           suggested_boff > b_off) {
-        dout(20) << __func__ << " forcing blob_offset to 0x"
-                 << std::hex << suggested_boff << std::dec << dendl;
-        ceph_assert(suggested_boff >= b_off);
-        csum_length += suggested_boff - b_off;
-        b_off = suggested_boff;
-      }
-      if (csum != Checksummer::CSUM_NONE) {
-        dout(20) << __func__
-		 << " initialize csum setting for new blob " << *wi.b
-                 << " csum_type " << Checksummer::get_csum_type_string(csum)
-                 << " csum_order " << csum_order
-                 << " csum_length 0x" << std::hex << csum_length << std::dec
-                 << dendl;
-        dblob.init_csum(csum, csum_order, csum_length);
-      }
-    }
 
     PExtentVector extents;
-    int64_t left = final_length;
-    auto prefer_deferred_size_snapshot = prefer_deferred_size.load();
+    int64_t alloc_length = p2roundup(wi.get_ondisk_length(), min_alloc_size);
+    int64_t left = alloc_length;
     while (left > 0) {
       ceph_assert(prealloc_left > 0);
       if (prealloc_pos->length <= left) {
@@ -17660,61 +17531,51 @@ int BlueStore::_do_alloc_write(
 	break;
       }
     }
+    auto prefer_deferred_size_snapshot = prefer_deferred_size.load();
     for (auto& p : extents) {
       txc->allocated.insert(p.offset, p.length);
     }
-    dblob.allocated(p2align(b_off, min_alloc_size), final_length, extents);
+    dblob.allocated(p2align(wi.b_off, min_alloc_size), alloc_length, extents);
 
     dout(20) << __func__ << " blob " << *wi.b << dendl;
-    if (dblob.has_csum()) {
-      dblob.calc_csum(b_off, *l);
-    }
-
-    if (wi.mark_unused) {
-      ceph_assert(!dblob.is_compressed());
-      auto b_end = b_off + wi.bl.length();
-      if (b_off) {
-        dblob.add_unused(0, b_off);
-      }
-      uint64_t llen = dblob.get_logical_length();
-      if (b_end < llen) {
-        dblob.add_unused(b_end, llen - b_end);
-      }
-    }
 
     Extent *le = o->extent_map.set_lextent(coll, wi.logical_offset,
-                                           b_off + (wi.b_off0 - wi.b_off),
-                                           wi.length0,
+					   wi.b_off_orig,
+                                           wi.get_original_length(),
                                            wi.b,
                                            nullptr);
-    wi.b->dirty_blob().mark_used(le->blob_offset, le->length);
+    if (wi.mark_unused) {
+      dblob.add_unused_all();
+    }
+    dblob.mark_used(le->blob_offset, le->length);
+
     txc->statfs_delta.stored() += le->length;
     dout(20) << __func__ << "  lex " << *le << dendl;
-    bufferlist without_pad;
-    without_pad.substr_of(wi.bl, wi.b_off0-wi.b_off, wi.length0);
-    _buffer_cache_write(txc, o, wi.logical_offset, std::move(without_pad),
-                        wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
+    _buffer_cache_write(txc, o, wi.logical_offset, wi.get_original_data(),
+      _get_write_caching(o, wi.logical_offset, wi.get_original_length(),
+         wctx->fadv_flags));
 
     // queue io
     if (!g_conf()->bluestore_debug_omit_block_device_write) {
       if (data_size < prefer_deferred_size_snapshot) {
+	auto len = wi.get_ondisk_length();
 	dout(20) << __func__ << " deferring 0x" << std::hex
-		 << l->length()  << " write via deferred, pds=0x"
+		 << len << " write via deferred, pds=0x"
                  << prefer_deferred_size_snapshot
                  << std::dec<< dendl;
-	bluestore_deferred_op_t *op = _get_deferred_op(txc, l->length());
+	bluestore_deferred_op_t *op = _get_deferred_op(txc, len);
 	op->op = bluestore_deferred_op_t::OP_WRITE;
 	int r = wi.b->get_blob().map(
-	  b_off, l->length(),
+	  wi.b_off, len,
 	  [&](uint64_t offset, uint64_t length) {
 	    op->extents.emplace_back(bluestore_pextent_t(offset, length));
 	    return 0;
 	  });
         ceph_assert(r == 0);
-        op->data = *l;
+        op->data = wi.get_ondisk_data();
       } else {
 	wi.b->get_blob().map_bl(
-	  b_off, *l,
+	  wi.b_off, wi.get_ondisk_data(),
 	  [&](uint64_t offset, bufferlist& t) {
 	    bdev->aio_write(offset, t, &txc->ioc, false);
 	  });
@@ -17855,15 +17716,7 @@ void BlueStore::_choose_write_options(
    uint32_t fadvise_flags,
    WriteContext *wctx)
 {
-  if (fadvise_flags & CEPH_OSD_OP_FLAG_FADVISE_WILLNEED) {
-    dout(20) << __func__ << " will do buffered write" << dendl;
-    wctx->buffered = true;
-  } else if (cct->_conf->bluestore_default_buffered_write &&
-	     (fadvise_flags & (CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
-			       CEPH_OSD_OP_FLAG_FADVISE_NOCACHE)) == 0) {
-    dout(20) << __func__ << " defaulting to buffered write" << dendl;
-    wctx->buffered = true;
-  }
+  wctx->fadv_flags = fadvise_flags;
 
   // apply basic csum block size
   wctx->csum_order = block_size_order;
@@ -17939,8 +17792,30 @@ void BlueStore::_choose_write_options(
   dout(20) << __func__ << " prefer csum_order " << wctx->csum_order
            << " target_blob_size 0x" << std::hex << wctx->target_blob_size
 	   << " compress=" << (int)wctx->compress
-	   << " buffered=" << (int)wctx->buffered
+	   << " fadv=0x" << std::hex << wctx->fadv_flags
            << std::dec << dendl;
+}
+
+unsigned BlueStore::_get_write_caching(
+  OnodeRef& o,
+  uint64_t offset, size_t len,
+  uint32_t fadvise_flags)
+{
+  unsigned ret = Buffer::FLAG_NOCACHE;
+  uint64_t end_offs = offset + len;
+  if (fadvise_flags & CEPH_OSD_OP_FLAG_FADVISE_WILLNEED) {
+    dout(20) << __func__ << " will need, do buffered write" << dendl;
+    ret = 0;
+  } else if (cct->_conf->bluestore_default_buffered_write &&
+	     (fadvise_flags & (CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
+			       CEPH_OSD_OP_FLAG_FADVISE_NOCACHE)) == 0) {
+    dout(20) << __func__ << " defaulting to buffered write" << dendl;
+    ret = 0;
+  } else if (end_offs >= o->onode.size && !p2aligned(end_offs, min_alloc_size)) {
+    dout(20) << __func__ << " at tail, do buffered write" << dendl;
+    ret = 0;
+  }
+  return ret;
 }
 
 int BlueStore::_do_gc(

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -347,10 +347,10 @@ public:
       FLAG_NOCACHE = 1,  ///< trim when done WRITING (do not become CLEAN)
       // NOTE: fix operator<< when you define a second flag
     };
-    static const char *get_flag_name(int s) {
+    static std::string get_flag_name(const char* prefix, int s) {
       switch (s) {
-      case FLAG_NOCACHE: return "nocache";
-      default: return "???";
+      case FLAG_NOCACHE: return std::string(prefix) + "nocache";
+      default: return "";
       }
     }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3404,7 +3404,8 @@ private:
     OnodeRef& o,
     uint32_t offset,
     uint32_t length,
-    ceph::buffer::list& bl);
+    ceph::buffer::list& bl,
+    uint32_t op_flags = 0);
 
   int _do_readv(
     Collection *c,
@@ -3797,39 +3798,46 @@ private:
     struct write_item {
       uint64_t logical_offset;      ///< write logical offset
       BlobRef b;
-      uint64_t blob_length;
-      uint64_t b_off;
-      ceph::buffer::list bl;
-      uint64_t b_off0; ///< original offset in a blob prior to padding
-      uint64_t length0; ///< original data length prior to padding
+      uint64_t b_off_orig;    ///< original offset in a blob
+      uint64_t b_off;         ///< offset in a blob with padding applied
+      ceph::buffer::list orig_bl;
+      ceph::buffer::list ondisk_bl;
 
       bool mark_unused;
       bool new_blob; ///< whether new blob was created
 
       bool compressed = false;
-      ceph::buffer::list compressed_bl;
-      size_t compressed_len = 0;
+      size_t compressed_len = 0; ///< the size of the compressed data without padding
 
       write_item(
 	uint64_t logical_offs,
         BlobRef b,
-        uint64_t blob_len,
-        uint64_t o,
+        uint64_t blob_offs,
         ceph::buffer::list& bl,
-        uint64_t o0,
-        uint64_t l0,
         bool _mark_unused,
 	bool _new_blob)
        :
          logical_offset(logical_offs),
          b(b),
-         blob_length(blob_len),
-         b_off(o),
-         bl(bl),
-         b_off0(o0),
-         length0(l0),
+         b_off_orig(blob_offs),
+         b_off(blob_offs),
+         orig_bl(bl),
          mark_unused(_mark_unused),
 	 new_blob(_new_blob) {}
+      size_t get_original_length() { return orig_bl.length(); }
+      ceph::bufferlist& get_original_data() { return orig_bl;}
+      size_t get_ondisk_length() { return get_ondisk_data().length(); }
+      ceph::bufferlist& get_ondisk_data() { return ondisk_bl.size() ? ondisk_bl : orig_bl; }
+
+      void set_compressed_data(size_t _compressed_len, ceph::bufferlist&& bl) {
+        compressed = true;
+        compressed_len = _compressed_len;
+        ondisk_bl.swap(bl);
+      }
+      void set_padded_data(uint64_t _b_off, ceph::bufferlist&& bl) {
+        b_off = _b_off;
+        ondisk_bl.swap(bl);
+      }
     };
     std::vector<write_item> writes;                 ///< blobs we're writing
 
@@ -3844,20 +3852,14 @@ private:
     void write(
       uint64_t loffs,
       BlobRef b,
-      uint64_t blob_len,
-      uint64_t o,
+      uint64_t blob_off,
       ceph::buffer::list& bl,
-      uint64_t o0,
-      uint64_t len0,
       bool _mark_unused,
       bool _new_blob) {
       writes.emplace_back(loffs,
                           b,
-                          blob_len,
-                          o,
+                          blob_off,
                           bl,
-                          o0,
-                          len0,
                           _mark_unused,
                           _new_blob);
     }
@@ -3886,19 +3888,6 @@ private:
     ceph::buffer::list::iterator& blp,
     WriteContext *wctx);
 
-  /// Determines if small write can reuse existing blob
-  /// and hence omit blob relocation.
-  /// Returns the amount of remaining bytes which need relocation,
-  /// effectively the possibe return values are for now:
-  /// * 0 - blob has been reused and writing has been staged
-  /// * min_alloc_size - no writing staged, blob to be relocated.
-  uint32_t _do_write_small_with_maybe_blob_reuse(
-    TransContext* txc,
-    CollectionRef& c,
-    OnodeRef& o,
-    uint64_t offset, uint64_t length,
-    bufferlist& bl,
-    WriteContext* wctx);
   void _do_write_big_apply_deferred(
     TransContext* txc,
     CollectionRef& c,
@@ -3931,8 +3920,8 @@ private:
 	     uint64_t offset, size_t len,
 	     ceph::buffer::list& bl,
 	     uint32_t fadvise_flags);
-  void _pad_zeros(ceph::buffer::list *bl, uint64_t *offset,
-		  uint64_t chunk_size);
+  size_t _pad_zeros(ceph::buffer::list *bl, uint64_t *offset,
+		    uint64_t chunk_size);
 
   void _choose_write_options(CollectionRef& c,
                              OnodeRef& o,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3782,7 +3782,7 @@ private:
   // write ops
   public:
   struct WriteContext {
-    bool buffered = false;          ///< buffered write
+    unsigned fadv_flags = 0;        ///< requested write mode
     bool compress = false;          ///< compressed write
     CompressorRef compressor;       ///< effective compression engine
     double crr = 0.0;               ///< compression required ratio
@@ -3843,7 +3843,7 @@ private:
 
     /// partial clone of the context
     void fork(const WriteContext& other) {
-      buffered = other.buffered;
+      fadv_flags = other.fadv_flags;
       compress = other.compress;
       target_blob_size = other.target_blob_size;
       csum_type = other.csum_type;
@@ -3927,6 +3927,10 @@ private:
                              OnodeRef& o,
                              uint32_t fadvise_flags,
                              WriteContext *wctx);
+
+  unsigned _get_write_caching(OnodeRef& o,
+	                      uint64_t offset, size_t len,
+                              uint32_t fadvise_flags);
 
   int _do_gc(TransContext *txc,
              CollectionRef& c,

--- a/src/os/bluestore/BlueStore_debug.cc
+++ b/src/os/bluestore/BlueStore_debug.cc
@@ -268,10 +268,8 @@ std::ostream& operator<<(std::ostream& out, const BlueStore::Onode::printer &p)
       for (auto& i : o.bc.buffer_map) {
         if (space) out << " ";
         out << "0x" << std::hex << i.offset << "~" << i.length << std::dec
-          << BlueStore::Buffer::get_state_name_short(i.state);
-        if (i.flags) {
-          out << "," << BlueStore::Buffer::get_flag_name(i.flags);
-        }
+          << BlueStore::Buffer::get_state_name_short(i.state)
+          << BlueStore::Buffer::get_flag_name(",", i.flags);
         space = true;
       }
       out << ")";

--- a/src/os/bluestore/Writer.cc
+++ b/src/os/bluestore/Writer.cc
@@ -1452,11 +1452,11 @@ void BlueStore::Writer::do_write_with_blobs(
   for (auto& b : bd) {
     if (b.is_compressed()) {
       bstore->_buffer_cache_write(this->txc, onode, pos, b.object_data,
-        wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
+        bstore->_get_write_caching(onode, pos, b.object_data.length(), wctx->fadv_flags));
       pos += b.object_data.length();
     } else {
       bstore->_buffer_cache_write(this->txc, onode, pos, b.disk_data,
-        wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
+        bstore->_get_write_caching(onode, pos, b.disk_data.length(), wctx->fadv_flags));
       pos += b.disk_data.length();
     }
   }

--- a/src/os/bluestore/Writer.cc
+++ b/src/os/bluestore/Writer.cc
@@ -204,6 +204,8 @@ inline void BlueStore::Writer::_maybe_expand_blob(
 
 #define dout_context bstore->cct
 #define dout_subsys ceph_subsys_bluestore
+#undef dout_prefix
+#define dout_prefix *_dout << "bluestore.w2 "
 
 //general levels:
 // 10 init, fundamental state changes (not present here)

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -740,7 +740,7 @@ public:
       if (++p == extents.end())
         return false;
     }
-    ceph_abort_msg("we should not get here");
+    // indicate false if ending offset is beyond blob capacity
     return false;
   }
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2923,7 +2923,8 @@ void doAppendCaching(ObjectStore* store,
     c.wait();
     off += size;
   }
-  {
+  // do not show by default
+  if (0) {
     cout <<" Perf counters:\n";
     JSONFormatter f(true);
     store->dump_perf_counters(&f);
@@ -2969,10 +2970,10 @@ TEST_P(StoreTestSpecificAUSize, AppendCaching) {
   size_t write_size = min_alloc / 2;
   doAppendCaching(store.get(), 0, write_size,
     0,
-    4, 0);
+    4, write_size * 2);
   doAppendCaching(store.get(), write_size, write_size,
     0,
-    4, 0);
+    4, write_size);
   doAppendCaching(store.get(), 0, write_size,
     CEPH_OSD_OP_FLAG_FADVISE_WILLNEED,
     4, write_size * 2);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2847,6 +2847,148 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
   }
 }
 
+void doAppendCaching(ObjectStore* store,
+  uint64_t off0, size_t size, unsigned fadv_flags,
+  uint64_t expected_writes_small, uint64_t expected_hit_bytes)
+{
+  int r;
+  coll_t cid;
+  ghobject_t a(hobject_t(sobject_t("fooo", CEPH_NOSNAP)));
+
+  cerr << "Starting  4*writes at " << off0 << " bs=" << size
+       << std::hex << " fadv = 0x" << fadv_flags << std::dec
+       << " expecting wsmall = " << expected_writes_small
+       << ", hit_bytes = " << expected_hit_bytes
+       << std::endl;
+
+  auto ch = store->create_new_collection(cid);
+  const PerfCounters* logger = store->get_perf_counters();
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    r = store->queue_transaction(ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  uint64_t off = off0;
+
+  bufferlist bla;
+  bla.append(std::string(size, 'a'));
+  {
+    // Appending half AU (offs = 0)
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.register_on_commit(&c);
+    t.write(cid, a, off, bla.length(), bla, fadv_flags);
+    r = store->queue_transaction(ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+    off += size;
+  }
+  bufferlist blb;
+  blb.append(std::string(size, 'b'));
+  {
+    // Appending half AU (offs = AU/2)
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.register_on_commit(&c);
+    t.write(cid, a, off, blb.length(), blb, fadv_flags);
+    r = store->queue_transaction(ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+    off += size;
+  }
+  bufferlist blc;
+  blc.append(std::string(size, 'c'));
+  {
+    // Appending half AU (offs = AU)
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.register_on_commit(&c);
+    t.write(cid, a, off, blc.length(), blc, fadv_flags);
+    r = store->queue_transaction(ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+    off += size;
+  }
+  bufferlist bld;
+  bld.append(std::string(size, 'd'));
+  {
+    // Appending half AU (offs = AU/2)
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.register_on_commit(&c);
+    t.write(cid, a, off, bld.length(), bld, fadv_flags);
+    r = store->queue_transaction(ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+    off += size;
+  }
+  {
+    cout <<" Perf counters:\n";
+    JSONFormatter f(true);
+    store->dump_perf_counters(&f);
+    f.flush(cout);
+    cout << std::endl;
+  }
+  ASSERT_EQ(logger->get(l_bluestore_write_small), expected_writes_small);
+  ASSERT_EQ(logger->get(l_bluestore_buffer_hit_bytes), expected_hit_bytes);
+
+  bufferlist final;
+  final.append(bla);
+  final.append(blb);
+  final.append(blc);
+  final.append(bld);
+  bufferlist actual;
+  {
+    ASSERT_EQ((int)final.length(),
+	      store->read(ch, a, off0, final.length(), actual));
+    ASSERT_TRUE(bl_eq(final, actual));
+  }
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, a);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = store->queue_transaction(ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  const_cast<PerfCounters*>(logger)->reset();
+}
+
+TEST_P(StoreTestSpecificAUSize, AppendCaching) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "ssd");
+  SetVal(g_conf(), "bluestore_write_v2", "false");
+  g_conf().apply_changes(nullptr);
+
+  size_t min_alloc = 4096;
+  StartDeferred(min_alloc);
+
+  size_t write_size = min_alloc / 2;
+  doAppendCaching(store.get(), 0, write_size,
+    0,
+    4, 0);
+  doAppendCaching(store.get(), write_size, write_size,
+    0,
+    4, 0);
+  doAppendCaching(store.get(), 0, write_size,
+    CEPH_OSD_OP_FLAG_FADVISE_WILLNEED,
+    4, write_size * 2);
+  doAppendCaching(store.get(), write_size, write_size,
+    CEPH_OSD_OP_FLAG_FADVISE_WILLNEED,
+    4, write_size);
+
+  write_size = min_alloc /4;
+  doAppendCaching(store.get(), 0, write_size,
+    CEPH_OSD_OP_FLAG_FADVISE_WILLNEED,
+    4, write_size * 6);
+  doAppendCaching(store.get(), write_size, write_size,
+    CEPH_OSD_OP_FLAG_FADVISE_WILLNEED,
+    4, write_size * 3);
+}
+
 TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
   if(string(GetParam()) != "bluestore")
     return;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2773,6 +2773,8 @@ TEST_P(StoreTest, SmallSkipFront) {
 }
 
 TEST_P(StoreTest, AppendDeferredVsTailCache) {
+  if(string(GetParam()) != "bluestore")
+    return;
   int r;
   coll_t cid;
   ghobject_t a(hobject_t(sobject_t("fooo", CEPH_NOSNAP)));
@@ -2784,12 +2786,11 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
     r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  unsigned min_alloc = g_conf()->bluestore_min_alloc_size;
+  unsigned min_alloc = 4096;
   unsigned size = min_alloc / 3;
-  bufferptr bpa(size);
-  memset(bpa.c_str(), 1, bpa.length());
   bufferlist bla;
-  bla.append(bpa);
+  bla.append(std::string(size, 'a'));
+
   {
     ObjectStore::Transaction t;
     t.write(cid, a, 0, bla.length(), bla, 0);
@@ -2806,21 +2807,19 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
     ASSERT_EQ(0, r);
     ch = store->open_collection(cid);
   }
+  const PerfCounters* logger = store->get_perf_counters();
 
-  bufferptr bpb(size);
-  memset(bpb.c_str(), 2, bpb.length());
   bufferlist blb;
-  blb.append(bpb);
+  blb.append(std::string(size, 'b'));
+
   {
     ObjectStore::Transaction t;
     t.write(cid, a, bla.length(), blb.length(), blb, 0);
     r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  bufferptr bpc(size);
-  memset(bpc.c_str(), 3, bpc.length());
   bufferlist blc;
-  blc.append(bpc);
+  blc.append(std::string(size, 'c'));
   {
     ObjectStore::Transaction t;
     t.write(cid, a, bla.length() + blb.length(), blc.length(), blc, 0);
@@ -2837,6 +2836,7 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
 	      store->read(ch, a, 0, final.length(), actual));
     ASSERT_TRUE(bl_eq(final, actual));
   }
+  ASSERT_EQ(logger->get(l_bluestore_write_small), 3u);
   {
     ObjectStore::Transaction t;
     t.remove(cid, a);
@@ -2848,6 +2848,8 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
 }
 
 TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
+  if(string(GetParam()) != "bluestore")
+    return;
   int r;
   coll_t cid;
   ghobject_t a(hobject_t(sobject_t("fooo", CEPH_NOSNAP)));
@@ -2861,12 +2863,10 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
     r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  unsigned min_alloc = g_conf()->bluestore_min_alloc_size;
+  unsigned min_alloc = 4096;
   unsigned size = min_alloc / 3;
-  bufferptr bpa(size);
-  memset(bpa.c_str(), 1, bpa.length());
   bufferlist bla;
-  bla.append(bpa);
+  bla.append(std::string(size, 'a'));
   // make sure there is some trailing gunk in the last block
   {
     bufferlist bt;
@@ -2893,10 +2893,8 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
   }
 
   // append with implicit zeroing
-  bufferptr bpb(size);
-  memset(bpb.c_str(), 2, bpb.length());
   bufferlist blb;
-  blb.append(bpb);
+  blb.append(std::string(size, 'b'));
   {
     ObjectStore::Transaction t;
     t.write(cid, a, min_alloc * 3, blb.length(), blb, 0);
@@ -2913,10 +2911,10 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
   {
     ASSERT_EQ((int)final.length(),
 	      store->read(ch, a, 0, final.length(), actual));
-    final.hexdump(cout);
-    actual.hexdump(cout);
     ASSERT_TRUE(bl_eq(final, actual));
   }
+  const PerfCounters* logger = store->get_perf_counters();
+  ASSERT_EQ(logger->get(l_bluestore_write_small), 2u);
   {
     ObjectStore::Transaction t;
     t.remove(cid, a);


### PR DESCRIPTION
Plus some refactoring for small writes processing and around.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
