### PR TITLE
script/redmine-upkeep: handle unknown base commits

### DIFF
--- a/src/script/redmine-upkeep.py
+++ b/src/script/redmine-upkeep.py
@@ -209,6 +209,24 @@ Possible resolutions:
 * **Do nothing. This script will ignore this issue while the upkeep-failed tag is applied.**
 """
 
+class BaseCommitMissingException(UpkeepException):
+    def __init__(self, issue_update, pr_id, base_ref, **kwargs):
+        super().__init__(issue_update, **kwargs)
+        self.pr_id = pr_id
+        self.base_ref = base_ref
+
+    def __str__(self):
+        return "Base commit could not be fetched"
+
+    def comment(self):
+        return f"""
+Issue #{self.issue_update.issue.id} references "PR #{self.pr_id}":https://github.com/ceph/ceph/pull/{self.pr_id}. The base branch `{self.base_ref}` or its commit could not be resolved locally.
+
+<pre>
+{self.traceback.strip()}
+</pre>
+"""
+
 class RedmineUpdateException(UpkeepException):
     def __init__(self, issue_update, **kwargs):
         super().__init__(issue_update, **kwargs)
@@ -869,10 +887,13 @@ class RedmineUpkeep:
 
         try:
             BASE = self.G.commit(base['sha'])
-        except git.exc.GitCommandError as e:
+        except (git.exc.GitCommandError, ValueError) as e:
             issue_update.logger.debug(f"Fetching {base['ref']}")
-            self.G.git.fetch(self.remote_url, base['ref'])
-            BASE = self.G.commit('FETCH_HEAD')
+            try:
+                self.G.git.fetch(self.remote_url, base['ref'])
+                BASE = self.G.commit('FETCH_HEAD')
+            except (git.exc.GitCommandError, ValueError) as e2:
+                raise BaseCommitMissingException(issue_update, pr_id, base['ref'], exception=e2, traceback=traceback.format_exc())
 
         m = self._find_merge_commit(issue_update, HEAD, BASE)
         if m:


### PR DESCRIPTION
Resolves this error:

    An unhandled error occurred during Redmine upkeep: SHA b'67473e3d4c369dd7edef15ccf0957a9c65cc562d' could not be resolved, git returned: b'67473e3d4c369dd7edef15ccf0957a9c65cc562d missing'
    Traceback (most recent call last):
      File "/home/runner/work/ceph/ceph/ceph/src/script/redmine-upkeep.py", line 1766, in main
        RU.filter_and_process_issues() # No arguments needed here anymore
      File "/home/runner/work/ceph/ceph/ceph/src/script/redmine-upkeep.py", line 1521, in filter_and_process_issues
        self._execute_filters()
      File "/home/runner/work/ceph/ceph/ceph/src/script/redmine-upkeep.py", line 1701, in _execute_filters
        self._process_issue_transformations(issue)
      File "/home/runner/work/ceph/ceph/ceph/src/script/redmine-upkeep.py", line 1370, in _process_issue_transformations
        if transform_method(issue_update):
      File "/home/runner/work/ceph/ceph/ceph/src/script/redmine-upkeep.py", line 477, in wrapper
        return func(*args, **kwargs)
      File "/home/runner/work/ceph/ceph/ceph/src/script/redmine-upkeep.py", line 910, in _transform_merged
        commit = self._get_merge_commit(issue_update)
      File "/home/runner/work/ceph/ceph/ceph/src/script/redmine-upkeep.py", line 871, in _get_merge_commit
        BASE = self.G.commit(base['sha'])
      File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/git/repo/base.py", line 726, in commit
        return self.rev_parse(str(rev) + "^0")
      File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/git/repo/fun.py", line 284, in rev_parse
        obj = name_to_object(repo, rev[:start])
      File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/git/repo/fun.py", line 205, in name_to_object
        return Object.new_from_sha(repo, hex_to_bin(hexsha))
      File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/git/objects/base.py", line 149, in new_from_sha
        oinfo = repo.odb.info(sha1)
      File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/git/db.py", line 41, in info
        hexsha, typename, size = self._git.get_object_header(bin_to_hex(binsha))
      File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/git/cmd.py", line 1679, in get_object_header
        return self.__get_object_header(cmd, ref)
      File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/git/cmd.py", line 1663, in __get_object_header
        return self._parse_object_header(cmd.stdout.readline())
      File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/git/cmd.py", line 1624, in _parse_object_header
        raise ValueError("SHA %s could not be resolved, git returned: %r" % (tokens[0], header_line.strip()))
    ValueError: SHA b'67473e3d4c369dd7edef15ccf0957a9c65cc562d' could not be resolved, git returned: b'67473e3d4c369dd7edef15ccf0957a9c65cc562d missing'

caused by a merge on a working integration branch.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
