### PR TITLE
node-proxy: stop showing "unknown" when Redfish has no Description/Name

### DIFF
--- a/src/ceph-node-proxy/ceph_node_proxy/atollon.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/atollon.py
@@ -14,40 +14,9 @@ class AtollonRedfishProvider(BaseRedfishSystem):
         super().__init__(**kw)
         self.log = get_logger(__name__)
 
-    def get_component_spec_overrides(self) -> Dict[str, Dict[str, Any]]:
-        return {
-            "memory": {
-                "fields": [
-                    "Id" if field == "Description" else field
-                    for field in BaseRedfishSystem.MEMORY_FIELDS
-                ],
-            },
-        }
-
-    def _update_memory(self) -> None:
-        super()._update_memory()
-        for members in self._sys.get("memory", {}).values():
-            for member_data in members.values():
-                member_id = member_data.get("id")
-                if member_id is not None and member_data.get("description") is None:
-                    member_data["description"] = member_id
-
     def _update_storage(self) -> None:
         super()._update_storage()
-        self.fix_storage_descriptions()
         self.enrich_storage_from_controllers()
-
-    def fix_storage_descriptions(self) -> None:
-        for members in self._sys.get("storage", {}).values():
-            for drive_id, drive_data in members.items():
-                description = drive_data.get("description")
-                if description is not None and description != "unknown":
-                    continue
-                endpoint = drive_data.get("redfish_endpoint", "")
-                if isinstance(endpoint, str) and endpoint:
-                    drive_data["description"] = endpoint.rstrip("/").split("/")[-1]
-                else:
-                    drive_data["description"] = drive_id
 
     def enrich_storage_from_controllers(self) -> None:
         for member in self.endpoints["systems"].get_members_names():

--- a/src/ceph-node-proxy/ceph_node_proxy/baseredfishsystem.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/baseredfishsystem.py
@@ -12,13 +12,20 @@ from ceph_node_proxy.redfish import (
     update_component,
 )
 from ceph_node_proxy.redfish_client import RedFishClient
-from ceph_node_proxy.util import DEFAULTS, get_logger, normalize_dict, to_snake_case
+from ceph_node_proxy.util import (
+    DEFAULTS,
+    fill_missing_identity,
+    get_logger,
+    normalize_dict,
+    to_snake_case,
+)
 
 
 class BaseRedfishSystem(BaseSystem):
-    NETWORK_FIELDS: List[str] = ["Description", "Name", "SpeedMbps", "Status"]
+    NETWORK_FIELDS: List[str] = ["Description", "Name", "Id", "SpeedMbps", "Status"]
     PROCESSORS_FIELDS: List[str] = [
         "Description",
+        "Id",
         "TotalCores",
         "TotalThreads",
         "ProcessorType",
@@ -28,13 +35,15 @@ class BaseRedfishSystem(BaseSystem):
     ]
     MEMORY_FIELDS: List[str] = [
         "Description",
+        "Id",
         "MemoryDeviceType",
         "CapacityMiB",
         "Status",
     ]
