### PR TITLE
test/librados: do not set allow_ec_overwrites in FastEC pool

### DIFF
--- a/src/test/librados/test_pool_types.h
+++ b/src/test/librados/test_pool_types.h
@@ -10,6 +10,7 @@
 
 #include "include/rados/librados.hpp"
 #include "include/scope_guard.h"
+#include "test/librados/crimson_utils.h"
 #include "test/librados/test_cxx.h"
 #include "gtest/gtest.h"
 
@@ -53,7 +54,13 @@ inline std::string create_pool_by_type(
       if (result != "") {
         return result;
       }
-      result = set_allow_ec_overwrites_pp(pool_name, cluster, true);
+      // Crimson natively supports overwrites, we do not need to set the flag 
+      if (!is_crimson_cluster()) {
+        result = set_allow_ec_overwrites_pp(pool_name, cluster, true);
+        if (result != "") {
+          return result;
+        }
+      }
       cluster.wait_for_latest_osdmap();
       return result;
     }


### PR DESCRIPTION
## Issue 

In teuthology, when running `api_omap_pp` with crimson and seastore, clients were dumping core: 

```
2026-08-26T13:43:53.981 INFO:tasks.workunit.client.0.trial055.stderr:+ for f in "${RADOS_TESTS[@]}" 
2026-08-26T13:43:53.981 INFO:tasks.workunit.client.0.trial055.stderr:+ executable=ceph_test_rados_api_omap_pp
2026-08-26T13:43:53.981 INFO:tasks.workunit.client.0.trial055.stderr:+ '[' 0 -eq 1 ']'
2026-08-26T13:43:53.982 INFO:tasks.workunit.client.0.trial055.stderr:+ '[' 0 -eq 1 ']'
2026-08-26T13:43:53.982 INFO:tasks.workunit.client.0.trial055.stderr:+ timeout 5400 ceph_test_rados_api_omap_pp
2026-08-26T13:43:53.996 INFO:tasks.workunit.client.0.trial055.stdout:Running main() from gmock_main.cc
2026-08-26T13:43:53.996 INFO:tasks.workunit.client.0.trial055.stdout:[==========] Running 50 tests from 1 test suite.
2026-08-26T13:43:53.996 INFO:tasks.workunit.client.0.trial055.stdout:[----------] Global test environment set-up.
2026-08-26T13:43:53.996 INFO:tasks.workunit.client.0.trial055.stdout:[----------] 50 tests from OmapTest
2026-08-26T13:43:53.996 INFO:tasks.workunit.client.0.trial055.stderr:Client id is: 0
2026-08-26T13:44:00.078 INFO:tasks.workunit.client.0.trial055.stderr:timeout: the monitored command dumped core
2026-08-26T13:44:00.078 INFO:tasks.workunit.client.0.trial055.stderr:/home/ubuntu/cephtest/clone.client.0/qa/workunits/rados/test.sh: line 134: 155203 Segmentation fault      timeout $timeout $executable $gtest_inject_filter
2026-08-26T13:44:00.078 INFO:tasks.workunit.client.0.trial055.stderr:+ echo 'ERROR: Test api_omap_pp timed out after 5400 seconds'
2026-08-26T13:44:00.078 INFO:tasks.workunit.client.0.trial055.stdout:ERROR: Test api_omap_pp timed out after 5400 seconds
```

## Investigation 

Using https://github.com/ceph/ceph/pull/71510, I invoked gdb in the dumped core to get the backtrace: 

```
#0  librados::v14_2_0::RadosClient::wait_for_latest_osdmap (this=0x0)
    at /usr/src/debug/ceph-21.3.0-2520.ge1ecde02.el10.x86_64/src/librados/RadosClient.cc:601
        ec = {{d1_ = {val_ = 0, cat_ = 0x0},
            d2_ = "\000\000\000\000\240\177\000\000\000\000\000\000\000\000\000"},
          lc_flags_ = 0}
#1  0x00007fa0852ad76a in librados::v14_2_0::Rados::wait_for_latest_osdmap (
    this=this@entry=0x55b2cc4c4558 <ceph::test::PoolTypeTestFixture::rados>)
    at /usr/src/debug/ceph-21.3.0-2520.ge1ecde02.el10.x86_64/src/librados/librados_cxx.cc:2889
No locals.
#2  0x000055b2cc471db6 in ceph::test::create_pool_by_type (
    pool_name="pool_type_test_FastEC_trial055-155204-2", cluster=...,
    type=<optimized out>)
    at /usr/src/debug/ceph-21.3.0-2520.ge1ecde02.el10.x86_64/src/test/librados/test_pool_types.h:57
        result = "mon_command osd pool set pool:pool_type_test_FastEC_trial055-155204-2 pool_type:erasure allow_ec_overwrites true failed with error -22"
#3  0x000055b2cc472f5d in ceph::test::PoolTypeTestFixture::SetUpTestSuite ()
    at /usr/src/debug/ceph-21.3.0-2520.ge1ecde02.el10.x86_64/src/test/librados/test_pool_types.cc:66
        gtest_ar = {success_ = true,
          message_ = std::unique_ptr<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >> = {get() = 0x0}}
        pname = "pool_type_test_FastEC_trial055-155204-2"
        type = ceph::test::PoolType::FAST_EC
        __for_range = @0x7ffc759f1cf0: std::vector of length 2, capacity 2 = {
          ceph::test::PoolType::REPLICATED, ceph::test::PoolType::FAST_EC}
        __for_begin = ceph::test::PoolType::FAST_EC
        __for_end = <optimized out>
#4  0x000055b2cc437b2f in testing::TestSuite::RunSetUpTestSuite (this=<optimized out>)
```

According to the backtrace, `PoolTypeTestFixture::SetUpTestSuite` invokes `create_pool_by_type`, which for Fast EC, does the following: 

```jsx
 case PoolType::FAST_EC: {
      std::string result = create_ec_pool_pp(pool_name, cluster, true);
      if (result != "") {
        return result;
      }
      result = set_allow_ec_overwrites_pp(pool_name, cluster, true);
      cluster.wait_for_latest_osdmap();
      return result;
```

In, `set_allow_ec_overwrites_pp`, if setting the `allow_ec_overwrites` config fails, it shuts down the cluster, and now `cluster` is null. Since, `create_pool_by_type` does not check for an error, we call `wait_for_latest_osdmap` which SIGSEVs.

The reason setting `allow_ec_overwrites` fails is logged by mon as: 
```
2026-08-26T13:43:59.958+0000 7f6de15f16c0  2 mon.a@0(leader) e1 send_reply 0x557cc6b0d1e0 0x557cc6eb4820 mon_command_ack([{"prefix": "osd pool set", "pool": "pool_type_test_FastEC_trial055-155204-2", "var": "allow_ec_overwrites", "val": "true"}]=-22 pool must only be stored on bluestore for scrubbing to work: osd.0 uses seastore v1065)
```
ie scrubbing is only supported in bluestore, not seastore. 

## Fix  

Fast EC has overwrites enabled by default. We should not be setting the config `allow_ec_overwrites` for Fast EC pools. Simply, not calling the `set_allow_ec_overwrites_pp` function from `PoolTypeTestFixture::SetUpTestSuite` should fix this issue. 

## Testing 

This QA has passed! https://pulpito.ceph.com/shraddhaag-2026-09-03_15:05:50-crimson-rados-main-distro-debug-trial/ 

(the 1 red job is a failure in teardown, not an actual failure)

Fixes: https://tracker.ceph.com/issues/80230

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
