### PR TITLE
tentacle: rgw/logging: use assumed-role ARN as Requester for STS requests

### DIFF
--- a/qa/suites/rgw/bucket-logging/overrides.yaml
+++ b/qa/suites/rgw/bucket-logging/overrides.yaml
@@ -6,6 +6,8 @@ overrides:
         setgroup: ceph
         debug rgw: 20
         rgw bucket logging obj roll time: 5
+        rgw sts key: abcdefghijklmnop
+        rgw s3 auth use sts: true
   rgw:
     storage classes:
       LUKEWARM:

--- a/src/rgw/rgw_bucket_logging.cc
+++ b/src/rgw/rgw_bucket_logging.cc
@@ -550,9 +550,19 @@ int log_record(rgw::sal::Driver* driver,
   const auto tt = ceph::coarse_real_time::clock::to_time_t(s->time);
   std::tm t{};
   localtime_r(&tt, &t);
-  auto user_or_account = s->account_name;
+  // AWS S3 spec: log the assumed-role ARN for STS-credentialed requests.
+  std::string user_or_account;
+  if (s->auth.identity && s->auth.identity->get_identity_type() == TYPE_ROLE) {
+    if (auto caller_arn = s->auth.identity->get_caller_identity(); caller_arn) {
+      user_or_account = caller_arn->to_string();
+    }
+  }
   if (user_or_account.empty()) {
-    s->user->get_id().to_str(user_or_account);
+    if (s->account_name.empty()) {
+      s->user->get_id().to_str(user_or_account);
+    } else {
+      user_or_account = s->account_name;
+    }
   }
   auto fqdn = s->info.host;
   if (!s->info.domain.empty() && !fqdn.empty()) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/77035

---

backport of https://github.com/ceph/ceph/pull/68887
parent tracker: https://tracker.ceph.com/issues/71742

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh