### PR TITLE
qa/suites/rados: add MDS_ALL_DOWN and MDS_UP_LESS_THAN_MAX to relevant ignorelists

### DIFF
--- a/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
+++ b/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
@@ -44,6 +44,7 @@ tasks:
     - slow request
     - evicting unresponsive client
     - MDS_ALL_DOWN
+    - MDS_UP_LESS_THAN_MAX
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
+++ b/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
@@ -43,6 +43,7 @@ tasks:
     - \(SLOW_OPS\)
     - slow request
     - evicting unresponsive client
+    - MDS_ALL_DOWN
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
@@ -17,6 +17,7 @@ overrides:
       - \(POOL_FULL\)
       - \(POOL_APP_NOT_ENABLED\)
       - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
@@ -16,6 +16,7 @@ overrides:
       - \(MDS_READ_ONLY\)
       - \(POOL_FULL\)
       - \(POOL_APP_NOT_ENABLED\)
+      - MDS_ALL_DOWN
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
@@ -10,6 +10,7 @@ tasks:
       - \(PG_AVAILABILITY\)
       - \(POOL_APP_NOT_ENABLED\)
       - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
 - cram:
     clients:
       client.0:

--- a/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
@@ -9,6 +9,7 @@ tasks:
     log-ignorelist:
       - \(PG_AVAILABILITY\)
       - \(POOL_APP_NOT_ENABLED\)
+      - MDS_ALL_DOWN
 - cram:
     clients:
       client.0:

--- a/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
@@ -14,6 +14,7 @@ overrides:
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)
     - MDS_ALL_DOWN
+    - MDS_UP_LESS_THAN_MAX
 
 tasks:
 - install:

--- a/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
@@ -13,6 +13,7 @@ overrides:
     - but it is still running
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)
+    - MDS_ALL_DOWN
 
 tasks:
 - install:

--- a/qa/suites/rados/singleton-nomsgr/all/ceph-snapmapper.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/ceph-snapmapper.yaml
@@ -14,6 +14,7 @@ overrides:
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)
     - MDS_ALL_DOWN
+    - MDS_UP_LESS_THAN_MAX
 
 tasks:
 - install:

--- a/qa/suites/rados/singleton-nomsgr/all/ceph-snapmapper.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/ceph-snapmapper.yaml
@@ -13,6 +13,7 @@ overrides:
     - but it is still running
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)
+    - MDS_ALL_DOWN
 
 tasks:
 - install:

--- a/qa/suites/rados/singleton-nomsgr/all/crushdiff.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/crushdiff.yaml
@@ -15,6 +15,7 @@ overrides:
     - \(POOL_APP_NOT_ENABLED\)
     - \(PG_DEGRADED\)
     - MDS_ALL_DOWN
+    - MDS_UP_LESS_THAN_MAX
 
 tasks:
 - install:

--- a/qa/suites/rados/singleton-nomsgr/all/crushdiff.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/crushdiff.yaml
@@ -14,6 +14,7 @@ overrides:
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)
     - \(PG_DEGRADED\)
+    - MDS_ALL_DOWN
 
 tasks:
 - install:

--- a/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
@@ -18,6 +18,7 @@ tasks:
       - \(PG_
       - \(POOL_APP_NOT_ENABLED\)
       - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
@@ -17,6 +17,7 @@ tasks:
       - \(OSD_
       - \(PG_
       - \(POOL_APP_NOT_ENABLED\)
+      - MDS_ALL_DOWN
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
@@ -17,6 +17,7 @@ overrides:
       - Large omap object found
       - application not enabled
       - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
     conf:
       osd:
         osd scrub backoff ratio: 0

--- a/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
@@ -16,6 +16,7 @@ overrides:
       - large omap objects
       - Large omap object found
       - application not enabled
+      - MDS_ALL_DOWN
     conf:
       osd:
         osd scrub backoff ratio: 0

--- a/qa/suites/rados/singleton-nomsgr/all/lazy_omap_stats_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/lazy_omap_stats_output.yaml
@@ -9,6 +9,7 @@ overrides:
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
       - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton-nomsgr/all/lazy_omap_stats_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/lazy_omap_stats_output.yaml
@@ -8,6 +8,7 @@ overrides:
   ceph:
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
+      - MDS_ALL_DOWN
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton-nomsgr/all/librados_hello_world.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/librados_hello_world.yaml
@@ -5,6 +5,7 @@ overrides:
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
       - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
 tasks:
 - install:
     extra_packages:

--- a/qa/suites/rados/singleton-nomsgr/all/librados_hello_world.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/librados_hello_world.yaml
@@ -4,6 +4,7 @@ overrides:
   ceph:
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
+      - MDS_ALL_DOWN
 tasks:
 - install:
     extra_packages:

--- a/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
@@ -24,6 +24,7 @@ tasks:
       - \(OBJECT_
       - \(POOL_APP_NOT_ENABLED\)
       - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
@@ -23,6 +23,7 @@ tasks:
       - \(OSD_
       - \(OBJECT_
       - \(POOL_APP_NOT_ENABLED\)
+      - MDS_ALL_DOWN
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/rados/singleton-nomsgr/all/osd_stale_reads.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/osd_stale_reads.yaml
@@ -15,6 +15,7 @@ overrides:
       - application not enabled
       - slow request
       - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
     conf:
       osd:
         osd scrub backoff ratio: 0

--- a/qa/suites/rados/singleton-nomsgr/all/osd_stale_reads.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/osd_stale_reads.yaml
@@ -14,6 +14,7 @@ overrides:
       - \(PG_DEGRADED\)
       - application not enabled
       - slow request
+      - MDS_ALL_DOWN
     conf:
       osd:
         osd scrub backoff ratio: 0

--- a/qa/suites/rados/singleton-nomsgr/all/pool-access.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/pool-access.yaml
@@ -12,6 +12,7 @@ tasks:
     log-ignorelist:
     - \(POOL_APP_NOT_ENABLED\)
     - MDS_ALL_DOWN
+    - MDS_UP_LESS_THAN_MAX
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/pool-access.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/pool-access.yaml
@@ -11,6 +11,7 @@ tasks:
       - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
     - \(POOL_APP_NOT_ENABLED\)
+    - MDS_ALL_DOWN
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/recovery-unfound-found.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/recovery-unfound-found.yaml
@@ -27,6 +27,7 @@ tasks:
       - \(PG_
       - overall HEALTH
       - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
 - exec:
     osd.0:
       - ceph osd pool create foo 32

--- a/qa/suites/rados/singleton-nomsgr/all/recovery-unfound-found.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/recovery-unfound-found.yaml
@@ -26,6 +26,7 @@ tasks:
       - \(OBJECT_
       - \(PG_
       - overall HEALTH
+      - MDS_ALL_DOWN
 - exec:
     osd.0:
       - ceph osd pool create foo 32

--- a/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
@@ -5,6 +5,7 @@ overrides:
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
       - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
@@ -4,6 +4,7 @@ overrides:
   ceph:
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
+      - MDS_ALL_DOWN
 tasks:
 - install:
 - ceph:


### PR DESCRIPTION
This warning was always added by default to override ignorelists until https://github.com/ceph/teuthology/commit/bc021a2753345943d013be0aa0f78d347a431bdc. The rados/singleton-bluestore and rados/singleton-nomsgr tests intentionally induce this warning by removing filesystems.

Fixes: https://tracker.ceph.com/issues/79878





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
