### PR TITLE
script/ceph-debug-docker.sh: add rocky10 support and mount configurable

### DIFF
--- a/src/script/ceph-debug-docker.sh
+++ b/src/script/ceph-debug-docker.sh
@@ -16,6 +16,7 @@ CACHE=""
 FLAVOR="default"
 SUDO=""
 PRIVILEGED=""
+ARCHIVE_DIR="/teuthology"
 
 function run {
     printf "%s\n" "$*"
@@ -23,12 +24,12 @@ function run {
 }
 
 function main {
-    eval set -- $(getopt --name "$0" --options 'h' --longoptions 'help,no-cache,flavor:,sudo,privileged' -- "$@")
+    eval set -- $(getopt --name "$0" --options 'h' --longoptions 'help,no-cache,flavor:,sudo,privileged,archive-dir:' -- "$@")
 
     while [ "$#" -gt 0 ]; do
         case "$1" in
             -h|--help)
-                printf '%s: [--no-cache] <branch>[:sha1] <environment>\n' "$0"
+                printf '%s: [--no-cache] [--flavor FLAVOR] [--sudo] [--privileged] [--archive-dir DIR] <branch>[:sha1] <environment>\n' "$0"
                 exit 0
                 ;;
             --no-cache)
@@ -46,6 +47,10 @@ function main {
             --sudo)
                 SUDO=sudo
                 shift 1
+                ;;
+            --archive-dir)
+                ARCHIVE_DIR=$2
+                shift 2
                 ;;
             --)
                 shift
@@ -98,6 +103,10 @@ function main {
         centos:stream|centos:stream9)
             env=quay.io/centos/centos:stream9
             distro="centos/9"
+            ;;
+        rocky:10)
+            env=rockylinux/rockylinux:10
+            distro="rocky/10"
             ;;
         centos:stream8)
             distro="centos/8"
@@ -160,6 +169,12 @@ EOF
                     ceph_debuginfo="ceph-base-debuginfo"
                     debuginfo=/etc/yum.repos.d/centos.repo
                     ;;
+                rockylinux/rockylinux:10)
+                    python_bindings="python3-rados python3-cephfs"
+                    base_debuginfo="glibc-debuginfo"
+                    ceph_debuginfo="ceph-base-debuginfo"
+                    debuginfo=/etc/yum.repos.d/rocky.repo
+                    ;;
             esac
             if [ "${FLAVOR}" = "crimson" ]; then
                 ceph_debuginfo+=" ceph-crimson-osd-debuginfo ceph-crimson-osd"
@@ -182,7 +197,7 @@ EOF
 
     printf "built image %s\n" "$tag"
 
-    run $SUDO docker run $PRIVILEGED -ti -v /teuthology:/teuthology:ro "$tag"
+    run $SUDO docker run $PRIVILEGED -ti -v "${ARCHIVE_DIR}:/teuthology:ro" "$tag"
     return 0
 }
 


### PR DESCRIPTION
This commit makes the following changes to ceph-debug-docker.sh:

1. Adds support for rocky10 distro.
2. Make the teuthology archive mount path configurable.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
