### PR TITLE
rgw: avoid copy of RGWUserInfo on hot request path

### DIFF
--- a/src/rgw/driver/daos/rgw_sal_daos.cc
+++ b/src/rgw/driver/daos/rgw_sal_daos.cc
@@ -202,7 +202,7 @@ int DaosUser::trim_usage(const DoutPrefixProvider* dpp, uint64_t start_epoch,
 }
 
 int DaosUser::load_user(const DoutPrefixProvider* dpp, optional_yield y) {
-  const string name = info.user_id.to_str();
+  const string name = get_info().user_id.to_str();
   ldpp_dout(dpp, 20) << "DEBUG: load_user, name=" << name << dendl;
 
   DaosUserInfo duinfo;
@@ -212,7 +212,7 @@ int DaosUser::load_user(const DoutPrefixProvider* dpp, optional_yield y) {
     return ret;
   }
 
-  info = duinfo.info;
+  get_info_mut() = duinfo.info;
   attrs = duinfo.attrs;
   objv_tracker.read_version = duinfo.user_version;
   return 0;
@@ -230,7 +230,7 @@ int DaosUser::merge_and_store_attrs(const DoutPrefixProvider* dpp,
 
 int DaosUser::store_user(const DoutPrefixProvider* dpp, optional_yield y,
                          bool exclusive, RGWUserInfo* old_info) {
-  const string name = info.user_id.to_str();
+  const string name = get_info().user_id.to_str();
   ldpp_dout(dpp, 10) << "DEBUG: Store_user(): User name=" << name << dendl;
 
   // Read user
@@ -319,19 +319,19 @@ std::unique_ptr<struct ds3_user_info> DaosUser::get_encoded_info(
     bufferlist& bl, obj_version& obj_ver) {
   // Encode user data
   struct DaosUserInfo duinfo;
-  duinfo.info = info;
+  duinfo.info = get_info();
   duinfo.attrs = attrs;
   duinfo.user_version = obj_ver;
   duinfo.encode(bl);
 
   // Initialize ds3_user_info
   access_ids.clear();
-  for (auto const& [id, key] : info.access_keys) {
+  for (auto const& [id, key] : get_info().access_keys) {
     access_ids.push_back(id.c_str());
   }
   return std::unique_ptr<struct ds3_user_info>(
-      new ds3_user_info{.name = info.user_id.to_str().c_str(),
-                        .email = info.user_email.c_str(),
+      new ds3_user_info{.name = get_info().user_id.to_str().c_str(),
+                        .email = get_info().user_email.c_str(),
                         .access_ids = access_ids.data(),
                         .access_ids_nr = access_ids.size(),
                         .encoded = bl.c_str(),
@@ -339,7 +339,7 @@ std::unique_ptr<struct ds3_user_info> DaosUser::get_encoded_info(
 }
 
 int DaosUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y) {
-  const string name = info.user_id.to_str();
+  const string name = get_info().user_id.to_str();
 
   // TODO: the expectation is that the object version needs to be passed in as a
   // method arg see int DB::remove_user(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/dbstore/common/dbstore.cc
+++ b/src/rgw/driver/dbstore/common/dbstore.cc
@@ -329,7 +329,7 @@ out:
 }
 
 int DB::store_user(const DoutPrefixProvider *dpp,
-    RGWUserInfo& uinfo, bool exclusive, map<string, bufferlist> *pattrs,
+    const RGWUserInfo& uinfo, bool exclusive, map<string, bufferlist> *pattrs,
     RGWObjVersionTracker *pobjv, RGWUserInfo* pold_info)
 {
   DBOpParams params = {};
@@ -393,7 +393,7 @@ out:
 }
 
 int DB::remove_user(const DoutPrefixProvider *dpp,
-    RGWUserInfo& uinfo, RGWObjVersionTracker *pobjv)
+    const RGWUserInfo& uinfo, RGWObjVersionTracker *pobjv)
 {
   DBOpParams params = {};
   InitializeParams(dpp, &params);

--- a/src/rgw/driver/dbstore/common/dbstore.h
+++ b/src/rgw/driver/dbstore/common/dbstore.h
@@ -1742,10 +1742,10 @@ class DB {
         RGWUserInfo& uinfo, std::map<std::string, bufferlist> *pattrs,
         RGWObjVersionTracker *pobjv_tracker);
     int store_user(const DoutPrefixProvider *dpp,
-        RGWUserInfo& uinfo, bool exclusive, std::map<std::string, bufferlist> *pattrs,
+        const RGWUserInfo& uinfo, bool exclusive, std::map<std::string, bufferlist> *pattrs,
         RGWObjVersionTracker *pobjv_tracker, RGWUserInfo* pold_info);
     int remove_user(const DoutPrefixProvider *dpp,
-        RGWUserInfo& uinfo, RGWObjVersionTracker *pobjv_tracker);
+        const RGWUserInfo& uinfo, RGWObjVersionTracker *pobjv_tracker);
     int list_users(const DoutPrefixProvider *dpp,
         const std::string& marker,
         uint64_t max,

--- a/src/rgw/driver/motr/rgw_sal_motr.cc
+++ b/src/rgw/driver/motr/rgw_sal_motr.cc
@@ -356,13 +356,13 @@ int MotrUser::load_user_from_idx(const DoutPrefixProvider *dpp,
 int MotrUser::load_user(const DoutPrefixProvider *dpp,
                         optional_yield y)
 {
-  ldpp_dout(dpp, 20) << "load user: user id =   " << info.user_id.to_str() << dendl;
-  return load_user_from_idx(dpp, store, info, &attrs, &objv_tracker);
+  ldpp_dout(dpp, 20) << "load user: user id =   " << get_info().user_id.to_str() << dendl;
+  return load_user_from_idx(dpp, store, get_info_mut(), &attrs, &objv_tracker);
 }
 
 int MotrUser::create_user_info_idx()
 {
-  string user_info_iname = "motr.rgw.user.info." + info.user_id.to_str();
+  string user_info_iname = "motr.rgw.user.info." + get_info().user_id.to_str();
   return store->create_motr_idx_by_name(user_info_iname);
 }
 
@@ -382,6 +382,7 @@ int MotrUser::store_user(const DoutPrefixProvider* dpp,
   RGWUserInfo orig_info;
   RGWObjVersionTracker objv_tr = {};
   obj_version& obj_ver = objv_tr.read_version;
+  const RGWUserInfo& info = get_info();
 
   ldpp_dout(dpp, 20) << "Store_user(): User = " << info.user_id.id << dendl;
   orig_info.user_id = info.user_id;
@@ -484,6 +485,7 @@ int MotrUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y)
   // Delete email for user - TODO
   bufferlist bl;
   int rc;
+  const RGWUserInfo& info = get_info();
   // Remove the user info from cache.
   store->get_user_cache()->remove(dpp, info.user_id.id);
 

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2382,7 +2382,8 @@ int POSIXBucket::create(const DoutPrefixProvider* dpp,
 
 int POSIXUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y)
 {
-  return driver->get_user_db()->get_user(dpp, std::string("user_id"), this->get_id().id, this->get_info(), &(this->get_attrs()),
+  const std::string& id = this->get_id().id;
+  return driver->get_user_db()->get_user(dpp, std::string("user_id"), id, this->get_info_mut(), &(this->get_attrs()),
         &(this->get_version_tracker()));
 }
 
@@ -2399,7 +2400,8 @@ int POSIXUser::merge_and_store_attrs(const DoutPrefixProvider* dpp,
 
 int POSIXUser::load_user(const DoutPrefixProvider* dpp, optional_yield y)
 {
-  return driver->get_user_db()->get_user(dpp, std::string("user_id"), this->get_id().id, this->get_info(), &(this->get_attrs()),
+  const std::string& id = this->get_id().id;
+  return driver->get_user_db()->get_user(dpp, std::string("user_id"), id, this->get_info_mut(), &(this->get_attrs()),
            &(this->get_version_tracker()));
 }
 

--- a/src/rgw/driver/rados/rgw_cr_tools.cc
+++ b/src/rgw/driver/rados/rgw_cr_tools.cc
@@ -94,7 +94,12 @@ int RGWUserCreateCR::Request::_send_request(const DoutPrefixProvider *dpp)
 template<>
 int RGWGetUserInfoCR::Request::_send_request(const DoutPrefixProvider *dpp)
 {
-  return store->ctl()->user->get_info_by_uid(dpp, params.user, result.get(), null_yield);
+  std::shared_ptr<const RGWUserInfo> info;
+  int r = store->ctl()->user->get_info_by_uid(dpp, params.user, info, null_yield);
+  if (r >= 0) {
+    *result.get() = *info;
+  }
+  return r;
 }
 
 template<>

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -4800,16 +4800,16 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
   }
 
   if (override_owner) {
-    RGWUserInfo owner_info;
-    if (ctl.user->get_info_by_uid(rctx.dpp, *override_owner, &owner_info, rctx.y) < 0) {
+    std::shared_ptr<const RGWUserInfo> owner_info;
+    if (ctl.user->get_info_by_uid(rctx.dpp, *override_owner, owner_info, rctx.y) < 0) {
       ldpp_dout(rctx.dpp, 10) << "owner info does not exist" << dendl;
       return -EINVAL;
     }
 
     owner.id = *override_owner;
-    owner.display_name = owner_info.display_name;
+    owner.display_name = owner_info->display_name;
 
-    policy.create_default(owner_info.user_id, owner_info.display_name);
+    policy.create_default(owner_info->user_id, owner_info->display_name);
 
     bufferlist bl;
     policy.encode(bl);

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -283,12 +283,23 @@ int RadosUser::trim_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, u
 
 int RadosUser::load_user(const DoutPrefixProvider* dpp, optional_yield y)
 {
-    return store->ctl()->user->get_info_by_uid(dpp, info.user_id, &info, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker).set_attrs(&attrs));
+    std::shared_ptr<const RGWUserInfo> uinfo;
+    int r = store->ctl()->user->get_info_by_uid(dpp, get_info().user_id, uinfo, y,
+        RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker).set_attrs(&attrs));
+    /*
+     * In RGWSI_User_RADOS::read_user_info the decode may be skipped without error, the
+     * returned uinfo is empty then. Before using shared_ptr the this.info was kept in
+     * this case because read_user_info directly worked on it. Keep this behaviour.
+     */
+    if (r >= 0 && !uinfo->user_id.empty()) {
+      set_info_shared(std::move(uinfo));
+    }
+    return r;
 }
 
 int RadosUser::store_user(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info)
 {
-    return store->ctl()->user->store_info(dpp, info, y,
+    return store->ctl()->user->store_info(dpp, get_info(), y,
 					  RGWUserCtl::PutParams().set_objv_tracker(&objv_tracker)
 					  .set_exclusive(exclusive)
 					  .set_attrs(&attrs)
@@ -297,7 +308,7 @@ int RadosUser::store_user(const DoutPrefixProvider* dpp, optional_yield y, bool 
 
 int RadosUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y)
 {
-    return store->ctl()->user->remove_info(dpp, info, y,
+    return store->ctl()->user->remove_info(dpp, get_info(), y,
 					  RGWUserCtl::RemoveParams().set_objv_tracker(&objv_tracker));
 }
 
@@ -315,6 +326,7 @@ int RadosUser::verify_mfa(const std::string& mfa_str, bool* verified,
   string& serial = params[0];
   string& pin = params[1];
 
+  const auto& info = get_info();
   auto i = info.mfa_ids.find(serial);
   if (i == info.mfa_ids.end()) {
     ldpp_dout(dpp, 5) << "NOTICE: user does not have mfa device with serial=" << serial << dendl;
@@ -339,7 +351,7 @@ int RadosUser::list_groups(const DoutPrefixProvider* dpp, optional_yield y,
   RGWSI_SysObj& sysobj = *store->svc()->sysobj;
   const RGWZoneParams& zone = store->svc()->zone->get_zone_params();
 
-  const auto& ids = info.group_ids;
+  const auto& ids = get_info().group_ids;
   for (auto id = ids.lower_bound(marker); id != ids.end(); ++id) {
     if (listing.groups.size() >= max_items) {
       listing.next_marker = *id;
@@ -1629,22 +1641,18 @@ std::string RadosStore::get_cluster_id(const DoutPrefixProvider* dpp,  optional_
 
 int RadosStore::get_user_by_access_key(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user)
 {
-  RGWUserInfo uinfo;
-  User* u;
+  std::shared_ptr<const RGWUserInfo> uinfo;
   RGWObjVersionTracker objv_tracker;
   Attrs attrs;
 
   int r = ctl()->user->get_info_by_access_key(
-      dpp, key, &uinfo, y,
+      dpp, key, uinfo, y,
       RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker)
                              .set_attrs(&attrs));
   if (r < 0)
     return r;
 
-  u = new RadosUser(this, uinfo);
-  if (!u)
-    return -ENOMEM;
-
+  User* u = new RadosUser(this, std::move(uinfo));
   u->get_version_tracker() = objv_tracker;
   u->get_attrs() = std::move(attrs);
 
@@ -1654,22 +1662,18 @@ int RadosStore::get_user_by_access_key(const DoutPrefixProvider* dpp, const std:
 
 int RadosStore::get_user_by_email(const DoutPrefixProvider* dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user)
 {
-  RGWUserInfo uinfo;
-  User* u;
+  std::shared_ptr<const RGWUserInfo> uinfo;
   RGWObjVersionTracker objv_tracker;
   Attrs attrs;
 
   int r = ctl()->user->get_info_by_email(
-      dpp, email, &uinfo, y,
+      dpp, email, uinfo, y,
       RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker)
                              .set_attrs(&attrs));
   if (r < 0)
     return r;
 
-  u = new RadosUser(this, uinfo);
-  if (!u)
-    return -ENOMEM;
-
+  User* u = new RadosUser(this, std::move(uinfo));
   u->get_version_tracker() = objv_tracker;
   u->get_attrs() = std::move(attrs);
 
@@ -1679,22 +1683,18 @@ int RadosStore::get_user_by_email(const DoutPrefixProvider* dpp, const std::stri
 
 int RadosStore::get_user_by_swift(const DoutPrefixProvider* dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user)
 {
-  RGWUserInfo uinfo;
-  User* u;
+  std::shared_ptr<const RGWUserInfo> uinfo;
   RGWObjVersionTracker objv_tracker;
   Attrs attrs;
 
   int r = ctl()->user->get_info_by_swift(
-      dpp, user_str, &uinfo, y,
+      dpp, user_str, uinfo, y,
       RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker)
                              .set_attrs(&attrs));
   if (r < 0)
     return r;
 
-  u = new RadosUser(this, uinfo);
-  if (!u)
-    return -ENOMEM;
-
+  User* u = new RadosUser(this, std::move(uinfo));
   u->get_version_tracker() = objv_tracker;
   u->get_attrs() = std::move(attrs);
 
@@ -1965,15 +1965,15 @@ int RadosStore::list_account_users(const DoutPrefixProvider* dpp,
     uid.tenant = tenant;
     uid.id = std::move(id);
 
-    RGWUserInfo info;
-    r = ctl()->user->get_info_by_uid(dpp, uid, &info, y);
+    std::shared_ptr<const RGWUserInfo> info;
+    r = ctl()->user->get_info_by_uid(dpp, uid, info, y);
     if (r == -ENOENT) {
       continue;
     }
     if (r < 0) {
       return r;
     }
-    listing.users.push_back(std::move(info));
+    listing.users.push_back(*info);
   }
 
   return 0;
@@ -2060,15 +2060,15 @@ int RadosStore::list_group_users(const DoutPrefixProvider* dpp,
     uid.tenant = tenant;
     uid.id = std::move(id);
 
-    RGWUserInfo info;
-    r = ctl()->user->get_info_by_uid(dpp, uid, &info, y);
+    std::shared_ptr<const RGWUserInfo> info;
+    r = ctl()->user->get_info_by_uid(dpp, uid, info, y);
     if (r == -ENOENT) {
       continue;
     }
     if (r < 0) {
       return r;
     }
-    listing.users.push_back(std::move(info));
+    listing.users.push_back(*info);
   }
 
   return 0;

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -465,6 +465,7 @@ class RadosUser : public StoreUser {
   public:
     RadosUser(RadosStore *_st, const rgw_user& _u) : StoreUser(_u), store(_st) { }
     RadosUser(RadosStore *_st, const RGWUserInfo& _i) : StoreUser(_i), store(_st) { }
+    RadosUser(RadosStore *_st, std::shared_ptr<const RGWUserInfo> _i) : StoreUser(std::move(_i)), store(_st) { }
     RadosUser(RadosStore *_st) : store(_st) { }
     RadosUser(RadosUser& _o) = default;
 

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -2888,14 +2888,13 @@ int RGWUserCtl::get_info_by_uid(const DoutPrefixProvider *dpp,
                                 const GetParams& params)
 
 {
-  return svc.user->read_user_info(uid,
-                                  info,
-                                  params.objv_tracker,
-                                  params.mtime,
-                                  params.cache_info,
-                                  params.attrs,
-                                  y,
-                                  dpp);
+  return svc.user->get_user_info_by_uid(uid,
+                                        info,
+                                        params.objv_tracker,
+                                        params.attrs,
+                                        params.mtime,
+                                        y,
+                                        dpp);
 }
 
 int RGWUserCtl::get_info_by_email(const DoutPrefixProvider *dpp, 

--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -255,7 +255,7 @@ void RGWUserAdminOpState::set_user_id(const rgw_user& id)
   if (id.empty())
     return;
 
-  user->get_info().user_id = id;
+  user->get_info_mut().user_id = id;
 }
 
 void RGWUserAdminOpState::set_subuser(std::string& _subuser)
@@ -268,9 +268,9 @@ void RGWUserAdminOpState::set_subuser(std::string& _subuser)
     rgw_user tmp_id;
     tmp_id.from_str(_subuser.substr(0, pos));
     if (tmp_id.tenant.empty()) {
-      user->get_info().user_id.id = tmp_id.id;
+      user->get_info_mut().user_id.id = tmp_id.id;
     } else {
-      user->get_info().user_id = tmp_id;
+      user->get_info_mut().user_id = tmp_id;
     }
     subuser = _subuser.substr(pos+1);
   } else {
@@ -280,9 +280,9 @@ void RGWUserAdminOpState::set_subuser(std::string& _subuser)
   subuser_specified = true;
 }
 
-void RGWUserAdminOpState::set_user_info(RGWUserInfo& user_info)
+void RGWUserAdminOpState::set_user_info(const RGWUserInfo& user_info)
 {
-  user->get_info() = user_info;
+  user->get_info_mut() = user_info;
 }
 
 void RGWUserAdminOpState::set_user_version_tracker(RGWObjVersionTracker& objv_tracker)
@@ -304,29 +304,34 @@ const rgw_user& RGWUserAdminOpState::get_user_id()
   return user->get_id();
 }
 
-RGWUserInfo& RGWUserAdminOpState::get_user_info()
+const RGWUserInfo& RGWUserAdminOpState::get_user_info() const
 {
   return user->get_info();
 }
 
+RGWUserInfo& RGWUserAdminOpState::get_user_info_mut()
+{
+  return user->get_info_mut();
+}
+
 map<std::string, RGWAccessKey>* RGWUserAdminOpState::get_swift_keys()
 {
-  return &user->get_info().swift_keys;
+  return &user->get_info_mut().swift_keys;
 }
 
 map<std::string, RGWAccessKey>* RGWUserAdminOpState::get_access_keys()
 {
-  return &user->get_info().access_keys;
+  return &user->get_info_mut().access_keys;
 }
 
 map<std::string, RGWSubUser>* RGWUserAdminOpState::get_subusers()
 {
-  return &user->get_info().subusers;
+  return &user->get_info_mut().subusers;
 }
 
 RGWUserCaps *RGWUserAdminOpState::get_caps_obj()
 {
-  return &user->get_info().caps;
+  return &user->get_info_mut().caps;
 }
 
 std::string RGWUserAdminOpState::build_default_swift_kid()
@@ -1590,7 +1595,7 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
 
   // update the 'stub user' with all of the other fields and rewrite all of the
   // associated index objects
-  RGWUserInfo& user_info = op_state.get_user_info();
+  RGWUserInfo& user_info = op_state.get_user_info_mut();
   user_info.user_id = new_user->get_id();
   op_state.objv = user->get_version_tracker();
   op_state.set_user_version_tracker(user->get_version_tracker());
@@ -2881,12 +2886,11 @@ public:
   }
 };
 
-int RGWUserCtl::get_info_by_uid(const DoutPrefixProvider *dpp, 
+int RGWUserCtl::get_info_by_uid(const DoutPrefixProvider *dpp,
                                 const rgw_user& uid,
-                                RGWUserInfo *info,
+                                std::shared_ptr<const RGWUserInfo>& info,
                                 optional_yield y,
                                 const GetParams& params)
-
 {
   return svc.user->get_user_info_by_uid(uid,
                                         info,
@@ -2897,9 +2901,9 @@ int RGWUserCtl::get_info_by_uid(const DoutPrefixProvider *dpp,
                                         dpp);
 }
 
-int RGWUserCtl::get_info_by_email(const DoutPrefixProvider *dpp, 
+int RGWUserCtl::get_info_by_email(const DoutPrefixProvider *dpp,
                                   const string& email,
-                                  RGWUserInfo *info,
+                                  std::shared_ptr<const RGWUserInfo>& info,
                                   optional_yield y,
                                   const GetParams& params)
 {
@@ -2914,7 +2918,7 @@ int RGWUserCtl::get_info_by_email(const DoutPrefixProvider *dpp,
 
 int RGWUserCtl::get_info_by_swift(const DoutPrefixProvider *dpp, 
                                   const string& swift_name,
-                                  RGWUserInfo *info,
+                                  std::shared_ptr<const RGWUserInfo>& info,
                                   optional_yield y,
                                   const GetParams& params)
 {
@@ -2929,7 +2933,7 @@ int RGWUserCtl::get_info_by_swift(const DoutPrefixProvider *dpp,
 
 int RGWUserCtl::get_info_by_access_key(const DoutPrefixProvider *dpp, 
                                        const string& access_key,
-                                       RGWUserInfo *info,
+                                       std::shared_ptr<const RGWUserInfo>& info,
                                        optional_yield y,
                                        const GetParams& params)
 {
@@ -2948,9 +2952,9 @@ int RGWUserCtl::get_attrs_by_uid(const DoutPrefixProvider *dpp,
                                  optional_yield y,
                                  RGWObjVersionTracker *objv_tracker)
 {
-  RGWUserInfo user_info;
+  std::shared_ptr<const RGWUserInfo> user_info;
 
-  return get_info_by_uid(dpp, user_id, &user_info, y, RGWUserCtl::GetParams()
+  return get_info_by_uid(dpp, user_id, user_info, y, RGWUserCtl::GetParams()
                          .set_attrs(pattrs)
                          .set_objv_tracker(objv_tracker));
 }

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -327,7 +327,7 @@ struct RGWUserAdminOpState {
     sync_stats = is_sync_stats;
   }
 
-  void set_user_info(RGWUserInfo& user_info);
+  void set_user_info(const RGWUserInfo& user_info);
 
   void set_user_version_tracker(RGWObjVersionTracker& objv_tracker);
 
@@ -454,7 +454,8 @@ struct RGWUserAdminOpState {
   bool get_overwrite_new_user() const { return overwrite_new_user; }
   std::map<int, std::string>& get_temp_url_keys() { return temp_url_keys; }
 
-  RGWUserInfo&  get_user_info();
+  const RGWUserInfo& get_user_info() const;
+  RGWUserInfo&  get_user_info_mut();
 
   std::map<std::string, RGWAccessKey>* get_swift_keys();
   std::map<std::string, RGWAccessKey>* get_access_keys();
@@ -828,17 +829,21 @@ public:
     }
   };
 
-  int get_info_by_uid(const DoutPrefixProvider *dpp, 
-                      const rgw_user& uid, RGWUserInfo *info,
+  int get_info_by_uid(const DoutPrefixProvider *dpp,
+                      const rgw_user& uid,
+                      std::shared_ptr<const RGWUserInfo>& info,
                       optional_yield y, const GetParams& params = {});
   int get_info_by_email(const DoutPrefixProvider *dpp, 
-                        const std::string& email, RGWUserInfo *info,
+                        const std::string& email,
+                        std::shared_ptr<const RGWUserInfo>& info,
                         optional_yield y, const GetParams& params = {});
   int get_info_by_swift(const DoutPrefixProvider *dpp, 
-                        const std::string& swift_name, RGWUserInfo *info,
+                        const std::string& swift_name,
+                        std::shared_ptr<const RGWUserInfo>& info,
                         optional_yield y, const GetParams& params = {});
   int get_info_by_access_key(const DoutPrefixProvider *dpp, 
-                             const std::string& access_key, RGWUserInfo *info,
+                             const std::string& access_key,
+                             std::shared_ptr<const RGWUserInfo>& info,
                              optional_yield y, const GetParams& params = {});
 
   int get_attrs_by_uid(const DoutPrefixProvider *dpp, 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -1794,7 +1794,7 @@ int show_bucket_ratelimit(rgw::sal::Driver* driver, const string& tenant_name,
 int set_user_bucket_quota(OPT opt_cmd, RGWUser& user, RGWUserAdminOpState& op_state, int64_t max_size, int64_t max_objects,
                           bool have_max_size, bool have_max_objects)
 {
-  RGWUserInfo& user_info = op_state.get_user_info();
+  RGWUserInfo& user_info = op_state.get_user_info_mut();
 
   set_quota_info(user_info.quota.bucket_quota, opt_cmd, max_size, max_objects, have_max_size, have_max_objects);
 
@@ -1812,7 +1812,7 @@ int set_user_bucket_quota(OPT opt_cmd, RGWUser& user, RGWUserAdminOpState& op_st
 int set_user_quota(OPT opt_cmd, RGWUser& user, RGWUserAdminOpState& op_state, int64_t max_size, int64_t max_objects,
                    bool have_max_size, bool have_max_objects)
 {
-  RGWUserInfo& user_info = op_state.get_user_info();
+  RGWUserInfo& user_info = op_state.get_user_info_mut();
 
   set_quota_info(user_info.quota.user_quota, opt_cmd, max_size, max_objects, have_max_size, have_max_objects);
 
@@ -11867,7 +11867,7 @@ next:
       return -ret;
     }
     
-    RGWUserInfo& user_info = user_op.get_user_info();
+    RGWUserInfo& user_info = user_op.get_user_info_mut();
     user_info.mfa_ids.insert(totp_serial);
     user_op.set_mfa_ids(user_info.mfa_ids);
     string err;
@@ -11904,7 +11904,7 @@ next:
       return -ret;
     }
 
-    RGWUserInfo& user_info = user_op.get_user_info();
+    RGWUserInfo& user_info = user_op.get_user_info_mut();
     user_info.mfa_ids.erase(totp_serial);
     user_op.set_mfa_ids(user_info.mfa_ids);
     string err;

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -647,12 +647,11 @@ void rgw::auth::WebIdentityApplier::create_account(const DoutPrefixProvider* dpp
                                               RGWUserInfo& user_info) const      /* out */
 {
   std::unique_ptr<rgw::sal::User> user = driver->get_user(acct_user);
-  user->get_info().display_name = display_name;
-  user->get_info().type = TYPE_WEB;
-  user->get_info().max_buckets =
-    cct->_conf.get_val<int64_t>("rgw_user_max_buckets");
-  rgw_apply_default_bucket_quota(user->get_info().quota.bucket_quota, cct->_conf);
-  rgw_apply_default_user_quota(user->get_info().quota.user_quota, cct->_conf);
+  user->get_info_mut().display_name = display_name;
+  user->get_info_mut().type = TYPE_WEB;
+  user->set_max_buckets(cct->_conf.get_val<int64_t>("rgw_user_max_buckets"));
+  rgw_apply_default_bucket_quota(user->get_info_mut().quota.bucket_quota, cct->_conf);
+  rgw_apply_default_user_quota(user->get_info_mut().quota.user_quota, cct->_conf);
 
   int ret = user->store_user(dpp, null_yield, true);
   if (ret < 0) {
@@ -673,7 +672,7 @@ auto rgw::auth::WebIdentityApplier::load_acct_info(const DoutPrefixProvider* dpp
   if (account) {
     // we don't need shadow users for account roles because bucket ownership,
     // quota, and stats are tracked by the account instead of the user
-    RGWUserInfo& user_info = user->get_info();
+    RGWUserInfo& user_info = user->get_info_mut();
     user_info.display_name = user_name;
     user_info.type = TYPE_WEB;
     // the user_info.user_id is initialized by driver->get_user(...)
@@ -718,7 +717,7 @@ auto rgw::auth::WebIdentityApplier::load_acct_info(const DoutPrefixProvider* dpp
   }
 
   ldpp_dout(dpp, 0) << "NOTICE: couldn't map oidc federated user " << federated_user << dendl;
-  create_account(dpp, federated_user, this->user_name, user->get_info());
+  create_account(dpp, federated_user, this->user_name, user->get_info_mut());
   return user;
 }
 
@@ -954,15 +953,14 @@ void rgw::auth::RemoteApplier::create_account(const DoutPrefixProvider* dpp,
   }
 
   std::unique_ptr<rgw::sal::User> user = driver->get_user(owner_acct_user);
-  user->get_info().display_name = info.acct_name;
+  user->get_info_mut().display_name = info.acct_name;
   if (info.acct_type) {
     //ldap/keystone for s3 users
-    user->get_info().type = info.acct_type;
+    user->get_info_mut().type = info.acct_type;
   }
-  user->get_info().max_buckets =
-    cct->_conf.get_val<int64_t>("rgw_user_max_buckets");
-  rgw_apply_default_bucket_quota(user->get_info().quota.bucket_quota, cct->_conf);
-  rgw_apply_default_user_quota(user->get_info().quota.user_quota, cct->_conf);
+  user->set_max_buckets(cct->_conf.get_val<int64_t>("rgw_user_max_buckets"));
+  rgw_apply_default_bucket_quota(user->get_info_mut().quota.bucket_quota, cct->_conf);
+  rgw_apply_default_user_quota(user->get_info_mut().quota.user_quota, cct->_conf);
   user_info = user->get_info();
 
   int ret = user->store_user(dpp, null_yield, true);
@@ -1048,7 +1046,7 @@ auto rgw::auth::RemoteApplier::load_acct_info(const DoutPrefixProvider* dpp) con
   }
 
   ldpp_dout(dpp, 0) << "NOTICE: couldn't map swift user " << acct_user << dendl;
-  create_account(dpp, acct_user, implicit_tenant, user->get_info());
+  create_account(dpp, acct_user, implicit_tenant, user->get_info_mut());
 
   /* Succeeded if we are here (create_account() hasn't thrown). */
   return user;
@@ -1094,8 +1092,8 @@ ACLOwner rgw::auth::LocalApplier::get_aclowner() const
     owner.id = account->id;
     owner.display_name = account->name;
   } else {
-    owner.id = user_info.user_id;
-    owner.display_name = user_info.display_name;
+    owner.id = user_info->user_id;
+    owner.display_name = user_info->display_name;
   }
   return owner;
 }
@@ -1104,7 +1102,7 @@ uint32_t rgw::auth::LocalApplier::get_perms_from_aclspec(const DoutPrefixProvide
 {
   // match acl grants to the specific user id
   uint32_t mask = rgw_perms_from_aclspec_default_strategy(
-      user_info.user_id.to_str(), aclspec, dpp);
+      user_info->user_id.to_str(), aclspec, dpp);
 
   if (account) {
     // account users also match acl grants to the account id. in aws, grantees
@@ -1118,12 +1116,12 @@ uint32_t rgw::auth::LocalApplier::get_perms_from_aclspec(const DoutPrefixProvide
 
 bool rgw::auth::LocalApplier::is_admin() const
 {
-  return user_info.admin || user_info.system;
+  return user_info->admin || user_info->system;
 }
 
 bool rgw::auth::LocalApplier::is_owner_of(const rgw_owner& o) const
 {
-  return match_owner(o, user_info.user_id, account);
+  return match_owner(o, user_info->user_id, account);
 }
 
 bool rgw::auth::LocalApplier::is_root() const
@@ -1138,16 +1136,16 @@ bool rgw::auth::LocalApplier::is_identity(const Principal& p) const {
   if (p.is_wildcard()) {
     return true;
   } else if (p.is_account()) {
-    return match_account_or_tenant(account, user_info.user_id.tenant,
+    return match_account_or_tenant(account, user_info->user_id.tenant,
                                    p.get_account());
   } else if (p.is_user()) {
     // account users can match both account- and tenant-based arns
     if (account && p.get_account() == account->id) {
-      return match_principal(user_info.path, user_info.display_name,
+      return match_principal(user_info->path, user_info->display_name,
                              subuser, p.get_id());
     } else {
-      return p.get_account() == user_info.user_id.tenant
-          && match_principal(user_info.path, user_info.user_id.id,
+      return p.get_account() == user_info->user_id.tenant
+          && match_principal(user_info->path, user_info->user_id.id,
                              subuser, p.get_id());
     }
   }
@@ -1155,11 +1153,11 @@ bool rgw::auth::LocalApplier::is_identity(const Principal& p) const {
 }
 
 void rgw::auth::LocalApplier::to_str(std::ostream& out) const {
-  out << "rgw::auth::LocalApplier(acct_user=" << user_info.user_id
-      << ", acct_name=" << user_info.display_name
+  out << "rgw::auth::LocalApplier(acct_user=" << user_info->user_id
+      << ", acct_name=" << user_info->display_name
       << ", subuser=" << subuser
       << ", perm_mask=" << get_perm_mask()
-      << ", is_admin=" << static_cast<bool>(user_info.admin) << ")";
+      << ", is_admin=" << static_cast<bool>(user_info->admin) << ")";
 }
 
 uint32_t rgw::auth::LocalApplier::get_perm_mask(const std::string& subuser_name,
@@ -1190,7 +1188,7 @@ auto rgw::auth::LocalApplier::load_acct_info(const DoutPrefixProvider* dpp) cons
 void rgw::auth::LocalApplier::modify_request_state(const DoutPrefixProvider* dpp, req_state* s) const
 {
   string key = "aws:userid";
-  string value = user_info.type == TYPE_ROOT ? user_info.account_id : user_info.user_id.id;
+  string value = user_info->type == TYPE_ROOT ? user_info->account_id : user_info->user_id.id;
   s->env.emplace(key, value);
 
   // copy our identity policies into req_state
@@ -1214,7 +1212,7 @@ rgw::auth::LocalApplier::LocalApplier(CephContext* const cct,
                                       std::string subuser,
                                       const std::optional<uint32_t>& perm_mask,
                                       const std::string access_key_id)
-  : user_info(user->get_info()),
+  : user_info(user->get_info_shared()),
     user(std::move(user)),
     account(std::move(account)),
     policies(std::move(policies)),
@@ -1375,7 +1373,7 @@ rgw::auth::AnonymousEngine::authenticate(const DoutPrefixProvider* dpp, const re
     RGWUserInfo user_info;
     rgw_get_anon_user(user_info);
     std::unique_ptr<rgw::sal::User> user = s->user->clone();
-    user->get_info() = user_info;
+    user->get_info_mut() = std::move(user_info);
     auto apl = \
       apl_factory->create_apl_local(cct, s, std::move(user), std::nullopt, {},
                                     rgw::auth::LocalApplier::NO_SUBUSER,

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -730,7 +730,7 @@ class LocalApplier : public IdentityApplier {
   using aclspec_t = rgw::auth::Identity::aclspec_t;
 
 protected:
-  const RGWUserInfo user_info;
+  const std::shared_ptr<const RGWUserInfo> user_info;
   mutable std::unique_ptr<rgw::sal::User> user;
   const std::optional<RGWAccountInfo> account;
   const std::vector<IAM::Policy> policies;
@@ -761,7 +761,7 @@ public:
   bool is_identity(const Principal& p) const override;
   uint32_t get_perm_mask() const override {
     if (this->perm_mask == RGW_PERM_INVALID) {
-      return get_perm_mask(subuser, user_info);
+      return get_perm_mask(subuser, *user_info);
     } else {
       return this->perm_mask;
     }
@@ -769,24 +769,24 @@ public:
   void to_str(std::ostream& out) const override;
   auto load_acct_info(const DoutPrefixProvider* dpp) const -> std::unique_ptr<rgw::sal::User> override; /* out */
   void modify_request_state(const DoutPrefixProvider* dpp, req_state* s) const override;
-  uint32_t get_identity_type() const override { return user_info.type; }
+  uint32_t get_identity_type() const override { return user_info->type; }
 
   std::optional<rgw::ARN> get_caller_identity() const override {
-    bool has_account_id = !user_info.account_id.empty();
-    std::string acct = has_account_id ? user_info.account_id : user_info.user_id.tenant;
-    if(user_info.type == TYPE_ROOT) {
+    bool has_account_id = !user_info->account_id.empty();
+    std::string acct = has_account_id ? user_info->account_id : user_info->user_id.tenant;
+    if(user_info->type == TYPE_ROOT) {
       return rgw::ARN("", "root", acct, true);
     }
 
-    std::string username = has_account_id ? user_info.display_name : user_info.user_id.id;
-    std::string path = user_info.path.empty() ? "/" : user_info.path;
+    std::string username = has_account_id ? user_info->display_name : user_info->user_id.id;
+    std::string path = user_info->path.empty() ? "/" : user_info->path;
     return rgw::ARN(string_cat_reserve(path, username), "user", acct, true);
   }
 
   std::string get_acct_name() const override { return {}; }
   std::string get_subuser() const override { return subuser; }
   const std::string& get_tenant() const override {
-    return user_info.user_id.tenant;
+    return user_info->user_id.tenant;
   }
   const std::optional<RGWAccountInfo>& get_account() const override {
     return account;

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -192,9 +192,9 @@ auto ThirdPartyAccountApplier<T>::load_acct_info(const DoutPrefixProvider* dpp) 
      * to the correct tenant */
     luser = driver->get_user(rgw_user(RGW_USER_ANON_ID));
     if (acct_user_override.tenant.empty())
-      luser->get_info().user_id = rgw_user(acct_user_override.id, RGW_USER_ANON_ID);
+      luser->get_info_mut().user_id = rgw_user(acct_user_override.id, RGW_USER_ANON_ID);
     else
-      luser->get_info().user_id = rgw_user(acct_user_override.tenant, RGW_USER_ANON_ID);
+      luser->get_info_mut().user_id = rgw_user(acct_user_override.tenant, RGW_USER_ANON_ID);
   } else {
     /* Compatibility mechanism for multi-tenancy. For more details refer to
      * load_acct_info method of rgw::auth::RemoteApplier. */

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -660,7 +660,7 @@ struct RGWUserInfo
       type(TYPE_NONE) {
   }
 
-  RGWAccessKey* get_key(const std::string& access_key) {
+  const RGWAccessKey* get_key(const std::string& access_key) const {
     if (access_keys.empty())
       return nullptr;
 

--- a/src/rgw/rgw_file_int.h
+++ b/src/rgw/rgw_file_int.h
@@ -1002,7 +1002,7 @@ namespace rgw {
     int authorize(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver) {
       int ret = driver->get_user_by_access_key(dpp, key.id, null_yield, &user);
       if (ret == 0) {
-	RGWAccessKey* k = user->get_info().get_key(key.id);
+	const RGWAccessKey* k = user->get_info().get_key(key.id);
 	if (!k || (k->key != key.key))
 	  return -EINVAL;
 	if (user->get_info().suspended)
@@ -1310,7 +1310,7 @@ namespace rgw {
 
     uint64_t get_fsid() { return root_fh.state.dev; }
 
-    RGWUserInfo* get_user() { return &user->get_info(); }
+    const RGWUserInfo* get_user() { return &user->get_info(); }
 
     void update_user(const DoutPrefixProvider *dpp) {
       (void) g_rgwlib->get_driver()->get_user_by_access_key(dpp, key.id, null_yield, &user);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5670,7 +5670,7 @@ void RGWPutMetadataAccount::execute(optional_yield y)
   }
 
   RGWUserInfo old_info = s->user->get_info();
-  RGWUserInfo& info = s->user->get_info();
+  RGWUserInfo& info = s->user->get_info_mut();
 
   /* Handle the TempURL-related stuff. */
   if (!temp_url_keys.empty()) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5669,22 +5669,25 @@ void RGWPutMetadataAccount::execute(optional_yield y)
     return;
   }
 
+  RGWUserInfo old_info = s->user->get_info();
+  RGWUserInfo& info = s->user->get_info();
+
   /* Handle the TempURL-related stuff. */
   if (!temp_url_keys.empty()) {
     for (auto& pair : temp_url_keys) {
-      s->user->get_info().temp_url_keys[pair.first] = std::move(pair.second);
+      info.temp_url_keys[pair.first] = std::move(pair.second);
     }
   }
 
   /* Handle the quota extracted at the verify_permission step. */
   if (new_quota_extracted) {
-    s->user->get_info().quota.user_quota = std::move(new_quota);
+    info.quota.user_quota = std::move(new_quota);
   }
 
   /* We are passing here the current (old) user info to allow the function
    * optimize-out some operations. */
   s->user->set_attrs(attrs);
-  op_ret = s->user->store_user(this, y, false, &s->user->get_info());
+  op_ret = s->user->store_user(this, y, false, &old_info);
 }
 
 int RGWPutMetadataBucket::verify_permission(optional_yield y)

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2596,7 +2596,7 @@ public:
   RGWGetObjLayout() {
   }
 
-  int check_caps(RGWUserCaps& caps) {
+  int check_caps(const RGWUserCaps& caps) {
     return caps.check_cap("admin", RGW_CAP_READ);
   }
   int verify_permission(optional_yield) override {

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -135,7 +135,7 @@ public:
   void gen_request(const std::string& method, const std::string& resource,
 		  int content_length, std::atomic<bool>* fail_flag);
 
-  void set_access_key(RGWAccessKey& key) { access_key = key; }
+  void set_access_key(const RGWAccessKey& key) { access_key = key; }
 };
 /* process stream request */
 extern int process_request(const RGWProcessEnv& penv,

--- a/src/rgw/rgw_rest_iam_group.cc
+++ b/src/rgw/rgw_rest_iam_group.cc
@@ -905,8 +905,8 @@ void RGWAddUserToGroup_IAM::execute(optional_yield y)
 
   op_ret = retry_raced_user_write(this, y, user.get(),
       [this, y] {
-        RGWUserInfo& info = user->get_info();
-        RGWUserInfo old_info = info;
+        RGWUserInfo old_info = user->get_info();
+        RGWUserInfo& info = user->get_info_mut();
 
         if (!info.group_ids.insert(group.id).second) {
           return 0; // nothing to do, return success
@@ -1042,8 +1042,8 @@ void RGWRemoveUserFromGroup_IAM::execute(optional_yield y)
 
   op_ret = retry_raced_user_write(this, y, user.get(),
       [this, y] {
-        RGWUserInfo& info = user->get_info();
-        RGWUserInfo old_info = info;
+        RGWUserInfo old_info = user->get_info();
+        RGWUserInfo& info = user->get_info_mut();
 
         auto id = info.group_ids.find(group.id);
         if (id == info.group_ids.end()) {

--- a/src/rgw/rgw_rest_iam_user.cc
+++ b/src/rgw/rgw_rest_iam_user.cc
@@ -205,7 +205,7 @@ void RGWCreateUser_IAM::execute(optional_yield y)
   }
 
   std::unique_ptr<rgw::sal::User> user = driver->get_user(info.user_id);
-  user->get_info() = info;
+  user->get_info_mut() = info;
 
   constexpr bool exclusive = true;
   op_ret = user->store_user(this, y, exclusive, nullptr);
@@ -432,8 +432,8 @@ void RGWUpdateUser_IAM::execute(optional_yield y)
 
   op_ret = retry_raced_user_write(this, y, user.get(),
       [this, y] {
-        RGWUserInfo& info = user->get_info();
-        RGWUserInfo old_info = info;
+        RGWUserInfo old_info = user->get_info();
+        RGWUserInfo& info = user->get_info_mut();
 
         if (!new_path.empty()) {
           info.path = new_path;
@@ -957,8 +957,8 @@ void RGWCreateAccessKey_IAM::execute(optional_yield y)
 
   op_ret = retry_raced_user_write(this, y, user.get(),
       [this, y, &max_keys] {
-        RGWUserInfo& info = user->get_info();
-        RGWUserInfo old_info = info;
+        RGWUserInfo old_info = user->get_info();
+        RGWUserInfo& info = user->get_info_mut();
 
         info.access_keys[key.id] = key;
 
@@ -1126,8 +1126,8 @@ void RGWUpdateAccessKey_IAM::execute(optional_yield y)
 
   op_ret = retry_raced_user_write(this, y, user.get(),
       [this, y] {
-        RGWUserInfo& info = user->get_info();
-        RGWUserInfo old_info = info;
+        RGWUserInfo old_info = user->get_info();
+        RGWUserInfo& info = user->get_info_mut();
 
         auto key = info.access_keys.find(access_key_id);
         if (key == info.access_keys.end()) {
@@ -1273,8 +1273,8 @@ void RGWDeleteAccessKey_IAM::execute(optional_yield y)
 
   op_ret = retry_raced_user_write(this, y, user.get(),
       [this, y, &site] {
-        RGWUserInfo& info = user->get_info();
-        RGWUserInfo old_info = info;
+        RGWUserInfo old_info = user->get_info();
+        RGWUserInfo& info = user->get_info_mut();
 
         auto key = info.access_keys.find(access_key_id);
         if (key == info.access_keys.end()) {

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -758,7 +758,7 @@ class User {
     virtual std::unique_ptr<User> clone() = 0;
 
     /** Get the display name for this User */
-    virtual std::string& get_display_name() = 0;
+    virtual const std::string& get_display_name() = 0;
     /** Get the tenant name for this User */
     virtual const std::string& get_tenant() = 0;
     /** Set the tenant name for this User */
@@ -820,7 +820,9 @@ class User {
                             GroupList& listing) = 0;
 
     /* dang temporary; will be removed when User is complete */
-    virtual RGWUserInfo& get_info() = 0;
+    virtual const RGWUserInfo& get_info() const = 0;
+    virtual RGWUserInfo& get_info_mut() = 0;
+    virtual std::shared_ptr<const RGWUserInfo> get_info_shared() = 0;
 
     /** Print the User to @a out */
     virtual void print(std::ostream& out) const = 0;

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -80,7 +80,8 @@ namespace rgw::sal {
   int DBUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y)
   {
     int ret;
-    ret = store->getDB()->get_user(dpp, string("user_id"), get_id().id, info, &attrs,
+    std::string id = get_id().id;
+    ret = store->getDB()->get_user(dpp, string("user_id"), id, get_info_mut(), &attrs,
         &objv_tracker);
     return ret;
   }
@@ -99,9 +100,9 @@ namespace rgw::sal {
 
   int DBUser::load_user(const DoutPrefixProvider *dpp, optional_yield y)
   {
-    int ret = 0;
-
-    ret = store->getDB()->get_user(dpp, string("user_id"), get_id().id, info, &attrs,
+    int ret;
+    std::string id = get_id().id;
+    ret = store->getDB()->get_user(dpp, string("user_id"), id, get_info_mut(), &attrs,
         &objv_tracker);
 
     return ret;
@@ -117,7 +118,7 @@ namespace rgw::sal {
   {
     int ret = 0;
 
-    ret = store->getDB()->store_user(dpp, info, exclusive, &attrs, &objv_tracker, old_info);
+    ret = store->getDB()->store_user(dpp, get_info(), exclusive, &attrs, &objv_tracker, old_info);
 
     return ret;
   }
@@ -126,7 +127,7 @@ namespace rgw::sal {
   {
     int ret = 0;
 
-    ret = store->getDB()->remove_user(dpp, info, &objv_tracker);
+    ret = store->getDB()->remove_user(dpp, get_info(), &objv_tracker);
 
     return ret;
   }

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -515,7 +515,7 @@ public:
   virtual std::unique_ptr<User> clone() override {
     return std::make_unique<FilterUser>(*this);
   }
-  virtual std::string& get_display_name() override { return next->get_display_name(); }
+  virtual const std::string& get_display_name() override { return next->get_display_name(); }
   virtual const std::string& get_tenant() override { return next->get_tenant(); }
   virtual void set_tenant(std::string& _t) override { next->set_tenant(_t); }
   virtual const std::string& get_ns() override { return next->get_ns(); }
@@ -553,7 +553,11 @@ public:
                   std::string_view marker, uint32_t max_items,
                   GroupList& listing) override;
 
-  RGWUserInfo& get_info() override { return next->get_info(); }
+  virtual const RGWUserInfo& get_info() const override { return next->get_info(); }
+  virtual RGWUserInfo& get_info_mut() override { return next->get_info_mut(); }
+  virtual std::shared_ptr<const RGWUserInfo> get_info_shared() override {
+    return next->get_info_shared();
+  }
   virtual void print(std::ostream& out) const override { return next->print(out); }
 
   /* Internal to Filters */

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -154,41 +154,71 @@ class StoreDriver : public Driver {
 
 class StoreUser : public User {
   protected:
-    RGWUserInfo info;
+    /* Holds either a shared (immutable, cache-sourced) RGWUserInfo
+     * or an owned (mutable) copy.
+     * If in shared mode and write access is requested (via get_info_mut()),
+     * the value is copied and mode is changed to owned.
+     * The shared value is kept in case references to it have already
+     * been returned.
+     */
+    bool shared_mode = false;
+    RGWUserInfo owned_info;
+    std::shared_ptr<const RGWUserInfo> shared_info;
     RGWObjVersionTracker objv_tracker;
     Attrs attrs;
 
   public:
-    StoreUser() : info() {}
-    StoreUser(const rgw_user& _u) : info() { info.user_id = _u; }
-    StoreUser(const RGWUserInfo& _i) : info(_i) {}
+    StoreUser() {}
+    StoreUser(const rgw_user& _u) { owned_info.user_id = _u; }
+    StoreUser(const RGWUserInfo& _i) : owned_info(_i) {}
+    StoreUser(RGWUserInfo&& _i) : owned_info(std::move(_i)) {}
+    StoreUser(std::shared_ptr<const RGWUserInfo> _i) { set_info_shared(std::move(_i)); }
     StoreUser(StoreUser& _o) = default;
     virtual ~StoreUser() = default;
 
-    virtual std::string& get_display_name() override { return info.display_name; }
-    virtual const std::string& get_tenant() override { return info.user_id.tenant; }
-    virtual void set_tenant(std::string& _t) override { info.user_id.tenant = _t; }
-    virtual const std::string& get_ns() override { return info.user_id.ns; }
-    virtual void set_ns(std::string& _ns) override { info.user_id.ns = _ns; }
-    virtual void clear_ns() override { info.user_id.ns.clear(); }
-    virtual const rgw_user& get_id() const override { return info.user_id; }
-    virtual uint32_t get_type() const override { return info.type; }
-    virtual int32_t get_max_buckets() const override { return info.max_buckets; }
-    virtual void set_max_buckets(int32_t _max_buckets) override {
-      info.max_buckets = _max_buckets;
+    void set_info_shared(std::shared_ptr<const RGWUserInfo> _i) {
+      ceph_assert(_i);
+      shared_mode = true;
+      shared_info = std::move(_i);
     }
-    virtual const RGWUserCaps& get_caps() const override { return info.caps; }
+
+    virtual const std::string& get_display_name() override { return get_info().display_name; }
+    virtual const std::string& get_tenant() override { return get_info().user_id.tenant; }
+    virtual void set_tenant(std::string& _t) override { get_info_mut().user_id.tenant = _t; }
+    virtual const std::string& get_ns() override { return get_info().user_id.ns; }
+    virtual void set_ns(std::string& _ns) override { get_info_mut().user_id.ns = _ns; }
+    virtual void clear_ns() override { get_info_mut().user_id.ns.clear(); }
+    virtual const rgw_user& get_id() const override { return get_info().user_id; }
+    virtual uint32_t get_type() const override { return get_info().type; }
+    virtual int32_t get_max_buckets() const override { return get_info().max_buckets; }
+    virtual void set_max_buckets(int32_t _max_buckets) override {
+      get_info_mut().max_buckets = _max_buckets;
+    }
+    virtual const RGWUserCaps& get_caps() const override { return get_info().caps; }
     virtual RGWObjVersionTracker& get_version_tracker() override { return objv_tracker; }
     virtual Attrs& get_attrs() override { return attrs; }
     virtual void set_attrs(Attrs& _attrs) override { attrs = _attrs; }
-    virtual bool empty() const override { return info.user_id.id.empty(); }
-    virtual RGWUserInfo& get_info() override { return info; }
-    virtual void set_info(RGWQuotaInfo& _quota) override {
-      info.quota.user_quota.max_size = _quota.max_size;
-      info.quota.user_quota.max_objects = _quota.max_objects;
+    virtual bool empty() const override { return get_info().user_id.id.empty(); }
+    virtual const RGWUserInfo& get_info() const override {
+      return shared_mode ? *shared_info : owned_info;
+    }
+    virtual RGWUserInfo& get_info_mut() override {
+      if (shared_mode) {
+        owned_info = *shared_info;
+        shared_mode = false;
+      }
+      return owned_info;
+    }
+    virtual std::shared_ptr<const RGWUserInfo> get_info_shared() override {
+      return shared_mode ?
+        shared_info : std::make_shared<const RGWUserInfo>(owned_info);
     }
 
-    virtual void print(std::ostream& out) const override { out << info.user_id; }
+    virtual void set_info(RGWQuotaInfo& _quota) override {
+      get_info_mut().quota.user_quota.max_size = _quota.max_size;
+      get_info_mut().quota.user_quota.max_objects = _quota.max_objects;
+    }
+    virtual void print(std::ostream& out) const override { out << get_info().user_id; }
 
     friend class StoreBucket;
 };

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -563,7 +563,7 @@ static int build_token(const string& swift_user,
 
 }
 
-static int encode_token(CephContext *cct, string& swift_user, string& key,
+static int encode_token(CephContext *cct, const string& swift_user, const string& key,
 			bufferlist& bl)
 {
   const auto nonce = ceph::util::generate_random_number<uint64_t>();
@@ -711,8 +711,8 @@ void RGW_SWIFT_Auth_Get::execute(optional_yield y)
   string user_str;
   std::unique_ptr<rgw::sal::User> user;
   bufferlist bl;
-  RGWAccessKey *swift_key;
-  map<string, RGWAccessKey>::iterator siter;
+  const RGWAccessKey *swift_key;
+  map<string, RGWAccessKey>::const_iterator siter;
 
   string swift_url = g_conf()->rgw_swift_url;
   string swift_prefix = g_conf()->rgw_swift_url_prefix;

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -270,7 +270,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
      * mechanism that requires  account name internally, so there is no
      * business with delegating the responsibility outside. */
     std::unique_ptr<rgw::sal::User> user = s->user->clone();
-    user->get_info() = user_info;
+    user->get_info_mut() = user_info;
     return aplptr_t(new rgw::auth::swift::TempURLApplier(cct, std::move(user)));
   }
 

--- a/src/rgw/services/svc_user.h
+++ b/src/rgw/services/svc_user.h
@@ -69,6 +69,12 @@ public:
                                optional_yield y,
                                const DoutPrefixProvider *dpp) = 0;
 
+  virtual int get_user_info_by_uid(const rgw_user& uid, RGWUserInfo *info,
+                             RGWObjVersionTracker *objv_tracker,
+                             std::map<std::string, bufferlist>* pattrs,
+                             real_time *pmtime,
+                             optional_yield y,
+                             const DoutPrefixProvider *dpp) = 0;
   virtual int get_user_info_by_email(const std::string& email, RGWUserInfo *info,
                              RGWObjVersionTracker *objv_tracker,
                              std::map<std::string, bufferlist>* pattrs,

--- a/src/rgw/services/svc_user.h
+++ b/src/rgw/services/svc_user.h
@@ -69,27 +69,29 @@ public:
                                optional_yield y,
                                const DoutPrefixProvider *dpp) = 0;
 
-  virtual int get_user_info_by_uid(const rgw_user& uid, RGWUserInfo *info,
+  virtual int get_user_info_by_uid(const rgw_user& uid,
+                             std::shared_ptr<const RGWUserInfo>& info,
                              RGWObjVersionTracker *objv_tracker,
                              std::map<std::string, bufferlist>* pattrs,
                              real_time *pmtime,
                              optional_yield y,
                              const DoutPrefixProvider *dpp) = 0;
-  virtual int get_user_info_by_email(const std::string& email, RGWUserInfo *info,
+  virtual int get_user_info_by_email(const std::string& email,
+                             std::shared_ptr<const RGWUserInfo>& info,
                              RGWObjVersionTracker *objv_tracker,
                              std::map<std::string, bufferlist>* pattrs,
                              real_time *pmtime,
                              optional_yield y,
                              const DoutPrefixProvider *dpp) = 0;
   virtual int get_user_info_by_swift(const std::string& swift_name,
-                             RGWUserInfo *info,        /* out */
+                             std::shared_ptr<const RGWUserInfo>& info,
                              RGWObjVersionTracker * const objv_tracker,
                              std::map<std::string, bufferlist>* pattrs,
                              real_time * const pmtime,
                              optional_yield y,
                              const DoutPrefixProvider *dpp) = 0;
   virtual int get_user_info_by_access_key(const std::string& access_key,
-                                  RGWUserInfo *info,
+                                  std::shared_ptr<const RGWUserInfo>& info,
                                   RGWObjVersionTracker* objv_tracker,
                                   std::map<std::string, bufferlist>* pattrs,
                                   real_time *pmtime,

--- a/src/rgw/services/svc_user_rados.cc
+++ b/src/rgw/services/svc_user_rados.cc
@@ -223,10 +223,10 @@ public:
       if (!key.active || swift_key_active(old_info, id))
         continue;
       /* check if swift mapping exists */
-      RGWUserInfo inf;
-      int r = svc.user->get_user_info_by_swift(id, &inf, nullptr, nullptr, nullptr, y, dpp);
-      if (r >= 0 && inf.user_id != info.user_id &&
-          (!old_info || inf.user_id != old_info->user_id)) {
+      std::shared_ptr<const RGWUserInfo> inf;
+      int r = svc.user->get_user_info_by_swift(id, inf, nullptr, nullptr, nullptr, y, dpp);
+      if (r >= 0 && inf->user_id != info.user_id &&
+          (!old_info || inf->user_id != old_info->user_id)) {
         ldpp_dout(dpp, 0) << "WARNING: can't store user info, swift id (" << id
           << ") already mapped to another user (" << info.user_id << ")" << dendl;
         return -EEXIST;
@@ -239,10 +239,10 @@ public:
         continue;
       if (s3_key_active(old_info, id)) // old key already active
         continue;
-      RGWUserInfo inf;
-      int r = svc.user->get_user_info_by_access_key(id, &inf, nullptr, nullptr, nullptr, y, dpp);
-      if (r >= 0 && inf.user_id != info.user_id &&
-          (!old_info || inf.user_id != old_info->user_id)) {
+      std::shared_ptr<const RGWUserInfo> inf;
+      int r = svc.user->get_user_info_by_access_key(id, inf, nullptr, nullptr, nullptr, y, dpp);
+      if (r >= 0 && inf->user_id != info.user_id &&
+          (!old_info || inf->user_id != old_info->user_id)) {
         ldpp_dout(dpp, 0) << "WARNING: can't store user info, access key already mapped to another user" << dendl;
         return -EEXIST;
       }
@@ -645,7 +645,7 @@ static int read_index(const DoutPrefixProvider* dpp, optional_yield y,
 
 int RGWSI_User_RADOS::get_user_info_from_index(const string& key,
                                                const rgw_pool& pool,
-                                               RGWUserInfo *info,
+                                               std::shared_ptr<const RGWUserInfo>& info,
                                                RGWObjVersionTracker* objv_tracker,
                                                std::map<std::string, bufferlist>* pattrs,
                                                real_time* pmtime, optional_yield y,
@@ -654,7 +654,7 @@ int RGWSI_User_RADOS::get_user_info_from_index(const string& key,
   string cache_key = pool.to_str() + "/" + key;
 
   if (auto e = uinfo_cache->find(cache_key)) {
-    *info = e->info;
+    info = e->info;
     if (objv_tracker)
       *objv_tracker = e->objv_tracker;
     if (pattrs)
@@ -677,16 +677,18 @@ int RGWSI_User_RADOS::get_user_info_from_index(const string& key,
     return -ENOENT;
   }
 
+  RGWUserInfo new_info;
   rgw_cache_entry_info cache_info;
-  ret = read_user_info(rgw_user{uid.id}, &e.info, &e.objv_tracker,
+  ret = read_user_info(rgw_user{uid.id}, &new_info, &e.objv_tracker,
                        nullptr, &cache_info, &e.attrs, y, dpp);
   if (ret < 0) {
     return ret;
   }
+  e.info = std::make_shared<const RGWUserInfo>(std::move(new_info));
 
   uinfo_cache->put(dpp, svc.cache, cache_key, &e, { &cache_info });
 
-  *info = e.info;
+  info = e.info;
   if (objv_tracker)
     *objv_tracker = e.objv_tracker;
   if (pmtime)
@@ -698,7 +700,8 @@ int RGWSI_User_RADOS::get_user_info_from_index(const string& key,
   return 0;
 }
 
-int RGWSI_User_RADOS::get_user_info_by_uid(const rgw_user& uid, RGWUserInfo *info,
+int RGWSI_User_RADOS::get_user_info_by_uid(const rgw_user& uid,
+                                       std::shared_ptr<const RGWUserInfo>& info,
                                        RGWObjVersionTracker* objv_tracker,
                                        std::map<std::string, bufferlist>* pattrs,
                                        real_time* pmtime, optional_yield y,
@@ -708,7 +711,7 @@ int RGWSI_User_RADOS::get_user_info_by_uid(const rgw_user& uid, RGWUserInfo *inf
   const string cache_key = pool.to_str() + "/" + uid.to_str();
 
   if (auto e = uinfo_cache->find(cache_key)) {
-    *info = e->info;
+    info = e->info;
     if (objv_tracker)
       *objv_tracker = e->objv_tracker;
     if (pattrs)
@@ -718,19 +721,19 @@ int RGWSI_User_RADOS::get_user_info_by_uid(const rgw_user& uid, RGWUserInfo *inf
     return 0;
   }
 
-  RGWUserInfo new_info(info ? *info : RGWUserInfo{});
+  RGWUserInfo new_info;
   user_info_cache_entry e;
   rgw_cache_entry_info cache_info;
-  int ret = read_user_info(ctx, uid, &new_info, &e.objv_tracker,
+  int ret = read_user_info(uid, &new_info, &e.objv_tracker,
                            &e.mtime, &cache_info, &e.attrs, y, dpp);
   if (ret < 0) {
     return ret;
   }
-  e.info = std::move(new_info);
+  e.info = std::make_shared<const RGWUserInfo>(std::move(new_info));
 
   uinfo_cache->put(dpp, svc.cache, cache_key, &e, { &cache_info });
 
-  *info = e.info;
+  info = e.info;
   if (objv_tracker)
     *objv_tracker = e.objv_tracker;
   if (pmtime)
@@ -744,7 +747,8 @@ int RGWSI_User_RADOS::get_user_info_by_uid(const rgw_user& uid, RGWUserInfo *inf
  * Given an email, finds the user info associated with it.
  * returns: 0 on success, -ERR# on failure (including nonexistence)
  */
-int RGWSI_User_RADOS::get_user_info_by_email(const string& email, RGWUserInfo *info,
+int RGWSI_User_RADOS::get_user_info_by_email(const string& email,
+                                       std::shared_ptr<const RGWUserInfo>& info,
                                        RGWObjVersionTracker *objv_tracker,
                                        std::map<std::string, bufferlist>* pattrs,
                                        real_time *pmtime, optional_yield y,
@@ -761,7 +765,7 @@ int RGWSI_User_RADOS::get_user_info_by_email(const string& email, RGWUserInfo *i
  * returns: 0 on success, -ERR# on failure (including nonexistence)
  */
 int RGWSI_User_RADOS::get_user_info_by_swift(const string& swift_name,
-                                       RGWUserInfo *info,        /* out */
+                                       std::shared_ptr<const RGWUserInfo>& info,
                                        RGWObjVersionTracker * const objv_tracker,
                                        std::map<std::string, bufferlist>* pattrs,
                                        real_time * const pmtime, optional_yield y,
@@ -777,7 +781,7 @@ int RGWSI_User_RADOS::get_user_info_by_swift(const string& swift_name,
  * returns: 0 on success, -ERR# on failure (including nonexistence)
  */
 int RGWSI_User_RADOS::get_user_info_by_access_key(const std::string& access_key,
-                                            RGWUserInfo *info,
+                                            std::shared_ptr<const RGWUserInfo>& info,
                                             RGWObjVersionTracker* objv_tracker,
                                             std::map<std::string, bufferlist>* pattrs,
                                             real_time *pmtime, optional_yield y,

--- a/src/rgw/services/svc_user_rados.cc
+++ b/src/rgw/services/svc_user_rados.cc
@@ -698,6 +698,48 @@ int RGWSI_User_RADOS::get_user_info_from_index(const string& key,
   return 0;
 }
 
+int RGWSI_User_RADOS::get_user_info_by_uid(const rgw_user& uid, RGWUserInfo *info,
+                                       RGWObjVersionTracker* objv_tracker,
+                                       std::map<std::string, bufferlist>* pattrs,
+                                       real_time* pmtime, optional_yield y,
+                                       const DoutPrefixProvider* dpp)
+{
+  const rgw_pool& pool = svc.zone->get_zone_params().user_uid_pool;
+  const string cache_key = pool.to_str() + "/" + uid.to_str();
+
+  if (auto e = uinfo_cache->find(cache_key)) {
+    *info = e->info;
+    if (objv_tracker)
+      *objv_tracker = e->objv_tracker;
+    if (pattrs)
+      *pattrs = e->attrs;
+    if (pmtime)
+      *pmtime = e->mtime;
+    return 0;
+  }
+
+  RGWUserInfo new_info(info ? *info : RGWUserInfo{});
+  user_info_cache_entry e;
+  rgw_cache_entry_info cache_info;
+  int ret = read_user_info(ctx, uid, &new_info, &e.objv_tracker,
+                           &e.mtime, &cache_info, &e.attrs, y, dpp);
+  if (ret < 0) {
+    return ret;
+  }
+  e.info = std::move(new_info);
+
+  uinfo_cache->put(dpp, svc.cache, cache_key, &e, { &cache_info });
+
+  *info = e.info;
+  if (objv_tracker)
+    *objv_tracker = e.objv_tracker;
+  if (pmtime)
+    *pmtime = e.mtime;
+  if (pattrs)
+    *pattrs = std::move(e.attrs);
+  return 0;
+}
+
 /**
  * Given an email, finds the user info associated with it.
  * returns: 0 on success, -ERR# on failure (including nonexistence)

--- a/src/rgw/services/svc_user_rados.h
+++ b/src/rgw/services/svc_user_rados.h
@@ -40,7 +40,7 @@ class RGWSI_User_RADOS : public RGWSI_User
   friend class PutOperation;
 
   struct user_info_cache_entry {
-    RGWUserInfo info;
+    std::shared_ptr<const RGWUserInfo> info;
     RGWObjVersionTracker objv_tracker;
     std::map<std::string, bufferlist> attrs;
     real_time mtime;
@@ -53,7 +53,7 @@ class RGWSI_User_RADOS : public RGWSI_User
 
   int get_user_info_from_index(const std::string& key,
                                const rgw_pool& pool,
-                               RGWUserInfo *info,
+                               std::shared_ptr<const RGWUserInfo>& info,
                                RGWObjVersionTracker * const objv_tracker,
                                std::map<std::string, bufferlist>* pattrs,
                                real_time * const pmtime,
@@ -115,27 +115,29 @@ public:
                        optional_yield y,
                        const DoutPrefixProvider *dpp) override;
 
-  int get_user_info_by_uid(const rgw_user& uid, RGWUserInfo *info,
+  int get_user_info_by_uid(const rgw_user& uid,
+                           std::shared_ptr<const RGWUserInfo>& info,
                            RGWObjVersionTracker *objv_tracker,
                            std::map<std::string, bufferlist>* pattrs,
                            real_time *pmtime,
                            optional_yield y,
                            const DoutPrefixProvider *dpp) override;
-  int get_user_info_by_email(const std::string& email, RGWUserInfo *info,
+  int get_user_info_by_email(const std::string& email,
+                             std::shared_ptr<const RGWUserInfo>& info,
                              RGWObjVersionTracker *objv_tracker,
                              std::map<std::string, bufferlist>* pattrs,
                              real_time *pmtime,
                              optional_yield y,
                              const DoutPrefixProvider *dpp) override;
   int get_user_info_by_swift(const std::string& swift_name,
-                             RGWUserInfo *info,        /* out */
+                             std::shared_ptr<const RGWUserInfo>& info,
                              RGWObjVersionTracker * const objv_tracker,
                              std::map<std::string, bufferlist>* pattrs,
                              real_time * const pmtime,
                              optional_yield y,
                              const DoutPrefixProvider *dpp) override;
   int get_user_info_by_access_key(const std::string& access_key,
-                                  RGWUserInfo *info,
+                                  std::shared_ptr<const RGWUserInfo>& info,
                                   RGWObjVersionTracker* objv_tracker,
                                   std::map<std::string, bufferlist>* pattrs,
                                   real_time *pmtime,

--- a/src/rgw/services/svc_user_rados.h
+++ b/src/rgw/services/svc_user_rados.h
@@ -115,6 +115,12 @@ public:
                        optional_yield y,
                        const DoutPrefixProvider *dpp) override;
 
+  int get_user_info_by_uid(const rgw_user& uid, RGWUserInfo *info,
+                           RGWObjVersionTracker *objv_tracker,
+                           std::map<std::string, bufferlist>* pattrs,
+                           real_time *pmtime,
+                           optional_yield y,
+                           const DoutPrefixProvider *dpp) override;
   int get_user_info_by_email(const std::string& email, RGWUserInfo *info,
                              RGWObjVersionTracker *objv_tracker,
                              std::map<std::string, bufferlist>* pattrs,

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -252,6 +252,10 @@ add_executable(unittest_rgw_putobj test_rgw_putobj.cc)
 add_ceph_unittest(unittest_rgw_putobj)
 target_link_libraries(unittest_rgw_putobj ${rgw_libs} ${UNITTEST_LIBS})
 
+add_executable(unittest_rgw_sal_store test_rgw_sal_store.cc)
+add_ceph_unittest(unittest_rgw_sal_store)
+target_link_libraries(unittest_rgw_sal_store ${rgw_libs} ${UNITTEST_LIBS})
+
 add_executable(unittest_rgw_throttle test_rgw_throttle.cc)
 add_ceph_unittest(unittest_rgw_throttle)
 target_link_libraries(unittest_rgw_throttle ${rgw_libs} ${UNITTEST_LIBS})

--- a/src/test/rgw/test_d4n_filter.cc
+++ b/src/test/rgw/test_d4n_filter.cc
@@ -152,7 +152,7 @@ class D4NFilterFixture: public ::testing::Test {
       rgw_user u("test_tenant", "test_user", "ns");
 
       testUser = driver->get_user(u);
-      testUser->get_info().user_id = u;
+      testUser->get_info_mut().user_id = u;
 
       ASSERT_EQ(testUser->store_user(env->dpp, optional_yield{yield}, false), 0);
     }

--- a/src/test/rgw/test_rgw_sal_store.cc
+++ b/src/test/rgw/test_rgw_sal_store.cc
@@ -1,0 +1,67 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "rgw/rgw_sal_store.h"
+#include <gtest/gtest.h>
+
+namespace {
+
+class TestUser : public rgw::sal::StoreUser {
+public:
+  std::unique_ptr<rgw::sal::User> clone() override {
+    return std::make_unique<TestUser>(*this);
+  }
+  int read_attrs(const DoutPrefixProvider*, optional_yield) override { return 0; }
+  int read_usage(const DoutPrefixProvider*, uint64_t, uint64_t, uint32_t,
+                 bool*, RGWUsageIter&,
+                 std::map<rgw_user_bucket, rgw_usage_log_entry>&) override { return 0; }
+  int trim_usage(const DoutPrefixProvider*, uint64_t, uint64_t,
+                 optional_yield) override { return 0; }
+  int load_user(const DoutPrefixProvider*, optional_yield) override { return 0; }
+  int store_user(const DoutPrefixProvider*, optional_yield, bool,
+                 RGWUserInfo*) override { return 0; }
+  int remove_user(const DoutPrefixProvider*, optional_yield) override { return 0; }
+  int merge_and_store_attrs(const DoutPrefixProvider*, rgw::sal::Attrs&,
+                            optional_yield) override { return 0; }
+  int verify_mfa(const std::string&, bool*, const DoutPrefixProvider*,
+                 optional_yield) override { return 0; }
+  int list_groups(const DoutPrefixProvider*, optional_yield,
+                  std::string_view, uint32_t,
+                  rgw::sal::GroupList&) override { return 0; }
+};
+
+} // namespace
+
+TEST(StoreUserCOW, get_info_mut_does_not_mutate_shared)
+{
+  RGWUserInfo orig;
+  orig.display_name = "shared";
+  auto shared = std::make_shared<const RGWUserInfo>(orig);
+
+  TestUser user;
+  EXPECT_EQ(user.get_info().display_name, "");
+
+  user.get_info_mut().display_name = "owned1";
+  EXPECT_EQ(user.get_info().display_name, "owned1");
+
+  // Verify that get_info_mut() after set_info_shared() performs a
+  // copy-on-write: the shared object must not be mutated, and the
+  // user's own view must reflect the change.
+  user.set_info_shared(shared);
+  auto info = user.get_info();
+  EXPECT_EQ(user.get_info().display_name, "shared");
+
+  user.get_info_mut().display_name = "owned2";
+  EXPECT_EQ(user.get_info().display_name, "owned2");
+
+  EXPECT_EQ(shared->display_name, "shared");
+
+  // get_info_shared() returns the user info as shared_ptr,
+  // regardless of current mode
+  auto shared2 = user.get_info_shared();
+  EXPECT_EQ(shared2->display_name, "owned2");
+
+  // Info saved while shared stays valid.
+  shared.reset();
+  EXPECT_EQ(info.display_name, "shared");
+}


### PR DESCRIPTION
During authentication a RGWUserInfo is retrieved and copied several times, finally into the req_state.

We have users with a quite large number of access_keys (>700). Copy of the RGWUserInfo uses much CPU for those users (we saw 30% of the cpu time consumed in new/copy/free).

This pull requst removes the copy but passes the RGWUserInfo around as a shared pointer. The value is read only, whenever modification is needed, a copy is made and the copy is modified and used from this point.

The uinfo cache is changed to store and return shared pointer instead of values.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
