### PR TITLE
cephfs: volumes module: add a new --protocols option to fs subvolume create

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -361,7 +361,7 @@ Use a command of the following form to create a subvolume:
 
 .. prompt:: bash #
 
-   ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--namespace-isolated] [--earmark <earmark>] [--normalization <form>] [--casesensitive <bool>] [--enctag <enctag>]
+   ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--namespace-isolated] [--earmark <earmark>] [--normalization <form>] [--casesensitive <bool>] [--enctag <enctag>] [--protocols {default|smb}]
 
 
 The command succeeds even if the subvolume already exists.
@@ -436,6 +436,16 @@ The encryption tag can be used to identify a subvolume to its associated encrypt
 master key and policy. One can map the value of enctag with a corresponding master
 key. This can then be used to unlock the subvolume. This master key may be stored
 in a secure location such as a key management server.
+
+For convenience, a ``--protocols`` option exists to select defaults that are
+optimized for a particular file-sharing protocol. Pass ``--protocols=smb`` to
+automatically opt in to settings tuned for use with SMB shares. Currently, this
+sets the mode to 0777, sets case insensitivity, and sets the smb earmark. You
+may also pass ``--protocols=default`` to explicitly choose the normal defaults.
+The ``--protocols`` option may be combined with the options it sets to
+customize a particular value while taking the other preferred defaults. For
+example, ``--protocols=smb --casesensitive=1`` takes the preferred smb defaults
+for mode and earmark but forces the subvolume to be case sensitive.
 
 Removing a Subvolume
 ~~~~~~~~~~~~~~~~~~~~

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_basic.yaml
@@ -29,7 +29,7 @@ tasks:
       host.a:
         # create a subvolume so we can verify that we're sharing something
         - cmd: ceph fs subvolumegroup create cephfs g1
-        - cmd: ceph fs subvolume create cephfs sub1 --group-name=g1 --mode=0777
+        - cmd: ceph fs subvolume create cephfs sub1 --group-name=g1 --protocols=smb
         # Create a user access the file system from samba
         - cmd: ceph fs authorize cephfs client.smbdata / rw
         # Create a rados pool and store the config in it

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_ctdb_node_gone_state.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_ctdb_node_gone_state.yaml
@@ -39,7 +39,7 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       - cmd: sleep 30

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_domain.yaml
@@ -28,7 +28,7 @@ tasks:
     host.a:
       # create a subvolume so we can verify that we're sharing something
       - cmd: ceph fs subvolumegroup create cephfs g1
-      - cmd: ceph fs subvolume create cephfs sub1 --group-name=g1 --mode=0777
+      - cmd: ceph fs subvolume create cephfs sub1 --group-name=g1 --protocols=smb
       # Create a user access the file system from samba
       - cmd: ceph fs authorize cephfs client.smbdata / rw
       # Create a rados pool and store the config in it

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_basic.yaml
@@ -29,8 +29,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_clustering_ips.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_clustering_ips.yaml
@@ -41,8 +41,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       - cmd: sleep 30

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
@@ -39,8 +39,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_dom.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_dom.yaml
@@ -39,8 +39,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ips.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ips.yaml
@@ -41,8 +41,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ports2c.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ports2c.yaml
@@ -41,9 +41,9 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv3 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv3 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
@@ -29,8 +29,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_basic.yaml
@@ -29,8 +29,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_dom.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_dom.yaml
@@ -29,8 +29,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_keybridge.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_keybridge.yaml
@@ -54,9 +54,9 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs spare1 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs spare1 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_ports.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_ports.yaml
@@ -29,8 +29,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_remotectl.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_remotectl.yaml
@@ -44,8 +44,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_proxy_disabled.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_proxy_disabled.yaml
@@ -29,8 +29,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_proxy_enabled.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_proxy_enabled.yaml
@@ -29,8 +29,8 @@ tasks:
     host.a:
       # add subvolgroup & subvolumes for test
       - cmd: ceph fs subvolumegroup create cephfs smb
-      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
-      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --protocols=smb
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --protocols=smb
       # set up smb cluster and shares
       - cmd: ceph mgr module enable smb
       # TODO: replace sleep with poll of mgr state?

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -58,6 +58,26 @@ def name_to_json(names):
     return json.dumps(namedict, indent=4, sort_keys=True)
 
 
