### PR TITLE
mgr/cephadm: don't drop the OSD removal queue on an unreadable osdmap

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -571,9 +571,24 @@ class RemoveUtil(object):
     def __init__(self, mgr: "CephadmOrchestrator") -> None:
         self.mgr: "CephadmOrchestrator" = mgr
 
-    def get_osds_in_cluster(self) -> List[str]:
-        osd_map = self.mgr.get_osdmap()
-        return [str(x.get('osd')) for x in osd_map.dump().get('osds', [])]
+    def get_osds_in_cluster(self) -> Optional[List[str]]:
+        """OSD ids present in the osdmap, or None if the osdmap could not be read.
+
+        Returning None rather than an empty list matters: callers use this to decide
+        whether a queued OSD still exists, and an empty list would make every OSD look
+        gone. A real cluster always has at least one OSD in its map, so an empty dump
+        means we failed to read it, not that the cluster is empty.
+        """
+        try:
+            osd_map = self.mgr.get_osdmap()
+            osds = osd_map.dump().get('osds', [])
+        except Exception:
+            logger.exception('failed to read the osdmap')
+            return None
+        if not osds:
+            logger.warning('osdmap contained no OSDs; treating as unreadable')
+            return None
+        return [str(x.get('osd')) for x in osds]
 
     def osd_df(self) -> dict:
         base_cmd = 'osd df'
@@ -890,8 +905,12 @@ class OSD:
         return self.rm_util.get_pg_count(self.osd_id)
 
     @property
-    def exists(self) -> bool:
-        return str(self.osd_id) in self.rm_util.get_osds_in_cluster()
+    def exists(self) -> Optional[bool]:
+        """True/False if known, None if the osdmap could not be read."""
+        in_cluster = self.rm_util.get_osds_in_cluster()
+        if in_cluster is None:
+            return None
+        return str(self.osd_id) in in_cluster
 
     def drain_status_human(self) -> str:
         default_status = 'not started'
@@ -1087,6 +1106,8 @@ class OSDRemovalQueue(object):
         # OSDs can always be cleaned up manually. This ensures that we run on existing OSDs
         with self.lock:
             for osd in self._not_in_cluster():
+                logger.info(
+                    f'{osd} is no longer in the osdmap, dropping it from the removal queue')
                 self.osds.remove(osd)
 
     def _ready_to_drain_osds(self) -> List["OSD"]:
@@ -1144,9 +1165,16 @@ class OSDRemovalQueue(object):
             return [osd.to_json() for osd in self.osds]
 
     def _not_in_cluster(self) -> List["OSD"]:
-        return [osd for osd in self.osds if not osd.exists]
+        # osd.exists is None when the osdmap could not be read. Do not treat that as
+        # "gone": dropping the queue on a transient read failure silently abandons an
+        # in-progress drain, and the empty queue is then persisted by _save_to_store(),
+        # so it does not come back on the next pass or after a mgr restart. Only evict
+        # an OSD we positively know is absent from the map.
+        return [osd for osd in self.osds if osd.exists is False]
 
     def enqueue(self, osd: "OSD") -> None:
+        # exists is None when the osdmap could not be read; `not None` is True, so an
+        # unreadable map refuses the enqueue rather than guessing.
         if not osd.exists:
             raise NotFoundError()
         with self.lock:

--- a/src/pybind/mgr/cephadm/tests/test_osd_removal.py
+++ b/src/pybind/mgr/cephadm/tests/test_osd_removal.py
@@ -296,3 +296,39 @@ class TestOSDRemovalQueue:
         q.osds.add(osd_obj)
         q.rm(osd_obj)
         osd_obj.stop.assert_called_once()
+
+    def test_cleanup_keeps_queue_when_osdmap_unreadable(self, osd_obj):
+        """A transient osdmap read failure must not empty the removal queue.
+
+        cleanup() runs at the top of every process_removal_queue() pass, and that pass
+        ends by persisting the queue. If an unreadable osdmap made every queued OSD look
+        absent, an in-progress drain would be silently abandoned and the empty queue
+        written to the store, so it would not recover on the next pass or a mgr restart.
+        """
+        q = OSDRemovalQueue(mock.Mock())
+        q.osds.add(osd_obj)
+        assert q.queue_size() == 1
+
+        osd_obj.rm_util.get_osds_in_cluster.return_value = None
+        q.cleanup()
+        assert q.queue_size() == 1, "queue must survive an unreadable osdmap"
+
+        osd_obj.rm_util.get_osds_in_cluster.return_value = ['999']
+        q.cleanup()
+        assert q.queue_size() == 0, "an OSD positively absent from the map is evicted"
+
+    def test_cleanup_keeps_queue_when_osdmap_empty(self, rm_util, osd_obj):
+        """An empty osds list means we failed to read the map, not that all OSDs vanished.
+
+        Drives the real get_osds_in_cluster() through a mocked osdmap dump so the
+        empty-list -> None conversion this change introduces is actually exercised,
+        rather than stubbing the helper's return value.
+        """
+        q = OSDRemovalQueue(mock.Mock())
+        q.osds.add(osd_obj)
+        osd_obj.rm_util = rm_util
+        osd_map = mock.Mock()
+        osd_map.dump.return_value = {'osds': []}
+        rm_util.mgr.get_osdmap.return_value = osd_map
+        q.cleanup()
+        assert q.queue_size() == 1


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/80202

