### PR TITLE
test/objectstore: skip block-device tests when libaio is unusable

### DIFF
--- a/src/test/objectstore/libaio_probe.h
+++ b/src/test/objectstore/libaio_probe.h
@@ -1,0 +1,57 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "acconfig.h"
+#include "common/errno.h"
+
+#if defined(HAVE_LIBAIO)
+#include <libaio.h>
+#endif
+
+// KernelDevice's aio thread aborts on any io_getevents(2) error it does not
+// recognise.  Ubuntu 24.04 build containers let io_setup(2) succeed and deny
+// io_getevents(2) with EPERM, so any test that opens a block device crashes
+// there.  https://tracker.ceph.com/issues/78144
+//
+// Returns 0 if libaio is usable, else the negative errno that proved it is not.
+inline int probe_libaio()
+{
+#if defined(HAVE_LIBAIO)
+  io_context_t ctx = 0;
+  // io_setup(2) failing is not "unusable": -EAGAIN only means aio-max-nr is
+  // exhausted, which a parallel make check can do.  Let the test run and fail.
+  // (No io_destroy: the kernel does not write ctx unless io_setup succeeds.)
+  if (io_setup(1, &ctx) < 0) {
+    return 0;
+  }
+  io_event event{};
+  // Must be non-zero: libaio answers a zero timeout from the completion ring
+  // in userspace, without issuing the syscall that gets denied.
+  struct timespec timeout = {0, 1000 * 1000};
+  int r;
+  do {
+    r = io_getevents(ctx, 1, 1, &event, &timeout);
+  } while (r == -EINTR);            // as aio_queue_t::get_next_completed()
+  io_destroy(ctx);
+  if (r < 0) {
+    return r;
+  }
+#endif
+  return 0;
+}
+
+// First statement of any test that opens a block device.  Per test, not a
+// global ::testing::Environment: skipping from Environment::SetUp() stops the
+// tests but googletest still counts them PASSED.
+#define SKIP_IF_NO_LIBAIO()                                              \
+  do {                                                                   \
+    int libaio_r_ = probe_libaio();                                      \
+    if (libaio_r_ < 0) {                                                 \
+      GTEST_SKIP() << "libaio is unusable in this environment ("         \
+                   << cpp_strerror(libaio_r_)                            \
+                   << "); a BlueStore block device cannot be opened here"; \
+    }                                                                    \
+  } while (0)

--- a/src/test/objectstore/test_bdev.cc
+++ b/src/test/objectstore/test_bdev.cc
@@ -12,6 +12,7 @@
 #include "include/stringify.h"
 #include "common/errno.h"
 
+#include "libaio_probe.h"
 #include "blk/BlockDevice.h"
 
 using namespace std;
@@ -45,6 +46,7 @@ private:
 };
 
 TEST(KernelDevice, Ticket45337) {
+  SKIP_IF_NO_LIBAIO();
    // Large (>=2 GB) writes are incomplete when bluefs_buffered_io = true
 
   uint64_t size = 1048576ull * 8192;

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -20,6 +20,7 @@
 #include "include/scope_guard.h"
 #include "common/errno.h"
 
+#include "libaio_probe.h"
 #include "os/bluestore/Allocator.h"
 #include "os/bluestore/bluefs_types.h"
 #include "os/bluestore/bluestore_common.h"
@@ -106,6 +107,7 @@ public:
 };
 
 TEST(BlueFS, mkfs) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   uuid_d fsid;
@@ -115,6 +117,7 @@ TEST(BlueFS, mkfs) {
 }
 
 TEST(BlueFS, mkfs_mount) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   BlueFS fs(g_ceph_context);
@@ -129,6 +132,7 @@ TEST(BlueFS, mkfs_mount) {
 }
 
 TEST(BlueFS, write_read) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   BlueFS fs(g_ceph_context);
