### PR TITLE
squid: doc/cephadm: note Podman release floor in services/smb.rst

### DIFF
--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -14,6 +14,10 @@ SMB Service
     is developed it will be the preferred method for managing
     SMB on ceph.
 
+.. important::
+
+    If using Podman, the SMB service requires Podman release 4.1.0 or later.
+
 
 Deploying Samba Containers
 ==========================


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80152
backport of https://github.com/ceph/ceph/pull/71401 (generated with ceph-backport-doc.sh)


---

The cephadm SMB service configures `shareable` IPC mode for the samba containers. [The code](https://github.com/ceph/ceph/blame/main/src/cephadm/cephadmlib/daemons/smb.py#L953) includes a comment that it is explicitly wanted. Shareable IPC support was added in Podman 4.1.0 so add a prominent note about that requirement.



parent tracker: https://tracker.ceph.com/issues/76275



- Original: https://docs.ceph.com/en/latest/cephadm/services/smb/

- Rendered PR: https://ceph--71401.org.readthedocs.build/en/71401/cephadm/services/smb/
