### PR TITLE
qa/lsan.supp: match OpenSSL error state on ERR_set_mark

### DIFF
--- a/qa/lsan.supp
+++ b/qa/lsan.supp
@@ -64,8 +64,11 @@ leak:libcryptsetup
 leak:^RAND_bytes_ex
 leak:^RAND_priv_bytes_ex
 # OpenSSL per-thread error stack/strings, freed only by OPENSSL_thread_stop.
+# ossl_err_get_state_int is internal, so a stripped .dynsym leaves
+# only its exported caller ERR_set_mark to match on.
 leak:^ossl_err_get_state_int
 leak:^ERR_add_error_vdata
+leak:^ERR_set_mark
 
 # unittest-seastore stops the seastar reactor (SeastarRunner, on its own thread)
 # without draining its pending tasks, so a few cached extents those tasks still


### PR DESCRIPTION
ossl_err_get_state_int is unexported, so the existing entry never
matches and unittest_librbd fails on the error state
EVP_get_cipherbyname() leaves behind. Match its exported caller
ERR_set_mark instead.

A CI failure on this: https://github.com/sunyuechi/ceph-ci/actions/runs/33388158788

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
