### PR TITLE
rgw: declare rgw_a's dependency on heap_profiler

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -648,6 +648,7 @@ target_link_libraries(rgw_a
   PRIVATE
     rgw_schedulers
     kmip
+    heap_profiler
     legacy-option-headers
     common_utf8 global
     ${CRYPTO_LIBS}
@@ -746,7 +747,6 @@ target_include_directories(radosgw
 target_link_libraries(radosgw PRIVATE
   legacy-option-headers
   ${rgw_libs}
-  heap_profiler
   ${ALLOC_LIBS})
 
 if(WITH_RADOSGW_FDB)
@@ -959,7 +959,6 @@ target_link_libraries(rgw
   PRIVATE
   ${rgw_libs}
   rgw_common
-  heap_profiler
   librados
   cls_rgw_client
   cls_otp_client


### PR DESCRIPTION
Building `main` (and `wip-s3vector`, which is rebased on it) with
`-DWITH_MOLD=ON` fails to link `radosgw-admin`:

```
mold: error: undefined symbol: ceph_heap_profiler_init()
mold: error: undefined symbol: ceph_using_tcmalloc()
mold: error: undefined symbol: ceph_heap_profiler_handle_command(std::vector<std::string>...)
```

Root cause: 6d8851a28fa (#67446) made `rgw_appmain.cc` — a member of
`rgw_a` — call the heap profiler, but declared `heap_profiler` only on
`radosgw`, `rgw` (librgw) and `rgw_a_standalone`, never on `rgw_a`.
`radosgw-admin` does not use `AppMain`; mold pulls the object in anyway
through archive resolution. Replaying the link with `-Wl,-y`:

```
trace-symbol: src/arrow/lib/libarrow.a(pretty_print.cc.o) keeps lib/librgw_a.a(rgw_file.cc.o) for std::__cxx11::basic_string<...>::front()
trace-symbol: lib/librgw_a.a(rgw_lib.cc.o): definition of rgw::RGWLibProcess::process_request(rgw::RGWLibRequest*)
trace-symbol: lib/librgw_a.a(rgw_appmain.cc.o): definition of rgw::AppMain::init_frontends1(bool)
trace-symbol: lib/librgw_a.a(rgw_appmain.cc.o): unresolved symbol ceph_heap_profiler_init()
```

The identical link command with `-fuse-ld=bfd` succeeds (lazy extraction
never touches `rgw_appmain.o`), which is why CI does not see it.

This declares the dependency on the library whose translation unit uses
it — the pattern kv/mon/osd/mds/bluestore already follow, and the same fix
shape as 056b7061315 ("rgw: declare rgw_a's dependency on rgw_schedulers
and kmip") — and drops the now-redundant explicit links.

Consequences: under tcmalloc builds, `rgw_a`-linking tools gain a
`libtcmalloc.so.4` runtime dependency (radosgw-admin, rgw-policy-check/
-test, radosgw-es, radosgw-object-expirer, denc-mod-rgw); packaging picks
it up automatically, as it already does for rgw-standalone-admin. Under
`ALLOCATOR=libc` the stub archive has no dependencies. Note that
6d8851a28fa also re-linked librgw.so against tcmalloc (cf. c4b4ba554d2 /
tracker 63394); this change leaves librgw as it is today.

Verified: Ubuntu 24.04 aarch64, gcc-14, mold 2.41.0, Debug, tcmalloc —
radosgw-admin, radosgw, radosgw-es, radosgw-object-expirer,
rgw-policy-check and rgw-policy-test link; `ceph_heap_profiler_init` is
defined in each; vstart `radosgw-admin user list` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E63tgb7eXHwzmaQBSErFWu


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`

</details>
