### PR TITLE
tentacle: rgw/keystone: fix Swift ACL evaluation and add EC2Engine ACL strategy

### DIFF
--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -177,3 +177,21 @@ Enabling this will cause an expired token given in the X-Auth-Token header to be
 if coupled with a X-Service-Token header that contains a valid token with the accepted
 roles. This can allow long running processes using a user token in X-Auth-Token to function
 beyond the expiration of the token.
+
+Swift and S3 ACL Interoperability
+---------------------------------
+
+When Keystone is the identity provider, ACLs set via the Swift API are
+automatically honored by S3 API requests (and vice versa). This enables
+mixed deployments where some clients use Swift and others use S3 to access
+the same buckets/containers.
+
+The following ACL grant formats are supported for cross-API access:
+
+- **Project:User grants** (e.g., ``project_id:user_id``): ACLs using the
+  ``project:user`` format set via Swift container ACLs are matched against
+  S3 Keystone-authenticated requests by comparing all combinations of
+  project/user UUIDs and names.
+
+- **Wildcard grants**: Standard Swift wildcards (``project_id:*``,
+  ``*:user_id``) are supported for both Swift and S3 access.

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -174,52 +174,63 @@ make_spec_item(const std::string& tenant, const std::string& id)
   return tenant + ":" + id;
 }
 