-    POWER_FIELDS: List[str] = ["Name", "Model", "Manufacturer", "Status"]
+    POWER_FIELDS: List[str] = ["Name", "Id", "Model", "Manufacturer", "Status"]
     FANS_FIELDS: List[str] = [
         "Name",
+        "Id",
         "PhysicalContext",
         "Reading",
         "ReadingUnits",
@@ -42,6 +51,7 @@ class BaseRedfishSystem(BaseSystem):
     ]
     TEMPERATURES_FIELDS: List[str] = [
         "Name",
+        "Id",
         "PhysicalContext",
         "Reading",
         "ReadingUnits",
@@ -50,6 +60,7 @@ class BaseRedfishSystem(BaseSystem):
     FIRMWARE_FIELDS: List[str] = [
         "Name",
         "Description",
+        "Id",
         "ReleaseDate",
         "Version",
         "Updateable",
@@ -320,6 +331,7 @@ class BaseRedfishSystem(BaseSystem):
                             if use_single_key
                             else f"{path_prefix}_{member_id}"
                         )
+                        fill_missing_identity(data, key)
                         self._sys[component][sys_id][key] = data
             except Exception as e:
                 self.log.debug(
@@ -338,6 +350,7 @@ class BaseRedfishSystem(BaseSystem):
     def _update_storage(self) -> None:
         fields = [
             "Description",
+            "Id",
             "CapacityBytes",
             "Model",
             "Protocol",
@@ -367,6 +380,8 @@ class BaseRedfishSystem(BaseSystem):
                         result[member][drive_id]["entity"] = entity
             # do not normalize the first level of the dictionary
             result[member] = normalize_dict(result[member])
+            for drive_id, drive_data in result[member].items():
+                fill_missing_identity(drive_data, drive_id)
             self._sys["storage"] = result
 
     def _update_sn(self) -> None:

--- a/src/ceph-node-proxy/ceph_node_proxy/util.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/util.py
@@ -149,6 +149,34 @@ def normalize_dict(test_dict: Dict) -> Dict:
     return res
 
 
+def is_unknown(value: Any) -> bool:
+    if value is None:
+        return True
+    return isinstance(value, str) and value.strip().lower() in ("", "unknown")
+
+
+def fill_missing_identity(member_data: Dict[str, Any], member_key: Any) -> None:
+    """Fill description/name from Redfish Id, endpoint, or collection member key."""
+    endpoint = member_data.get("redfish_endpoint")
+    endpoint_name = None
+    if isinstance(endpoint, str) and endpoint.strip():
+        endpoint_name = endpoint.rstrip("/").split("/")[-1]
+    fallback = next(
+        (
+            candidate
+            for candidate in (endpoint_name, member_data.get("id"), member_key)
+            if not is_unknown(candidate)
+        ),
+        None,
+    )
+    if is_unknown(fallback):
+        return
+    if is_unknown(member_data.get("description")):
+        member_data["description"] = fallback
+    if "name" in member_data and is_unknown(member_data.get("name")):
+        member_data["name"] = fallback
+
+
 def retry(
     exceptions: Any = Exception, retries: int = 20, delay: int = 1
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:

--- a/src/ceph-node-proxy/tests/test_atollon.py
+++ b/src/ceph-node-proxy/tests/test_atollon.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ceph_node_proxy.atollon import AtollonRedfishProvider
-from ceph_node_proxy.baseredfishsystem import BaseRedfishSystem
 
 
 @pytest.fixture
@@ -21,60 +20,7 @@ def atollon_redfish():
         )
 
 
-class TestAtollonRedfishProviderMemoryOverrides:
-    def test_get_specs_memory_uses_id_instead_of_description(self, atollon_redfish):
-        specs = atollon_redfish.get_specs("memory")
-        assert len(specs) == 1
-        assert "Id" in specs[0].fields
-        assert "Description" not in specs[0].fields
-        assert "MemoryDeviceType" in specs[0].fields
-
-    def test_update_memory_maps_id_to_description(self, atollon_redfish):
-        atollon_redfish._sys["memory"] = {
-            "1": {
-                "dimm0": {
-                    "id": "dimm0",
-                    "memory_device_type": "DDR4",
-                    "capacity_mib": 16384,
-                    "status": {"health": "OK", "state": "Enabled"},
-                },
-            },
-        }
-
-        with patch.object(BaseRedfishSystem, "_update_memory") as mock_super:
-            mock_super.side_effect = lambda: None
-            atollon_redfish._update_memory()
-
-        assert atollon_redfish._sys["memory"]["1"]["dimm0"]["description"] == "dimm0"
-
-
 class TestAtollonRedfishProviderStorageOverrides:
-    def test_update_storage_replaces_unknown_description(self, atollon_redfish):
-        atollon_redfish._sys["storage"] = {
-            "Self": {
-                "nvme_device0_nsid1": {
-                    "description": "unknown",
-                    "model": "Micron_2550_MTFDKBK512TGE",
-                    "capacity_bytes": 512110190592,
-                    "protocol": "NVMe",
-                    "serial_number": "24424BAA3C40",
-                    "status": {"health": "OK", "state": "Enabled"},
-                    "redfish_endpoint": (
-                        "/redfish/v1/Systems/Self/Storage/StorageUnit_0/"
-                        "Drives/NVMe_Device0_NSID1"
-                    ),
-                    "entity": "StorageUnit_0",
-                },
-            },
-        }
-
-        with patch.object(BaseRedfishSystem, "_update_storage") as mock_super:
-            mock_super.side_effect = lambda: None
-            atollon_redfish.fix_storage_descriptions()
-
-        drive = atollon_redfish._sys["storage"]["Self"]["nvme_device0_nsid1"]
-        assert drive["description"] == "NVMe_Device0_NSID1"
-
     def test_enrich_storage_from_controllers_by_serial(self, atollon_redfish):
         atollon_redfish._sys["storage"] = {
             "Self": {

--- a/src/ceph-node-proxy/tests/test_baseredfishsystem.py
+++ b/src/ceph-node-proxy/tests/test_baseredfishsystem.py
@@ -166,6 +166,8 @@ class TestBaseRedfishSystemGetSpecs:
         assert specs[0].collection == "systems"
         assert specs[0].path == "Memory"
         assert "CapacityMiB" in specs[0].fields
+        assert "Description" in specs[0].fields
+        assert "Id" in specs[0].fields
 
     def test_get_specs_power(self, system):
         specs = system.get_specs("power")
@@ -258,3 +260,73 @@ class TestBaseRedfishSystemComponentSpecs:
         assert len(BaseRedfishSystem.NETWORK_FIELDS) > 0
         assert len(BaseRedfishSystem.MEMORY_FIELDS) > 0
         assert len(BaseRedfishSystem.POWER_FIELDS) > 0
+
+
+class TestFillMissingIdentityDuringUpdate:
+    def test_run_update_keeps_existing_description(self, system):
+        with patch("ceph_node_proxy.baseredfishsystem.get_component_data") as mock_gcd:
+            mock_gcd.return_value = {
+                "Self": {
+                    "dimm0": {
+                        "id": "DevType2_DIMM0",
+                        "description": "DIMM A1",
+                        "memory_device_type": "DDR4",
+                        "status": {"health": "OK", "state": "Enabled"},
+                    }
+                }
+            }
+            system._run_update("memory")
+        assert system._sys["memory"]["Self"]["dimm0"]["description"] == "DIMM A1"
+
+    def test_run_update_fills_unknown_description_from_id(self, system):
+        with patch("ceph_node_proxy.baseredfishsystem.get_component_data") as mock_gcd:
+            mock_gcd.return_value = {
+                "Self": {
+                    "dimm0": {
+                        "id": "DevType2_DIMM0",
+                        "description": "unknown",
+                        "memory_device_type": "DDR4",
+                        "status": {"health": "OK", "state": "Enabled"},
+                    }
+                }
+            }
+            system._run_update("memory")
+        assert (
+            system._sys["memory"]["Self"]["dimm0"]["description"] == "DevType2_DIMM0"
+        )
+
+    def test_run_update_fills_unknown_description_from_member_key(self, system):
+        with patch("ceph_node_proxy.baseredfishsystem.get_component_data") as mock_gcd:
+            mock_gcd.return_value = {
+                "Self": {
+                    "DevType2_DIMM3": {
+                        "id": "unknown",
+                        "description": "unknown",
+                        "memory_device_type": "DDR4",
+                        "status": {"health": "OK", "state": "Enabled"},
+                    }
+                }
+            }
+            system._run_update("memory")
+        assert (
+            system._sys["memory"]["Self"]["DevType2_DIMM3"]["description"]
+            == "DevType2_DIMM3"
+        )
+
+    def test_run_update_fills_unknown_name_from_id(self, system):
+        with patch("ceph_node_proxy.baseredfishsystem.get_component_data") as mock_gcd:
+            mock_gcd.return_value = {
+                "Self": {
+                    "nic1": {
+                        "id": "NIC.Slot.1",
+                        "name": "unknown",
+                        "description": "unknown",
+                        "speed_mbps": 25000,
+                        "status": {"health": "OK", "state": "Enabled"},
+                    }
+                }
+            }
+            system._run_update("network")
+        nic = system._sys["network"]["Self"]["ethernetinterfaces_nic1"]
+        assert nic["name"] == "NIC.Slot.1"
+        assert nic["description"] == "NIC.Slot.1"

--- a/src/ceph-node-proxy/tests/test_util.py
+++ b/src/ceph-node-proxy/tests/test_util.py
@@ -1,0 +1,53 @@
+from ceph_node_proxy.util import fill_missing_identity, is_unknown
+
+
+def test_is_unknown_treats_none_empty_and_unknown() -> None:
+    assert is_unknown(None)
+    assert is_unknown("")
+    assert is_unknown("unknown")
+    assert is_unknown("Unknown")
+    assert not is_unknown("DIMM A1")
+    assert not is_unknown("DevType2_DIMM0")
+
+
+def test_fill_missing_identity_keeps_existing_description() -> None:
+    member = {"id": "DevType2_DIMM0", "description": "DIMM A1"}
+    fill_missing_identity(member, "dimm0")
+    assert member["description"] == "DIMM A1"
+
+
+def test_fill_missing_identity_uses_id() -> None:
+    member = {"id": "DevType2_DIMM0", "description": "unknown"}
+    fill_missing_identity(member, "dimm0")
+    assert member["description"] == "DevType2_DIMM0"
+
+
+def test_fill_missing_identity_uses_member_key() -> None:
+    member = {"id": "unknown", "description": "unknown"}
+    fill_missing_identity(member, "DevType2_DIMM3")
+    assert member["description"] == "DevType2_DIMM3"
+
+
+def test_fill_missing_identity_prefers_redfish_endpoint() -> None:
+    member = {
+        "id": "nvme_device0_nsid1",
+        "description": "unknown",
+        "redfish_endpoint": (
+            "/redfish/v1/Systems/Self/Storage/StorageUnit_0/Drives/NVMe_Device0_NSID1"
+        ),
+    }
+    fill_missing_identity(member, "nvme_device0_nsid1")
+    assert member["description"] == "NVMe_Device0_NSID1"
+
+
+def test_fill_missing_identity_fills_name_when_present() -> None:
+    member = {"id": "NIC.Slot.1", "name": "unknown", "description": "unknown"}
+    fill_missing_identity(member, "nic1")
+    assert member["name"] == "NIC.Slot.1"
+    assert member["description"] == "NIC.Slot.1"
+
+
+def test_fill_missing_identity_does_not_add_name() -> None:
+    member = {"id": "DevType2_DIMM0", "description": "unknown"}
+    fill_missing_identity(member, "dimm0")
+    assert "name" not in member


### PR DESCRIPTION
Some BMCs (Atollon in particular) omit Description on DIMMs and similar resources, so hardware status ended up with NAME=unknown.

Let's collect Id alongside the usual fields and when description/name is empty or "unknown", fall back to the Redfish endpoint, Id, or the collection member key. That covers memory, storage, and the other inventory components in the generic path, so the 'atollon only' memory and storage description hacks can go away.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