+def _normalize_volume_create_options(kwargs):
+    out = dict(kwargs)  # copy kwargs to avoid mutating input dict
+    if out.get('protocols') == 'smb':
+        # set defaults that are preferred for smb unless manually given.
+        # protocols itself just chooses better defaults for real attributes
+        casesensitive = out['casesensitive']
+        out['casesensitive'] = False if casesensitive is None else casesensitive
+        earmark = out['earmark']
+        out['earmark'] = 'smb' if earmark is None else earmark
+        mode = out['mode']
+        out['mode'] = '777' if mode is None else mode
+    # if not set, default to 755
+    out['mode'] = out.get('mode') or '755'
+    # if not set, default to empty string --> no earmark
+    out['earmark'] = out.get('earmark') or ''
+    # if not set, default to empty string --> no encryption tag
+    out['enctag'] = out.get('enctag') or ''
+    return out
+
+
 class VolumeClient(CephfsClient["Module"]):
     def __init__(self, mgr):
         super().__init__(mgr)
@@ -249,6 +269,7 @@ class VolumeClient(CephfsClient["Module"]):
             raise ve
 
     def create_subvolume(self, **kwargs):
+        kwargs = _normalize_volume_create_options(kwargs)
         ret        = 0, "", ""
         volname    = kwargs['vol_name']
         subvolname = kwargs['sub_name']
@@ -259,10 +280,10 @@ class VolumeClient(CephfsClient["Module"]):
         gid        = kwargs['gid']
         mode       = kwargs['mode']
         isolate_nspace = kwargs['namespace_isolated']
-        earmark    = kwargs['earmark'] or ''  # if not set, default to empty string --> no earmark
+        earmark    = kwargs['earmark']
         normalization = kwargs['normalization']
         casesensitive = kwargs['casesensitive']
-        enctag    = kwargs['enctag'] or ''  # if not set, default to empty string --> no encryption tag
+        enctag    = kwargs['enctag']
 
         try:
             with open_volume(self, volname) as fs_handle:

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -252,10 +252,10 @@ class VolumeClient(CephfsClient["Module"]):
         gid        = kwargs['gid']
         mode       = kwargs['mode']
         isolate_nspace = kwargs['namespace_isolated']
-        earmark    = kwargs['earmark'] or ''  # if not set, default to empty string --> no earmark
+        earmark    = kwargs['earmark']
         normalization = kwargs['normalization']
         casesensitive = kwargs['casesensitive']
-        enctag = kwargs['enctag'] or '' # if not set, default to empty string
+        enctag = kwargs['enctag']
 
         oct_mode = octal_str_to_decimal_int(mode)
 

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -152,6 +152,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=earmark,type=CephString,req=false '
                    'name=normalization,type=CephChoices,strings=nfd|nfc|nfkd|nfkc,req=false '
                    'name=casesensitive,type=CephBool,req=false '
+                   'name=protocols,type=CephChoices,strings=default|smb,req=false '
                    'name=enctag,type=CephString,req=false ',
             'desc': "Create a CephFS subvolume in a volume, and optionally, "
                     "with a specific size (in bytes), a specific data pool layout, "
@@ -820,11 +821,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                         pool_layout=cmd.get('pool_layout', None),
                                         uid=cmd.get('uid', None),
                                         gid=cmd.get('gid', None),
-                                        mode=cmd.get('mode', '755'),
+                                        mode=cmd.get('mode', None),
                                         namespace_isolated=cmd.get('namespace_isolated', False),
                                         earmark=cmd.get('earmark', None),
                                         normalization=cmd.get('normalization', None),
                                         casesensitive=cmd.get('casesensitive', None),
+                                        protocols=cmd.get('protocols', None),
                                         enctag=cmd.get('enctag', None))
 
     @mgr_cmd_wrap


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/80217

Add a new --protocols option to the cephfs volumes module for the MGR. This option is a "macro" option that selects better defaults for the indicated protocols. Initially it supports: `default` - no change from standard defauls; and `smb` - which changes the defaults to set an 'smb' earmark, set case insensitivity, and default the mode to 777.  All of these values can still be manually set on the CLI if, for example, you really wanted to pass `--casesensitive=1` to force case sensitive subvolumes.

This option can change over time reflecting what we think are the best defaults at any particular version. We can also extend it with defaults for nfs or whatever use cases we have in the future.




## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
