### PR TITLE
test/ceph_breakpad: skip death tests where minidumps cannot be written

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -192,7 +192,13 @@ static bool dumpCallback(
     const google_breakpad::MinidumpDescriptor& descriptor, void* context,
     bool succeeded) {
   char buf[1024];
-  snprintf(buf, sizeof(buf), "minidump created in path %s", descriptor.path());
+  if (succeeded) {
+    snprintf(buf, sizeof(buf), "minidump created in path %s",
+             descriptor.path());
+  } else {
+    snprintf(buf, sizeof(buf), "failed to create minidump in path %s",
+             descriptor.path());
+  }
   dout_emergency(buf);
   return succeeded;
 }

--- a/src/test/ceph_breakpad.cc
+++ b/src/test/ceph_breakpad.cc
@@ -29,13 +29,35 @@
 #include "global/global_init.h"
 #include "gtest/gtest.h"
 #include "include/ceph_assert.h"
+#include <breakpad/client/linux/handler/exception_handler.h>
 #include <google_breakpad/common/minidump_format.h>
+
+// breakpad writes a minidump from a cloned child process that
+// ptrace-attaches to the crashing process. Sandboxes may block ptrace
+// (e.g. container seccomp or AppArmor profiles without CAP_SYS_PTRACE),
+// in which case no minidump can ever be produced and these tests cannot
+// pass. Probe with the same clone+ptrace machinery the crash handler
+// uses, and skip if it does not work here.
+static bool minidumps_supported() {
+  const auto probe_dir =
+      std::filesystem::temp_directory_path() / "ceph_breakpad_probe";
+  std::filesystem::create_directories(probe_dir);
+  const bool ok = google_breakpad::ExceptionHandler::WriteMinidump(
+      probe_dir.string(), nullptr, nullptr);
+  std::filesystem::remove_all(probe_dir);
+  return ok;
+}
 
 class BreakpadDeathTest : public ::testing::Test {
   const std::filesystem::path crash_dir{
       g_conf().get_val<std::string>("crash_dir")};
 
   void SetUp() override {
+    if (!minidumps_supported()) {
+      GTEST_SKIP() << "cannot write minidumps in this environment (ptrace "
+                      "may be blocked; containers may need "
+                      "--cap-add=SYS_PTRACE)";
+    }
     std::filesystem::create_directories(crash_dir);
     std::cout << "using crash dir: " << crash_dir << std::endl;
   }


### PR DESCRIPTION
`unittest_ceph_breakpad` fails in sandboxes that block ptrace, e.g. containers started without `--cap-add=SYS_PTRACE` (as `build-with-container.py` does via podman). breakpad writes minidumps from a cloned child process that ptrace-attaches to the crashing process, so in such environments no minidump can ever be produced: all four `BreakpadDeathTest` cases die with the expected message but no `.dmp` file appears, failing the entire `tests` step even though nothing is wrong with the code under test.

Two commits:

* **test/ceph_breakpad:** probe the environment in `SetUp()` using `google_breakpad::ExceptionHandler::WriteMinidump()`, which exercises the same clone+ptrace machinery as the crash path, and `GTEST_SKIP()` with an explanatory message when it does not work.
* **global:** `dumpCallback()` printed "minidump created in path ..." even when breakpad reported the dump had failed, which made this failure mode confusing to diagnose (the death tests matched the success message despite no dump existing). Print a distinct message on failure.

Verified inside the `build-with-container.py` podman container on Ubuntu 22.04:

* without `--cap-add=SYS_PTRACE`: previously 4 failures; now all 4 tests `SKIPPED`, ctest reports the suite as passed
* with `--cap-add=SYS_PTRACE`: all 4 tests execute and pass

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests