### PR TITLE
python-common: fix with_units_to_int() crashes on malformed size strings

### DIFF
--- a/src/python-common/ceph/deployment/utils.py
+++ b/src/python-common/ceph/deployment/utils.py
@@ -137,7 +137,7 @@ def verify_size_with_units(field: Any, field_name: str) -> Optional[int]:
         return None
     try:
         size = with_units_to_int(str(field))
-    except (ValueError, TypeError, IndexError, UnboundLocalError):
+    except (ValueError, TypeError):
         raise SpecValidationError(f'{field_name}: invalid size {field!r}')
     if size < 0:
         raise SpecValidationError(f"{field_name} can't be negative")

--- a/src/python-common/ceph/tests/test_utils.py
+++ b/src/python-common/ceph/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ceph.deployment.utils import is_ipv6, unwrap_ipv6, wrap_ipv6, valid_addr
+from ceph.utils import with_units_to_int
 from typing import NamedTuple
 
 
@@ -73,3 +74,32 @@ def test_valid_addr(addr_object: Address):
     valid, description = valid_addr(addr_object.addr)
     assert valid == addr_object.status
     assert description == addr_object.description
+
+
+@pytest.mark.parametrize('value,expected', [
+    # No unit suffix
+    ('', 0),
+    ('100', 100),
+    # Decimal (SI) suffixes
+    ('100B', 100),
+    ('100KB', 100 * 1000),
+    ('100MB', 100 * 1000 ** 2),
+    ('1GB', 1000 ** 3),
+    ('1TB', 1000 ** 4),
+    # Binary (IEC) suffixes
+    ('100KiB', 100 * 1024),
+    ('100MiB', 100 * 1024 ** 2),
+    ('1GiB', 1024 ** 3),
+    ('1TiB', 1024 ** 4),
+    # Bare unit letters, without a trailing B. These are binary, matching
+    # size_to_bytes() and the behaviour this helper had before the decimal
+    # suffixes were added.
+    ('128K', 128 * 1024),
+    ('500M', 500 * 1024 ** 2),
+    ('1G', 1024 ** 3),
+    ('2T', 2 * 1024 ** 4),
+    ('1g', 1024 ** 3),
+    ('1.5G', 1610612736),
+])
+def test_with_units_to_int(value, expected):
+    assert with_units_to_int(value) == expected

--- a/src/python-common/ceph/tests/test_utils.py
+++ b/src/python-common/ceph/tests/test_utils.py
@@ -103,3 +103,26 @@ def test_valid_addr(addr_object: Address):
 ])
 def test_with_units_to_int(value, expected):
     assert with_units_to_int(value) == expected
+
+
+@pytest.mark.parametrize('value', [
+    # A unit suffix with nothing in front of it
+    'B',
+    'iB',
+    'K',
+    'KB',
+    'GiB',
+    # The B and iB suffixes are matched case sensitively, the unit letter
+    # is not, so '1g' is valid but '1gb' is not
+    '1gb',
+    # Not a size at all
+    'abc',
+    '1X',
+    # float() accepts these, int() then overflows
+    'inf',
+    '1e400',
+])
+def test_with_units_to_int_invalid(value):
+    # Callers guard on ValueError only, so every bad value must be one.
+    with pytest.raises(ValueError, match='invalid size'):
+        with_units_to_int(value)

--- a/src/python-common/ceph/utils.py
+++ b/src/python-common/ceph/utils.py
@@ -243,6 +243,7 @@ def bytes_to_human(num: float, mode: str = 'decimal') -> str:
 def with_units_to_int(v: str) -> int:
     if not v:
         return 0
+    orig = v
     # A bare unit letter has no B or iB to select decimal or binary, so
     # treat it as binary, like size_to_bytes() above and like this helper
     # did before decimal units were added.
@@ -253,16 +254,22 @@ def with_units_to_int(v: str) -> int:
         v = v[:-1]
         bytes_mult = 1000
     mult = 1
-    if v[-1].upper() == 'K':
+    unit = v[-1:].upper()
+    if unit == 'K':
         mult = bytes_mult
         v = v[:-1]
-    elif v[-1].upper() == 'M':
+    elif unit == 'M':
         mult = bytes_mult * bytes_mult
         v = v[:-1]
-    elif v[-1].upper() == 'G':
+    elif unit == 'G':
         mult = bytes_mult * bytes_mult * bytes_mult
         v = v[:-1]
-    elif v[-1].upper() == 'T':
+    elif unit == 'T':
         mult = bytes_mult * bytes_mult * bytes_mult * bytes_mult
         v = v[:-1]
-    return int(float(v) * mult)
+    try:
+        return int(float(v) * mult)
+    except (ValueError, OverflowError):
+        raise ValueError(
+            f'invalid size "{orig}" (examples: 10737418240, 10G, 512M)'
+        ) from None

--- a/src/python-common/ceph/utils.py
+++ b/src/python-common/ceph/utils.py
@@ -243,9 +243,12 @@ def bytes_to_human(num: float, mode: str = 'decimal') -> str:
 def with_units_to_int(v: str) -> int:
     if not v:
         return 0
+    # A bare unit letter has no B or iB to select decimal or binary, so
+    # treat it as binary, like size_to_bytes() above and like this helper
+    # did before decimal units were added.
+    bytes_mult = 1024
     if v.endswith('iB'):
         v = v[:-2]
-        bytes_mult = 1024
     elif v.endswith('B'):
         v = v[:-1]
         bytes_mult = 1000


### PR DESCRIPTION
with_units_to_int() raises UnboundLocalError for '1G' / '500M' / '128K',
and IndexError for 'B' / 'iB'. Both reach user input: the NFS QoS
bandwidth CLI and NFSServiceSpec.client_object_cache_size.

No backport. f43262d8eb6 was merged to main on 2026-04-30 (PR #61826),
after the tentacle branch point; with_units_to_int() does not exist in
python-common on squid, reef or tentacle.

No behaviour change for any input that previously returned a value. I ran
the pre-patch and post-patch implementations over a matrix of numeric
parts x every suffix (325 inputs): 219 identical, 96 exception -> value,
10 exception -> a different exception, and 0 changed values. cephadm
container stats parsing is unaffected, podman emits '456.4MB' and docker
emits '456.4MiB', both carry a B, so that path never hit the bug and its
values are identical.

Docs unchanged deliberately. doc/mgr/nfs.rst and
doc/cephadm/services/nfs.rst enumerate only the B-suffixed spellings;
bare unit letters were accepted-but-undocumented before f43262d8eb6 and
are again now, so this restores prior behaviour rather than adding a
documented form.

The existing NFS QoS tests could not have caught this: test_nfs.py
derives its expected values with bytes_to_human(with_units_to_int(...)),
so the function under test is its own oracle. The regression test is at
the python-common layer instead.

Ran `tox -e lint,rstcheck,mypy,py3,check-black` in src/python-common.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
