### PR TITLE
client,mds: remove redundant argument from ceph_lock_state_t::remove_lock

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13877,8 +13877,6 @@ void Client::_release_filelocks(Fh *fh)
   Inode *in = fh->inode.get();
   ldout(cct, 10) << __func__ << " " << fh << " ino " << in->ino << dendl;
 
-  list<ceph_filelock> activated_locks;
-
   list<pair<int, ceph_filelock> > to_release;
 
   if (fh->fcntl_locks) {
@@ -13886,7 +13884,7 @@ void Client::_release_filelocks(Fh *fh)
     for(auto p = lock_state->held_locks.begin(); p != lock_state->held_locks.end(); ) {
       auto q = p++;
       if (in->flags & I_ERROR_FILELOCK) {
-	lock_state->remove_lock(q->second, activated_locks);
+	lock_state->remove_lock(q->second);
       } else {
 	to_release.push_back(pair<int, ceph_filelock>(CEPH_LOCK_FCNTL, q->second));
       }
@@ -13898,7 +13896,7 @@ void Client::_release_filelocks(Fh *fh)
     for(auto p = lock_state->held_locks.begin(); p != lock_state->held_locks.end(); ) {
       auto q = p++;
       if (in->flags & I_ERROR_FILELOCK) {
-	lock_state->remove_lock(q->second, activated_locks);
+	lock_state->remove_lock(q->second);
       } else {
 	to_release.push_back(pair<int, ceph_filelock>(CEPH_LOCK_FLOCK, q->second));
       }
@@ -13949,8 +13947,7 @@ void Client::_update_lock_state(struct flock *fl, uint64_t owner,
   filelock.type = lock_cmd;
 
   if (filelock.type == CEPH_LOCK_UNLOCK) {
-    list<ceph_filelock> activated_locks;
-    lock_state->remove_lock(filelock, activated_locks);
+    lock_state->remove_lock(filelock);
   } else {
     bool r = lock_state->add_lock(filelock, false, false, NULL);
     ceph_assert(r);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5377,7 +5377,6 @@ void Server::handle_client_file_setlock(const MDRequestRef& mdr)
 
   dout(10) << " state prior to lock change: " << *lock_state << dendl;
   if (CEPH_LOCK_UNLOCK == set_lock.type) {
-    list<ceph_filelock> activated_locks;
     MDSContext::vec waiters;
     bool changed = false;
     if (lock_state->is_waiting(set_lock)) {
@@ -5387,7 +5386,7 @@ void Server::handle_client_file_setlock(const MDRequestRef& mdr)
     }
     if (!interrupt) {
       dout(10) << " unlock attempt on " << set_lock << dendl;
-      lock_state->remove_lock(set_lock, activated_locks);
+      lock_state->remove_lock(set_lock);
       changed = true;
     }
     if (changed)

--- a/src/mds/flock.cc
+++ b/src/mds/flock.cc
@@ -286,8 +286,7 @@ void ceph_lock_state_t::look_for_lock(ceph_filelock& testing_lock)
   testing_lock.type = CEPH_LOCK_UNLOCK;
 }
 
-void ceph_lock_state_t::remove_lock(ceph_filelock removal_lock,
-                 list<ceph_filelock>& activated_locks)
+void ceph_lock_state_t::remove_lock(ceph_filelock removal_lock)
 {
   list<multimap<uint64_t, ceph_filelock>::iterator> overlapping_locks,
     self_overlapping_locks;

--- a/src/mds/flock.h
+++ b/src/mds/flock.h
@@ -114,10 +114,8 @@ public:
    * previous lock or making a previous lock smaller.
    *
    * @param removal_lock The lock to remove
-   * @param activated_locks A return parameter, holding activated wait locks.
    */
-  void remove_lock(const ceph_filelock removal_lock,
-                   std::list<ceph_filelock>& activated_locks);
+  void remove_lock(const ceph_filelock removal_lock);
 
   bool remove_all_from(client_t client);
 


### PR DESCRIPTION
nothing every filled or read from `activated_locks` and ceph_lock_state_t::remove_lock never did make use of it.

Fixes: https://tracker.ceph.com/issues/80201





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
