### PR TITLE
squid: rgw: check for duplicate rule priorities in replication configuration

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1385,7 +1385,13 @@ struct ReplicationConfiguration {
     disabled_group.id = disabled_group_id;
     disabled_group.status = rgw_sync_policy_group::Status::ALLOWED; /* not enabled, not forbidden */
 
+    std::unordered_set<int32_t> priorities; // used to check for duplicates
     for (auto& rule : rules) {
+      if (!priorities.insert(rule.priority).second) {
+        s->err.message = fmt::format("Found duplicate priority {}.", rule.priority);
+        return -EINVAL;
+      }
+
       rgw_sync_bucket_pipes pipe;
       bool enabled;
       int r = rule.to_sync_policy_pipe(s, driver, &pipe, &enabled);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70529

---

backport of https://github.com/ceph/ceph/pull/61803
parent tracker: https://tracker.ceph.com/issues/69946

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh