### PR TITLE
rbd-mirror: coordinate image snapshot replay phases for group mirroring

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -3173,6 +3173,64 @@ test_multiple_mirror_group_snapshot_unlink_time()
   fi
 }
 
+declare -a test_group_snap_sync_after_user_snap_removal_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 8)
+
+test_group_snap_sync_after_user_snap_removal_scenarios=1
+
+test_group_snap_sync_after_user_snap_removal()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local image_prefix=$1 ; shift
+  local image_count=$(($1*"${image_multiplier}")) ; shift
+
+  local group0=test-group0
+  start_mirrors "${primary_cluster}"
+
+  group_create "${primary_cluster}" "${pool}/${group0}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" $(("${image_count}"-1))
+  write_image "${primary_cluster}" "${pool}" "${image_prefix}0" 10 4096
+  group_images_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${image_prefix}" $(("${image_count}"-1))
+
+  big_image=test-image-big
+  image_create "${primary_cluster}" "${pool}/${big_image}" 1G
+  group_image_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${big_image}"
+  mirror_group_enable "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group0}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group0}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  for i in $(seq 0 $(("${image_count}"-2))); do
+    write_image "${primary_cluster}" "${pool}" "${image_prefix}$i" 10 4096
+  done;
+  write_image "${primary_cluster}" "${pool}" "${big_image}" 256 4194304
+  snap='regular_snap'
+  group_snap_create "${primary_cluster}" "${pool}/${group0}" "${snap}"
+  check_group_snap_exists "${primary_cluster}" "${pool}/${group0}" "${snap}"
+  local group_snap_id
+  mirror_group_snapshot "${primary_cluster}" "${pool}/${group0}" group_snap_id
+  wait_for_group_snap_present "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}"
+  # if mirror snapshot is present => user snapshot must be present
+  check_group_snap_exists "${secondary_cluster}" "${pool}/${group0}" "${snap}"
+  group_snap_remove "${primary_cluster}" "${pool}/${group0}" "${snap}"
+  # user group snapshot removed during sync
+  test_group_snap_sync_incomplete "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  # snapshot sync can be completed only after removal of user snapshot
+  check_group_snap_doesnt_exist "${secondary_cluster}" "${pool}/${group0}" "${snap}"
+
+  mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
+  group_remove "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" $(("${image_count}"-1))
+  image_remove "${primary_cluster}" "${pool}/${big_image}"
+  wait_for_no_keys "${primary_cluster}"
+  stop_mirrors "${primary_cluster}"
+}
+
 # test force promote scenarios
 declare -a test_multiple_mirror_group_snapshot_whilst_stopped_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" 5)
 
@@ -4074,6 +4132,7 @@ run_all_tests()
   run_test_all_scenarios test_group_with_clone_image
   run_test_all_scenarios test_interrupted_sync_restarted_daemon
   run_test_all_scenarios test_interrupted_sync
+  run_test_all_scenarios test_group_snap_sync_after_user_snap_removal
   run_test_all_scenarios test_resync_after_relocate_and_force_promote
   run_test_all_scenarios test_multiple_mirror_group_snapshot_unlink_time
   run_test_all_scenarios test_force_promote_delete_group

--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -2637,14 +2637,11 @@ test_force_promote()
     wait_for_image_size_matches "${secondary_cluster}" "${pool}/${image_prefix}2" $(("${image_size}"+4*1024*1024))
   elif [ "${scenario}" = 'image_shrink' ]; then
     wait_for_image_size_matches "${secondary_cluster}" "${pool}/${image_prefix}3" $(("${image_size}"-4*1024*1024))
-  elif [ "${scenario}" = 'no_change' ] || [ "${scenario}" = 'no_change_primary_up' ]; then
-    # ensure that a small image has completed its sync
-    local snap_id
-    get_newest_mirror_snapshot_id_on_primary "${primary_cluster}" "${pool}/${image_prefix}0" snap_id
-    wait_for_snap_id_present "${secondary_cluster}" "${pool}/${image_prefix}0" "${snap_id}"
-    wait_for_snapshot_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}" "${pool}" "${image_prefix}0" "${snap_id}"
   fi
 
+  # Wait until preparation has finished and the group has started sync. The
+  # image status can move from 100% to complete before it can be polled.
+  wait_for_group_snap_phase "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}" 'created' 'false'
 
   # stop the daemon to prevent further syncing of snapshots
   stop_mirrors "${secondary_cluster}" '-9'
@@ -2653,8 +2650,7 @@ test_force_promote()
   test_group_snap_sync_incomplete "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}" 
 
   if [ "${scenario}" = 'no_change' ] || [ "${scenario}" = 'no_change_primary_up' ]; then
-    # if we waited for a small image to complete its sync then the big image should still be mid-sync
-    # if we didn't wait for the small image to sync then its possible that the big image hasn't even started syncing the latest image yet
+    # the large image should still be syncing
     local big_image_snap_id
     get_newest_mirror_snapshot_id_on_primary "${primary_cluster}" "${pool}/${big_image}" big_image_snap_id
     test_snap_complete "${secondary_cluster}" "${pool}/${big_image}" "${big_image_snap_id}" 'false' || fail "big image is synced"
@@ -3125,6 +3121,86 @@ test_interrupted_sync_restarted_daemon()
   images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
 }
 
+# test group-coordinated image snapshot replay phases
+declare -a test_image_replayer_snapshot_phases_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}")
+
+test_image_replayer_snapshot_phases_scenarios=1
+
+test_image_replayer_snapshot_phases()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local group=test-group0
+  local small_image=test-image-small
+  local big_image=test-image-big
+  local image_count=2
+
+  start_mirrors "${primary_cluster}"
+  start_mirrors "${secondary_cluster}"
+
+  group_create "${primary_cluster}" "${pool}/${group}"
+  image_create "${primary_cluster}" "${pool}/${small_image}" 1G
+  image_create "${primary_cluster}" "${pool}/${big_image}" 4G
+  group_image_add "${primary_cluster}" "${pool}/${group}" "${pool}/${small_image}"
+  group_image_add "${primary_cluster}" "${pool}/${group}" "${pool}/${big_image}"
+  mirror_group_enable "${primary_cluster}" "${pool}/${group}"
+
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}/${group}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}/${group}" 'up+replaying' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}/${group}" "${secondary_cluster}" "${pool}/${group}"
+
+  # keep the large image busy while the small image completes
+  write_image "${primary_cluster}" "${pool}" "${small_image}" 10 4096
+  write_image "${primary_cluster}" "${pool}" "${big_image}" 1024 4194304
+
+  # Queue the snapshot while the secondary daemon is down. This lets the test
+  # watch the preparation phase as soon as replay starts again.
+  stop_mirrors "${secondary_cluster}"
+
+  local group_snap_id
+  mirror_group_snapshot "${primary_cluster}" "${pool}/${group}" group_snap_id
+
+  # Start watching for the creating, but don't block the script progress, as we
+  # must start the daemon.
+  wait_for_group_snap_phase "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}" 'creating' 'false' &
+  local phase_wait_pid=$!
+  start_mirrors "${secondary_cluster}"
+
+  # wait for creating state, the prepare_snapshot keeps the group snapshot CREATING and incomplete
+  wait "${phase_wait_pid}"
+
+  # image snapshots should be prepared and incomplete
+  local small_local_snap_id big_local_snap_id
+  wait_for_image_snapshot_with_group_snap_info "${secondary_cluster}" "${pool}" "${small_image}" "${group_snap_id}" small_local_snap_id
+  wait_for_image_snapshot_with_group_snap_info "${secondary_cluster}" "${pool}" "${big_image}" "${group_snap_id}" big_local_snap_id
+
+  local small_complete big_complete
+  get_image_snap_complete "${secondary_cluster}" "${pool}/${small_image}" "${small_local_snap_id}" small_complete
+  get_image_snap_complete "${secondary_cluster}" "${pool}/${big_image}" "${big_local_snap_id}" big_complete
+  test "${small_complete}" = 'false' || { fail "prepared snapshot ${small_local_snap_id} is already complete"; return 1; }
+  test "${big_complete}" = 'false' || { fail "prepared snapshot ${big_local_snap_id} is already complete"; return 1; }
+
+  # the group snapshot is published after all image snapshots are prepared
+  wait_for_group_snap_phase "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}" 'created' 'false'
+
+  # image snapshots complete before the group snapshot
+  wait_for_image_snap_complete "${secondary_cluster}" "${pool}/${small_image}" "${small_local_snap_id}" 'true'
+  wait_for_image_snap_complete "${secondary_cluster}" "${pool}/${big_image}" "${big_local_snap_id}" 'true'
+  test_group_synced_image_status "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}" "${image_count}"
+
+  wait_for_group_snap_sync_complete "${secondary_cluster}" "${pool}/${group}" "${group_snap_id}"
+
+  # tidy up
+  mirror_group_disable "${primary_cluster}" "${pool}/${group}"
+  group_remove "${primary_cluster}" "${pool}/${group}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group}"
+  image_remove "${primary_cluster}" "${pool}/${small_image}"
+  image_remove "${primary_cluster}" "${pool}/${big_image}"
+}
+
 # Scenario 1: The snapshot on the secondary is in the creating phase when the daemon is restarted.
 declare -a test_interrupted_sync_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 'snap_creating' 2)
 # Scenario 2: The snapshot on the secondary is in the created phase when the daemon is restarted.
@@ -3161,15 +3237,27 @@ test_interrupted_sync()
 
   write_image "${primary_cluster}" "${pool}" "${big_image}" 1024 4194304
 
+  if [ "${scenario}" = 'snap_creating' ]; then
+    # Queue the snapshot so replay starts from the CREATING phase below.
+    stop_mirrors "${secondary_cluster}"
+  fi
+
   local group_snap_id
   mirror_group_snapshot "${primary_cluster}" "${pool}/${group0}" group_snap_id
 
-  local image_snap_id
-  wait_for_image_snapshot_with_group_snap_info "${secondary_cluster}" "${pool}" "${image_prefix}1" "${group_snap_id}" image_snap_id
+  local image_snap_id=""
   if [ "${scenario}" = 'snap_creating' ]; then
-    stop_mirror_while_group_snapshot_incomplete "${secondary_cluster}" "${pool}" "${group0}" "${group_snap_id}" "creating"
+    # Start watching for the creating & incomplete and then stop the mirror, but don't block the script progress, as we
+    # must start the daemon.
+    stop_mirror_while_group_snapshot_incomplete "${secondary_cluster}" "${pool}" "${group0}" "${group_snap_id}" "creating" &
+    local stop_wait_pid=$!
+    start_mirrors "${secondary_cluster}"
+    # stop before image snapshot preparation completes
+    wait "${stop_wait_pid}"
     test_group_snap_state "${secondary_cluster}" "${pool}" "${group0}" "${group_snap_id}" "creating"
+    get_image_snapshot_with_group_snap_info "${secondary_cluster}" "${pool}" "${image_prefix}1" "${group_snap_id}" image_snap_id || image_snap_id=""
   elif [ "${scenario}" = 'snap_created' ]; then
+    wait_for_image_snapshot_with_group_snap_info "${secondary_cluster}" "${pool}" "${image_prefix}1" "${group_snap_id}" image_snap_id
     stop_mirror_while_group_snapshot_incomplete "${secondary_cluster}" "${pool}" "${group0}" "${group_snap_id}" "created"
     test_group_snap_state "${secondary_cluster}" "${pool}" "${group0}" "${group_snap_id}" "created"
     test_group_snap_sync_incomplete "${secondary_cluster}" "${pool}/${group0}" "${group_snap_id}"
@@ -3185,7 +3273,9 @@ test_interrupted_sync()
   get_image_snapshot_with_group_snap_info "${secondary_cluster}" "${pool}" "${image_prefix}1" "${group_snap_id}" new_image_snap_id ||
     fail "failed to find image snapshot associated with group snap ${group_snap_id}"
   if [ "${scenario}" = 'snap_creating' ]; then
-    test "${image_snap_id}" != "${new_image_snap_id}" ||  { fail "failed to recreate image snapshot with a new snap_id after restart"; return 1; }
+    if [ -n "${image_snap_id}" ]; then
+      test "${image_snap_id}" != "${new_image_snap_id}" ||  { fail "failed to recreate image snapshot with a new snap_id after restart"; return 1; }
+    fi
   elif [ "${scenario}" = 'snap_created' ]; then
     test "${image_snap_id}" == "${new_image_snap_id}" ||  { fail "image snapshot recreated with a new snap_id after restart"; return 1; }
   fi
@@ -4189,6 +4279,7 @@ run_all_tests()
   run_test_all_scenarios test_empty_group_omap_keys
   # TODO: add the capabilty to have clone images support in the mirror group
   run_test_all_scenarios test_group_with_clone_image
+  run_test_all_scenarios test_image_replayer_snapshot_phases
   run_test_all_scenarios test_interrupted_sync_restarted_daemon
   run_test_all_scenarios test_interrupted_sync
   run_test_all_scenarios test_group_snap_sync_after_user_snap_removal

--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -2731,6 +2731,64 @@ test_force_promote()
   start_mirrors "${secondary_cluster}"
 }
 
+declare -a test_mirror_group_snapshot_unlink_peer_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 3 '')
+
+test_mirror_group_snapshot_unlink_peer_scenarios=1
+
+test_mirror_group_snapshot_unlink_peer()
+{
+  local primary_cluster=$1 ; shift
+  local secondary_cluster=$1 ; shift
+  local pool=$1 ; shift
+  local image_prefix=$1 ; shift
+  local image_count=$(($1*"${image_multiplier}")) ; shift
+
+  local group0=test-group-unlink
+  start_mirrors "${primary_cluster}"
+
+  local mirror_peer_uuid
+  get_remote_peer_uuid "${primary_cluster}" "${pool}" "${secondary_cluster}" mirror_peer_uuid
+  group_create "${primary_cluster}" "${pool}/${group0}"
+  images_create "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+  for ((i = 0; i < image_count; i++)); do
+    write_image "${primary_cluster}" "${pool}" "${image_prefix}${i}" 10 4096
+  done
+  group_images_add "${primary_cluster}" "${pool}/${group0}" "${pool}/${image_prefix}" "${image_count}"
+
+  mirror_group_enable "${primary_cluster}" "${pool}/${group0}"
+  local group_snap_id group_id_before secondary_group_snap_id
+  get_newest_complete_mirror_group_snapshot_id "${primary_cluster}" "${pool}/${group0}" group_snap_id
+  wait_for_group_present "${secondary_cluster}" "${pool}" "${group0}" "${image_count}"
+  wait_for_group_replay_started "${secondary_cluster}" "${pool}"/"${group0}" "${image_count}"
+  wait_for_group_status_in_pool_dir "${secondary_cluster}" "${pool}"/"${group0}" 'up+replaying' "${image_count}"
+  wait_for_group_status_in_pool_dir "${primary_cluster}" "${pool}"/"${group0}" 'up+stopped' "${image_count}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}"/"${group0}"
+  mirror_group_snapshot_and_wait_for_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}"/"${group0}"
+  wait_for_group_snapshot_peer_uuid_removed "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}" "${mirror_peer_uuid}"
+  test_group_image_snapshots_peer_uuid_removed "${primary_cluster}" "${pool}/${group0}" "${group_snap_id}" "${mirror_peer_uuid}"
+  get_id_from_group_info "${secondary_cluster}" "${pool}/${group0}" group_id_before
+  mirror_group_resync "${secondary_cluster}" "${pool}/${group0}"
+  wait_for_group_id_changed "${secondary_cluster}" "${pool}/${group0}" "${group_id_before}"
+  wait_for_group_synced "${primary_cluster}" "${pool}"/"${group0}" "${secondary_cluster}" "${pool}/${group0}"
+  get_newest_complete_mirror_group_snapshot_id "${secondary_cluster}" "${pool}/${group0}" secondary_group_snap_id
+  local count
+  count_mirror_group_snaps "${secondary_cluster}" "${pool}"/"${group0}" count
+  test "${count}" -eq 1 || { fail "mirror snap count = ${count}"; return 1; }
+  for ((i = 0; i < image_count; i++)); do
+    # verify that there are no orphan image snapshots present without a associated group snapshot
+    test "$(count_mirror_snaps ${secondary_cluster} ${pool} ${image_prefix}${i})" -eq 1
+    assert_image_snap_present_in_group_snap "${secondary_cluster}" "${pool}" "${group0}" "${image_prefix}${i}" "${secondary_group_snap_id}"
+  done
+
+  mirror_group_disable "${primary_cluster}" "${pool}/${group0}"
+  group_remove "${primary_cluster}" "${pool}/${group0}"
+  wait_for_group_not_present "${primary_cluster}" "${pool}" "${group0}"
+  wait_for_group_not_present "${secondary_cluster}" "${pool}" "${group0}"
+  images_remove "${primary_cluster}" "${pool}/${image_prefix}" "${image_count}"
+  wait_for_no_keys "${primary_cluster}"
+  stop_mirrors "${primary_cluster}"
+}
+
 declare -a test_force_promote_delete_group_1=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 5 '')
 declare -a test_force_promote_delete_group_2=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${image_prefix}" 5 'disable_reenable_primary')
 
@@ -4118,6 +4176,7 @@ run_all_tests()
   run_test_all_scenarios test_create_group_with_images_then_mirror_with_regular_snapshots
   run_test_all_scenarios test_create_group_with_large_image
   run_test_all_scenarios test_create_group_with_multiple_images_do_io
+  run_test_all_scenarios test_mirror_group_snapshot_unlink_peer
   run_test_all_scenarios test_group_and_standalone_images_do_io
   run_test_all_scenarios test_stopped_daemon
   run_test_all_scenarios test_create_group_with_regular_snapshots_then_mirror

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -871,11 +871,25 @@ test_image_replay_state()
     local pool=$2
     local image=$3
     local test_state=$4
