### PR TITLE
mgr/volumes: sanitize subvolume path traversal to prevent xattr corruption

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -5121,6 +5121,151 @@ class TestSubvolumes(TestVolumesHelper):
             errmsgs='Error ENAMETOOLONG: use shorter group or subvol name, '
                     'combination of both should be less than 249 characters')
 
+    def test_subvolume_path_traversal_dot_and_dotdot_validation(self):
+        """
+        Verify that passing '.' or '..' as a subvolume name returns EINVAL and
+        fails early without side-effects across various subvolume commands.
+        """
+        group = self._gen_subvol_grp_name()
+        self._fs_cmd("subvolumegroup", "create", self.volname, group)
+
+        invalid_subvol_names = ['.', '..']
+
+        for invalid_name in invalid_subvol_names:
+            # 1. info
+            try:
+                self._fs_cmd("subvolume", "info", self.volname, invalid_name,
+                             "--group_name", group)
+            except CommandFailedError as ce:
+                self.assertEqual(ce.exitstatus, errno.EINVAL,
+                                 f"expected EINVAL for 'info' on subvolume '{invalid_name}'")
+            else:
+                self.fail("expected 'fs subvolume info' to fail for subvolume "
+                          f"'{invalid_name}'")
+
+            # 2. getpath
+            try:
+                self._fs_cmd("subvolume", "getpath", self.volname, invalid_name,
+                             "--group_name", group)
+            except CommandFailedError as ce:
+                self.assertEqual(ce.exitstatus, errno.EINVAL,
+                                 f"expected EINVAL for 'getpath' on subvolume '{invalid_name}'")
+            else:
+                self.fail(f"expected 'fs subvolume getpath' to fail for subvolume '{invalid_name}'")
+
+            # 3. metadata set
+            try:
+                self._fs_cmd("subvolume", "metadata", "set", self.volname, invalid_name,
+                             "key", "val", "--group_name", group)
+            except CommandFailedError as ce:
+                self.assertEqual(ce.exitstatus, errno.EINVAL,
+                                 f"expected EINVAL for 'metadata set' on subvolume '{invalid_name}'")
+            else:
+                self.fail("expected 'fs subvolume metadata set' to fail for subvolume "
+                          f"'{invalid_name}'")
+
+            # 4. rm
+            try:
+                self._fs_cmd("subvolume", "rm", self.volname, invalid_name,
+                             "--group_name", group)
+            except CommandFailedError as ce:
+                self.assertEqual(ce.exitstatus, errno.EINVAL,
+                                 f"expected EINVAL for 'rm' on subvolume '{invalid_name}'")
+            else:
+                self.fail(f"expected 'fs subvolume rm' to fail for subvolume '{invalid_name}'")
+
+            # 5. create
+            try:
+                self._fs_cmd("subvolume", "create", self.volname, invalid_name,
+                             "--group_name", group)
+            except CommandFailedError as ce:
+                self.assertEqual(ce.exitstatus, errno.EINVAL,
+                                 f"expected EINVAL for 'create' on subvolume '{invalid_name}'")
+            else:
+                self.fail(f"expected 'create' to fail for '{invalid_name}'")
+
+            # 6. resize
+            try:
+                self._fs_cmd("subvolume", "resize", self.volname, invalid_name,
+                             "inf", "--group_name", group)
+            except CommandFailedError as ce:
+                self.assertEqual(ce.exitstatus, errno.EINVAL,
+                                 f"expected EINVAL for 'resize' on subvolume '{invalid_name}'")
+            else:
+                self.fail(f"expected 'resize' to fail for '{invalid_name}'")
+
+            # 7. snapshot create
+            try:
+                self._fs_cmd("subvolume", "snapshot", "create", self.volname,
+                             invalid_name, "snap1", "--group_name", group)
+            except CommandFailedError as ce:
+                self.assertEqual(ce.exitstatus, errno.EINVAL,
+                                 f"expected EINVAL for 'snapshot create' on subvolume '{invalid_name}'")
+            else:
+                self.fail(f"expected 'snapshot create' to fail for '{invalid_name}'")
+
+            # 8. snapshot rm
+            try:
+                self._fs_cmd("subvolume", "snapshot", "rm", self.volname,
+                             invalid_name, "snap1", "--group_name", group)
+            except CommandFailedError as ce:
+                self.assertEqual(ce.exitstatus, errno.EINVAL,
+                                 f"expected EINVAL for 'snapshot rm' on subvolume '{invalid_name}'")
+            else:
+                self.fail(f"expected 'snapshot rm' to fail for '{invalid_name}'")
+
+            # 9. authorize
+            try:
+                self._fs_cmd("subvolume", "authorize", self.volname, invalid_name,
+                             "client1", "--group_name", group)
+            except CommandFailedError as ce:
+                self.assertEqual(ce.exitstatus, errno.EINVAL,
+                                 f"expected EINVAL for 'authorize' on subvolume '{invalid_name}'")
+            else:
+                self.fail(f"expected 'authorize' to fail for '{invalid_name}'")
+
+        # Clean up group
+        self._fs_cmd("subvolumegroup", "rm", self.volname, group)
+
+    def test_subvolume_info_dot_does_not_corrupt_group_xattr(self):
+        """
+        Verify that running 'fs subvolume info' with '.' as subvolume name
+        does not mistakenly set 'ceph.dir.subvolume=1' on the parent group directory,
+        allowing subsequent subvolume creation to succeed normally.
+        """
+        group = self._gen_subvol_grp_name()
+        subvol_valid = self._gen_subvol_name()
+
+        # Create subvolume group
+        self._fs_cmd("subvolumegroup", "create", self.volname, group)
+        group_path = self._get_subvolume_group_path(self.volname, group)
+
+        # Trigger the bug condition by querying info on '.'
+        try:
+            self._fs_cmd("subvolume", "info", self.volname, ".", "--group_name", group)
+        except CommandFailedError as ce:
+            self.assertEqual(ce.exitstatus, errno.EINVAL,
+                             "expected EINVAL for 'info' on subvolume '.'")
+        else:
+            self.fail("expected 'fs subvolume info' with '.' to fail with EINVAL")
+
+        # Verify parent group xattr 'ceph.dir.subvolume' was not set to 1
+        xattr_val = self.mount_a.getfattr(group_path, "ceph.dir.subvolume")
+        self.assertNotEqual(xattr_val, "1",
+                            "parent subvolume group directory was incorrectly marked as subvolume")
+
+        # Confirm that creating a new subvolume in this group still works and is not blocked by EINVAL
+        self._fs_cmd("subvolume", "create", self.volname, subvol_valid, "--group_name", group)
+
+        # Confirm the new subvolume has a valid .meta file initialized
+        subvol_path = self._get_subvolume_path(self.volname, subvol_valid, group_name=group)
+        self.assertNotEqual(subvol_path, None)
+
+        # Clean up
+        self._fs_cmd("subvolume", "rm", self.volname, subvol_valid, "--group_name", group)
+        self._fs_cmd("subvolumegroup", "rm", self.volname, group)
+        self._wait_for_trash_empty()
+
 class TestPausePurging(TestVolumesHelper):
     '''
     Tests related to config "mgr/volumes/pause_purging".

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -29,6 +29,13 @@ class SubvolumeBase(object):
     LEGACY_CONF_DIR = "_legacy"
 
     def __init__(self, mgr, fs, vol_spec, group, subvolname, legacy=False):
+        # Normalize subvolname to str if it was passed as bytes
+        subvol_name_str = subvolname.decode('utf-8') if isinstance(subvolname, bytes) else subvolname
+
+        # Reject empty names or path traversal tokens ('.', '..')
+        if not subvol_name_str or subvol_name_str in ('.', '..'):
+            raise VolumeException(-errno.EINVAL, f"invalid subvolume name '{subvolname}'")
+
         self.mgr = mgr
         self.fs = fs
         self.auth_mdata_mgr = AuthMetadataManager(fs)
@@ -39,6 +46,13 @@ class SubvolumeBase(object):
         self.group = group
         self.subvolname = subvolname
         self.legacy_mode = legacy
+
+        # Sanity check: Ensure base_path stays inside the target group directory
+        resolved_base = os.path.normpath(self.base_path)
+        resolved_group = os.path.normpath(self.group.path)
+        if resolved_base == resolved_group or not resolved_base.startswith(resolved_group + b'/'):
+            raise VolumeException(-errno.EINVAL, f"invalid subvolume path resolution for '{subvolname}'")
+
         self.load_config()
 
     @property

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -93,6 +93,10 @@ class SubvolumeV2(SubvolumeV1):
                 raise VolumeException(-e.args[0], e.args[1])
 
     def mark_subvolume(self):
+        # Guard against setting xattr on parent group or root volume directory
+        if os.path.normpath(self.base_path) == os.path.normpath(self.group.path):
+            raise VolumeException(-errno.EINVAL, "cannot mark group directory as a subvolume")
+
         # set subvolume attr, on subvolume root, marking it as a CephFS subvolume
         # subvolume root is where snapshots would be taken, and hence is the base_path for v2 subvolumes
         try:


### PR DESCRIPTION
* **Resolves group directory corruption**: Fixes an issue where passing path traversal tokens (. or ..) to non-create subcommands or programmatic APIs mapped the target path to the parent group directory, inadvertently writing ceph.dir.subvolume=1 and breaking future subvolume creations with EINVAL.

* **Enforces strict path containment**: Decodes and validates subvolume names during initialization to reject traversal tokens, and adds structural checks to guarantee the resolved path remains strictly within the bounds of the target group directory.

* **Adds defensive xattr safeguards**: Implements a circuit breaker in the metadata update path to explicitly block unintended extended attribute modifications on parent group directories.

* **QA test coverage**: Adds comprehensive tests to test_volumes.py validating EINVAL rejection for traversal tokens across all subvolume commands, plus a targeted regression test confirming that executing `info .` no longer corrupts the parent group directory.

Fixes: https://tracker.ceph.com/issues/79962

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
