### PR TITLE
crimson/os/seastore/transaction_manager: retire prior_instance's shadow when retiring mutation_pending extents

### DIFF
--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -620,6 +620,7 @@ TransactionManager::relocate_shadow_extent(
     )->template cast<LogicalChildNode>();
   } else {
     extent = co_await std::move(v.get_child_fut());
+    ceph_assert(extent->is_stable());
     if (extent->is_stable_dirty()) {
       // the extent is dirty, skip it.
       DEBUGT("skipping dirty extent: {}", t, *extent);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -251,9 +251,16 @@ TransactionManager::ref_ret TransactionManager::remove(
   co_await lba_manager->update_mapping_refcount(
     t, std::move(cursor), -1);
   if (refcount == 0) {
+    LogicalChildNodeRef shadow;
+    if (ref->is_mutation_pending()) {
+      auto &prior = static_cast<LogicalChildNode&>(*ref->get_prior_instance());
+      shadow = prior.get_shadow();
+    } else {
+      shadow = ref->get_shadow();
+    }
     cache->retire_extent(t, ref);
     if (shadow_addr != P_ADDR_NULL) {
-      if (auto shadow = ref->get_shadow(); shadow) {
+      if (shadow) {
         cache->retire_extent(t, shadow);
       } else {
         auto laddr = ref->get_laddr();
@@ -333,9 +340,17 @@ TransactionManager::_remove(
 	LogicalChildNode
 	>();
       ceph_assert(extent);
+      LogicalChildNodeRef shadow;
+      if (extent->is_mutation_pending()) {
+        auto &prior = static_cast<LogicalChildNode&>(
+          *extent->get_prior_instance());
+        shadow = prior.get_shadow();
+      } else {
+        shadow = extent->get_shadow();
+      }
       cache->retire_extent(t, extent);
       if (mapping.has_shadow_val()) {
-        if (auto shadow = extent->get_shadow(); shadow) {
+        if (shadow) {
           cache->retire_extent(t, shadow);
         } else {
           auto laddr = mapping.get_intermediate_base();
@@ -585,6 +600,7 @@ TransactionManager::relocate_shadow_extent(
   auto v = get_extent_if_linked(t, *mapping.direct_cursor);
   LogicalChildNodeRef extent;
   auto laddr = mapping.get_intermediate_base();
+  LogicalChildNodeRef shadow;
   if (!v.has_child()) {
     auto &child_pos = v.get_child_pos();
     extent = cache->retire_absent_extent_addr_by_type(
@@ -609,9 +625,10 @@ TransactionManager::relocate_shadow_extent(
       DEBUGT("skipping dirty extent: {}", t, *extent);
       co_return LogicalChildNodeRef();
     }
+    shadow = extent->get_shadow();
     cache->retire_extent(t, extent);
   }
-  if (auto shadow = extent->get_shadow(); shadow) {
+  if (shadow) {
     cache->retire_extent(t, shadow);
   } else {
     auto shadow_paddr = mapping.get_shadow_val();


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/80136
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