-TokenEngine::acl_strategy_t
-TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
+/* Mirrors Swift keystoneauth's _authorize_cross_tenant() Cartesian product
+ * over {tenant_id, tenant_name, '*'} x {user_id, user_name, '*'}, plus a
+ * system-reader role grant. Shared by TokenEngine and EC2Engine so S3 and
+ * Swift requests authenticated via Keystone evaluate ACLs identically. */
+rgw::auth::RemoteApplier::acl_strategy_t
+make_keystone_acl_strategy(const std::string& tenant_id,
+                           const std::string& tenant_name,
+                           const std::string& user_id,
+                           const std::string& user_name,
+                           std::list<rgw::keystone::TokenEnvelope::Role> roles)
 {
-  /* The primary identity is constructed upon UUIDs. */
-  const auto& tenant_uuid = token.get_project_id();
-  const auto& user_uuid = token.get_user_id();
-
-  /* For Keystone v2 an alias may be also used. */
-  const auto& tenant_name = token.get_project_name();
-  const auto& user_name = token.get_user_name();
-
-  /* Construct all possible combinations including Swift's wildcards. */
-  const std::array<std::string, 6> allowed_items = {
-    make_spec_item(tenant_uuid, user_uuid),
+  const std::array<std::string, 7> allowed_items = {
+    make_spec_item(tenant_id, user_id),
     make_spec_item(tenant_name, user_name),
-
-    /* Wildcards. */
-    make_spec_item(tenant_uuid, "*"),
+    make_spec_item(tenant_id, "*"),
     make_spec_item(tenant_name, "*"),
-    make_spec_item("*", user_uuid),
+    make_spec_item("*", user_id),
     make_spec_item("*", user_name),
+    make_spec_item("*", "*"),
   };
 
-  /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
-  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
+  /* Capture allowed_items and roles by value so the strategy outlives token. */
+  return [allowed_items, token_roles=std::move(roles)](const rgw::auth::Identity::aclspec_t& aclspec) {
     uint32_t perm = 0;
 
     for (const auto& allowed_item : allowed_items) {
       const auto iter = aclspec.find(allowed_item);
-
       if (std::end(aclspec) != iter) {
         perm |= iter->second;
       }
     }
 
     for (const auto& r : token_roles) {
-      if (r.is_reader) {
-        if (r.is_admin) {
-          /* System scope reader defeats project-level permissions. */
-          perm |= RGW_OP_TYPE_READ;
-        }
+      if (r.is_reader && r.is_admin) {
+        /* System scope reader defeats project-level permissions. */
+        perm |= RGW_OP_TYPE_READ;
       }
     }
 
     return perm;
   };
+}
+
+static rgw::auth::RemoteApplier::acl_strategy_t
+keystone_acl_strategy_from_token(const rgw::keystone::TokenEnvelope& token)
+{
+  return make_keystone_acl_strategy(token.get_project_id(),
+                                    token.get_project_name(),
+                                    token.get_user_id(),
+                                    token.get_user_name(),
+                                    token.roles);
+}
+
+TokenEngine::acl_strategy_t
+TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
+{
+  return keystone_acl_strategy_from_token(token);
 }
 
 TokenEngine::result_t
@@ -633,51 +644,7 @@ auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
 EC2Engine::acl_strategy_t
 EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t& token) const
 {
-  /* The primary identity is constructed upon UUIDs. */
-  const auto& tenant_uuid = token.get_project_id();
-  const auto& user_uuid = token.get_user_id();
-
-  /* For Keystone v2 an alias may be also used. */
-  const auto& tenant_name = token.get_project_name();
-  const auto& user_name = token.get_user_name();
-
-  /* Construct all possible combinations including Swift's wildcards.
-   * This mirrors TokenEngine::get_acl_strategy() to allow S3 requests
-   * authenticated via Keystone to honor Swift-format ACL entries. */
-  const std::array<std::string, 6> allowed_items = {
-    make_spec_item(tenant_uuid, user_uuid),
-    make_spec_item(tenant_name, user_name),
-
-    /* Wildcards. */
-    make_spec_item(tenant_uuid, "*"),
-    make_spec_item(tenant_name, "*"),
-    make_spec_item("*", user_uuid),
-    make_spec_item("*", user_name),
-  };
-
-  /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
-  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
-    uint32_t perm = 0;
-
-    for (const auto& allowed_item : allowed_items) {
-      const auto iter = aclspec.find(allowed_item);
-
-      if (std::end(aclspec) != iter) {
-        perm |= iter->second;
-      }
-    }
-
-    for (const auto& r : token_roles) {
-      if (r.is_reader) {
-        if (r.is_admin) {
-          /* System scope reader defeats project-level permissions. */
-          perm |= RGW_OP_TYPE_READ;
-        }
-      }
-    }
-
-    return perm;
-  };
+  return keystone_acl_strategy_from_token(token);
 }
 
 EC2Engine::auth_info_t

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -211,11 +211,8 @@ TokenEngine::get_acl_strategy(const TokenEngine::token_envelope_t& token) const
 
     for (const auto& r : token_roles) {
       if (r.is_reader) {
-        if (r.is_admin) {    /* system scope reader persona */
-          /*
-           * Because system reader defeats permissions,
-           * we don't even look at the aclspec.
-           */
+        if (r.is_admin) {
+          /* System scope reader defeats project-level permissions. */
           perm |= RGW_OP_TYPE_READ;
         }
       }
@@ -634,11 +631,53 @@ auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
 }
 
 EC2Engine::acl_strategy_t
-EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t&) const
+EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t& token) const
 {
-  /* This is based on the assumption that the default acl strategy in
-   * get_perms_from_aclspec, will take care. Extra acl spec is not required. */
-  return nullptr;
+  /* The primary identity is constructed upon UUIDs. */
+  const auto& tenant_uuid = token.get_project_id();
+  const auto& user_uuid = token.get_user_id();
+
+  /* For Keystone v2 an alias may be also used. */
+  const auto& tenant_name = token.get_project_name();
+  const auto& user_name = token.get_user_name();
+
+  /* Construct all possible combinations including Swift's wildcards.
+   * This mirrors TokenEngine::get_acl_strategy() to allow S3 requests
+   * authenticated via Keystone to honor Swift-format ACL entries. */
+  const std::array<std::string, 6> allowed_items = {
+    make_spec_item(tenant_uuid, user_uuid),
+    make_spec_item(tenant_name, user_name),
+
+    /* Wildcards. */
+    make_spec_item(tenant_uuid, "*"),
+    make_spec_item(tenant_name, "*"),
+    make_spec_item("*", user_uuid),
+    make_spec_item("*", user_name),
+  };
+
+  /* Lambda will obtain a copy of (not a reference to!) allowed_items. */
+  return [allowed_items, token_roles=token.roles](const rgw::auth::Identity::aclspec_t& aclspec) {
+    uint32_t perm = 0;
+
+    for (const auto& allowed_item : allowed_items) {
+      const auto iter = aclspec.find(allowed_item);
+
+      if (std::end(aclspec) != iter) {
+        perm |= iter->second;
+      }
+    }
+
+    for (const auto& r : token_roles) {
+      if (r.is_reader) {
+        if (r.is_admin) {
+          /* System scope reader defeats project-level permissions. */
+          perm |= RGW_OP_TYPE_READ;
+        }
+      }
+    }
+
+    return perm;
+  };
 }
 
 EC2Engine::auth_info_t

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <list>
 #include <string_view>
 #include <utility>
 #include <boost/optional.hpp>