@@ -159,6 +163,7 @@ TEST(BlueFS, write_read) {
 }
 
 TEST(BlueFS, small_appends) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   BlueFS fs(g_ceph_context);
@@ -190,6 +195,7 @@ TEST(BlueFS, small_appends) {
 }
 
 TEST(BlueFS, very_large_write) {
+  SKIP_IF_NO_LIBAIO();
   SKIP_JENKINS();
   // we'll write a ~5G file, so allocate more than that for the whole fs
   uint64_t size = 1048576 * 1024 * 6ull;
@@ -265,6 +271,7 @@ TEST(BlueFS, very_large_write) {
 }
 
 TEST(BlueFS, very_large_write2) {
+  SKIP_IF_NO_LIBAIO();
   SKIP_JENKINS();
   // we'll write a ~5G file, so allocate more than that for the whole fs
   uint64_t size_full = 1048576 * 1024 * 6ull;
@@ -431,6 +438,7 @@ void join_all(std::vector<std::thread>& v)
 #define NUM_MULTIPLE_FILE_WRITERS 2
 
 TEST(BlueFS, test_flush_1) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   g_ceph_context->_conf.set_val(
@@ -465,6 +473,7 @@ TEST(BlueFS, test_flush_1) {
 }
 
 TEST(BlueFS, test_flush_2) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 256;
   TempBdev bdev{size};
   g_ceph_context->_conf.set_val(
@@ -492,6 +501,7 @@ TEST(BlueFS, test_flush_2) {
 }
 
 TEST(BlueFS, test_flush_3) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 256;
   TempBdev bdev{size};
   g_ceph_context->_conf.set_val(
@@ -526,6 +536,7 @@ TEST(BlueFS, test_flush_3) {
 }
 
 TEST(BlueFS, test_simple_compaction_sync) {
+  SKIP_IF_NO_LIBAIO();
   g_ceph_context->_conf.set_val(
     "bluefs_compact_log_sync",
     "true");
@@ -578,6 +589,7 @@ TEST(BlueFS, test_simple_compaction_sync) {
 }
 
 TEST(BlueFS, test_simple_compaction_async) {
+  SKIP_IF_NO_LIBAIO();
   g_ceph_context->_conf.set_val(
     "bluefs_compact_log_sync",
     "false");
@@ -630,6 +642,7 @@ TEST(BlueFS, test_simple_compaction_async) {
 }
 
 TEST(BlueFS, test_compaction_sync) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   g_ceph_context->_conf.set_val(
@@ -694,6 +707,7 @@ TEST(BlueFS, test_compaction_sync) {
 }
 
 TEST(BlueFS, test_compaction_async) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   g_ceph_context->_conf.set_val(
@@ -758,6 +772,7 @@ TEST(BlueFS, test_compaction_async) {
 }
 
 TEST(BlueFS, test_replay) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   g_ceph_context->_conf.set_val(
@@ -799,6 +814,7 @@ TEST(BlueFS, test_replay) {
 }
 
 TEST(BlueFS, test_replay_growth) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576LL * (2 * 1024 + 128);
   TempBdev bdev{size};
 
@@ -837,6 +853,7 @@ TEST(BlueFS, test_replay_growth) {
 }
 
 TEST(BlueFS, test_tracker_50965) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size_wal = 1048576 * 64;
   TempBdev bdev_wal{size_wal};
   uint64_t size_db = 1048576 * 128;
@@ -932,6 +949,7 @@ static bool bl_eq(bufferlist& expected, bufferlist& actual) {
 }
 
 TEST(BlueFS, test_wal_write) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size_wal = 1048576 * 64;
   TempBdev bdev_wal{size_wal};
   uint64_t size_db = 1048576 * 128;
@@ -1100,6 +1118,7 @@ public:
 };
 
 TEST(BlueFS, test_wal_migrate) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size_wal = 1048576 * 64;
   TempBdev bdev_wal{size_wal};
   uint64_t size_db = 1048576 * 128;
@@ -1158,6 +1177,7 @@ TEST(BlueFS, test_wal_migrate) {
 
 TEST_F(BlueFS_wal, wal_v2_check)
 {
+  SKIP_IF_NO_LIBAIO();
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_min_flush_size", "65536");
   conf.SetVal("bluefs_wal_envelope_mode", "true");
@@ -1178,6 +1198,7 @@ TEST_F(BlueFS_wal, wal_v2_check)
 
 TEST_F(BlueFS_wal, wal_v2_check_split_header)
 {
+  SKIP_IF_NO_LIBAIO();
   // Check if wal v2 envelope header is properly located
   // when FileWrite'r buffer is exhausted.
   //
@@ -1202,6 +1223,7 @@ TEST_F(BlueFS_wal, wal_v2_check_split_header)
 
 TEST_F(BlueFS_wal, wal_v2_check_split_header_small_alloc)
 {
+  SKIP_IF_NO_LIBAIO();
   // Check if wal v2 envelope header is properly located
   // when FileWrite'r buffer is exhausted.
   // Case for single 4K page buffer.
@@ -1227,6 +1249,7 @@ TEST_F(BlueFS_wal, wal_v2_check_split_header_small_alloc)
 
 TEST_F(BlueFS_wal, wal_v2_check_feature)
 {
+  SKIP_IF_NO_LIBAIO();
   SKIP_JENKINS();
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_min_flush_size", "65536");
@@ -1266,6 +1289,7 @@ TEST_F(BlueFS_wal, wal_v2_check_feature)
 
 TEST_F(BlueFS_wal, wal_v2_truncate)
 {
+  SKIP_IF_NO_LIBAIO();
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_min_flush_size", "65536");
   conf.SetVal("bluefs_wal_envelope_mode", "true");
@@ -1299,6 +1323,7 @@ TEST_F(BlueFS_wal, wal_v2_truncate)
 
 TEST_F(BlueFS_wal, wal_v2_simulate_crash)
 {
+  SKIP_IF_NO_LIBAIO();
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_min_flush_size", "65536");
   conf.SetVal("bluefs_wal_envelope_mode", "true");
@@ -1353,6 +1378,7 @@ TEST_F(BlueFS_wal, wal_v2_simulate_crash)
 
 TEST_F(BlueFS_wal, wal_v2_repro_74765)
 {
+  SKIP_IF_NO_LIBAIO();
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_min_flush_size", "65536");
   conf.SetVal("bluefs_wal_envelope_mode", "true");
@@ -1426,6 +1452,7 @@ TEST_F(BlueFS_wal, wal_v2_repro_74765)
 
 TEST_F(BlueFS_wal, wal_v2_recovery_from_dirty_allocated)
 {
+  SKIP_IF_NO_LIBAIO();
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_alloc_size", "4096");
   conf.SetVal("bluefs_shared_alloc_size", "4096");
@@ -1469,6 +1496,7 @@ TEST_F(BlueFS_wal, wal_v2_recovery_from_dirty_allocated)
 
 TEST_F(BlueFS_wal, support_wal_v2_and_v1)
 {
+  SKIP_IF_NO_LIBAIO();
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_min_flush_size", "65536");
   conf.SetVal("bluefs_wal_envelope_mode", "true");
@@ -1515,6 +1543,7 @@ TEST_F(BlueFS_wal, support_wal_v2_and_v1)
 
 TEST_F(BlueFS_wal, wal_v2_read_after_write)
 {
+  SKIP_IF_NO_LIBAIO();
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_min_flush_size", "65536");
   conf.SetVal("bluefs_wal_envelope_mode", "true");
@@ -1544,6 +1573,7 @@ TEST_F(BlueFS_wal, wal_v2_read_after_write)
 }
 
 TEST(BlueFS, test_wal_read_after_rollback_to_v1) {
+  SKIP_IF_NO_LIBAIO();
   // test whether we still read with v2 version even though new files will be v1
   uint64_t size_wal = 1048576 * 64;
   TempBdev bdev_wal{size_wal};
@@ -1611,6 +1641,7 @@ TEST(BlueFS, test_wal_read_after_rollback_to_v1) {
 
 
 TEST(BlueFS, test_truncate_stable_53129) {
+  SKIP_IF_NO_LIBAIO();
 
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_min_flush_size", "65536");
@@ -1696,6 +1727,7 @@ TEST(BlueFS, test_truncate_stable_53129) {
 }
 
 TEST(BlueFS, test_update_ino1_delta_after_replay) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576LL * (2 * 1024 + 128);
   TempBdev bdev{size};
 
@@ -1742,6 +1774,7 @@ TEST(BlueFS, test_update_ino1_delta_after_replay) {
 }
 
 TEST(BlueFS, broken_unlink_fsync_seq) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   BlueFS fs(g_ceph_context);
@@ -1781,6 +1814,7 @@ TEST(BlueFS, broken_unlink_fsync_seq) {
 }
 
 TEST(BlueFS, truncate_fsync) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t bdev_size = 128 * 1048576;
   uint64_t block_size = 4096;
   TempBdev bdev{bdev_size};
@@ -1840,6 +1874,7 @@ TEST(BlueFS, truncate_fsync) {
 }
 
 TEST(BlueFS, test_shared_alloc) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev_slow{size};
   uint64_t size_db = 1048576 * 8;
@@ -1917,6 +1952,7 @@ TEST(BlueFS, test_shared_alloc) {
 }
 
 TEST(BlueFS, test_shared_alloc_sparse) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128 * 2;
   uint64_t main_unit = 4096;
   uint64_t bluefs_alloc_unit = 1048576;
@@ -2001,6 +2037,7 @@ TEST(BlueFS, test_shared_alloc_sparse) {
 }
 
 TEST(BlueFS, test_4k_shared_alloc) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128 * 2;
   uint64_t main_unit = 4096;
   uint64_t bluefs_alloc_unit = main_unit;
@@ -2104,6 +2141,7 @@ void create_files(BlueFS &fs,
 
 
 TEST(BlueFS, test_concurrent_dir_link_and_compact_log_56210) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   ConfSaver conf(g_ceph_context->_conf);
@@ -2149,6 +2187,7 @@ TEST(BlueFS, test_concurrent_dir_link_and_compact_log_56210) {
 }
 
 TEST(BlueFS, truncate_drops_allocations) {
+  SKIP_IF_NO_LIBAIO();
   constexpr uint64_t K = 1024;
   constexpr uint64_t M = 1024 * K;
   uuid_d fsid;
@@ -2241,6 +2280,7 @@ TEST(BlueFS, truncate_drops_allocations) {
 
 
 TEST(BlueFS, test_log_runway) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t max_log_runway = 65536;
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_compact_log_sync", "false");
@@ -2283,6 +2323,7 @@ TEST(BlueFS, test_log_runway) {
 }
 
 TEST(BlueFS, test_log_runway_2) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t max_log_runway = 65536;
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_compact_log_sync", "false");
@@ -2341,6 +2382,7 @@ TEST(BlueFS, test_log_runway_2) {
 }
 
 TEST(BlueFS, test_log_runway_3) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t max_log_runway = 65536;
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_alloc_size", "4096");
@@ -2402,6 +2444,7 @@ TEST(BlueFS, test_log_runway_3) {
 }
 
 TEST(BlueFS, test_log_runway_advance_seq) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t max_log_runway = 65536;
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_alloc_size", "4096");
@@ -2427,6 +2470,7 @@ TEST(BlueFS, test_log_runway_advance_seq) {
 }
 
 TEST(BlueFS, test_69481_truncate_corrupts_log) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   BlueFS fs(g_ceph_context);
@@ -2471,6 +2515,7 @@ TEST(BlueFS, test_69481_truncate_corrupts_log) {
 }
 
 TEST(BlueFS, test_69481_truncate_asserts) {
+  SKIP_IF_NO_LIBAIO();
   uint64_t size = 1048576 * 128;
   TempBdev bdev{size};
   BlueFS fs(g_ceph_context);

--- a/src/test/objectstore/test_bluefs_ex.cc
+++ b/src/test/objectstore/test_bluefs_ex.cc
@@ -19,6 +19,7 @@
 #include "include/scope_guard.h"
 #include "common/errno.h"
 
+#include "libaio_probe.h"
 #include "os/bluestore/Allocator.h"
 #include "os/bluestore/bluestore_common.h"
 #include "os/bluestore/BlueFS.h"
@@ -170,6 +171,7 @@ public:
 
 TEST_F(BlueFS_ex, test_interrupted_compaction)
 {
+  SKIP_IF_NO_LIBAIO();
   for (uint32_t stop_point = 1; stop_point <= 6; stop_point++)
   {
     pid_t fork_for_test = fork();


### PR DESCRIPTION
On Ubuntu 24.04 build containers `io_setup(2)` succeeds but `io_getevents(2)`
with a non-zero timeout is denied with `EPERM`. `KernelDevice::_aio_thread()`
retries only `-EINTR` and aborts on anything else, so every unit test that
opens a BlueStore block device crashes on its first poll, before testing
anything.

Probe and `GTEST_SKIP()` in the three affected binaries: `unittest_bluefs_ex`
(#78144), `unittest_bluefs` and `unittest_bdev` (both listed in #77592).
`test_bluefs.cc` also builds the installed `ceph_test_bluefs`, so this
reaches teuthology, not just `make check`.

Composes with #70572 rather than competing: that one stops the daemon
aborting, this one stops the in-process tests aborting. It uses the same
probe shape. Two differences worth folding back into #70572 if you agree:
it does not retry `-EINTR` (a signal in the 1 ms window would skip a test
for nothing), and `exit 77` only reads as a CTest skip when the test carries
`SKIP_RETURN_CODE`, which is set nowhere in Ceph.

Does not address #78145-#78148, where the abort is in a `ceph-osd` the test
spawns rather than in the test process.

### Verification

The denial is environmental, so it is injected with an `LD_PRELOAD` shim.

| case | `unittest_bdev` | `unittest_bluefs_ex` | `unittest_bluefs` |
|---|---|---|---|
| unpatched, `io_getevents` denied | reproduces the ticket abort | same | same |
| patched, `io_getevents` denied | 0 passed, 1 skipped | 0 passed, 1 skipped | 2 passed, 44 skipped |
| patched, `io_setup` → `-EAGAIN` | runs, no skip | runs, fails, exit 1 | — |
| patched, healthy machine | 1 passed | 1 passed | 46 passed |

The `2 passed` are the two tests that never open a device and so carry no
guard; they still run where aio is denied.

### Choices a reviewer might query

- **Non-zero timeout in the probe** — libaio answers a zero timeout from the
  completion ring in userspace without issuing the syscall that gets denied,
  so a zero-timeout probe reports healthy libaio in exactly the environment
  being detected.
- **`io_setup(2)` failure is not treated as unusable** — that is `-EAGAIN`
  from an exhausted `aio-max-nr`, which a parallel `make check` can cause. A
  resource shortage should stay a red test.
- **Per test, not a global `::testing::Environment`** — skipping from
  `Environment::SetUp()` stops the tests but googletest still counts them
  PASSED. A platform where nothing ran should not report green.
- **Not a fixture `SetUp()`** — 37 of the 48 tests are bare `TEST()`.
- **Not a ctest wrapper exiting 77** — no `SKIP_RETURN_CODE` plumbing in
  `add_ceph_unittest`, and it loses per-test granularity.

This does not make BlueStore testable on such a platform: a green
`make check` there means these tests did not run. Fixing the container
policy is the actual fix.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
