### PR TITLE
doc: always use external links to the Releases doc

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -100,7 +100,7 @@ Using Curl to Install Cephadm
 -----------------------------
 
 #. Determine which version of Ceph you will install. Use the releases page to
-   find the :ref:`active-releases`.  For example,
+   find the `latest active releases`_.  For example,
    you might find that ``18.2.1`` is the latest active release.
 
 #. Use ``curl`` to fetch a build of cephadm for that release.
@@ -610,3 +610,8 @@ would simply be a matter of getting another key signed by the same CA and provid
 cephadm with the new private key and the new signed certificate. No additional distribution of
 keys to cluster nodes is needed after the initial setup of the CA key as a trusted key,
 no matter how many new private key/signed cert pairs are rotated in.
+
+
+.. Needs to be an external link because doc/releases/index.rst is not in
+   stable branches and we want to always use the main branch version
+.. _latest active releases: https://docs.ceph.com/en/latest/releases/#active-releases

--- a/doc/install/clone-source.rst
+++ b/doc/install/clone-source.rst
@@ -121,9 +121,14 @@ will be on the ``main`` branch by default, which is the unstable
 development branch. You may choose other branches too.
 
 - ``main``: The unstable development branch.
-- ``stable-release-name``: The name of the stable, :ref:`active-releases`. e.g. ``Pacific``
+- ``stable-release-name``: The name of the stable, see `Active Releases`_. e.g. ``pacific``
 - ``next``: The release candidate branch.
 
 ::
 
 	git checkout main
+
+
+.. Needs to be an external link because doc/releases/index.rst is not in
+   stable branches and we want to always use the main branch version
+.. _Active Releases: https://docs.ceph.com/en/latest/releases/#active-releases

--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -130,7 +130,7 @@ For RPMs::
 
     https://download.ceph.com/rpm-{version}
 
-The major releases of Ceph are summarized at: :ref:`Releases <ceph-releases-index>`
+The major releases of Ceph are summarized at: `Releases`_
 
 .. tip:: For non-US users: There might be a mirror close to you where
          to download Ceph from. For more information see: :ref:`install-mirrors`.
@@ -415,3 +415,7 @@ of the Ceph release and ``{distro}`` with your distribution.
 
 .. _the testing Debian repository: https://download.ceph.com/debian-testing/dists
 .. _the shaman page: https://shaman.ceph.com
+
+.. Needs to be an external link because doc/releases/index.rst is not in
+   stable branches and we want to always use the main branch version
+.. _Releases: https://docs.ceph.com/en/latest/releases/


### PR DESCRIPTION
`doc/releases/index.rst` does not exist in stable branches and using validated links on such branches will fail.
Always use external links to the doc rendered from the `main` branch.

Fixes: https://tracker.ceph.com/issues/80138

- Original: https://docs.ceph.com/en/latest/cephadm/install/#using-curl-to-install-cephadm
- Rendered PR: https://ceph--71459.org.readthedocs.build/en/71459/cephadm/install/#using-curl-to-install-cephadm
- Original: https://docs.ceph.com/en/latest/install/clone-source/#choose-a-branch
- Rendered PR: https://ceph--71459.org.readthedocs.build/en/71459/install/clone-source/#choose-a-branch
- Original: https://docs.ceph.com/en/latest/install/get-packages/#ceph-release-packages
- Rendered PR: https://ceph--71459.org.readthedocs.build/en/71459/install/get-packages/#ceph-release-packages






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