@@ -19,6 +20,16 @@ namespace keystone {
 /* Dedicated namespace for Keystone-related auth engines. We need it because
  * Keystone offers three different authentication mechanisms (token, EC2 and
  * regular user/pass). RadosGW actually does support the first two. */
+
+/* Build the ACL-matching strategy shared by TokenEngine (Swift) and
+ * EC2Engine (S3). Exposed here for unit testing; see rgw_auth_keystone.cc
+ * for the identity/wildcard matching semantics. */
+rgw::auth::RemoteApplier::acl_strategy_t
+make_keystone_acl_strategy(const std::string& tenant_id,
+                           const std::string& tenant_name,
+                           const std::string& user_id,
+                           const std::string& user_name,
+                           std::list<rgw::keystone::TokenEnvelope::Role> roles);
 
 class TokenEngine : public rgw::auth::Engine {
   CephContext* const cct;

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -132,6 +132,11 @@ add_executable(unittest_http_manager test_http_manager.cc)
 add_ceph_unittest(unittest_http_manager)
 target_link_libraries(unittest_http_manager ${rgw_libs})
 
+# unittest_rgw_auth_keystone
+add_executable(unittest_rgw_auth_keystone test_rgw_auth_keystone.cc)
+add_ceph_unittest(unittest_rgw_auth_keystone)
+target_link_libraries(unittest_rgw_auth_keystone ${rgw_libs})
+
 # unittest_rgw_reshard_wait
 add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)
 add_ceph_unittest(unittest_rgw_reshard_wait)

--- a/src/test/rgw/test_rgw_auth_keystone.cc
+++ b/src/test/rgw/test_rgw_auth_keystone.cc
@@ -1,0 +1,172 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include <list>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "rgw_auth.h"
+#include "rgw_auth_keystone.h"
+#include "rgw_common.h"
+#include "rgw_keystone.h"
+
+namespace {
+
+constexpr const char* TENANT_ID   = "11111111111111111111111111111111";
+constexpr const char* TENANT_NAME = "shared";
+constexpr const char* USER_ID     = "22222222222222222222222222222222";
+constexpr const char* USER_NAME   = "consumer1";
+
+rgw::auth::RemoteApplier::acl_strategy_t make_strategy_no_roles()
+{
+  return rgw::auth::keystone::make_keystone_acl_strategy(
+      TENANT_ID, TENANT_NAME, USER_ID, USER_NAME, {});
+}
+
+rgw::auth::Identity::aclspec_t single_grant(const std::string& key, uint32_t perm)
+{
+  rgw::auth::Identity::aclspec_t spec;
+  spec[key] = perm;
+  return spec;
+}
+
+} // namespace
+
+TEST(KeystoneAclStrategy, MatchesProjectIdUserId)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{TENANT_ID} + ":" + USER_ID,
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesProjectNameUserName)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{TENANT_NAME} + ":" + USER_NAME,
+                                 RGW_OP_TYPE_WRITE);
+  EXPECT_EQ(RGW_OP_TYPE_WRITE, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesProjectIdWildcardUser)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{TENANT_ID} + ":*",
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesProjectNameWildcardUser)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{TENANT_NAME} + ":*",
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesWildcardTenantUserId)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{"*:"} + USER_ID,
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesWildcardTenantUserName)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant(std::string{"*:"} + USER_NAME,
+                                 RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, MatchesAuthenticatedWildcard)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant("*:*", RGW_OP_TYPE_READ);
+  EXPECT_EQ(RGW_OP_TYPE_READ, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, OrsMultipleMatchingGrants)
+{
+  auto strategy = make_strategy_no_roles();
+  rgw::auth::Identity::aclspec_t spec;
+  spec[std::string{TENANT_ID} + ":" + USER_ID] = RGW_OP_TYPE_READ;
+  spec[std::string{TENANT_ID} + ":*"] = RGW_OP_TYPE_WRITE;
+  EXPECT_EQ(RGW_OP_TYPE_READ | RGW_OP_TYPE_WRITE, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, NoMatchReturnsZero)
+{
+  auto strategy = make_strategy_no_roles();
+  const auto spec = single_grant("other_tenant:other_user", RGW_OP_TYPE_READ);
+  EXPECT_EQ(0u, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, EmptyAclspecReturnsZero)
+{
+  auto strategy = make_strategy_no_roles();
+  rgw::auth::Identity::aclspec_t spec;
+  EXPECT_EQ(0u, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, BareRoleNameIsNotHonored)
+{
+  /* Bare role-name ACL elements are intentionally unsupported until the
+   * acl_strategy_t callback can see the bucket owner; otherwise a role
+   * shared across projects would leak access. See PR #68795 commit message. */
+  rgw::keystone::TokenEnvelope::Role member;
+  member.name = "Member";
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{member};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      TENANT_ID, TENANT_NAME, USER_ID, USER_NAME, std::move(roles));
+  const auto spec = single_grant("Member", RGW_OP_TYPE_READ);
+  EXPECT_EQ(0u, strategy(spec));
+}
+
+TEST(KeystoneAclStrategy, SystemReaderAdminGrantsRead)
+{
+  rgw::keystone::TokenEnvelope::Role role;
+  role.name = "system-reader";
+  role.is_reader = true;
+  role.is_admin = true;
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{role};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      TENANT_ID, TENANT_NAME, USER_ID, USER_NAME, std::move(roles));
+
+  rgw::auth::Identity::aclspec_t empty;
+  EXPECT_EQ(static_cast<uint32_t>(RGW_OP_TYPE_READ), strategy(empty));
+}
+
+TEST(KeystoneAclStrategy, ReaderWithoutAdminDoesNotGrant)
+{
+  rgw::keystone::TokenEnvelope::Role role;
+  role.name = "reader";
+  role.is_reader = true;
+  role.is_admin = false;
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{role};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      TENANT_ID, TENANT_NAME, USER_ID, USER_NAME, std::move(roles));
+
+  rgw::auth::Identity::aclspec_t empty;
+  EXPECT_EQ(0u, strategy(empty));
+}
+
+TEST(KeystoneAclStrategy, SystemReaderAddsToAclMatchedPerm)
+{
+  rgw::keystone::TokenEnvelope::Role role;
+  role.name = "system-reader";
+  role.is_reader = true;
+  role.is_admin = true;
+  std::list<rgw::keystone::TokenEnvelope::Role> roles{role};
+
+  auto strategy = rgw::auth::keystone::make_keystone_acl_strategy(
+      TENANT_ID, TENANT_NAME, USER_ID, USER_NAME, std::move(roles));
+  const auto spec = single_grant(std::string{TENANT_ID} + ":" + USER_ID,
+                                 RGW_OP_TYPE_WRITE);
+  EXPECT_EQ(RGW_OP_TYPE_READ | RGW_OP_TYPE_WRITE, strategy(spec));
+}


### PR DESCRIPTION
Backport of PR #68795 (targeting main) to tentacle (Ceph 20.x).

> **⚠️ Do not merge yet** — this backport depends on upstream #68795, which is not
> yet merged to `main`. Opened as a draft to enable cherry-pick image builds for testing.

Two bugs fixed:

1. `*:*` wildcard missing from TokenEngine's `allowed_items` — containers with
   `X-Container-Read: *:*` returned 403 to any cross-project Keystone token.
2. `EC2Engine::get_acl_strategy()` returned `nullptr` — S3 requests could never match
   Swift-format ACL entries.

Both caused Glance shared image downloads to return zero bytes with
`swift_store_multi_tenant = True`.

Fixes: https://tracker.ceph.com/issues/68492
Fixes: https://tracker.ceph.com/issues/68476

## Backport notes

- Faithful cherry-pick (`-x`) of both commits from #68795; code is byte-identical to upstream.
- One conflict resolved in `src/test/rgw/CMakeLists.txt`: tentacle has no
  `if(WITH_RADOSGW_RADOS)` guard around the rgw test targets, so the new
  `unittest_rgw_auth_keystone` block was placed among the unguarded targets (matching
  tentacle's structure). No functional difference from upstream.