-    local current_state=stopped
+    local expected_state
+
+    # A start request fails while the image replayer is still Stopping.
+    # Wait for the exact state before allowing the test to continue.
+    case "${test_state}" in
+        started)
+            expected_state=Replaying
+            ;;
+        stopped)
+            expected_state=Stopped
+            ;;
+        *)
+            fail "unknown image replay state: ${test_state}"
+            return 1
+            ;;
+    esac
 
     admin_daemons "${cluster}" rbd mirror status ${pool}/${image} --format xml-pretty || { fail; return 1; }
-    test "Replaying" = "$(xmlstarlet sel -t -v "//image_replayer/state" < "$CMD_STDOUT" )" && current_state=started
-    test "${test_state}" = "${current_state}"
+    test "${expected_state}" = "$(xmlstarlet sel -t -v "//image_replayer/state" < "$CMD_STDOUT" )"
 }
 
 wait_for_image_replay_state()
@@ -1969,7 +1983,9 @@ stop_mirror_while_group_snapshot_incomplete() {
     local count=0
     local state=""
     local snaps_synced="false"
-    while [ "${count}" -lt 60 ]; do
+    # Snapshot preparation can finish in less than a second. Poll frequently
+    # so the daemon can be stopped while the snapshot is still CREATING.
+    while [ "${count}" -lt 600 ]; do
         run_cmd "rbd --cluster ${cluster} group snap ls ${pool}/${group} --format xml --pretty-format"
         state=$(xmlstarlet sel -t -v "//group_snaps/group_snap[id='${group_snap_id}']/state" < "$CMD_STDOUT") || { state=''; }
         snaps_synced=$(xmlstarlet sel -t -v "//group_snaps/group_snap[id='${group_snap_id}']/namespace/complete" < "$CMD_STDOUT") || { snaps_synced='false'; }
@@ -1981,7 +1997,7 @@ stop_mirror_while_group_snapshot_incomplete() {
         fi
 
         count=$((count+1))
-        sleep 1;
+        sleep 0.1;
     done
 
     if [ -z "${state}" ]; then
@@ -2635,8 +2651,12 @@ get_pool_obj_count()
     local obj_name=$3
     local -n _count=$4
 
-    run_cmd "rados --cluster ${cluster} -p ${pool} ls --format xml-pretty"
-    _count="$(xmlstarlet sel -t -v "count(//objects/object[name='${obj_name}'])" < "$CMD_STDOUT")"
+    # avoid listing all objects while deferred deletion is in progress
+    if try_cmd "rados --cluster ${cluster} -p ${pool} stat ${obj_name}"; then
+        _count=1
+    else
+        _count=0
+    fi
 }
 
 get_image_snap_id_from_group_snap_info()
@@ -2751,6 +2771,24 @@ get_image_snap_complete()
     local -n _is_complete=$4
     run_cmd "rbd --cluster=${cluster} snap list --all --format xml --pretty-format ${image_spec}"
     _is_complete="$(xmlstarlet sel -t -v "//snapshots/snapshot[id='${snap_id}']/namespace/complete" < "$CMD_STDOUT")"
+}
+
+wait_for_image_snap_complete()
+{
+    local cluster=$1
+    local image_spec=$2
+    local snap_id=$3
+    local expected_complete=$4
+    local is_complete s
+
+    for s in 0 0.1 0.2 0.4 0.8 1.6 2 2 4 4 8 8 16 16 32 32 64 64; do
+        sleep "${s}"
+        get_image_snap_complete "${cluster}" "${image_spec}" "${snap_id}" is_complete || continue
+        [ "${is_complete}" = "${expected_complete}" ] && return 0
+    done
+
+    fail "wait for image snapshot ${snap_id} of ${image_spec} to have complete=${expected_complete} failed on ${cluster}"
+    return 1
 }
 
 check_group_snap_doesnt_exist()
@@ -3031,6 +3069,57 @@ test_group_snap_state()
     elif [ "${expected_state}" != "${state}" ]; then
         fail "group snapshot ${group_snap_id} state mismatch: expected state '${expected_state}', got '${state}'"; return 1;
     fi
+}
+
+wait_for_group_snap_phase()
+{
+    local cluster=$1
+    local group_spec=$2
+    local group_snap_id=$3
+    local expected_state=$4
+    local expected_complete=$5
+    local count=0
+    local state complete
+
+    while [ "${count}" -lt 600 ]; do
+        if [ "${count}" -gt 0 ]; then
+            sleep 0.1
+        fi
+        if ! try_cmd "rbd --cluster ${cluster} group snap list ${group_spec} --format xml --pretty-format"; then
+            count=$((count+1))
+            continue
+        fi
+
+        # a missing snapshot is expected during the first few polls
+        state=$(xmlstarlet sel -t -v "//group_snaps/group_snap[id='${group_snap_id}']/state" < "$CMD_STDOUT") || state=""
+        complete=$(xmlstarlet sel -t -v "//group_snaps/group_snap[id='${group_snap_id}']/namespace/complete" < "$CMD_STDOUT") || complete=""
+        if [ "${state}" = "${expected_state}" ] && [ "${complete}" = "${expected_complete}" ]; then
+            return 0
+        fi
+        count=$((count+1))
+    done
+
+    fail "wait for group snapshot ${group_snap_id} phase ${expected_state}, complete=${expected_complete} failed on ${cluster}"
+    return 1
+}
+
+wait_for_user_group_snap_state()
+{
+    local cluster=$1
+    local group_spec=$2
+    local snap_name=$3
+    local expected_state=$4
+    local state s
+
+    for s in 0 0.1 0.2 0.4 0.8 1.6 2 2 4 4 8 8 16 16 32 32 64 64; do
+        sleep "${s}"
+        try_cmd "rbd --cluster ${cluster} group snap list ${group_spec} --format xml --pretty-format" || continue
+        state=$(xmlstarlet sel -t -v "//group_snaps/group_snap[snapshot='${snap_name}']/state" < "$CMD_STDOUT") || state=""
+        [ "${state}" = "${expected_state}" ] && return 0
+    done
+
+    fail "wait for user group snapshot ${snap_name} state ${expected_state} failed on ${cluster}"
+    return 1
 }
 
 test_group_snap_sync_complete()

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -1013,6 +1013,17 @@ get_newest_mirror_snapshot_id_on_primary()
 
 test_snap_present()
 {
+    local cluster=$1
+    local image_spec=$2
+    local snap_id=$3
+    local expected_snap_count=$4
+
+    run_cmd "rbd --cluster ${cluster} snap list -a ${image_spec} --format xml --pretty-format"
+    test "${expected_snap_count}" = "$(xmlstarlet sel -t -v "count(//snapshot[id='${snap_id}'])" < "$CMD_STDOUT")" || { fail; return 1; }
+}
+
+test_secondary_snap_present()
+{
     local secondary_cluster=$1
     local image_spec=$2
     local snap_id=$3
@@ -1043,7 +1054,7 @@ wait_for_test_snap_present()
 
     for s in 0.1 1 2 4 8 8 8 8 8 8 8 8 16 16 32 32; do
         sleep ${s}
-        test_snap_present "${secondary_cluster}" "${image_spec}" "${snap_id}" "${test_snap_count}" && return 0
+        test_secondary_snap_present "${secondary_cluster}" "${image_spec}" "${snap_id}" "${test_snap_count}" && return 0
     done
 
     fail "wait for count of snaps with id ${snap_id} to be ${test_snap_count} failed on ${secondary_cluster}"
@@ -1816,6 +1827,16 @@ count_mirror_snaps()
 
     rbd --cluster ${cluster} snap ls ${pool}/${image} --all |
         grep -c -F " mirror ("
+}
+
+count_mirror_group_snaps()
+{
+    local cluster=$1
+    local group_spec=$2
+    local -n _count=$3
+
+    run_cmd "rbd --cluster ${cluster} group snap ls ${group_spec} --format xml --pretty-format"
+    _count=$(xmlstarlet sel -t -v 'count(/group_snaps/group_snap[namespace/type="mirror"])' < "$CMD_STDOUT")
 }
 
 get_snaps_json()
@@ -2596,6 +2617,17 @@ get_pool_count()
     fi
 }
 
+get_remote_peer_uuid()
+{
+    local local_cluster=$1
+    local pool_name=$2
+    local remote_cluster=$3
+    local -n peer_uuid=$4
+
+    peer_uuid=$(rbd mirror pool info --cluster ${local_cluster} --pool ${pool_name} --format xml | \
+        xmlstarlet sel -t -v "//peers/peer[site_name='${remote_cluster}']/uuid")
+}
+
 get_pool_obj_count()
 {
     local cluster=$1
@@ -2629,6 +2661,86 @@ get_images_from_group_snap_info()
     run_cmd "rbd --cluster=${cluster} group snap info --format xml --pretty-format ${snap_spec}"
     # sed script removes extra path delimiter if namespace field is blank
     _images="$(xmlstarlet sel -t -m "//group_snapshot/images/image" -v "pool_name" -o "/" -v "namespace" -o "/" -v "image_name" -o " " < "$CMD_STDOUT" |  sed s/"\/\/"/"\/"/g )"
+}
+
+wait_for_group_snapshot_peer_uuid_removed()
+{
+    local cluster=$1
+    local group_spec=$2
+    local group_snap_id=$3
+    local mirror_peer_uuid=$4
+
+    test_group_snap_present "${cluster}" "${group_spec}" "${group_snap_id}" 1
+    # Verify the group snapshot mirror_peer_uuids list does not contain mirror_peer_uuid.
+    for s in 0.1 0.2 0.4 0.8 1 1 2 2 2 4 4 4 8 8 16; do
+        run_cmd "rbd --cluster=${cluster} group snap ls --format xml --pretty-format ${group_spec}"
+
+        local mirror_peer_uuids
+        # get multiple UUID's in multiple lines
+        mirror_peer_uuids=$(xmlstarlet sel -t -m "//group_snap[id='${group_snap_id}']/namespace/mirror_peer_uuids/peer_uuid" -v . -n < "$CMD_STDOUT" || true)
+
+        if ! grep -Fxq "${mirror_peer_uuid}" <<< "${mirror_peer_uuids}"; then
+            return 0
+        fi
+
+        sleep "${s}"
+    done
+    return 1
+}
+
+test_group_image_snapshots_peer_uuid_removed()
+{
+    local cluster=$1
+    local group_spec=$2
+    local group_snap_id=$3
+    local mirror_peer_uuid=$4
+
+    local group_snap_name
+    get_group_snap_name "${cluster}" "${group_spec}" "${group_snap_id}" group_snap_name
+    # Verify all image snapshots do not contain the mirror_peer_uuid.
+    local images
+    get_images_from_group_snap_info "${cluster}" "${group_spec}@${group_snap_name}" images
+
+    local image_spec
+    for image_spec in ${images}; do
+        local snap_id
+        get_image_snap_id_from_group_snap_info "${cluster}" "${group_spec}@${group_snap_name}" "${image_spec}" snap_id
+        test_snap_present "${cluster}" "${image_spec}" "${snap_id}" 1
+        run_cmd "rbd --cluster=${cluster} snap ls --all --format xml --pretty-format ${image_spec}"
+
+        local mirror_peer_uuids
+        # get multiple UUID's in multiple lines
+        mirror_peer_uuids=$(xmlstarlet sel -t -m "//snapshot[id='${snap_id}']/namespace/mirror_peer_uuids/peer_uuid" -v . -n < "$CMD_STDOUT" || true)
+
+        if grep -Fxq "${mirror_peer_uuid}" <<< "${mirror_peer_uuids}"; then
+            echo "mirror_peer_uuid ${mirror_peer_uuid} still present in ${image_spec} snapshot ${snap_id}"
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+assert_image_snap_present_in_group_snap()
+{
+    local cluster=$1
+    local pool=$2
+    local group=$3
+    local image=$4
+    local group_snap_id=$5
+
+    local group_snap_name
+    get_group_snap_name "${cluster}" "${pool}/${group}" "${group_snap_id}" group_snap_name
+
+    local snap_id
+    get_image_snap_id_from_group_snap_info "${cluster}" "${pool}/${group}@${group_snap_name}" "${pool}/${image}" snap_id
+
+    if [ -z "${snap_id}" ]; then
+        echo "image ${image} has no snapshot associated with group snap ID ${group_snap_id}"
+        return 1
+    fi
+
+    test_snap_present "${cluster}" "${pool}/${image}" "${snap_id}" 1
 }
 
 get_image_snap_complete()

--- a/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.cc
+++ b/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.cc
@@ -161,29 +161,119 @@ void GroupUnlinkPeerRequest<I>::process_snapshot(cls::rbd::GroupSnapshot group_s
       !is_mirror_group_snapshot_complete(group_snap.state, ns.complete)) {
     remove_group_snapshot(group_snap);
   } else {
-    // Note: avoid calling remove_peer_uuid() for CREATING snapshots as
-    // group_snap_set() returns EEXIST error
-    remove_peer_uuid(group_snap, mirror_peer_uuid);
+    // Note: avoid calling remove_peer_uuid_from_group_snap() for CREATING
+    // snapshots as group_snap_set() returns EEXIST error
+    remove_peer_uuid_from_group_snap(group_snap, mirror_peer_uuid);
   }
 }
 
-
 template <typename I>
-void GroupUnlinkPeerRequest<I>::remove_peer_uuid(
+void GroupUnlinkPeerRequest<I>::remove_peer_uuid_from_group_snap(
                               cls::rbd::GroupSnapshot group_snap,
                               std::string mirror_peer_uuid) {
   ldout(m_cct, 10) << dendl;
 
-  auto aio_comp = create_rados_callback(
-      new LambdaContext([this, group_snap](int r) {
-        handle_remove_peer_uuid(r, group_snap);
-      }));
+  if (!m_image_ctxs->empty() && m_image_ctx_map.empty()) {
+    for (size_t i = 0; i < m_image_ctxs->size(); ++i) {
+      ImageCtx *ictx = (*m_image_ctxs)[i];
+      m_image_ctx_map[ictx->id] = ictx;
+    }
+  }
 
-  auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-    &group_snap.snapshot_namespace);
-  ns->mirror_peer_uuids.erase(mirror_peer_uuid);
+  remove_peer_uuid_from_image_snaps(group_snap, mirror_peer_uuid);
+}
 
+template <typename I>
+void GroupUnlinkPeerRequest<I>::remove_peer_uuid_from_image_snaps(
+                              cls::rbd::GroupSnapshot group_snap,
+                              std::string mirror_peer_uuid) {
+  ldout(m_cct, 10) << dendl;
+
+  std::vector<cls::rbd::ImageSnapshotSpec> image_snaps = group_snap.snaps;
+  auto ctx = new LambdaContext([this, group_snap, mirror_peer_uuid](int r) {
+    handle_remove_peer_uuid_from_image_snaps(r, group_snap, mirror_peer_uuid);
+  });
+
+  C_Gather *unlink_gather_ctx = new C_Gather(m_cct, ctx);
+  for (const auto &spec : image_snaps) {
+    if (spec.snap_id == CEPH_NOSNAP) {
+      continue;
+    }
+
+    librados::IoCtx image_io_ctx;
+    if (m_image_ctx_map.find(spec.image_id) != m_image_ctx_map.end()) {
+      image_io_ctx = m_image_ctx_map[spec.image_id]->md_ctx;
+    } else {
+      ldout(m_cct, 10) << "image: " << spec.image_id
+                       << " was removed from the group" << dendl;
+      int r = librbd::util::create_ioctx(m_group_io_ctx, "image",
+                                         spec.pool, {}, &image_io_ctx);
+      if (r < 0) {
+        ldout(m_cct, 10) << "unlink peer failed for removed image snapshot "
+                         << spec.image_id << " snap_id: " << spec.snap_id
+                         << " : pool " << spec.pool
+                         << " inaccessible: " << cpp_strerror(r) << dendl;
+        unlink_gather_ctx->new_sub()->complete(r);
+        continue;
+      }
+    }
+    std::string image_header_oid = librbd::util::header_name(spec.image_id);
+    librados::ObjectWriteOperation op;
+    librbd::cls_client::mirror_image_snapshot_unlink_peer(
+        &op, spec.snap_id, mirror_peer_uuid);
+    auto img_snapshot_unlink = new LambdaContext(
+      [this, spec, new_sub_ctx=unlink_gather_ctx->new_sub()](int r) {
+        if (r == -ENOENT) {
+          r = 0;
+        }
+        if (r < 0) {
+          lderr(m_cct) << "failed to remove peer uuid for image snapshot "
+                       << spec.snap_id << " of image " << spec.image_id
+                       << ": " << cpp_strerror(r) << dendl;
+        }
+        new_sub_ctx->complete(r);
+      });
+    auto aio_comp = create_rados_callback(img_snapshot_unlink);
+    int r = image_io_ctx.aio_operate(image_header_oid, aio_comp, &op);
+    ceph_assert(r == 0);
+    aio_comp->release();
+  }
+
+  unlink_gather_ctx->activate();
+}
+
+template <typename I>
+void GroupUnlinkPeerRequest<I>::handle_remove_peer_uuid_from_image_snaps(
+                              int r, cls::rbd::GroupSnapshot group_snap,
+                              std::string mirror_peer_uuid) {
+  ldout(m_cct, 10) << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to remove group snapshot mirror peer: "
+                 << dendl;
+    finish(r);
+    return;
+  }
+
+  update_peer_uuids_on_group_snap(group_snap, mirror_peer_uuid);
+}
+
+template <typename I>
+void GroupUnlinkPeerRequest<I>::update_peer_uuids_on_group_snap(
+                              cls::rbd::GroupSnapshot group_snap,
+                              std::string mirror_peer_uuid) {
+  ldout(m_cct, 10) << dendl;
+
+  auto &ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+    group_snap.snapshot_namespace);
+  ns.mirror_peer_uuids.erase(mirror_peer_uuid);
   m_group_snap_id = group_snap.id;
