### PR TITLE
mgr/cephadm: redeploy node-proxy when hw_monitoring_vendor changes

### DIFF
--- a/src/pybind/mgr/cephadm/services/node_proxy.py
+++ b/src/pybind/mgr/cephadm/services/node_proxy.py
@@ -46,7 +46,7 @@ class NodeProxy(CephService):
             root_cert = mgr.cert_mgr.get_root_ca()
         except Exception:
             pass
-        return sorted([mgr.get_mgr_ip(), server_port, root_cert])
+        return sorted([mgr.get_mgr_ip(), server_port, root_cert, mgr.hw_monitoring_vendor])
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         # node-proxy is re-using the agent endpoint and therefore


### PR DESCRIPTION
generate_config already puts the vendor in node-proxy.json, but get_dependencies didn't include it so cephadm wouldn't notice when the option changes. the daemon just kept running with the old vendor.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
