### PR TITLE
qa/tasks/util/chacra: prefer newest ready build

### DIFF
--- a/qa/tasks/util/chacra.py
+++ b/qa/tasks/util/chacra.py
@@ -75,16 +75,18 @@ def get_binary_url(
     # that include the desired arch
     if arch:
         result = [r for r in result if ('archs' in r and arch in r['archs'])]
+        if len(result) == 0:
+            raise RuntimeError(f'no results for arch {arch} at {resp.url}')
 
-    # TODO: Is there any further filtering we should do beyond arch?
-    # We already use flavor, ref, etc. in our search.
-
-    # TODO: After filtering, does it matter which result we take?
-    result = result[0]
-
-    status = result['status']
-    if status != 'ready':
-        raise RuntimeError(f'cannot pull file with status: {status}')
+    # Results are newest-first, and a ref that is being rebuilt has its
+    # newest build in 'building' status while older completed builds
+    # remain available; take the newest ready build rather than failing
+    # (https://tracker.ceph.com/issues/80122).
+    ready = [r for r in result if r['status'] == 'ready']
+    if len(ready) == 0:
+        statuses = ', '.join(sorted({r['status'] for r in result}))
+        raise RuntimeError(f'cannot pull file with status: {statuses}')
+    result = ready[0]
 
     # build the chacra url
     chacra_host = urlparse(result['url']).netloc


### PR DESCRIPTION
\`get_binary_url()\` searched shaman without a status filter, took the newest result, and raised if it wasn't ready. When a stable branch is being rebuilt, its newest build is in \`building\` status while older completed builds remain available, so any running job fetching that branch's compiled cephadm (e.g. upgrade suites via \`_fetch_stable_branch_cephadm_from_chacra\`) failed spuriously with \`RuntimeError: cannot pull file with status: building\`.

In the job that hit this (see tracker), the squid build that was in \`building\` state went \`ready\` five minutes after the job died, and the previous ready squid build was the next entry in the same shaman search results.

Filter the results down to ready builds and take the newest one, matching teuthology's \`ShamanProject\` behavior (which puts \`status=ready\` in its search query). If nothing is ready at all, report every status seen instead of just the newest build's.

Fixes: https://tracker.ceph.com/issues/80122

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-intro/)
  - [ ] Includes bug reproducer
  - [x] No tests