### PR TITLE
umbrella: qa: fix mds_upgrade_sequence cephadm bootstrap failure (roleless + mon roles)

### DIFF
--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/0-from/squid.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/0-from/squid.yaml
@@ -13,7 +13,6 @@ tasks:
 - cephadm:
     image: quay.ceph.io/ceph-ci/ceph:squid
     skip_dashboard: true
-    roleless: true
     compiled_cephadm_branch: squid
     conf:
       osd:
@@ -22,11 +21,11 @@ tasks:
         osd_class_default_list: "*"
 - print: "**** done end installing squid cephadm ..."
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph config set mgr mgr/cephadm/use_repo_digest true --force
 - print: "**** done cephadm.shell ceph config set mgr..."
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph orch status
       - ceph orch ps
       - ceph orch ls

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/0-from/tentacle.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/0-from/tentacle.yaml
@@ -13,7 +13,6 @@ tasks:
 - cephadm:
     image: quay.ceph.io/ceph-ci/ceph:tentacle
     skip_dashboard: true
-    roleless: true
     compiled_cephadm_branch: tentacle
     conf:
       osd:
@@ -22,11 +21,11 @@ tasks:
         osd_class_default_list: "*"
 - print: "**** done end installing tentacle cephadm ..."
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph config set mgr mgr/cephadm/use_repo_digest true --force
 - print: "**** done cephadm.shell ceph config set mgr..."
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph orch status
       - ceph orch ps
       - ceph orch ls

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/0-create.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/0-create.yaml
@@ -1,5 +1,5 @@
 tasks:
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph fs volume create cephfs --placement=4
       - ceph fs dump

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/1-ranks/1.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/1-ranks/1.yaml
@@ -1,4 +1,4 @@
 tasks:
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph fs set cephfs max_mds 1

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/1-ranks/2.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/1-ranks/2.yaml
@@ -1,4 +1,4 @@
 tasks:
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph fs set cephfs max_mds 2

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/2-allow_standby_replay/no.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/2-allow_standby_replay/no.yaml
@@ -1,4 +1,4 @@
 tasks:
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph fs set cephfs allow_standby_replay false

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/2-allow_standby_replay/yes.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/2-allow_standby_replay/yes.yaml
@@ -1,4 +1,4 @@
 tasks:
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph fs set cephfs allow_standby_replay true

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/3-inline/no.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/3-inline/no.yaml
@@ -1,4 +1,4 @@
 tasks:
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph fs set cephfs inline_data false

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/3-inline/yes.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/3-inline/yes.yaml
@@ -1,4 +1,4 @@
 tasks:
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph fs set cephfs inline_data true --yes-i-really-really-mean-it

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/4-verify.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/1-volume/4-verify.yaml
@@ -1,6 +1,6 @@
 tasks:
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph fs dump
       - ceph --format=json fs dump | jq -e ".filesystems | length == 1"
       - while ! ceph --format=json mds versions | jq -e ". | add == 4"; do sleep 1; done

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/3-upgrade-mgr-staggered.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/3-upgrade-mgr-staggered.yaml
@@ -6,7 +6,7 @@ upgrade-tasks:
     - sequential: [ignore-auth-warn-cephadm]
     - cephadm.shell:
         env: [sha1]
-        host.a:
+        mon.a:
           - ceph config set mon mon_warn_on_insecure_global_id_reclaim false --force
           - ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false --force
           - ceph config set global log_to_journald false --force

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/4-config-upgrade/fail_fs.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/4-config-upgrade/fail_fs.yaml
@@ -2,7 +2,7 @@ teuthology:
   premerge: |
             local set = yaml.teuthology.variables.fail_fs
             local cmd = "ceph config set mgr mgr/orchestrator/fail_fs "..tostring(set)
-            local cmds = yaml_fragment['upgrade-tasks'].sequential[0]['cephadm.shell']['host.a']
+            local cmds = yaml_fragment['upgrade-tasks'].sequential[0]['cephadm.shell']['mon.a']
             if set then
               py_attrgetter(cmds).append "ceph config set mgr mgr/orchestrator/fail_fs true"
             else
@@ -12,4 +12,4 @@ upgrade-tasks:
   sequential:
     - cephadm.shell:
         env: [sha1]
-        host.a: []
+        mon.a: []

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/5-upgrade-with-workload.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/5-upgrade-with-workload.yaml
@@ -7,14 +7,14 @@ upgrade-tasks:
   sequential:
     - cephadm.shell:
         env: [sha1]
-        host.a:
+        mon.a:
           - ceph config set mon mon_warn_on_insecure_global_id_reclaim false --force
           - ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false --force
           - ceph config set global log_to_journald false --force
           - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
     - cephadm.shell:
         env: [sha1]
-        host.a:
+        mon.a:
           - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph fs dump; ceph orch upgrade status ; ceph health detail ; sleep 30 ; done
           - ceph orch ps
           - ceph orch upgrade status

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/6-verify.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/6-verify.yaml
@@ -1,6 +1,6 @@
 tasks:
 - cephadm.shell:
-    host.a:
+    mon.a:
       - ceph fs dump
       - ceph osd require-osd-release umbrella # after the upgrade, this should be bumped up
 - fs.post_upgrade_checks:

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1996,7 +1996,18 @@ def initialize_config(ctx, config):
         # mons will be named after hosts
         first_mon = None
         max_mons = config.get('max_mons', 5)
-        for remote, _ in remotes_and_roles:
+        for remote, roles in remotes_and_roles:
+            mon_roles = [r for r in roles
+                         if teuthology.is_type('mon', cluster_name)(r)]
+            if mon_roles:
+                # Fabricated host-named mons would be deployed on top of the
+                # mon roles, and the default mon service placement created by
+                # cephadm bootstrap races with the explicit placement applied
+                # later, deploying host-named mons on ports assigned to the
+                # role-named mons.
+                raise RuntimeError(
+                    'roleless cephadm requires host-only roles; found %s on %s'
+                    % (mon_roles, remote.shortname))
             ctx.cluster.remotes[remote].append('mon.' + remote.shortname)
             if not first_mon:
                 first_mon = remote.shortname


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80126

---

backport of https://github.com/ceph/ceph/pull/71197
parent tracker: https://tracker.ceph.com/issues/79685

Both commits cherry-pick cleanly. On umbrella-release the fs/orch/upgrade mds_upgrade_sequence suites fail 100% with "reached maximum tries (180)" because bootstrap's host-named mon takes the port assigned to mon.b (see https://tracker.ceph.com/issues/79685). Verified against yuriw-2026-09-02_13:4x-{orch,fs,upgrade}-umbrella-release runs.