+
+  auto aio_comp = create_rados_callback(
+    new LambdaContext([this, group_snap](int r) {
+      handle_update_peer_uuids_on_group_snap(r, group_snap);
+    }));
+
   librados::ObjectWriteOperation op;
   librbd::cls_client::group_snap_set(&op, group_snap);
   int r = m_group_io_ctx.aio_operate(
@@ -193,7 +283,7 @@ void GroupUnlinkPeerRequest<I>::remove_peer_uuid(
 }
 
 template <typename I>
-void GroupUnlinkPeerRequest<I>::handle_remove_peer_uuid(
+void GroupUnlinkPeerRequest<I>::handle_update_peer_uuids_on_group_snap(
     int r, cls::rbd::GroupSnapshot group_snap) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 

--- a/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.h
+++ b/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.h
@@ -70,9 +70,16 @@ private:
   void process_snapshot(cls::rbd::GroupSnapshot group_snap,
                         std::string mirror_peer_uuid);
 
-  void remove_peer_uuid(cls::rbd::GroupSnapshot group_snap,
-                        std::string mirror_peer_uuid);
-  void handle_remove_peer_uuid(int r, cls::rbd::GroupSnapshot group_snap);
+  void remove_peer_uuid_from_group_snap(cls::rbd::GroupSnapshot group_snap,
+                                        std::string mirror_peer_uuid);
+  void remove_peer_uuid_from_image_snaps(cls::rbd::GroupSnapshot group_snap,
+                                         std::string mirror_peer_uuid);
+  void handle_remove_peer_uuid_from_image_snaps(int r,
+    cls::rbd::GroupSnapshot group_snap, std::string mirror_peer_uuid);
+  void update_peer_uuids_on_group_snap(cls::rbd::GroupSnapshot group_snap,
+                                       std::string mirror_peer_uuid);
+  void handle_update_peer_uuids_on_group_snap(
+      int r, cls::rbd::GroupSnapshot group_snap);
 
   void remove_group_snapshot(cls::rbd::GroupSnapshot group_snap);
   void handle_remove_group_snapshot(int r);

--- a/src/tools/rbd_mirror/GroupReplayer.cc
+++ b/src/tools/rbd_mirror/GroupReplayer.cc
@@ -906,6 +906,19 @@ void GroupReplayer<I>::shut_down(int r) {
       update_mirror_group_status(true, STATE_STOPPED);
       handle_shut_down(r);
     });
+  auto stop_image_replayers = [this](Context* on_finish) {
+    return new LambdaContext([this, on_finish](int r) {
+      C_Gather *gather_ctx = new C_Gather(g_ceph_context, on_finish);
+      {
+        std::lock_guard locker{m_lock};
+        for (auto &it : m_image_replayers) {
+          it.second->stop(gather_ctx->new_sub());
+        }
+      }
+      gather_ctx->activate();
+    });
+  };
+  bool drain_finalization = false;
 
   // stop and destroy the replayers
   if (m_destroy_replayers) {
@@ -922,27 +935,30 @@ void GroupReplayer<I>::shut_down(int r) {
       ctx->complete(0);
     });
   }
-  ctx = new LambdaContext([this, ctx](int r) {
-    C_Gather *gather_ctx = new C_Gather(g_ceph_context, ctx);
-    {
-      std::lock_guard locker{m_lock};
-      for (auto &it : m_image_replayers) {
-        it.second->stop(gather_ctx->new_sub());
-      }
-    }
-    gather_ctx->activate();
-  });
-
   if (m_replayer != nullptr) {
+    // Fence new replay work before stopping image replayers.
+    m_replayer->stop();
+    drain_finalization = m_replayer->is_draining();
+
     ctx = new LambdaContext([this, ctx](int r) {
       m_replayer->destroy();
       m_replayer = nullptr;
       ctx->complete(0);
     });
 
+    if (drain_finalization) {
+      // Keep image replayers running until the final image/group COMPLETE
+      // transition is durable.
+      ctx = stop_image_replayers(ctx);
+    }
+
     ctx = new LambdaContext([this, ctx](int r) {
       m_replayer->shut_down(ctx);
     });
+  }
+
+  if (!drain_finalization) {
+    ctx = stop_image_replayers(ctx);
   }
 
   m_threads->work_queue->queue(ctx, 0);

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -27,6 +27,7 @@
 #include "tools/rbd_mirror/image_replayer/Utils.h"
 #include "tools/rbd_mirror/image_replayer/journal/Replayer.h"
 #include "tools/rbd_mirror/image_replayer/journal/StateBuilder.h"
+#include "tools/rbd_mirror/image_replayer/snapshot/Replayer.h"
 #include <map>
 #include <shared_mutex> // for std::shared_lock
 
@@ -294,6 +295,73 @@ void ImageReplayer<I>::set_remote_snap_id_end_limit(uint64_t snap_id) {
   if (m_replayer != nullptr) {
     m_replayer->set_remote_snap_id_end_limit(snap_id);
   }
+}
+
+template <typename I>
+void ImageReplayer<I>::prepare_snapshot(uint64_t remote_snap_id,
+                                        uint64_t* local_snap_id,
+                                        Context* on_finish,
+                                        uint64_t updated_local_snap_id) {
+  std::unique_lock locker(m_lock);
+  if (m_replayer == nullptr) {
+    locker.unlock();
+    m_threads->work_queue->queue(on_finish, -EAGAIN);
+    return;
+  }
+
+  // group snapshot operations are only supported by the snapshot replayer
+  auto replayer = dynamic_cast<image_replayer::snapshot::Replayer<I>*>(
+      m_replayer);
+  if (replayer == nullptr) {
+    locker.unlock();
+    m_threads->work_queue->queue(on_finish, -EINVAL);
+    return;
+  }
+
+  replayer->prepare_snapshot(remote_snap_id, local_snap_id, on_finish,
+                             updated_local_snap_id);
+}
+
+template <typename I>
+void ImageReplayer<I>::start_sync(Context* on_finish) {
+  std::unique_lock locker(m_lock);
+  if (m_replayer == nullptr) {
+    locker.unlock();
+    m_threads->work_queue->queue(on_finish, -EAGAIN);
+    return;
+  }
+
+  // group snapshot operations are only supported by the snapshot replayer
+  auto replayer = dynamic_cast<image_replayer::snapshot::Replayer<I>*>(
+      m_replayer);
+  if (replayer == nullptr) {
+    locker.unlock();
+    m_threads->work_queue->queue(on_finish, -EINVAL);
+    return;
+  }
+
+  replayer->start_sync(on_finish);
+}
+
+template <typename I>
+void ImageReplayer<I>::complete_snapshot(Context* on_finish) {
+  std::unique_lock locker(m_lock);
+  if (m_replayer == nullptr) {
+    locker.unlock();
+    m_threads->work_queue->queue(on_finish, -EAGAIN);
+    return;
+  }
+
+  // group snapshot operations are only supported by the snapshot replayer
+  auto replayer = dynamic_cast<image_replayer::snapshot::Replayer<I>*>(
+      m_replayer);
+  if (replayer == nullptr) {
+    locker.unlock();
+    m_threads->work_queue->queue(on_finish, -EINVAL);
+    return;
+  }
+
+  replayer->complete_snapshot(on_finish);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -147,6 +147,11 @@ public:
 
   void prune_snapshot(uint64_t snap_id);
   void set_remote_snap_id_end_limit(uint64_t snap_id);
+  void prepare_snapshot(uint64_t remote_snap_id, uint64_t* local_snap_id,
+                        Context* on_finish,
+                        uint64_t updated_local_snap_id = CEPH_NOSNAP);
+  void start_sync(Context* on_finish);
+  void complete_snapshot(Context* on_finish);
   uint64_t get_remote_snap_id_end_limit();
   uint64_t get_last_snapshot_bytes() const;
 

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -868,8 +868,14 @@ void Replayer<I>::scan_for_unsynced_group_snapshots(
     // and the previous interrupted cycle, after which we reload the
     // replayer to start a new sync cycle.
     auto remote_snap_id = *unlink_snap_uuids.begin();
-    mirror_group_snapshot_unlink_peer(remote_snap_id);
-    load_replayer(locker);
+    m_in_flight_op_tracker.start_op();
+    auto on_unlink = new LambdaContext([this](int r) {
+      std::unique_lock locker{m_lock};
+      m_in_flight_op_tracker.finish_op();
+      load_replayer(&locker);
+      return;
+    });
+    mirror_group_snapshot_unlink_peer(locker, remote_snap_id, on_unlink);
     return;
   }
 
@@ -1443,15 +1449,16 @@ void Replayer<I>::handle_set_mirror_snapshot_complete(
     }
   }
 
-  {
-    std::unique_lock locker{m_lock};
-    m_last_snapshot_bytes = last_snapshot_bytes;
-  }
+  std::unique_lock locker{m_lock};
+  m_last_snapshot_bytes = last_snapshot_bytes;
 
   if (!m_last_synced_remote_snap_id.empty()) {
-    mirror_group_snapshot_unlink_peer(m_last_synced_remote_snap_id);
+    mirror_group_snapshot_unlink_peer(
+      &locker, m_last_synced_remote_snap_id, on_finish);
+  } else {
+    locker.unlock();
+    on_finish->complete(0);
   }
-  on_finish->complete(0);
 }
 
 template <typename I>
@@ -1695,7 +1702,11 @@ void Replayer<I>::handle_post_user_snapshot_created(
 }
 
 template <typename I>