Assisted by Claude Opus-5

## Problem

`OSDRemovalQueue.cleanup()` runs at the top of every `process_removal_queue()` pass and evicts any queued OSD whose `exists` is false. `exists` resolves to `str(osd_id) in rm_util.get_osds_in_cluster()`, and that helper returns whatever the osdmap dump contains with no check that the dump was readable.

If the dump comes back empty — mgr still starting, just failed over, a transient read — then every queued OSD evaluates as absent and the entire queue is evicted. The same pass then ends with `self.osds.intersection_update(new_queue)` and `self._save_to_store()`, so the empty queue is persisted immediately. The loss is durable: it does not recover on the next serve loop and it survives a mgr restart. `cleanup()` logs nothing, so there is no record that anything was dropped.

The visible result is a host drain that stops for no apparent reason. OSDs already drained are gone; those still *idling* in the queue — everything beyond `max_osd_draining_count`, 10 by default — stay `up`, `in`, and at their original weight indefinitely, with an empty `orch osd rm status` and `_no_schedule` still on the host. It looks exactly like an operator cancelled the drain.

Seen on a 68-host Squid cluster: two hosts drained partway (2 of 24 and 12 of 24 OSDs remaining) then stopped, empty removal queue, every remaining OSD at `reweight 1.00000`. Nobody had cancelled anything, and it has recurred there.

This is **not** the same as #67329 (`original_weight` breaking `load_from_store`), which fails loudly and takes the cephadm module down; here the module stays healthy throughout. #47700 is adjacent but concerns mutation during iteration.

## Change

Distinguish "not in the map" from "could not read the map":

- `get_osds_in_cluster()` returns `None` when the dump is unreadable or empty. A live cluster always has at least one OSD, so an empty list means the read failed rather than that every OSD vanished.
- `OSD.exists` propagates that as `None`.
- `_not_in_cluster()` evicts only OSDs it positively knows are absent (`osd.exists is False`).
- `cleanup()` logs each eviction, so a queue that does shrink says why.

`enqueue()` and `rm()` keep their existing truthiness check — `not None` is true, so an unreadable map refuses the operation rather than guessing. That also leaves the existing mocked tests for those paths behaving as before.

## Testing

Two regression tests added to `test_osd_removal.py` covering the unreadable-osdmap case and the genuinely-absent case.

Run locally with (thanks @JoshuaGabriel — an earlier version of this description wrongly claimed a built tree was needed):

```
cd src/pybind/mgr
tox -e py3 -- cephadm/tests/test_osd_removal.py
```

`52 passed`. Verified the tests actually fail without the fix, rather than only passing with it:

```
fix in place            : 52 passed
fix reverted (bug back) : 2 failed, 50 passed
```

The behavioural difference was also checked with a standalone harness replicating the `cleanup()` path:

```
healthy osdmap                   old: queue=2   new: queue=2
UNREADABLE osdmap (empty dump)   old: queue=0   new: queue=2   <-- the bug
osds genuinely purged            old: queue=0   new: queue=0   <-- still evicts correctly
```

## Relationship to #71506

@JoshuaGabriel's #71506 fixes `self.osds.intersection_update(new_queue)` discarding OSDs enqueued while a pass is running. Having read it, I think **that is the more likely cause** of the behaviour in the linked tracker, not this change: it empties the queue via `{1,2,3,4} ∩ ∅ = ∅` with **no osdmap failure required**, and `ceph orch host drain` enqueues an entire host's OSDs at once, which is exactly that race.

So this PR is better understood as **hardening** — `cleanup()` should not evict on a map it could not read, and should log when it does evict, since that eviction is currently silent and durable — rather than the root-cause fix. Happy to rebase on #71506, fold this into it, or close this, whichever maintainers prefer.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`

</details>

