### PR TITLE
umbrella: qa/tasks/cbt: stop hardcoding the pdsh version for el10

### DIFF
--- a/qa/tasks/cbt.py
+++ b/qa/tasks/cbt.py
@@ -69,17 +69,23 @@ class CBT(Task):
             install_cmd = ['sudo', 'yum', '-y', 'install']
             cbt_depends = ['librbd-devel', 'perf']
 
-            # pdsh is not available in the repos for el10, use el9 version which works fine
+            # pdsh is not available in the repos for el10, use el9 version which works fine.
+            # Pull it straight from the epel9 repo rather than hardcoding an rpm URL, since
+            # epel rebuilds/bumps pdsh and any pinned version eventually 404s. The repo is
+            # limited to the pdsh packages so nothing else gets resolved against el9.
             os_version = misc.get_distro_version(self.ctx)
             os_major_version = int(os_version.split('.')[0])
             if os_major_version >= 10:
                 self.log.info('Installing pdsh from el9 repo into el10 system')
-                pdsh_base = 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/p'
+                pdsh_packages = ['pdsh', 'pdsh-rcmd-ssh']
+                epel9_baseurl = 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/'
                 self.first_mon.run(args=[
-                    'sudo', 'yum', '-y', 'install',
-                    f'{pdsh_base}/pdsh-2.34-7.el9.x86_64.rpm',
-                    f'{pdsh_base}/pdsh-rcmd-ssh-2.34-7.el9.x86_64.rpm',
-                ])
+                    'sudo', 'yum', '-y',
+                    '--repofrompath', f'epel9-pdsh,{epel9_baseurl}',
+                    f'--setopt=epel9-pdsh.includepkgs={",".join(pdsh_packages)}',
+                    '--nogpgcheck',
+                    'install',
+                ] + pdsh_packages)
             else:
                 cbt_depends += ['pdsh', 'pdsh-rcmd-ssh']
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80214

---

backport of https://github.com/ceph/ceph/pull/70949
parent tracker: https://tracker.ceph.com/issues/79335

Clean cherry-pick. On umbrella-release every crimson-rados job on Rocky 10 fails in the cbt task because EPEL bumped pdsh to 2.36 and the pinned 2.34 URL now 404s (yuriw-2026-09-02_13:46:40-crimson-rados-umbrella-release).