-void Replayer<I>::mirror_group_snapshot_unlink_peer(const std::string &snap_id) {
+void Replayer<I>::mirror_group_snapshot_unlink_peer(
+  std::unique_lock<ceph::mutex>* locker,
+  const std::string &snap_id, Context* on_unlink) {
+  dout(10) << dendl;
+
   auto remote_snap = std::find_if(
       m_remote_group_snaps.begin(), m_remote_group_snaps.end(),
       [snap_id](const cls::rbd::GroupSnapshot &s) {
@@ -1703,44 +1714,132 @@ void Replayer<I>::mirror_group_snapshot_unlink_peer(const std::string &snap_id) 
       });
 
   if (remote_snap == m_remote_group_snaps.end()) {
+    locker->unlock();
+    on_unlink->complete(0);
     return;
   }
+  ceph_assert(*remote_snap != m_remote_group_snaps.back());
 
   auto rns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
       &remote_snap->snapshot_namespace);
   if (rns == nullptr) {
     derr << "remote group snapshot is not a mirror snapshot: "
          << snap_id << dendl;
+    locker->unlock();
+    on_unlink->complete(-EINVAL);
     return;
   }
 
-  if (rns->mirror_peer_uuids.count(m_remote_mirror_peer_uuid) != 0) {
-    rns->mirror_peer_uuids.erase(m_remote_mirror_peer_uuid);
-    auto comp = create_rados_callback(
-      new LambdaContext([this, snap_id](int r) {
-	handle_mirror_group_snapshot_unlink_peer(r, snap_id);
-      }));
-
-    librados::ObjectWriteOperation op;
-    librbd::cls_client::group_snap_set(&op, *remote_snap);
-    int r = m_remote_io_ctx.aio_operate(
-      librbd::util::group_header_name(m_remote_group_id), comp, &op);
-    ceph_assert(r == 0);
-    comp->release();
+  if (rns->mirror_peer_uuids.count(m_remote_mirror_peer_uuid) == 0) {
+    locker->unlock();
+    on_unlink->complete(0);
+    return;
   }
+
+  if (remote_snap->snaps.empty()) {
+    unlink_peer_uuid_from_group_snap(&(*remote_snap), on_unlink);
+    return;
+  }
+
+  unlink_peer_uuid_from_image_snaps(&(*remote_snap), on_unlink);
 }
 
 template <typename I>
-void Replayer<I>::handle_mirror_group_snapshot_unlink_peer(
-    int r, const std::string &snap_id) {
+void Replayer<I>::unlink_peer_uuid_from_image_snaps(
+    cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink) {
+  auto snap_id = remote_snap->id;
+  dout(10) << snap_id << dendl;
+
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  std::vector<cls::rbd::ImageSnapshotSpec> image_snaps = remote_snap->snaps;
+  auto ctx = new LambdaContext([this, remote_snap, on_unlink](int r) {
+    handle_unlink_peer_uuid_from_image_snaps(r, remote_snap, on_unlink);
+  });
+
+  C_Gather *unlink_gather_ctx = new C_Gather(g_ceph_context, ctx);
+  for (const auto &spec : image_snaps) {
+    if (spec.snap_id == CEPH_NOSNAP) {
+      continue;
+    }
+    std::string image_header_oid = librbd::util::header_name(spec.image_id);
+    librados::ObjectWriteOperation op;
+    librbd::cls_client::mirror_image_snapshot_unlink_peer(
+      &op, spec.snap_id, m_remote_mirror_peer_uuid);
+    auto img_snapshot_unlink = new LambdaContext(
+      [this, spec, new_sub_ctx=unlink_gather_ctx->new_sub()](int r) {
+        if (r == -ENOENT) {
+          r = 0;
+        }
+        if (r < 0) {
+          derr << "failed to unlink mirror peer from image snapshot "
+               << spec.snap_id << " of image " << spec.image_id
+               << ": " << cpp_strerror(r) << dendl;
+        }
+        new_sub_ctx->complete(r);
+      });
+    auto aio_comp = create_rados_callback(img_snapshot_unlink);
+    int r = m_remote_io_ctx.aio_operate(image_header_oid, aio_comp, &op);
+    ceph_assert(r == 0);
+    aio_comp->release();
+  }
+
+  unlink_gather_ctx->activate();
+}
+
+template <typename I>
+void Replayer<I>::handle_unlink_peer_uuid_from_image_snaps(
+    int r, cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink) {
+  std::unique_lock locker{m_lock};
+  auto snap_id = remote_snap->id;
   dout(10) << snap_id << ", r=" << r << dendl;
 
   if (r < 0) {
-    derr << "failed to remove mirror_peer_uuid for snap_id: "
-         << snap_id  << " : " << cpp_strerror(r) << dendl;
+    derr << "failed to remove mirror_peer_uuid for image snapshots"
+         << " of group snapshot snap_id: " << snap_id << dendl;
+    locker.unlock();
+    on_unlink->complete(r);
+    return;
   }
 
-  return;
+  unlink_peer_uuid_from_group_snap(remote_snap, on_unlink);
+}
+
+template <typename I>
+void Replayer<I>::unlink_peer_uuid_from_group_snap(
+  cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink) {
+  auto snap_id = remote_snap->id;
+  dout(10) << "unlinking peer uuid for remote group snapshot: "
+           << snap_id << dendl;
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+
+  auto &rns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+      remote_snap->snapshot_namespace);
+  rns.mirror_peer_uuids.erase(m_remote_mirror_peer_uuid);
+
+  auto comp = create_rados_callback(
+    new LambdaContext([this, snap_id, on_unlink](int r) {
+      handle_unlink_peer_uuid_from_group_snap(r, snap_id, on_unlink);
+    }));
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::group_snap_set(&op, *remote_snap);
+  int r = m_remote_io_ctx.aio_operate(
+    librbd::util::group_header_name(m_remote_group_id), comp, &op);
+  ceph_assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void Replayer<I>::handle_unlink_peer_uuid_from_group_snap(
+    int r, const std::string &group_snap_id, Context* on_unlink) {
+  dout(10) << group_snap_id << ", r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to remove mirror_peer_uuid for snap_id: "
+         << group_snap_id  << " : " << cpp_strerror(r) << dendl;
+  }
+
+  on_unlink->complete(r);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -38,15 +38,6 @@ namespace {
 
 const uint32_t MAX_RETURN = 1024;
 
-const cls::rbd::GroupSnapshot* get_latest_group_snapshot(
-    const std::vector<cls::rbd::GroupSnapshot>& gp_snaps) {
-  auto it = gp_snaps.rbegin();
-  if (it != gp_snaps.rend()) {
-    return &*it;
-  }
-  return nullptr;
-}
-
 const cls::rbd::GroupSnapshot* get_latest_complete_mirror_group_snapshot(
     const std::vector<cls::rbd::GroupSnapshot>& gp_snaps) {
   for (auto it = gp_snaps.rbegin(); it != gp_snaps.rend(); ++it) {
@@ -421,14 +412,8 @@ void Replayer<I>::validate_local_group_snapshots(
       continue;
     }
 
-    // setup validation callback
-    Context *sub_ctx = gather_ctx->new_sub();
-    auto ctx = new LambdaContext([sub_ctx](int r) {
-      sub_ctx->complete(r);
-    });
-
     // validate incomplete non-primary mirror or regular snapshots
-    validate_image_snaps_sync_complete(local_snap, ctx);
+    validate_image_snaps_sync_complete(local_snap, gather_ctx->new_sub());
   }
   gather_ctx->activate();
 }
@@ -528,6 +513,13 @@ void Replayer<I>::handle_load_remote_group_snapshots(int r) {
     derr << "error listing remote mirror group snapshots: " << cpp_strerror(r)
          << dendl;
     handle_replay_complete(&locker, r, "failed to list remote group snapshots");
+    return;
+  }
+
+  if (m_remote_group_snaps.empty()) {
+    dout(10) << "remote snapshots are empty" << dendl;
+    locker.unlock();
+    schedule_load_group_snapshots();
     return;
   }
 
@@ -809,35 +801,25 @@ void Replayer<I>::scan_for_unsynced_group_snapshots(
     return;
   }
 
-  auto last_local_snap = get_latest_group_snapshot(m_local_group_snaps);
-  // check if we have a matching snap on remote to start with it.
+  m_last_synced_remote_snap_id.clear();
+  auto last_local_snap = get_latest_complete_mirror_group_snapshot(
+      m_local_group_snaps);
   if (last_local_snap != nullptr) {
-    try_create_group_snapshot(last_local_snap->id, locker);
-  } else { // empty local cluster, started mirroring freshly
-    try_create_group_snapshot("", locker);
+    m_last_synced_remote_snap_id = last_local_snap->id;
+    m_update_group_state = false;
   }
-  locker->unlock();
-
-  schedule_load_group_snapshots();
-}
-
-template <typename I>
-void Replayer<I>::try_create_group_snapshot(
-    std::string prev_snap_id, std::unique_lock<ceph::mutex>* locker) {
-  if (m_remote_group_snaps.empty()) {
-    dout(10) << "remote snapshots are empty" << dendl;
-    return;
-  }
-
   bool found = false;
+  bool is_mirror_snap_exist = false;
+  std::vector<std::string> unlink_snap_uuids;
+  std::vector<cls::rbd::GroupSnapshot> user_snapshots;
   auto snap = m_remote_group_snaps.end();
   for (auto remote_snap = m_remote_group_snaps.begin();
       remote_snap != m_remote_group_snaps.end(); ++remote_snap) {
-    if (prev_snap_id.empty() ||
-        (found || prev_snap_id == remote_snap->id)) {
+    if (m_last_synced_remote_snap_id.empty() ||
+        (found || m_last_synced_remote_snap_id == remote_snap->id)) {
       found = true;
       snap = remote_snap; // sync this snapshot
-      if (!prev_snap_id.empty()) {
+      if (!m_last_synced_remote_snap_id.empty()) {
         snap = std::next(remote_snap); // attempt to sync next remote snapshot
       }
       if (snap != m_remote_group_snaps.end()) {
@@ -847,7 +829,7 @@ void Replayer<I>::try_create_group_snapshot(
           if (snap->state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
             dout(10) << "found remote user group snapshot: "
                      << snap->id << dendl;
-            create_group_snapshot(*snap, locker);
+            user_snapshots.push_back(*snap);
             continue;
           }
         } else if (next_remote_snap_ns->is_primary()) {
@@ -855,176 +837,111 @@ void Replayer<I>::try_create_group_snapshot(
                                                 next_remote_snap_ns->complete)) {
             dout(10) << "found primary remote mirror group snapshot: "
                      << snap->id << dendl;
-            create_group_snapshot(*snap, locker);
-            return;
+            is_mirror_snap_exist = true;
+            break;
           }
         } else {
           dout(10) << "skipping non-primary remote group snapshot: "
                    << snap->id << dendl;
           continue;
         }
-      } else {
-        dout(10) << "all remote snaps synced: idling waiting for new snapshot"
-                 << dendl;
-        ceph_assert(m_state == STATE_REPLAYING);
-        m_state = STATE_IDLE;
-        return;
+      }
+    } else {
+      auto remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
+          &remote_snap->snapshot_namespace);
+      if (remote_snap_ns) {
+        unlink_snap_uuids.emplace_back(remote_snap->id);
       }
     }
   }
 
-  if (!prev_snap_id.empty() && !found) {
+  if (!m_last_synced_remote_snap_id.empty() && !found) {
     dout(10) << "none of the local snaps match remote" << dendl;
     handle_replay_complete(locker, -EEXIST, "split-brain");
+    return;
+  }
+
+  if (!unlink_snap_uuids.empty()) {
+    // This case occurs when the previous sync cycle was interrupted
+    // (due to a crash or daemon failure) before performing unlink at
+    // the end. Unlinking the peer completes the outstanding cleanup
+    // and the previous interrupted cycle, after which we reload the
+    // replayer to start a new sync cycle.
+    auto remote_snap_id = *unlink_snap_uuids.begin();
+    mirror_group_snapshot_unlink_peer(remote_snap_id);
+    load_replayer(locker);
+    return;
+  }
+
+  if (is_mirror_snap_exist) {
+    create_user_group_snapshots(locker, &(*snap), user_snapshots);
+  } else {
+    dout(10) << "all remote mirror snapshots synced: idling waiting for new "
+             << "mirror snapshot" << dendl;
+    ceph_assert(m_state == STATE_REPLAYING);
+    m_state = STATE_IDLE;
+    locker->unlock();
+    schedule_load_group_snapshots();
   }
 }
 
 template <typename I>
-void Replayer<I>::create_group_snapshot(cls::rbd::GroupSnapshot snap,
-                                        std::unique_lock<ceph::mutex>* locker) {
-  dout(10) << snap.id << dendl;
+void Replayer<I>::create_user_group_snapshots(
+    std::unique_lock<ceph::mutex>* locker,
+    cls::rbd::GroupSnapshot* mirror_snap,
+    std::vector<cls::rbd::GroupSnapshot>& user_snapshots) {
+  dout(10) << dendl;
+
+  auto ctx = new LambdaContext([this, mirror_snap](int r) {
+    handle_create_user_group_snapshots(r, mirror_snap);
+    m_in_flight_op_tracker.finish_op();
+  });
+
+  auto gather_ctx = new C_Gather(g_ceph_context, ctx);
+  m_in_flight_op_tracker.start_op();
+  for (auto& user_snap : user_snapshots) {
+    create_user_group_snapshot(&user_snap, gather_ctx->new_sub());
+  }
+  locker->unlock();
+  gather_ctx->activate();
+}
+
+template <typename I>
+void Replayer<I>::handle_create_user_group_snapshots(
+    int r, cls::rbd::GroupSnapshot *mirror_snap) {
+  dout(10) << dendl;
+  std::unique_lock locker{m_lock};
+
+  if (is_replay_interrupted(&locker)) {
+    return;
+  }
+
+  if (r < 0) {
+    dout(10) << "failed to create user snapshots " << cpp_strerror(r) << dendl;
+    handle_replay_complete(&locker, r, "failed to create user group snapshots");
+    return;
+  }
+
+  create_mirror_group_snapshot(&locker, mirror_snap);
+}
+
+template <typename I>
+void Replayer<I>::create_mirror_group_snapshot(
+    std::unique_lock<ceph::mutex>* locker, cls::rbd::GroupSnapshot *snap) {
+  auto group_snap_id = snap->id;
+  dout(10) << group_snap_id << dendl;
 
   if (m_snapshot_start.is_zero()) {
     m_snapshot_start = ceph_clock_now();
   }
 
-  auto snap_type = cls::rbd::get_group_snap_namespace_type(
-      snap.snapshot_namespace);
-  if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
-    const auto& snap_ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-        snap.snapshot_namespace);
+  const auto& snap_ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+      snap->snapshot_namespace);
 
-    if (snap_ns.is_non_primary()) {
-      dout(10) << "remote group snapshot " << snap.id << " is non primary"
-               << dendl;
-      return;
-    }
-
-    auto snap_state =
-      snap_ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY ?
-      cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY :
-      cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED;
-
-    m_in_flight_op_tracker.start_op();
-
-    auto ctx = new LambdaContext([this, snap](int r) mutable {
-      std::unique_lock locker{m_lock};
-      if (r < 0) {
-        dout(10) << "create mirror snapshot failed, will be retried later: "
-                 << cpp_strerror(r) << dendl;
-        m_in_flight_op_tracker.finish_op();
-        return;
-      }
-      if (m_update_group_state) {
-        update_local_group_state(std::move(snap));
-      } else {
-        // if m_replayer in the ImageReplayer is null this cannot be forwarded.
-        // May be we should retry this setting in the validate_image_snaps_sync_complete().
-        // Same for image_replayer->prune_snapshot(); setting actually!!!!
-        set_image_replayer_limits("", &snap, &locker);
-      }
-      m_in_flight_op_tracker.finish_op();
-    });
-
-    create_mirror_snapshot(&snap, snap_state, ctx);
-  } else if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
-    auto itr = std::find_if(
-        m_remote_group_snaps.begin(), m_remote_group_snaps.end(),
-        [&snap](const cls::rbd::GroupSnapshot &s) {
-        return s.id == snap.id;
-        });
-
-    if (itr == m_remote_group_snaps.end()) {
-      dout(10) << "remote group snapshot not found: " << snap.id << dendl;
-      return;
-    }
-
-    auto next_remote_snap = std::next(itr);
-    if (next_remote_snap == m_remote_group_snaps.end()) {
-      return;
-    }
-
-    // check if we have a valid mirror snapshot to proceed
-    bool can_proceed = false;
-    for (; next_remote_snap != m_remote_group_snaps.end(); ++next_remote_snap) {
-      auto next_remote_snap_ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-            &next_remote_snap->snapshot_namespace);
-
-      if (next_remote_snap_ns == nullptr) {
-        continue; // skip user snapshots
-      } else if (!is_mirror_group_snapshot_complete(next_remote_snap->state,
-                                                    next_remote_snap_ns->complete)) {
-        dout(10) << "next mirror snapshot is incomplete, waiting: "
-                 << next_remote_snap->id << dendl;
-        return; // wait and try later
-      } else {
-        can_proceed = true; // we have a complete mirror snapshot
-        break;
-      }
-    }
-
-    if (!can_proceed) {
-      dout(10) << "no valid mirror snapshot found after: " << snap.id << dendl;
-      return;
-    }
-
-    dout(10) << "found user snap, snap name: " << snap.name
-             << ", remote group snap id: " << snap.id << dendl;
-
-    m_in_flight_op_tracker.start_op();
-    auto ctx = new LambdaContext([this, snap](int r) mutable {
-      if (r < 0) {
-        dout(10) << "create user snapshot failed, will be retried later: "
-                 << cpp_strerror(r) << dendl;
-      }
-      m_in_flight_op_tracker.finish_op();
-    });
-    create_user_snapshot(&snap, ctx);
-  }
-}
-
-template <typename I>
-void Replayer<I>::update_local_group_state(cls::rbd::GroupSnapshot snap) {
-  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
-  m_in_flight_op_tracker.start_op();
-  auto ctx = new LambdaContext([this, snap](int r) mutable {
-    handle_update_local_group_state(r, std::move(snap));
-    m_in_flight_op_tracker.finish_op();
-  });
-
-  // Set the mirror group state to enabled after the first non-primary
-  // mirror snapshot is created
-  auto req = GroupMirrorStateUpdateRequest<I>::create(m_local_io_ctx,
-                                                      m_local_group_id,
-                                                      m_image_replayers->size(),
-                                                      ctx);
-  req->send();
-}
-
-template <typename I>
-void Replayer<I>::handle_update_local_group_state(int r,
-                                                  cls::rbd::GroupSnapshot snap) {
-  std::unique_lock locker{m_lock};
-  dout(10) << dendl;
-  if (r < 0) {
-    derr << "failed to set group state: " << cpp_strerror(r) << dendl;
-    handle_replay_complete(&locker, r, "failed to set group state to enabled");
-    return;
-  }
-
-  m_update_group_state = false;
-
-  set_image_replayer_limits("", &snap, &locker);
-}
-
-template <typename I>
-void Replayer<I>::create_mirror_snapshot(
-    cls::rbd::GroupSnapshot *snap,
-    const cls::rbd::MirrorSnapshotState &snap_state,
-    Context *on_finish) {
-  auto group_snap_id = snap->id;
-  dout(10) << group_snap_id << dendl;
-  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  auto snap_state =
+    snap_ns.state == cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY ?
+    cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY :
+    cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED;
 
   auto itl = std::find_if(
       m_local_group_snaps.begin(), m_local_group_snaps.end(),
@@ -1035,7 +952,8 @@ void Replayer<I>::create_mirror_snapshot(
   if (itl != m_local_group_snaps.end()) {
     dout(20) << "group snapshot: " << group_snap_id << " already exists"
              << dendl;
-    on_finish->complete(0);
+    locker->unlock();
+    schedule_load_group_snapshots();
     return;
   }
 
@@ -1050,7 +968,7 @@ void Replayer<I>::create_mirror_snapshot(
     r = librbd::cls_client::mirror_peer_list(&default_ns_io_ctx, &mirror_peers);
     if (r < 0) {
       derr << "failed to list mirror peers: " << cpp_strerror(r) << dendl;
-      on_finish->complete(r);
+      handle_replay_complete(locker, r, "failed to list mirror peers");
       return;
     }
 
@@ -1068,7 +986,7 @@ void Replayer<I>::create_mirror_snapshot(
   if (r < 0) {
     derr << "failed to retrieve min OSD release: " << cpp_strerror(r)
          << dendl;
-    on_finish->complete(r);
+    handle_replay_complete(locker, r, "failed to list mirror peers");
     return;
   }
 
@@ -1085,10 +1003,12 @@ void Replayer<I>::create_mirror_snapshot(
                                                          group_snap_id);
 
   auto comp = create_rados_callback(
-      new LambdaContext([this, group_snap_id, on_finish](int r) {
-        handle_create_mirror_snapshot(r, group_snap_id, on_finish);
+      new LambdaContext([this, snap](int r) {
+        handle_create_mirror_group_snapshot(r, snap);
+        m_in_flight_op_tracker.finish_op();
         }));
 
+  m_in_flight_op_tracker.start_op();
   librados::ObjectWriteOperation op;
   librbd::cls_client::group_snap_set(&op, local_snap);
   r = m_local_io_ctx.aio_operate(
@@ -1098,18 +1018,74 @@ void Replayer<I>::create_mirror_snapshot(
 }
 
 template <typename I>
-void Replayer<I>::handle_create_mirror_snapshot(
-    int r, const std::string &group_snap_id, Context *on_finish) {
-  dout(10) << "group_snap_id=" << group_snap_id << ", r=" << r << dendl;
+void Replayer<I>::handle_create_mirror_group_snapshot(
+    int r, cls::rbd::GroupSnapshot *snap) {
+  dout(10) << "group_snap_id=" << snap->id << ", r=" << r << dendl;
+  std::unique_lock locker{m_lock};
+
+  if (is_replay_interrupted(&locker)) {
+    return;
+  }
 
   if (r < 0) {
-    derr << "failed to create mirror snapshot: " << group_snap_id
+    derr << "failed to create mirror snapshot: " << snap->id
          << ", error: " << cpp_strerror(r) << dendl;
+    handle_replay_complete(&locker, r, "failed to create mirror snapshot");
+    return;
   }
 
   m_retry_validate_snap = true;
+  update_local_group_state(&locker, snap);
+}
 
-  on_finish->complete(r);
+template <typename I>
+void Replayer<I>::update_local_group_state(std::unique_lock<ceph::mutex>* locker,
+                                           cls::rbd::GroupSnapshot* snap) {
+  dout(10) << dendl;
+  if (!m_update_group_state) {
+    // if m_replayer in the ImageReplayer is null this cannot be forwarded.
+    // May be we should retry this setting in the validate_image_snaps_sync_complete().
+    // Same for image_replayer->prune_snapshot(); setting actually!!!!
+    set_image_replayer_limits("", snap, locker);
+    locker->unlock();
+    schedule_load_group_snapshots();
+    return;
+  }
+
+  auto ctx = new LambdaContext([this, snap](int r) {
+    handle_update_local_group_state(r, snap);
+     m_in_flight_op_tracker.finish_op();
+  });
+
+  // Set the mirror group state to enabled after the first non-primary
+  // mirror snapshot is created
+  m_in_flight_op_tracker.start_op();
+  auto req = GroupMirrorStateUpdateRequest<I>::create(m_local_io_ctx,
+                                                      m_local_group_id,
+                                                      m_image_replayers->size(),
+                                                      ctx);
+  req->send();
+}
+
+template <typename I>
+void Replayer<I>::handle_update_local_group_state(int r,
+    cls::rbd::GroupSnapshot* snap) {
+  std::unique_lock locker{m_lock};
+  dout(10) << dendl;
+  if (is_replay_interrupted(&locker)) {
+    return;
+  }
+
+  if (r < 0) {
+    derr << "failed to set group state: " << cpp_strerror(r) << dendl;
+    handle_replay_complete(&locker, r, "failed to set group state to enabled");
+    return;
+  }
+
+  m_update_group_state = false;
+  set_image_replayer_limits("", snap, &locker);
+  locker.unlock();
+  schedule_load_group_snapshots();
 }
 
 template <typename I>
@@ -1472,16 +1448,22 @@ void Replayer<I>::handle_set_mirror_snapshot_complete(
     m_last_snapshot_bytes = last_snapshot_bytes;
   }
 
+  if (!m_last_synced_remote_snap_id.empty()) {
+    mirror_group_snapshot_unlink_peer(m_last_synced_remote_snap_id);
+  }
   on_finish->complete(0);
 }
 
 template <typename I>
-void Replayer<I>::create_user_snapshot(
-    cls::rbd::GroupSnapshot *snap,
-    Context *on_finish) {
+void Replayer<I>::create_user_group_snapshot(
+    cls::rbd::GroupSnapshot *snap, Context *on_finish) {
   auto group_snap_id = snap->id;
   dout(10) << group_snap_id << dendl;
   ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+
+  if (m_snapshot_start.is_zero()) {
+    m_snapshot_start = ceph_clock_now();
+  }
 
   // check if snapshot already exists
   auto itl = std::find_if(
@@ -1508,7 +1490,7 @@ void Replayer<I>::create_user_snapshot(
 
   auto comp = create_rados_callback(
       new LambdaContext([this, group_snap_id, on_finish](int r) {
-        handle_create_user_snapshot(r, group_snap_id, on_finish);
+        handle_create_user_group_snapshot(r, group_snap_id, on_finish);
       }));
 
   int r = m_local_io_ctx.aio_operate(
@@ -1518,7 +1500,7 @@ void Replayer<I>::create_user_snapshot(
 }
 
 template <typename I>
-void Replayer<I>::handle_create_user_snapshot(
+void Replayer<I>::handle_create_user_group_snapshot(
     int r, const std::string &group_snap_id, Context *on_finish) {
   dout(10) << "group_snap_id=" << group_snap_id << ", r=" << r << dendl;
 
@@ -1526,8 +1508,6 @@ void Replayer<I>::handle_create_user_snapshot(
     derr << "failed to create user snapshot: " << group_snap_id
          << ", error: " << cpp_strerror(r) << dendl;
   }
-
-  m_retry_validate_snap = true;
 
   on_finish->complete(r);
 }
@@ -2065,8 +2045,6 @@ int Replayer<I>::prune_mirror_group_snapshot(
   if (!m_prune_group_snap) {
     return 0;
   }
-
-  mirror_group_snapshot_unlink_peer(m_prune_group_snap->id);
 
   dout(10) << "pruning mirror group snap in-progress: "
            << m_prune_group_snap->name << ", with id: "

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -156,7 +156,8 @@ void Replayer<I>::schedule_load_group_snapshots() {
   std::lock_guard timer_locker{m_threads->timer_lock};
   std::lock_guard locker{m_lock};
 
-  if (m_state != STATE_REPLAYING && m_state != STATE_IDLE) {
+  if (m_draining ||
+      (m_state != STATE_REPLAYING && m_state != STATE_IDLE)) {
     return;
   }
 
@@ -177,6 +178,10 @@ void Replayer<I>::handle_schedule_load_group_snapshots(int r) {
 
   {
     std::unique_lock locker{m_lock};
+    if (m_draining) {
+      m_load_snapshots_task = nullptr;
+      return;
+    }
     if (m_state != STATE_REPLAYING && m_state != STATE_IDLE) {
       return;
     }
@@ -422,6 +427,10 @@ template <typename I>
 void Replayer<I>::load_replayer(
     std::unique_lock<ceph::mutex>* locker) {
   dout(10) << "m_global_group_id=" << m_global_group_id << dendl;
+  if (m_draining) {
+    locker->unlock();
+    return;
+  }
   if (is_replay_interrupted(locker)) {
     return;
   }
@@ -588,6 +597,7 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
   }
 
   m_prune_group_snap = nullptr;
+  m_retry_validate_snap = false;
   auto prune_creating_group_snaps =
     std::make_shared<std::vector<cls::rbd::GroupSnapshot>>();
   m_last_local_snap = nullptr;
@@ -601,6 +611,10 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
       if (m_check_creating_snaps &&
          local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
         prune_creating_group_snaps->push_back(local_snap);
+      }
+      if (local_snap.state != cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
+        // retry after the next mirror snapshot creates the image snapshots
+        m_retry_validate_snap = true;
       }
       continue;
     }
@@ -621,6 +635,8 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
       } else if (m_check_creating_snaps &&
         local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
         prune_creating_group_snaps->push_back(local_snap);
+      } else {
+        m_retry_validate_snap = true;
       }
     }
   }
@@ -633,7 +649,6 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
   // We must determine whether the local group is already primary here.
   // Otherwise, if the remote group snapshots are unavailable for any reason,
   // replayer will incorrectly report an error status for the local group.
-  m_retry_validate_snap = false;
   if (m_last_local_snap) {
     const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
         m_last_local_snap->snapshot_namespace);
@@ -1041,25 +1056,20 @@ void Replayer<I>::handle_create_mirror_group_snapshot(
   }
 
   m_retry_validate_snap = true;
-  update_local_group_state(&locker, snap);
+  update_local_group_state(&locker);
 }
 
 template <typename I>
-void Replayer<I>::update_local_group_state(std::unique_lock<ceph::mutex>* locker,
-                                           cls::rbd::GroupSnapshot* snap) {
+void Replayer<I>::update_local_group_state(std::unique_lock<ceph::mutex>* locker) {
   dout(10) << dendl;
   if (!m_update_group_state) {
-    // if m_replayer in the ImageReplayer is null this cannot be forwarded.
-    // May be we should retry this setting in the validate_image_snaps_sync_complete().
-    // Same for image_replayer->prune_snapshot(); setting actually!!!!
-    set_image_replayer_limits("", snap, locker);
     locker->unlock();
     schedule_load_group_snapshots();
     return;
   }
 
-  auto ctx = new LambdaContext([this, snap](int r) {
-    handle_update_local_group_state(r, snap);
+  auto ctx = new LambdaContext([this](int r) {
+    handle_update_local_group_state(r);
      m_in_flight_op_tracker.finish_op();
   });
 
@@ -1074,8 +1084,7 @@ void Replayer<I>::update_local_group_state(std::unique_lock<ceph::mutex>* locker
 }
 
 template <typename I>
-void Replayer<I>::handle_update_local_group_state(int r,
-    cls::rbd::GroupSnapshot* snap) {
+void Replayer<I>::handle_update_local_group_state(int r) {
   std::unique_lock locker{m_lock};
   dout(10) << dendl;
   if (is_replay_interrupted(&locker)) {
@@ -1089,7 +1098,6 @@ void Replayer<I>::handle_update_local_group_state(int r,
   }
 
   m_update_group_state = false;
-  set_image_replayer_limits("", snap, &locker);
   locker.unlock();
   schedule_load_group_snapshots();
 }
@@ -1131,11 +1139,6 @@ void Replayer<I>::mirror_snapshot_complete(
   cls::rbd::GroupSnapshot local_snap = *itl;
   cls::rbd::GroupSnapshot remote_snap = *itr;
   locker.unlock();
-
-  if (local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
-    check_mirror_snapshot_sync_complete(group_snap_id, local_snap, on_finish);
-    return;
-  }
 
   bufferlist* out_bl = new bufferlist();
   std::vector<cls::rbd::GroupImageStatus>* local_images =
@@ -1183,6 +1186,91 @@ void Replayer<I>::handle_mirror_snapshot_image_list(
 }
 
 template <typename I>
+int Replayer<I>::find_local_mirror_image_snapshot(
+    const std::string& group_snap_id,
+    const cls::rbd::GroupImageStatus& image,
+    bool* image_snap_created,
+    bool* image_snap_complete,
+    cls::rbd::ImageSnapshotSpec* snap_spec) {
+  *image_snap_created = false;
+  *image_snap_complete = false;
+
+  std::string image_header_oid = librbd::util::header_name(image.spec.image_id);
+  ::SnapContext snapc;
+  int r = librbd::cls_client::get_snapcontext(&m_local_io_ctx,
+      image_header_oid, &snapc);
+  if (r < 0) {
+    derr << "get snap context failed: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  for (auto snap_id : snapc.snaps) {
+    cls::rbd::SnapshotInfo snap_info;
+    r = librbd::cls_client::snapshot_get(&m_local_io_ctx, image_header_oid,
+        snap_id, &snap_info);
+    if (r < 0) {
+      derr << "failed getting snap info for snap id: " << snap_id
+           << ", : " << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    auto mirror_ns = std::get_if<cls::rbd::MirrorSnapshotNamespace>(
+      &snap_info.snapshot_namespace);
+    if (!mirror_ns) {
+      continue;
+    }
+    if (mirror_ns->group_snap_id != group_snap_id) {
+      dout(20) << "expecting remote group snap id: " << group_snap_id
+               << ", but group snap id: " << mirror_ns->group_snap_id
+               << " is reflecting in the local image: "
+               << image.spec.image_id << " with image snap id: "
+               << snap_info.id << dendl;
+      continue;
+    }
+
+    *image_snap_created = true;
+    *image_snap_complete = mirror_ns->complete;
+    snap_spec->pool = image.spec.pool_id;
+    snap_spec->image_id = image.spec.image_id;
+    snap_spec->snap_id = snap_info.id;
+    return 0;
+  }
+  return 0;
+}
+
+template <typename I>
+uint64_t Replayer<I>::find_remote_image_snapshot(
+    const cls::rbd::GroupSnapshot& remote_snap,
+    const std::string& global_image_id) {
+  for (const auto& remote_snap_spec : remote_snap.snaps) {
+    cls::rbd::MirrorImage mirror_image;
+    int r = librbd::cls_client::mirror_image_get(&m_remote_io_ctx,
+        remote_snap_spec.image_id, &mirror_image);
+    if (r < 0) {
+      derr << "mirror image get failed for: " << remote_snap_spec.image_id
+           << " : " << cpp_strerror(r) << dendl;
+      continue;
+    }
+    if (global_image_id != mirror_image.global_image_id) {
+      continue;
+    }
+
+    std::string image_header_oid = librbd::util::header_name(
+        remote_snap_spec.image_id);
+    cls::rbd::SnapshotInfo snap_info;
+    r = librbd::cls_client::snapshot_get(&m_remote_io_ctx, image_header_oid,
+        remote_snap_spec.snap_id, &snap_info);
+    if (r < 0) {
+      derr << "failed getting remote snap info for snap id: "
+           << remote_snap_spec.snap_id << ", : " << cpp_strerror(r) << dendl;
+      continue;
+    }
+    return snap_info.id;
+  }
+  return CEPH_NOSNAP;
+}
+
+template <typename I>
 void Replayer<I>::post_mirror_snapshot_created(
     const std::string &group_snap_id,
     const cls::rbd::GroupSnapshot &local_snap,
@@ -1191,206 +1279,331 @@ void Replayer<I>::post_mirror_snapshot_created(
     Context *on_finish) {
   std::unique_lock locker{m_lock};
   dout(10) << group_snap_id << dendl;
-  std::vector<cls::rbd::ImageSnapshotSpec> local_image_snap_specs;
-  local_image_snap_specs.reserve(remote_snap.snaps.size());
 
-  for (auto& image : local_images) {
+  // preserve a refresh requested by the current replay cycle
+  bool refresh_snaps = m_refresh_snaps;
+  m_refresh_snaps = false;
+  int r = prune_user_group_snapshots(&locker);
+  bool user_snaps_pruned = m_refresh_snaps;
+  if (refresh_snaps) {
+    m_refresh_snaps = true;
+  }
+  if (r != 0 || user_snaps_pruned) {
+    locker.unlock();
+    on_finish->complete(r != 0 ? r : -EAGAIN);
+    return;
+  }
+
+  auto replay_state = std::make_shared<MirrorSnapshotReplayState>();
+  replay_state->group_snap_id = group_snap_id;
+  replay_state->local_snap = local_snap;
+  replay_state->local_image_snap_specs.reserve(remote_snap.snaps.size());
+  replay_state->image_tasks.reserve(remote_snap.snaps.size());
+
+  // user snapshots created within this mirror snapshot interval
+  for (const auto& snap : m_local_group_snaps) {
+    if (snap.id == group_snap_id) {
+      break;
+    }
+    auto snap_type = cls::rbd::get_group_snap_namespace_type(
+      snap.snapshot_namespace);
+    if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
+      // older user snapshots belong to the previous mirror snapshot
+      replay_state->preceding_user_snap_ids.clear();
+    } else if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER &&
+               snap.state != cls::rbd::GROUP_SNAPSHOT_STATE_CREATED) {
+      replay_state->preceding_user_snap_ids.push_back(snap.id);
+    }
+  }
+
+  get_replayers_by_image_id(&locker);
+
+  for (const auto& image : local_images) {
     bool image_snap_created = false;
-    std::string image_header_oid = librbd::util::header_name(image.spec.image_id);
-    ::SnapContext snapc;
-    int r = librbd::cls_client::get_snapcontext(&m_local_io_ctx, image_header_oid, &snapc);
+    bool image_snap_complete = false;
+    cls::rbd::ImageSnapshotSpec snap_spec;
+    int r = find_local_mirror_image_snapshot(group_snap_id, image,
+        &image_snap_created, &image_snap_complete, &snap_spec);
     if (r < 0) {
-      derr << "get snap context failed: " << cpp_strerror(r) << dendl;
       locker.unlock();
       on_finish->complete(r);
       return;
     }
+    if (image_snap_created) {
+      replay_state->local_image_snap_specs.push_back(snap_spec);
+    }
 
-    // process snapshots in reverse order
-    for (auto snap_id : snapc.snaps) {
-      cls::rbd::SnapshotInfo snap_info;
-      r = librbd::cls_client::snapshot_get(&m_local_io_ctx, image_header_oid,
-          snap_id, &snap_info);
-      if (r < 0) {
-        derr << "failed getting snap info for snap id: " << snap_id
-             << ", : " << cpp_strerror(r) << dendl;
-        locker.unlock();
-        on_finish->complete(r);
-        return;
-      }
+    if (image_snap_created && image_snap_complete) {
+      continue;
+    }
 
-      auto mirror_ns = std::get_if<cls::rbd::MirrorSnapshotNamespace>(
-          &snap_info.snapshot_namespace);
-      if (!mirror_ns) {
-        continue;
-      }
+    auto ir = std::find_if(m_replayers_by_image_id.begin(),
+      m_replayers_by_image_id.end(),
+      [&image](const std::pair<std::string, ImageReplayer<I>*>& entry) {
+        return entry.first == image.spec.image_id;
+      });
+    if (ir == m_replayers_by_image_id.end()) {
+      continue;
+    }
 
-      if (mirror_ns->group_snap_id == group_snap_id) {
-        image_snap_created = true;
-        cls::rbd::ImageSnapshotSpec snap_spec;
-        snap_spec.pool = image.spec.pool_id;
-        snap_spec.image_id = image.spec.image_id;
-        snap_spec.snap_id = snap_info.id;
-        local_image_snap_specs.push_back(snap_spec);
-        break;
-      } else {
-        dout(20) << "expecting remote group snap id: " << group_snap_id
-                 << ", but group snap id: " << mirror_ns->group_snap_id
-                 << " is reflecting in the local image: " << image.spec.image_id
-                 << " with image snap id: " << snap_info.id << dendl;
-      }
+    auto global_image_id = get_global_image_id(ir->second, locker);
+    if (global_image_id.empty()) {
+      continue;
+    }
+
+    uint64_t remote_snap_id = find_remote_image_snapshot(remote_snap,
+        global_image_id);
+
+    if (remote_snap_id == CEPH_NOSNAP) {
+      continue;
     }
 
     if (!image_snap_created) {
-      set_image_replayer_limits(image.spec.image_id, &remote_snap, &locker);
+      cls::rbd::ImageSnapshotSpec snap_spec;
+      snap_spec.pool = image.spec.pool_id;
+      snap_spec.image_id = image.spec.image_id;
+      snap_spec.snap_id = CEPH_NOSNAP;
+      replay_state->local_image_snap_specs.push_back(snap_spec);
     }
+
+    bool image_snap_prepared = image_snap_created &&
+      local_snap.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATED &&
+      std::find(local_snap.snaps.begin(), local_snap.snaps.end(), snap_spec) !=
+        local_snap.snaps.end();
+
+    replay_state->image_tasks.push_back({ir->second, remote_snap_id,
+      replay_state->local_image_snap_specs.size() - 1,
+      image_snap_prepared ? static_cast<uint64_t>(snap_spec.snap_id) :
+                            CEPH_NOSNAP});
   }
 
-  // Old synced user snap is removed and not yet reflecting locally, wait for it.
-  bool prune_user_snap = false ;
-  std::unordered_set<std::string> remote_snap_ids;
-  remote_snap_ids.reserve(m_remote_group_snaps.size());
-  for (const auto& remote_snap : m_remote_group_snaps) {
-    remote_snap_ids.insert(remote_snap.id);
-  }
-
-  for (auto& local_snap : m_local_group_snaps) {
-    auto snap_type = cls::rbd::get_group_snap_namespace_type(
-        local_snap.snapshot_namespace);
-    if (snap_type != cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
-      continue;
-    }
-
-    if (remote_snap_ids.contains(local_snap.id)) {
-      continue;
-    }
-
-    // there is a user group snap removed on remote, so lets wait for it to removed locally
-    prune_user_snap = true;
-    int r = prune_group_snapshot(&local_snap, &locker);
-    if (r != 0) {
-      derr << "failed to remove user group snapshot: " << local_snap.id
-           << ", error: " << cpp_strerror(r) << dendl;
-      // ignore
-    }
-  }
-
-  if (prune_user_snap) {
+  // all images must have a local snapshot or an active image replayer
+  if (replay_state->local_image_snap_specs.size() != remote_snap.snaps.size()) {
     locker.unlock();
     on_finish->complete(-EAGAIN);
     return;
   }
 
-  // User snap is added and not yet turned created, wait for it.
-  for (auto local_snap = m_local_group_snaps.begin();
-      local_snap != m_local_group_snaps.end(); ++local_snap) {
-    if (local_snap->id == group_snap_id) {
-      break;
-    } else if (local_snap->state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATING) {
-      locker.unlock();
-      // there is a user group snap waiting sync, so lets wait for it to moved to created
-      on_finish->complete(-EAGAIN);
-      return;
-    }
-  }
-
-  if (remote_snap.snaps.size() == local_image_snap_specs.size()) {
-    cls::rbd::GroupSnapshot local_snap_copy = local_snap;
-    local_snap_copy.snaps = local_image_snap_specs;
-    const auto &mirror_namespace = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
-            local_snap_copy.snapshot_namespace);
-    if (mirror_namespace.complete ==
-        cls::rbd::MIRROR_GROUP_SNAPSHOT_COMPLETE_IF_CREATED) {
-      dout(10) << "local group snap info: "
-               << "id: " << local_snap_copy.id
-               << ", name: " << local_snap_copy.name
-               << ", state: " << local_snap_copy.state
-               << ", snaps.size: " << local_snap_copy.snaps.size()
-               << dendl;
-      locker.unlock();
-      check_mirror_snapshot_sync_complete(group_snap_id, local_snap_copy, on_finish);
-      return;
-    }
-    local_snap_copy.state = cls::rbd::GROUP_SNAPSHOT_STATE_CREATED;
-
-    librados::ObjectWriteOperation op;
-    librbd::cls_client::group_snap_set(&op, local_snap_copy);
-
-    auto comp = create_rados_callback(
-      new LambdaContext([this, group_snap_id, local_snap_copy, on_finish](int r) {
-        handle_post_mirror_snapshot_created(r, group_snap_id, local_snap_copy,
-                                            on_finish);
-      }));
-    int r = m_local_io_ctx.aio_operate(
-        librbd::util::group_header_name(m_local_group_id), comp, &op);
-    ceph_assert(r == 0);
-    comp->release();
-
-    dout(10) << "local group snap info: "
-             << "id: " << local_snap_copy.id
-             << ", name: " << local_snap_copy.name
-             << ", state: " << local_snap_copy.state
-             << ", snaps.size: " << local_snap_copy.snaps.size()
-             << dendl;
-  } else {
-    locker.unlock();
-    on_finish->complete(-EAGAIN); // try again
-  }
+  locker.unlock();
+  prepare_mirror_image_snapshots(replay_state, on_finish);
 }
 
 template <typename I>
-void Replayer<I>::handle_post_mirror_snapshot_created(
-    int r, const std::string &group_snap_id,
-    const cls::rbd::GroupSnapshot &local_snap,
-    Context *on_finish) {
-  dout(10) << group_snap_id << ", r=" << r << dendl;
+void Replayer<I>::prepare_mirror_image_snapshots(
+    std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish) {
+  dout(10) << "group snapshot " << replay_state->group_snap_id
+           << " is CREATING + INCOMPLETE, preparing "
+           << replay_state->image_tasks.size() << " image snapshots"
+           << dendl;
 
+  auto ctx = new LambdaContext([this, replay_state, on_finish](int r) {
+    handle_prepare_mirror_image_snapshots(r, replay_state, on_finish);
+  });
+  auto gather_ctx = new C_Gather(g_ceph_context, ctx);
+  for (auto& task : replay_state->image_tasks) {
+    // A CREATED group snapshot only updates ids after preparation succeeds.
+    // Pass such an id back to prepare_snapshot so a restarted image replayer
+    // can refer it.
+    task.image_replayer->prepare_snapshot(
+      task.remote_snap_id, &task.local_snap_id, gather_ctx->new_sub(),
+      task.local_snap_id);
+  }
+  gather_ctx->activate();
+}
+
+template <typename I>
+void Replayer<I>::handle_prepare_mirror_image_snapshots(
+    int r, std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish) {
+  if (r == -EBUSY) {
+    r = -EAGAIN;
+  }
   if (r < 0) {
-    derr << "failed to set snap state to created for group snap id: "
-         << group_snap_id << ", : " << cpp_strerror(r) << dendl;
+    dout(10) << "image snapshot preparation failed, will retry: "
+             << cpp_strerror(r) << dendl;
     on_finish->complete(r);
     return;
   }
 
-  check_mirror_snapshot_sync_complete(group_snap_id, local_snap, on_finish);
+  for (const auto& task : replay_state->image_tasks) {
+    if (task.local_snap_id == CEPH_NOSNAP) {
+      dout(10) << "prepared local snapshot id is invalid" << dendl;
+      on_finish->complete(-EAGAIN);
+      return;
+    }
+    replay_state->local_image_snap_specs[task.local_snap_spec_index].snap_id =
+      task.local_snap_id;
+  }
+
+  replay_state->local_snap.snaps = replay_state->local_image_snap_specs;
+  complete_preceding_user_group_snapshots(replay_state, on_finish);
 }
 
 template <typename I>
-void Replayer<I>::check_mirror_snapshot_sync_complete(
-    const std::string &group_snap_id,
-    const cls::rbd::GroupSnapshot &local_snap,
-    Context *on_finish) {
-  std::unique_lock locker{m_lock};
-  dout(10) << group_snap_id << dendl;
-
-  uint64_t num_images_sync_pending = 0;
-  for (const auto& snap_spec : local_snap.snaps) {
-    std::string image_header_oid = librbd::util::header_name(snap_spec.image_id);
-    cls::rbd::SnapshotInfo snap_info;
-    int r = librbd::cls_client::snapshot_get(&m_local_io_ctx, image_header_oid,
-                                             snap_spec.snap_id, &snap_info);
-    if (r < 0) {
-        derr << "failed getting snap info for snap id: " << snap_spec.snap_id
-             << ", : " << cpp_strerror(r) << dendl;
-        locker.unlock();
-        on_finish->complete(r);
-        return;
-      }
-    const auto& mirror_ns = std::get<cls::rbd::MirrorSnapshotNamespace>(
-          snap_info.snapshot_namespace);
-    if (!mirror_ns.complete) {
-      num_images_sync_pending++;
-    }
-  }
-
-  if (num_images_sync_pending == 0) {
-    // snapshot has been fully synced
-    set_mirror_snapshot_complete(group_snap_id, local_snap, on_finish);
-  } else {
-    locker.unlock();
-    on_finish->complete(0);
+void Replayer<I>::complete_preceding_user_group_snapshots(
+    std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish) {
+  if (replay_state->preceding_user_snap_ids.empty()) {
+    update_prepared_mirror_group_snapshot(replay_state, on_finish);
     return;
   }
+
+  dout(10) << "image snapshots for mirror group snapshot "
+           << replay_state->group_snap_id << " are prepared, completing "
+           << replay_state->preceding_user_snap_ids.size()
+           << " preceding user group snapshots" << dendl;
+
+  auto ctx = new LambdaContext([this, replay_state, on_finish](int r) {
+    handle_complete_preceding_user_group_snapshots(r,
+        replay_state, on_finish);
+  });
+  auto gather_ctx = new C_Gather(g_ceph_context, ctx);
+  for (const auto& user_snap_id : replay_state->preceding_user_snap_ids) {
+    user_snapshot_complete(user_snap_id, gather_ctx->new_sub());
+  }
+  gather_ctx->activate();
+}
+
+template <typename I>
+void Replayer<I>::handle_complete_preceding_user_group_snapshots(
+    int r, std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish) {
+  if (r < 0) {
+    derr << "failed to complete preceding user group snapshots: "
+         << cpp_strerror(r) << dendl;
+    on_finish->complete(r == -EBUSY ? -EAGAIN : r);
+    return;
+  }
+
+  dout(10) << "all preceding user group snapshots for mirror snapshot "
+           << replay_state->group_snap_id << " are CREATED" << dendl;
+  update_prepared_mirror_group_snapshot(replay_state, on_finish);
+}
+
+template <typename I>
+void Replayer<I>::update_prepared_mirror_group_snapshot(
+    std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish) {
+  dout(10) << "all image snapshots for group snapshot "
+           << replay_state->group_snap_id
+           << " are prepared, updating local image snapshot ids" << dendl;
+
+  replay_state->local_snap.state = cls::rbd::GROUP_SNAPSHOT_STATE_CREATED;
+  auto& mirror_ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+    replay_state->local_snap.snapshot_namespace);
+  mirror_ns.complete = cls::rbd::MIRROR_GROUP_SNAPSHOT_INCOMPLETE;
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::group_snap_set(&op, replay_state->local_snap);
+  auto comp = create_rados_callback(new LambdaContext(
+    [this, replay_state, on_finish](int r) {
+      handle_update_prepared_mirror_group_snapshot(
+        r, replay_state, on_finish);
+    }));
+  int r = m_local_io_ctx.aio_operate(
+    librbd::util::group_header_name(m_local_group_id), comp, &op);
+  ceph_assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void Replayer<I>::handle_update_prepared_mirror_group_snapshot(
+    int r, std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish) {
+  if (r < 0) {
+    derr << "failed to update prepared mirror group snapshot: "
+         << cpp_strerror(r) << dendl;
+    on_finish->complete(r);
+    return;
+  }
+
+  dout(10) << "group snapshot " << replay_state->group_snap_id
+           << " transitioned to CREATED + INCOMPLETE, starting "
+           << replay_state->image_tasks.size()
+           << " image snapshot synchronizations" << dendl;
+  sync_mirror_image_snapshots(replay_state, on_finish);
+}
+
+template <typename I>
+void Replayer<I>::sync_mirror_image_snapshots(
+    std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish) {
+  auto ctx = new LambdaContext(
+    [this, replay_state, on_finish](int r) {
+      handle_sync_mirror_image_snapshots(r, replay_state, on_finish);
+    });
+  auto gather_ctx = new C_Gather(g_ceph_context, ctx);
+  for (const auto& task : replay_state->image_tasks) {
+    task.image_replayer->start_sync(gather_ctx->new_sub());
+  }
+  gather_ctx->activate();
+}
+
+template <typename I>
+void Replayer<I>::handle_sync_mirror_image_snapshots(
+    int r, std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish) {
+  if (r < 0) {
+    derr << "failed to synchronize mirror image snapshots: "
+         << cpp_strerror(r) << dendl;
+    on_finish->complete(r);
+    return;
+  }
+
+  dout(10) << "all image snapshots for group snapshot "
+           << replay_state->group_snap_id
+           << " reached 100%, marking image snapshots COMPLETE" << dendl;
+
+  {
+    std::unique_lock locker{m_lock};
+    if (m_state == STATE_COMPLETE) {
+      locker.unlock();
+      on_finish->complete(-ECANCELED);
+      return;
+    }
+    m_completing_mirror_snapshot = true;
+  }
+  complete_mirror_image_snapshots(replay_state, on_finish);
+}
+
+template <typename I>
+void Replayer<I>::complete_mirror_image_snapshots(
+    std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish) {
+  auto ctx = new LambdaContext(
+    [this, replay_state, on_finish](int r) {
+      handle_complete_mirror_image_snapshots(r, replay_state, on_finish);
+    });
+  auto gather_ctx = new C_Gather(g_ceph_context, ctx);
+  for (const auto& task : replay_state->image_tasks) {
+    task.image_replayer->complete_snapshot(gather_ctx->new_sub());
+  }
+  gather_ctx->activate();
+}
+
+template <typename I>
+void Replayer<I>::handle_complete_mirror_image_snapshots(
+    int r, std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish) {
+  if (r < 0) {
+    derr << "failed to complete mirror image snapshots: "
+         << cpp_strerror(r) << dendl;
+    std::unique_lock locker{m_lock};
+    m_completing_mirror_snapshot = false;
+    locker.unlock();
+    on_finish->complete(r);
+    return;
+  }
+
+  dout(10) << "all image snapshots for group snapshot "
+           << replay_state->group_snap_id
+           << " are COMPLETE, transitioning group snapshot to "
+              "CREATED + COMPLETE"
+           << dendl;
+  std::unique_lock locker{m_lock};
+  set_mirror_snapshot_complete(replay_state->group_snap_id,
+      replay_state->local_snap, on_finish);
 }
 
 template <typename I>
@@ -1404,12 +1617,8 @@ void Replayer<I>::set_mirror_snapshot_complete(
   cls::rbd::GroupSnapshot local_snap_copy = local_snap;
   auto &mirror_namespace = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
           local_snap_copy.snapshot_namespace);
-  if (mirror_namespace.complete == cls::rbd::MIRROR_GROUP_SNAPSHOT_COMPLETE_IF_CREATED) {
-    local_snap_copy.state = cls::rbd::GROUP_SNAPSHOT_STATE_CREATED;
-  } else {
-    ceph_assert(local_snap_copy.state == cls::rbd::GROUP_SNAPSHOT_STATE_CREATED);
-    mirror_namespace.complete = cls::rbd::MIRROR_GROUP_SNAPSHOT_COMPLETE;
-  }
+  local_snap_copy.state = cls::rbd::GROUP_SNAPSHOT_STATE_CREATED;
+  mirror_namespace.complete = cls::rbd::MIRROR_GROUP_SNAPSHOT_COMPLETE;
   librados::ObjectWriteOperation op;
   librbd::cls_client::group_snap_set(&op, local_snap_copy);
 
@@ -1431,12 +1640,16 @@ void Replayer<I>::handle_set_mirror_snapshot_complete(
   if (r < 0) {
     derr << "failed to set mirror snapshot complete field for group snap id: "
          << group_snap_id << ", : " << cpp_strerror(r) << dendl;
+    std::unique_lock locker{m_lock};
+    m_completing_mirror_snapshot = false;
+    locker.unlock();
     on_finish->complete(r);
     return;
   }
 
   {
     std::unique_lock locker{m_lock};
+    m_completing_mirror_snapshot = false;
     utime_t duration = ceph_clock_now() - m_snapshot_start;
     m_last_snapshot_complete_seconds = duration.sec();
     m_snapshot_start = utime_t(0, 0);
@@ -2197,79 +2410,25 @@ std::string Replayer<I>::get_global_image_id(ImageReplayer<I>* image_replayer,
 }
 
 template <typename I>
-void Replayer<I>::set_image_replayer_end_limits(
-    ImageReplayer<I>* image_replayer,
-    uint64_t snap_id,
-    std::unique_lock<ceph::mutex>& locker) {
+void Replayer<I>::stop() {
+  dout(10) << dendl;
 
-  if (!image_replayer) {
-    return;
-  }
-
-  locker.unlock();
-  auto remote_snap_id_end =
-    image_replayer->get_remote_snap_id_end_limit();
-
-  if (remote_snap_id_end == CEPH_NOSNAP ||
-      remote_snap_id_end < snap_id) {
-    image_replayer->set_remote_snap_id_end_limit(snap_id);
-  }
-  locker.lock();
-}
-
-// set_image_replayer_limits, sets limits of remote_snap_id_end in the image
-// replayer for all the respective images part of a remote group snapshot.
-// If image_id is specified it will only set for image replayer belonging to
-// that image_id only, if the image_id is empty it sets for all matching image
-// replayers.
-template <typename I>
-void Replayer<I>::set_image_replayer_limits(const std::string &image_id,
-    const cls::rbd::GroupSnapshot *remote_snap,
-  std::unique_lock<ceph::mutex>* locker) {
-  if (!remote_snap) {
-    return;
-  }
-
-  get_replayers_by_image_id(locker);
-  auto ir = std::find_if(
-      m_replayers_by_image_id.begin(),
-      m_replayers_by_image_id.end(),
-      [&image_id](const std::pair<std::string, ImageReplayer<I>*>& entry) {
-      return entry.first == image_id;
-      });
-
-  if (ir != m_replayers_by_image_id.end()) {
-    ImageReplayer<I>* image_replayer = ir->second;
-    auto global_image_id = get_global_image_id(image_replayer, *locker);
-    if (global_image_id.empty()) {
-      derr << "global_image_id is empty for: " << image_id << dendl;
+  {
+    std::unique_lock locker{m_lock};
+    if (m_state == STATE_COMPLETE || m_draining) {
       return;
     }
-    for (auto &spec : remote_snap->snaps) {
-      cls::rbd::MirrorImage mirror_image;
-      int r = librbd::cls_client::mirror_image_get(&m_remote_io_ctx,
-          spec.image_id, &mirror_image);
-      if (r < 0) {
-        derr << "mirror image get failed for: " << spec.image_id << " : "
-             << cpp_strerror(r) << dendl;
-        continue;
-      }
-      if (global_image_id != mirror_image.global_image_id) {
-        continue;
-      }
-      std::string image_header_oid = librbd::util::header_name(spec.image_id);
-      cls::rbd::SnapshotInfo snap_info;
-      r = librbd::cls_client::snapshot_get(&m_remote_io_ctx, image_header_oid,
-          spec.snap_id, &snap_info);
-      if (r < 0) {
-        derr << "failed getting snap info for snap id: " << spec.snap_id
-             << ", : " << cpp_strerror(r) << dendl;
-        continue;
-      }
-      set_image_replayer_end_limits(image_replayer, snap_info.id, *locker);
-      break;
+    ceph_assert(m_state != STATE_INIT);
+    if (m_completing_mirror_snapshot) {
+      // Do not interrupt the final image/group COMPLETE transition.
+      m_draining = true;
+    } else {
+      m_state = STATE_COMPLETE;
     }
   }
+
+  // Fence new replay cycles while the final transition drains.
+  cancel_load_group_snapshots();
 }
 
 template <typename I>
@@ -2284,8 +2443,11 @@ void Replayer<I>::shut_down(Context* on_finish) {
     m_error_description = "";
 
     ceph_assert(m_state != STATE_INIT);
-    auto state = STATE_COMPLETE;
-    std::swap(m_state, state);
+    if (m_completing_mirror_snapshot) {
+      m_draining = true;
+    } else {
+      m_state = STATE_COMPLETE;
+    }
   }
 
   cancel_load_group_snapshots();
@@ -2311,6 +2473,7 @@ void Replayer<I>::handle_wait_for_in_flight_ops(int r) {
   {
     std::unique_lock locker{m_lock};
     ceph_assert(m_on_shutdown != nullptr);
+    m_state = STATE_COMPLETE;
     std::swap(m_on_shutdown, on_finish);
   }
   on_finish->complete(m_error_code);

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -61,11 +61,17 @@ public:
     delete this;
   }
   void init(Context* on_finish);
+  void stop();
   void shut_down(Context* on_finish);
 
   bool is_replaying() const {
     std::unique_lock locker{m_lock};
     return (m_state == STATE_REPLAYING || m_state == STATE_IDLE);
+  }
+
+  bool is_draining() const {
+    std::unique_lock locker{m_lock};
+    return m_draining;
   }
 
   bool get_replay_status(std::string* description);
@@ -179,9 +185,6 @@ private:
  *          UPDATE_LOCAL_GROUP_STATE (skip if group state already enabled)                 |                                       |
  *                   |                                                                     |                                       |
  *                   v                                                                     |                                       |
- *         SET_IMAGE_REPLAYER_LIMITS                                                       |                                       |
- *                   |                                                                     |                                       |
- *                   v                                                                     v                                       |
  *                    +------------------------------> + <-------------------------------- +                                     ^ |
  *                                                     |                                                                         | |
  *                                                     v                             m_retry_validate_snap == false            --+ |
@@ -212,27 +215,34 @@ private:
  *                                 |         POST_MIRROR_SNAPSHOT_CREATED      POST_USER_SNAPSHOT_CREATED                          |
  *                                 |                         |                         |                                           |
  *                                 |                         v                         |                                           |
- *                                 |      CHECK_MIRROR_SNAPSHOT_SYNC_COMPLETE          |                                           |
+ *                                 |      PREPARE_MIRROR_IMAGE_SNAPSHOTS               |                                           |
  *                                 |                         |                         |                                           |
  *                                 |                         v                         |                                           |
- *                                 |               + ------- + ------- +               |                                           |
- *                                 |        images |                   | all image     |                                           |
- *                                 |       syncing |                   | snapshots     |                                           |
- *                                 |  (retry next  |                   |  synced       |                                           |
- *                                 |     cycle)    |                   v               |                                           |
- *                                 |               |    SET_MIRROR_SNAPSHOT_COMPLETE   |                                           |
- *                                 |               |                   |               |                                           |
- *                                 |               |                   v               |                                           |
- *                                 |               | MIRROR_GROUP_SNAPSHOT_UNLINK_PEER |                                           |
- *                                 |               |                   |               |                                           |
- *                                 v               v                   v               v                                           |
- *                                 |               | UNLINK_PEER_UUID_FROM_IMAGE_SNAPS |                                           |
- *                                 |               |                   |               |                                           |
- *                                 |               |                   v               |                                           |
- *                                 |               | UNLINK_PEER_UUID_FROM_GROUP_SNAP  |                                           |
- *                                 |               |                   |               |                                           |
- *                                 v               v                   v               v                                           |
- *                                 + ------------- + ----------------- + ------------- +                                         ^ |
+ *                                 | COMPLETE_PRECEDING_USER_GROUP_SNAPSHOTS           |                                           |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 | UPDATE_PREPARED_MIRROR_GROUP_SNAPSHOT             |                                           |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 |        SYNC_MIRROR_IMAGE_SNAPSHOTS                |                                           |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 |      COMPLETE_MIRROR_IMAGE_SNAPSHOTS              |                                           |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 |       SET_MIRROR_SNAPSHOT_COMPLETE                |                                           |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 |    MIRROR_GROUP_SNAPSHOT_UNLINK_PEER              |                                           |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 |    UNLINK_PEER_UUID_FROM_IMAGE_SNAPS              |                                           |
+ *                                 |                         |                         |                                           |
+ *                                 |                         v                         |                                           |
+ *                                 |     UNLINK_PEER_UUID_FROM_GROUP_SNAP              |                                           |
+ *                                 |                         |                         |                                           |
+ *                                 v                         v                         v                                           |
+ *                                 + ----------------------- + ----------------------- +                                         ^ |
  *                                                           |                                                                   | |
  *                                                           v c_gather waits for all callbacks                                --+ |
  *                                                           + ------------------------------------------------------------------> +
@@ -305,7 +315,6 @@ private:
  * =================
  * GET_REPLAYERS_BY_IMAGE_ID
  * GET_GLOBAL_IMAGE_ID
- * SET_IMAGE_REPLAYER_END_LIMITS
  * NOTIFY_GROUP_LISTENER
  * IS_REPLAY_INTERRUPTED
  * GET_REPLAY_STATUS
@@ -317,6 +326,21 @@ private:
     STATE_REPLAYING,
     STATE_IDLE,
     STATE_COMPLETE
+  };
+
+  struct MirrorSnapshotImageTask {
+    ImageReplayer<ImageCtxT>* image_replayer;
+    uint64_t remote_snap_id;
+    size_t local_snap_spec_index;
+    uint64_t local_snap_id = CEPH_NOSNAP;
+  };
+
+  struct MirrorSnapshotReplayState {
+    std::string group_snap_id;
+    cls::rbd::GroupSnapshot local_snap;
+    std::vector<cls::rbd::ImageSnapshotSpec> local_image_snap_specs;
+    std::vector<MirrorSnapshotImageTask> image_tasks;
+    std::vector<std::string> preceding_user_snap_ids;
   };
 
   Threads<ImageCtxT> *m_threads;
@@ -361,6 +385,8 @@ private:
   uint64_t m_last_snapshot_bytes = 0;
 
   bool m_check_creating_snaps = true; // check and identify creating snaps just after restart
+  bool m_draining = false;
+  bool m_completing_mirror_snapshot = false;
   bool m_resync_requested = false;
   bool m_refresh_snaps = false;
 
@@ -410,9 +436,8 @@ private:
   void handle_create_mirror_group_snapshot(
     int r, cls::rbd::GroupSnapshot *snap);
 
-  void update_local_group_state(std::unique_lock<ceph::mutex>* locker,
-                                cls::rbd::GroupSnapshot* snap);
-  void handle_update_local_group_state(int r, cls::rbd::GroupSnapshot* snap);
+  void update_local_group_state(std::unique_lock<ceph::mutex>* locker);
+  void handle_update_local_group_state(int r);
 
   void mirror_snapshot_complete(
     const std::string &group_snap_id, Context *on_finish);
@@ -422,20 +447,53 @@ private:
     const cls::rbd::GroupSnapshot &remote_snap,
     const std::vector<cls::rbd::GroupImageStatus>& local_images,
     Context *on_finish);
+
+  int find_local_mirror_image_snapshot(
+    const std::string& group_snap_id,
+    const cls::rbd::GroupImageStatus& image,
+    bool* image_snap_created,
+    bool* image_snap_complete,
+    cls::rbd::ImageSnapshotSpec* snap_spec);
+  uint64_t find_remote_image_snapshot(
+    const cls::rbd::GroupSnapshot& remote_snap,
+    const std::string& global_image_id);
+
   void post_mirror_snapshot_created(
     const std::string &group_snap_id,
     const cls::rbd::GroupSnapshot &local_snap,
     const cls::rbd::GroupSnapshot &remote_snap,
     const std::vector<cls::rbd::GroupImageStatus>& local_images,
     Context *on_finish);
-  void handle_post_mirror_snapshot_created(
-    int r, const std::string &group_snap_id,
-    const cls::rbd::GroupSnapshot &local_snap,
-    Context *on_finish);
-  void check_mirror_snapshot_sync_complete(
-    const std::string &group_snap_id,
-    const cls::rbd::GroupSnapshot &local_snap,
-    Context *on_finish);
+  void prepare_mirror_image_snapshots(
+    std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish);
+  void handle_prepare_mirror_image_snapshots(
+    int r, std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish);
+  void complete_preceding_user_group_snapshots(
+    std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish);
+  void handle_complete_preceding_user_group_snapshots(
+    int r, std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish);
+  void update_prepared_mirror_group_snapshot(
+    std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish);
+  void handle_update_prepared_mirror_group_snapshot(
+    int r, std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish);
+  void sync_mirror_image_snapshots(
+    std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish);
+  void handle_sync_mirror_image_snapshots(
+    int r, std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish);
+  void complete_mirror_image_snapshots(
+    std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish);
+  void handle_complete_mirror_image_snapshots(
+    int r, std::shared_ptr<MirrorSnapshotReplayState> replay_state,
+    Context* on_finish);
   void set_mirror_snapshot_complete(
     const std::string &group_snap_id,
     const cls::rbd::GroupSnapshot &local_snap,
@@ -503,11 +561,6 @@ private:
   void get_replayers_by_image_id(std::unique_lock<ceph::mutex>* locker);
   std::string get_global_image_id(ImageReplayer<ImageCtxT>* image_replayer,
       std::unique_lock<ceph::mutex>& locker);
-  void set_image_replayer_end_limits(ImageReplayer<ImageCtxT>* image_replayer,
-      uint64_t snap_id, std::unique_lock<ceph::mutex>& locker);
-  void set_image_replayer_limits(const std::string &image_id,
-                                 const cls::rbd::GroupSnapshot *remote_snap,
-                                 std::unique_lock<ceph::mutex>* locker);
   void wait_for_in_flight_ops();
   void handle_wait_for_in_flight_ops(int r);
 };

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -160,27 +160,29 @@ private:
  *                   v                                                                     |                               v       |
  *    SCAN_FOR_UNSYNCED_GROUP_SNAPSHOTS                                                    |                HANDLE_REPLAY_COMPLETE |
  *                   |                                                                     |                                       |
- *                   v                                                                     |                                       |
- *        TRY_CREATE_GROUP_SNAPSHOT                                                        |                                       |
+ *                   | !unlink_peer_uuids.empty()?                                        ╭─╮                                      |
+ *                   + ------------------------>  MIRROR_GROUP_SNAPSHOT_UNLINK_PEER ---->-╯|╰->----------------------------------> +
+ *                   |                                                                     |                                       |
  *                   |    if all snaps synced                                              |                                       |
  *                   + --------> m_state = STATE_IDLE                                      |                                       |
  *                   |                                                                     |                                       |
  *                   v                                                                     |                                       |
- *       CREATE_GROUP_SNAPSHOT                                                             |                                       |
+ *         CREATE_USER_GROUP_SNAPSHOTS                                                     |                                       |
  *                   |                                                                     |                                       |
  *                   v                                                                     |                                       |
- *             + --- + --------------- +                                                   |                                       |
- *             |                       |                                                   |                                       |
- *             v                       v                                                   |                                       |
- *    CREATE_MIRROR_SNAPSHOT     CREATE_USER_SNAPSHOT                                      |                                       |
- *             | m_retry_validate_snap | m_retry_validate_snap                             |                                       |
- *             v               = true  |               = true                              |                                       |
- *    UPDATE_LOCAL_GROUP_STATE         |                                                   |                                       |
- *             |                       |                                                   |                                       |
- *             v                       v                                                   |                                       |
- *             + --------- + --------- +                                                   |                                       |
- *                         |                                                               v                                       |
- *                         + ------------------------> + <-------------------------------- +                                     ^ |
+ *         CREATE_USER_GROUP_SNAPSHOT                                                      |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     |                                       |
+ *        CREATE_MIRROR_GROUP_SNAPSHOT                                                     |                                       |
+ *                   | m_retry_validate_snap = true                                        |                                       |
+ *                   v                                                                     |                                       |
+ *          UPDATE_LOCAL_GROUP_STATE (skip if group state already enabled)                 |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     |                                       |
+ *         SET_IMAGE_REPLAYER_LIMITS                                                       |                                       |
+ *                   |                                                                     |                                       |
+ *                   v                                                                     v                                       |
+ *                    +------------------------------> + <-------------------------------- +                                     ^ |
  *                                                     |                                                                         | |
  *                                                     v                             m_retry_validate_snap == false            --+ |
  *                                         SCHEDULE_LOAD_GROUP_SNAPSHOTS --------------------------------------------------------> +
@@ -213,15 +215,18 @@ private:
  *                                 |      CHECK_MIRROR_SNAPSHOT_SYNC_COMPLETE          |                                           |
  *                                 |                         |                         |                                           |
  *                                 |                         v                         |                                           |
- *                                 |            + ---------- + ---------- +            |                                           |
- *                                 |  images    |                         | all image  |                                           |
- *                                 |  syncing   |                         | snapshots  |                                           |
- *                                 |  ( retry   |                         |  sycned    |                                           |
- *                                 |   next     |                         v            |                                           |
- *                                 |   cycle)   |         SET_MIRROR_SNAPSHOT_COMPLETE |                                           |
- *                                 |            |                         |            |                                           |
- *                                 v            v                         v            v                                           |
- *                                 + ---------- + ---------- + ---------- + ---------- +                                         ^ |
+ *                                 |               + ------- + ------- +               |                                           |
+ *                                 |        images |                   | all image     |                                           |
+ *                                 |       syncing |                   | snapshots     |                                           |
+ *                                 |  (retry next  |                   |  synced       |                                           |
+ *                                 |     cycle)    |                   v               |                                           |
+ *                                 |               |    SET_MIRROR_SNAPSHOT_COMPLETE   |                                           |
+ *                                 |               |                   |               |                                           |
+ *                                 |               |                   v               |                                           |
+ *                                 |               | MIRROR_GROUP_SNAPSHOT_UNLINK_PEER |                                           |
+ *                                 |               |                   |               |                                           |
+ *                                 v               v                   v               v                                           |
+ *                                 + ------------- + ----------------- + ------------- +                                         ^ |
  *                                                           |                                                                   | |
  *                                                           v c_gather waits for all callbacks                                --+ |
  *                                                           + ------------------------------------------------------------------> +
@@ -261,9 +266,6 @@ private:
  *     PRUNE_MIRROR_GROUP_SNAPSHOT
  *                 |
  *                 v
- *    MIRROR_GROUP_SNAPSHOT_UNLINK_PEER
- *                 |
- *                 v
  *        PRUNE_GROUP_SNAPSHOT
  *                 |
  *                 v
@@ -297,7 +299,6 @@ private:
  * =================
  * GET_REPLAYERS_BY_IMAGE_ID
  * GET_GLOBAL_IMAGE_ID
- * SET_IMAGE_REPLAYER_LIMITS
  * SET_IMAGE_REPLAYER_END_LIMITS
  * NOTIFY_GROUP_LISTENER
  * IS_REPLAY_INTERRUPTED
@@ -346,6 +347,7 @@ private:
   std::string m_error_description;
 
   bool m_retry_validate_snap = false;
+  std::string m_last_synced_remote_snap_id;
 
   utime_t m_snapshot_start;
   uint64_t m_last_snapshot_complete_seconds = 0;
@@ -392,21 +394,19 @@ private:
   void check_local_group_snapshots(std::unique_lock<ceph::mutex>* locker);
 
   void scan_for_unsynced_group_snapshots(std::unique_lock<ceph::mutex>* locker);
+  void create_user_group_snapshots(std::unique_lock<ceph::mutex>* locker,
+    cls::rbd::GroupSnapshot* mirror_snap,
+    std::vector<cls::rbd::GroupSnapshot>& user_snapshots);
+  void handle_create_user_group_snapshots(
+    int r, cls::rbd::GroupSnapshot* mirror_snap);
+  void create_mirror_group_snapshot(std::unique_lock<ceph::mutex>* locker,
+                                    cls::rbd::GroupSnapshot *snap);
+  void handle_create_mirror_group_snapshot(
+    int r, cls::rbd::GroupSnapshot *snap);
 
-  void try_create_group_snapshot(std::string prev_snap_id,
-                                 std::unique_lock<ceph::mutex>* locker);
-  void create_group_snapshot(cls::rbd::GroupSnapshot snap,
-                             std::unique_lock<ceph::mutex>* locker);
-
-  void create_mirror_snapshot(
-    cls::rbd::GroupSnapshot *snap,
-    const cls::rbd::MirrorSnapshotState &snap_state,
-    Context *on_finish);
-  void handle_create_mirror_snapshot(
-    int r, const std::string &group_snap_id, Context *on_finish);
-
-  void update_local_group_state(cls::rbd::GroupSnapshot snap);
-  void handle_update_local_group_state(int r, cls::rbd::GroupSnapshot snap);
+  void update_local_group_state(std::unique_lock<ceph::mutex>* locker,
+                                cls::rbd::GroupSnapshot* snap);
+  void handle_update_local_group_state(int r, cls::rbd::GroupSnapshot* snap);
 
   void mirror_snapshot_complete(
     const std::string &group_snap_id, Context *on_finish);
@@ -437,10 +437,9 @@ private:
   void handle_set_mirror_snapshot_complete(
     int r, const std::string &group_snap_id, Context *on_finish);
 
-  void create_user_snapshot(
-    cls::rbd::GroupSnapshot *snap,
-    Context *on_finish);
-  void handle_create_user_snapshot(
+  void create_user_group_snapshot(
+    cls::rbd::GroupSnapshot *snap, Context *on_finish);
+  void handle_create_user_group_snapshot(
       int r, const std::string &group_snap_id, Context *on_finish);
 
   void user_snapshot_complete(

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -226,6 +226,12 @@ private:
  *                                 |               | MIRROR_GROUP_SNAPSHOT_UNLINK_PEER |                                           |
  *                                 |               |                   |               |                                           |
  *                                 v               v                   v               v                                           |
+ *                                 |               | UNLINK_PEER_UUID_FROM_IMAGE_SNAPS |                                           |
+ *                                 |               |                   |               |                                           |
+ *                                 |               |                   v               |                                           |
+ *                                 |               | UNLINK_PEER_UUID_FROM_GROUP_SNAP  |                                           |
+ *                                 |               |                   |               |                                           |
+ *                                 v               v                   v               v                                           |
  *                                 + ------------- + ----------------- + ------------- +                                         ^ |
  *                                                           |                                                                   | |
  *                                                           v c_gather waits for all callbacks                                --+ |
@@ -460,9 +466,16 @@ private:
   void handle_post_user_snapshot_created(
     int r, const std::string &group_snap_id, Context *on_finish);
 
-  void mirror_group_snapshot_unlink_peer(const std::string &snap_id);
-  void handle_mirror_group_snapshot_unlink_peer(
-      int r, const std::string &snap_id);
+  void mirror_group_snapshot_unlink_peer(std::unique_lock<ceph::mutex>* locker,
+    const std::string &snap_id, Context *on_unlink);
+  void unlink_peer_uuid_from_image_snaps(
+    cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink);
+  void handle_unlink_peer_uuid_from_image_snaps(
+    int r, cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink);
+  void unlink_peer_uuid_from_group_snap(
+    cls::rbd::GroupSnapshot* remote_snap, Context* on_unlink);
+  void handle_unlink_peer_uuid_from_group_snap(
+    int r, const std::string &group_snap_id, Context* on_unlink);
 
   void prune_image_snapshot(ImageReplayer<ImageCtxT>* image_replayer,
       uint64_t snap_id,

--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
@@ -148,6 +148,112 @@ Replayer<I>::~Replayer() {
 }
 
 template <typename I>
+void Replayer<I>::prepare_snapshot(uint64_t remote_snap_id,
+                                   uint64_t* local_snap_id,
+                                   Context* on_finish,
+                                   uint64_t updated_local_snap_id) {
+  dout(10) << "remote_snap_id=" << remote_snap_id
+           << ", updated_local_snap_id=" << updated_local_snap_id << dendl;
+
+  ceph_assert(remote_snap_id != CEPH_NOSNAP);
+  ceph_assert(local_snap_id != nullptr);
+  ceph_assert(on_finish != nullptr);
+
+  {
+    std::unique_lock locker{m_lock};
+    if (m_state != STATE_IDLE) {
+      locker.unlock();
+      m_threads->work_queue->queue(on_finish, -EBUSY);
+      return;
+    }
+
+    if (m_snapshot_replay_phase != SNAPSHOT_REPLAY_PHASE_NONE) {
+      if (m_remote_group_image_snap_id == remote_snap_id &&
+          (m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_PREPARED ||
+           m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_SYNCED)) {
+        ceph_assert(m_local_snap_id_end != CEPH_NOSNAP);
+        *local_snap_id = m_local_snap_id_end;
+        locker.unlock();
+        m_threads->work_queue->queue(on_finish, 0);
+      } else {
+        locker.unlock();
+        m_threads->work_queue->queue(on_finish, -EBUSY);
+      }
+      return;
+    }
+
+    ceph_assert(m_on_prepare_snapshot == nullptr);
+
+    m_remote_group_image_snap_id = remote_snap_id;
+    m_prepared_local_snap_id = local_snap_id;
+    m_updated_local_snap_id = updated_local_snap_id;
+    m_on_prepare_snapshot = on_finish;
+    m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_PREPARING;
+    m_state = STATE_REPLAYING;
+  }
+
+  load_local_image_meta();
+}
+
+template <typename I>
+void Replayer<I>::start_sync(Context* on_finish) {
+  dout(10) << dendl;
+
+  ceph_assert(on_finish != nullptr);
+
+  {
+    std::unique_lock locker{m_lock};
+    if (m_state != STATE_IDLE) {
+      locker.unlock();
+      m_threads->work_queue->queue(on_finish, -EBUSY);
+      return;
+    }
+
+    if (m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_SYNCED) {
+      locker.unlock();
+      m_threads->work_queue->queue(on_finish, 0);
+      return;
+    } else if (m_snapshot_replay_phase != SNAPSHOT_REPLAY_PHASE_PREPARED) {
+      locker.unlock();
+      m_threads->work_queue->queue(on_finish, -EAGAIN);
+      return;
+    }
+
+    ceph_assert(m_on_snapshot_sync == nullptr);
+    m_on_snapshot_sync = on_finish;
+    m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_SYNCING;
+    m_state = STATE_REPLAYING;
+  }
+
+  request_sync();
+}
+
+template <typename I>
+void Replayer<I>::complete_snapshot(Context* on_finish) {
+  dout(10) << dendl;
+
+  ceph_assert(on_finish != nullptr);
+
+  std::unique_lock locker{m_lock};
+  if (m_state != STATE_IDLE) {
+    locker.unlock();
+    m_threads->work_queue->queue(on_finish, -EBUSY);
+    return;
+  }
+  if (m_snapshot_replay_phase != SNAPSHOT_REPLAY_PHASE_SYNCED) {
+    locker.unlock();
+    m_threads->work_queue->queue(on_finish, -EAGAIN);
+    return;
+  }
+
+  ceph_assert(m_on_complete_snapshot == nullptr);
+  m_on_complete_snapshot = on_finish;
+  m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_COMPLETING;
+  m_state = STATE_REPLAYING;
+  update_non_primary_snapshot(true);
+}
+
+template <typename I>
 void Replayer<I>::init(Context* on_finish) {
   dout(10) << dendl;
 
@@ -528,6 +634,14 @@ void Replayer<I>::scan_local_mirror_snapshots(
         }
       } else if (mirror_ns->last_copied_object_number == 0 &&
                  m_local_snap_id_start > 0) {
+        if (local_snap_id == m_updated_local_snap_id &&
+            mirror_ns->primary_snap_id == m_remote_group_image_snap_id) {
+          // The group snapshot already records this image snapshot id, so its
+          // preparation completed before the daemon stopped.
+          m_local_snap_id_end = local_snap_id;
+          break;
+        }
+
         // snapshot might be missing image state, object-map, etc, so just
         // delete and re-create it if we haven't started copying data
         // objects. Also only prune this snapshot since we will need the
@@ -986,6 +1100,15 @@ void Replayer<I>::handle_get_local_image_state(int r) {
     return;
   }
 
+  {
+    std::unique_lock locker{m_lock};
+    if (m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_PREPARING) {
+      locker.unlock();
+      finish_prepare_snapshot(0);
+      return;
+    }
+  }
+
   request_sync();
 }
 
@@ -1091,6 +1214,15 @@ void Replayer<I>::handle_create_non_primary_snapshot(int r) {
 template <typename I>
 void Replayer<I>::update_mirror_image_state() {
   if (m_local_snap_id_start > 0) {
+    {
+      std::unique_lock locker{m_lock};
+      if (m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_PREPARING) {
+        locker.unlock();
+        finish_prepare_snapshot(0);
+        return;
+      }
+    }
+
     request_sync();
     return;
   }
@@ -1119,7 +1251,55 @@ void Replayer<I>::handle_update_mirror_image_state(int r) {
     return;
   }
 
+  {
+    std::unique_lock locker{m_lock};
+    if (m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_PREPARING) {
+      locker.unlock();
+      finish_prepare_snapshot(0);
+      return;
+    }
+  }
+
   request_sync();
+}
+
+template <typename I>
+void Replayer<I>::finish_prepare_snapshot(int r) {
+  Context* on_finish = nullptr;
+  uint64_t* local_snap_id = nullptr;
+
+  {
+    std::unique_lock locker{m_lock};
+    ceph_assert(m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_PREPARING);
+    ceph_assert(m_on_prepare_snapshot != nullptr);
+
+    if (r == 0) {
+      ceph_assert(m_local_snap_id_end != CEPH_NOSNAP);
+      *m_prepared_local_snap_id = m_local_snap_id_end;
+    }
+
+    local_snap_id = m_prepared_local_snap_id;
+    std::swap(on_finish, m_on_prepare_snapshot);
+    m_prepared_local_snap_id = nullptr;
+    m_updated_local_snap_id = CEPH_NOSNAP;
+    m_snapshot_replay_phase = (r == 0 ? SNAPSHOT_REPLAY_PHASE_PREPARED :
+                                        SNAPSHOT_REPLAY_PHASE_NONE);
+
+    if (r < 0) {
+      m_error_code = r;
+      m_error_description = "failed to prepare local mirror snapshot";
+    }
+
+    if (m_state == STATE_REPLAYING) {
+      m_state = STATE_IDLE;
+      notify_status_updated();
+    }
+  }
+
+  dout(10) << "prepare snapshot complete: r=" << r
+           << ", local_snap_id="
+           << (r == 0 ? *local_snap_id : CEPH_NOSNAP) << dendl;
+  on_finish->complete(r);
 }
 
 template <typename I>
@@ -1284,6 +1464,17 @@ void Replayer<I>::handle_apply_image_state(int r) {
   }
 
   std::unique_lock locker{m_lock};
+  if (m_on_snapshot_sync != nullptr) {
+    ceph_assert(m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_SYNCING);
+    // persist the final progress before completing the snapshot
+    m_local_mirror_snap_ns.last_copied_object_number = m_local_object_count;
+    m_snapshot_sync_complete_pending = true;
+    if (!m_updating_sync_point) {
+      m_snapshot_sync_final_update = true;
+      update_non_primary_snapshot(false);
+    }
+    return;
+  }
   update_non_primary_snapshot(true);
 }
 
@@ -1338,6 +1529,60 @@ void Replayer<I>::handle_update_non_primary_snapshot(bool complete, int r) {
 
     ceph_assert(m_updating_sync_point);
     m_updating_sync_point = false;
+    if (m_snapshot_sync_complete_pending) {
+      bool shut_down_pending = (m_state == STATE_COMPLETE);
+      if (r < 0) {
+        m_snapshot_sync_complete_pending = false;
+        m_snapshot_sync_final_update = false;
+        Context* on_finish = nullptr;
+        std::swap(on_finish, m_on_snapshot_sync);
+        m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_PREPARED;
+        if (!shut_down_pending) {
+          m_state = STATE_IDLE;
+          notify_status_updated();
+        }
+        locker.unlock();
+        on_finish->complete(r);
+        if (shut_down_pending) {
+          unregister_remote_update_watcher();
+        }
+        return;
+      }
+
+      if (!m_snapshot_sync_final_update) {
+        // persist the final object count before reporting sync completion
+        m_snapshot_sync_final_update = true;
+        update_non_primary_snapshot(false);
+        return;
+      }
+
+      m_snapshot_sync_complete_pending = false;
+      m_snapshot_sync_final_update = false;
+      // finish the current sync request before reporting completion
+      if (m_sync_in_progress) {
+        m_sync_in_progress = false;
+        m_instance_watcher->notify_sync_complete(
+          m_state_builder->local_image_ctx->id);
+      }
+      Context* on_finish = nullptr;
+      std::swap(on_finish, m_on_snapshot_sync);
+      m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_SYNCED;
+      if (!shut_down_pending) {
+        m_state = STATE_IDLE;
+        notify_status_updated();
+      }
+      locker.unlock();
+      on_finish->complete(r);
+      if (shut_down_pending) {
+        unregister_remote_update_watcher();
+      }
+    }
+    return;
+  }
+
+  if (m_on_complete_snapshot != nullptr) {
+    // refresh snap_info before reporting completion
+    notify_image_update();
     return;
   }
 
@@ -1359,6 +1604,30 @@ void Replayer<I>::handle_notify_image_update(int r) {
 
   if (r < 0) {
     derr << "failed to notify local image update: " << cpp_strerror(r) << dendl;
+  }
+
+  {
+    std::unique_lock locker{m_lock};
+    if (m_on_complete_snapshot != nullptr) {
+      bool shut_down_pending = (m_state == STATE_COMPLETE);
+      bool image_updated = m_image_updated;
+      Context* on_finish = nullptr;
+      std::swap(on_finish, m_on_complete_snapshot);
+      m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_NONE;
+      m_image_updated = false;
+      if (!shut_down_pending) {
+        m_state = STATE_IDLE;
+        notify_status_updated();
+      }
+      locker.unlock();
+      on_finish->complete(r);
+      if (shut_down_pending) {
+        unregister_remote_update_watcher();
+      } else if (image_updated) {
+        handle_image_update_notify();
+      }
+      return;
+    }
   }
 
   bool unlink = true;
@@ -1598,6 +1867,12 @@ void Replayer<I>::handle_image_update_notify() {
     dout(15) << "flagging snapshot rescan required" << dendl;
     m_image_updated = true;
   } else if (m_state == STATE_IDLE) {
+    if (m_snapshot_replay_phase != SNAPSHOT_REPLAY_PHASE_NONE) {
+      dout(15) << "deferring snapshot rescan during coordinated replay"
+               << dendl;
+      m_image_updated = true;
+      return;
+    }
     m_state = STATE_REPLAYING;
     locker.unlock();
 
@@ -1625,8 +1900,30 @@ void Replayer<I>::handle_replay_complete(std::unique_lock<ceph::mutex>* locker,
       m_state_builder->local_image_ctx->id);
   }
 
-  // don't set error code and description if resuming a pending
-  // shutdown
+  auto snapshot_replay_phase = m_snapshot_replay_phase;
+  Context* on_finish = cancel_coordinated_replay();
+
+  if (on_finish != nullptr) {
+    bool shut_down_pending = (m_state == STATE_COMPLETE);
+    if (snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_PREPARING &&
+        !shut_down_pending && m_error_code == 0) {
+      m_error_code = r;
+      m_error_description = description;
+    }
+    if (!shut_down_pending) {
+      m_state = STATE_IDLE;
+      notify_status_updated();
+    } else {
+      m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_NONE;
+    }
+    locker->unlock();
+    on_finish->complete(r);
+    if (shut_down_pending) {
+      unregister_remote_update_watcher();
+    }
+    return;
+  }
+
   if (is_replay_interrupted(locker)) {
     return;
   }
@@ -1642,6 +1939,28 @@ void Replayer<I>::handle_replay_complete(std::unique_lock<ceph::mutex>* locker,
 
   m_state = STATE_COMPLETE;
   notify_status_updated();
+}
+
+template <typename I>
+Context* Replayer<I>::cancel_coordinated_replay() {
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+
+  Context* on_finish = nullptr;
+  if (m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_PREPARING) {
+    std::swap(on_finish, m_on_prepare_snapshot);
+    m_prepared_local_snap_id = nullptr;
+    m_updated_local_snap_id = CEPH_NOSNAP;
+    m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_NONE;
+  } else if (m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_SYNCING) {
+    std::swap(on_finish, m_on_snapshot_sync);
+    m_snapshot_sync_complete_pending = false;
+    m_snapshot_sync_final_update = false;
+    m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_PREPARED;
+  } else if (m_snapshot_replay_phase == SNAPSHOT_REPLAY_PHASE_COMPLETING) {
+    std::swap(on_finish, m_on_complete_snapshot);
+    m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_SYNCED;
+  }
+  return on_finish;
 }
 
 template <typename I>
@@ -1665,8 +1984,18 @@ bool Replayer<I>::is_replay_interrupted() {
 template <typename I>
 bool Replayer<I>::is_replay_interrupted(std::unique_lock<ceph::mutex>* locker) {
   if (m_state == STATE_COMPLETE) {
+    if (m_sync_in_progress) {
+      m_sync_in_progress = false;
+      m_instance_watcher->notify_sync_complete(
+        m_state_builder->local_image_ctx->id);
+    }
+    auto on_finish = cancel_coordinated_replay();
+    m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_NONE;
     locker->unlock();
 
+    if (on_finish != nullptr) {
+      on_finish->complete(-ECANCELED);
+    }
     dout(10) << "resuming pending shut down" << dendl;
     unregister_remote_update_watcher();
     return true;

--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.h
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.h
@@ -124,6 +124,17 @@ public:
     handle_image_update_notify();
   }
 
+  // prepare the local mirror snapshot without synchronizing image data
+  void prepare_snapshot(uint64_t remote_snap_id, uint64_t* local_snap_id,
+                        Context* on_finish,
+                        uint64_t updated_local_snap_id = CEPH_NOSNAP);
+
+  // synchronize the prepared snapshot
+  void start_sync(Context* on_finish);
+
+  // mark the prepared snapshot complete
+  void complete_snapshot(Context* on_finish);
+
   uint64_t get_remote_snap_id_end_limit() {
     std::unique_lock locker(m_lock);
     return m_remote_group_image_snap_id;
@@ -237,6 +248,15 @@ private:
     STATE_COMPLETE
   };
 
+  enum SnapshotReplayPhase {
+    SNAPSHOT_REPLAY_PHASE_NONE,
+    SNAPSHOT_REPLAY_PHASE_PREPARING,
+    SNAPSHOT_REPLAY_PHASE_PREPARED,
+    SNAPSHOT_REPLAY_PHASE_SYNCING,
+    SNAPSHOT_REPLAY_PHASE_SYNCED,
+    SNAPSHOT_REPLAY_PHASE_COMPLETING
+  };
+
   struct C_UpdateWatchCtx;
   struct DeepCopyHandler;
 
@@ -304,6 +324,15 @@ private:
   bool m_updating_sync_point = false;
   bool m_sync_in_progress = false;
 
+  SnapshotReplayPhase m_snapshot_replay_phase = SNAPSHOT_REPLAY_PHASE_NONE;
+  uint64_t* m_prepared_local_snap_id = nullptr;
+  uint64_t m_updated_local_snap_id = CEPH_NOSNAP;
+  Context* m_on_prepare_snapshot = nullptr;
+  Context* m_on_snapshot_sync = nullptr;
+  Context* m_on_complete_snapshot = nullptr;
+  bool m_snapshot_sync_complete_pending = false;
+  bool m_snapshot_sync_final_update = false;
+
   PerfCounters *m_perf_counters = nullptr;
 
   bool is_remote_primary();
@@ -331,6 +360,8 @@ private:
 
   void get_local_image_state();
   void handle_get_local_image_state(int r);
+
+  void finish_prepare_snapshot(int r);
 
   void create_non_primary_snapshot();
   void handle_create_non_primary_snapshot(int r);
@@ -381,6 +412,7 @@ private:
   void handle_replay_complete(int r, const std::string& description);
   void handle_replay_complete(std::unique_lock<ceph::mutex>* locker,
                               int r, const std::string& description);
+  Context* cancel_coordinated_replay();
   void notify_status_updated();
 
   bool is_replay_interrupted();


### PR DESCRIPTION
Give the group replayer explicit control over the snapshot replay lifecycle of each image in a mirrored group.

A mirror group snapshot now progresses through these phases:

1. `CREATING + incomplete`
   - The group replayer asks every image replayer to prepare its local mirror snapshot.
   - Preparation creates the image snapshot, object map, and image state, but does not copy image data.
   - The group replayer collects the local image snapshot ids.

2. `CREATED + incomplete`
   - The group replayer writes the prepared image snapshot ids to the group snapshot metadata.
   - It then starts synchronization for all participating image snapshots.
   - The group snapshot remains incomplete while data is copied.

3. `CREATED + complete`
   - After every image snapshot reaches 100% copy progress, the group replayer asks each image replayer to mark its snapshot complete.
   - The group snapshot is marked complete only after all image snapshots are complete.

**Restart and shutdown handling**

A `CREATED` group snapshot records image snapshots whose preparation completed successfully. After restart, the group replayer passes the recorded local image snapshot id back to the image replayer so it can restore the prepared state, this is needed especially when copy progress is still 0%.

A `CREATING` group snapshot has not published its image snapshot ids. It and its image snapshots are pruned on restart and prepared again.

During shutdown, an active copy can be cancelled so the daemon does not wait for a long synchronization. Once all image snapshots have reached 100%, the final image and group `COMPLETE` transitions are drained together to avoid leaving completed image snapshots behind an incomplete group snapshot.

User group snapshots continue to use `CREATED` to mean that their image snapshot references are available. It does not mean image data has been copied.

The PR also adds test coverage for the coordinated replay phases and checks their ordering.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - []] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
