### PR TITLE
freebsd/build-tools: fix build script defaults for current toolchain and cmake options

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -ex
+export PS4='+ $BASH_SOURCE:$LINENO: '
+set -exv
 
 if [ -d .git ]; then
     git submodule update --init --recursive --recommend-shallow
@@ -76,16 +77,22 @@ elif type ccache > /dev/null 2>&1 ; then
     ARGS+=" -DWITH_CCACHE=ON"
 fi
 
-cxx_compiler="g++"
-c_compiler="gcc"
-# 20 is used for more future-proof
-for i in $(seq 20 -1 11); do
-  if type -t gcc-$i > /dev/null; then
-    cxx_compiler="g++-$i"
-    c_compiler="gcc-$i"
-    break
-  fi
-done
+if [ "$(uname)" != FreeBSD ] ; then
+	cxx_compiler="g++"
+	c_compiler="gcc"
+	# 20 is used for more future-proof
+	for i in $(seq 20 -1 11); do
+	  if type -t gcc-$i > /dev/null; then
+		cxx_compiler="g++-$i"
+		c_compiler="gcc-$i"
+		break
+	  fi
+	done
+else
+	# To force Clang (default behavior on FreeBSD)
+	export CC=clang
+	export CXX=clang++
+fi
 ARGS+=" -DCMAKE_CXX_COMPILER=$cxx_compiler"
 ARGS+=" -DCMAKE_C_COMPILER=$c_compiler"
 

--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -1,8 +1,12 @@
 #!/bin/sh -xve
 export NPROC=`sysctl -n hw.ncpu`
 
+# Get sudo activated. So login is only at the beginning 
+# of running this script 
+$SUDO echo
+
 if [ x"$1"x = x"--deps"x ]; then
-    sudo ./install-deps.sh
+    $SUDO ./install-deps.sh
 fi
 
 if [ x"$CEPH_DEV"x != xx ]; then
@@ -15,7 +19,7 @@ fi
 #	-D CMAKE_CXX_COMPILER="/usr/local/bin/clang++-devel" \
 #	-D CMAKE_C_COMPILER="/usr/local/bin/clang-devel" \
 COMPILE_FLAGS="-O0 -g"
-COMPILE_FLAGS="${COMPILE_FLAGS} -fuse-ld=/usr/local/bin/ld -Wno-unused-command-line-argument"
+COMPILE_FLAGS="${COMPILE_FLAGS} -Wno-unused-command-line-argument"
 CMAKE_CXX_FLAGS_DEBUG="$CXX_FLAGS_DEBUG $COMPILE_FLAGS"
 CMAKE_C_FLAGS_DEBUG="$C_FLAGS_DEBUG $COMPILE_FLAGS"
 
@@ -28,47 +32,62 @@ CMAKE_C_FLAGS_DEBUG="$C_FLAGS_DEBUG $COMPILE_FLAGS"
 
 echo Keeping the old build
 if [ -d ${BUILD_DIR}.old ]; then
-    sudo mv ${BUILD_DIR}.old ${BUILD_DIR}.del
-    sudo rm -rf ${BUILD_DIR}.del &
+    $SUDO mv ${BUILD_DIR}.old ${BUILD_DIR}.del
+    $SUDO rm -rf ${BUILD_DIR}.del &
 fi
 if [ -d ${BUILD_DIR} ]; then
-    sudo mv ${BUILD_DIR} ${BUILD_DIR}.old
+    $SUDO mv ${BUILD_DIR} ${BUILD_DIR}.old
 fi
 
-mkdir ${BUILD_DIR}
+# mkdir ${BUILD_DIR}
 ./do_cmake.sh "$*" \
 	-D WITH_CCACHE=ON \
+	-D NINJA_MAX_COMPILE_JOBS=${NPROC} -DNINJA_MAX_LINK_JOBS=${NPROC} \
 	-D CMAKE_BUILD_TYPE=Debug \
 	-D CMAKE_CXX_FLAGS_DEBUG="$CMAKE_CXX_FLAGS_DEBUG" \
 	-D CMAKE_C_FLAGS_DEBUG="$CMAKE_C_FLAGS_DEBUG" \
 	-D ENABLE_GIT_VERSION=OFF \
-	-D WITH_RADOSGW_AMQP_ENDPOINT=OFF \
-	-D WITH_RADOSGW_KAFKA_ENDPOINT=OFF \
 	-D WITH_SYSTEMD=OFF \
 	-D WITH_SYSTEM_BOOST=ON \
 	-D WITH_SYSTEM_NPM=ON \
 	-D WITH_LTTNG=OFF \
 	-D WITH_BABELTRACE=OFF \
 	-D WITH_CRIMSON=OFF \
-	-D WITH_FUSE=ON \
+	-D WITH_FUSE=OFF \
 	-D WITH_KRBD=OFF \
 	-D WITH_XFS=OFF \
 	-D WITH_KVS=ON \
 	-D CEPH_MAN_DIR=man \
-	-D WITH_LIBCEPHFS=OFF \
+	-D WITH_LIBCEPHFS=ON \
 	-D WITH_CEPHFS=OFF \
-	-D WITH_MGR=YES \
+	-D WITH_MGR=ON -D WITH_MGR_DASHBOARD_FRONTEND=OFF \
 	-D WITH_RDMA=OFF \
 	-D WITH_SPDK=OFF \
 	-D WITH_JAEGER=OFF \
+	-D WITH_LIBURING=OFF \
+	-D WITH_BREAKPAD=OFF \
+	-D WITH_RADOSGW_AMQP_ENDPOINT=OFF \
+	-D WITH_RADOSGW_KAFKA_ENDPOINT=OFF \
+	-D WITH_RADOSGW_ARROW_FLIGHT=OFF \
+	-D WITH_RADOSGW_SELECT_PARQUET=OFF \
+	-D WITH_RADOSGW_POSIX=OFF \
+	-D WITH_NVMEOF_GATEWAY_MONITOR_CLIENT=OFF \
+	-D WITH_QATLIB=OFF -D WITH_QATZIP=OFF \
 	2>&1 | tee cmake.log
 
 echo -n "start building: "; date
 printenv
 
 cd ${BUILD_DIR}
+if [ -f build.ninja ]; then
+  ninja -j$NPROC 
+  ninja tests 
+else
   gmake -j$CPUS V=1 VERBOSE=1 
   gmake tests 
+fi
+
+# Build the tests
   echo -n "start testing: "; date ;
   ctest -j $CPUS || RETEST=1
 


### PR DESCRIPTION
do_cmake.sh unconditionally searched for gcc-11 through gcc-20 and set
CMAKE_C_COMPILER/CMAKE_CXX_COMPILER accordingly, which is wrong on
FreeBSD where clang is the system compiler. Skip that search on FreeBSD
and let clang be used.

do_freebsd.sh passed -fuse-ld=/usr/local/bin/ld; clang no longer accepts
an absolute path in -fuse-ld= and errors out at link time. FreeBSD's base
linker is lld, so the flag is not needed.
We used the GNU linker to use the link-maps, but now llvm-lld has the
same capabilities.

Also drive ninja directly when build.ninja is present rather than falling
through to gmake, and disable the options that have no FreeBSD support:
QAT, the nvmeof gateway monitor client, breakpad, and the RGW POSIX,
parquet and arrow-flight backends.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
