### PR TITLE
squid: rgw: segfault in rgw_http_req_data::set_state() after request completion

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -148,6 +148,10 @@ void rgw_http_req_data::set_state(int bitmask) {
   /* no need to lock here, moreover curl_easy_pause() might trigger
    * the data receive callback :/
    */
+  if (done || !curl_handle) {
+    // the request finished before the change was applied
+    return;
+  }
   CURLcode rc = curl_easy_pause(**curl_handle, bitmask);
   if (rc != CURLE_OK) {
     dout(0) << "ERROR: curl_easy_pause() returned rc=" << rc << dendl;
@@ -851,7 +855,15 @@ void RGWHTTPManager::_finish_request(rgw_http_req_data *req_data, int ret)
 
 void RGWHTTPManager::_set_req_state(set_state& ss)
 {
-  ss.req->set_state(ss.bitmask);
+  /*
+   * requests are erased from reqs under reqs_lock when they finish,
+   * so a missing id means there is nothing to pause or resume
+   */
+  auto iter = reqs.find(ss.id);
+  if (iter == reqs.end()) {
+    return;
+  }
+  iter->second->set_state(ss.bitmask);
 }
 /*
  * hook request to the curl multi handle
@@ -1049,7 +1061,7 @@ int RGWHTTPManager::set_request_state(RGWHTTPClient *client, RGWHTTPRequestSetSt
 
   {
     std::lock_guard l{reqs_change_state_lock};
-    reqs_change_state.push_back(set_state(req_data, bitmask));
+    reqs_change_state.push_back(set_state(req_data->id, bitmask));
   }
   int ret = signal_thread();
   if (ret < 0) {

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -285,10 +285,10 @@ enum RGWHTTPRequestSetState {
 
 class RGWHTTPManager {
   struct set_state {
-    rgw_http_req_data *req;
+    uint64_t id;
     int bitmask;
 
-    set_state(rgw_http_req_data *_req, int _bitmask) : req(_req), bitmask(_bitmask) {}
+    set_state(uint64_t _id, int _bitmask) : id(_id), bitmask(_bitmask) {}
   };
   CephContext *cct;
   RGWCompletionManager *completion_mgr;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80198

---

backport of https://github.com/ceph/ceph/pull/70930
parent tracker: https://tracker.ceph.com/issues/79277

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh