### PR TITLE
cephadm: zap raw OSD devices on rm-cluster

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -40,7 +40,7 @@ def _get_bluestore_info(devices: _List[str]) -> Dict[str, Any]:
             if oj.get(device):
                 try:
                     osd_uuid = oj[device]['osd_uuid']
-                    result[osd_uuid] = disk.bluestore_info(device, oj)
+                    result.setdefault(osd_uuid, {}).update(disk.bluestore_info(device, oj))
                 except KeyError as e:
                     # this will appear for devices that have a bluestore header but aren't valid OSDs
                     # for example, due to incomplete rollback of OSDs: https://tracker.ceph.com/issues/51869

--- a/src/ceph-volume/ceph_volume/tests/devices/raw/test_list.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/raw/test_list.py
@@ -1,4 +1,5 @@
 # type: ignore
+import json
 import pytest
 from .data_list import ceph_bluestore_tool_show_label_output
 from unittest.mock import patch, Mock
@@ -222,3 +223,35 @@ class TestList(object):
             list_command.List([]).generate()
             mock.assert_called_once()
 
+    @patch('ceph_volume.devices.raw.list.process.call')
+    def test_merges_db_and_wal_with_same_osd_uuid(self, patched_call):
+        labels = {
+            '/dev/vdb': {
+                'osd_uuid': 'same-uuid',
+                'description': 'main',
+                'ceph_fsid': 'cluster-fsid',
+                'whoami': '0',
+                'type': 'bluestore',
+            },
+            '/dev/vdc': {
+                'osd_uuid': 'same-uuid',
+                'description': 'bluefs db',
+            },
+            '/dev/vdd': {
+                'osd_uuid': 'same-uuid',
+                'description': 'bluefs wal',
+            },
+        }
+        patched_call.return_value = (json.dumps(labels), '', 0)
+
+        for order in (
+            ['/dev/vdb', '/dev/vdc', '/dev/vdd'],
+            ['/dev/vdc', '/dev/vdd', '/dev/vdb'],
+        ):
+            result = list_command._get_bluestore_info(order)
+            info = result['same-uuid']
+            assert info['device'] == '/dev/vdb'
+            assert info['device_db'] == '/dev/vdc'
+            assert info['device_wal'] == '/dev/vdd'
+            assert info['ceph_fsid'] == 'cluster-fsid'
+            assert info['osd_id'] == 0

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -4372,6 +4372,30 @@ def _zap_osds(ctx: CephadmContext) -> None:
             # id isn't part of the output here!)
             logger.warning(f'Not zapping LVs (not implemented): {lv_names}')
 
+    c = get_ceph_volume_container(ctx,
+                                  args=['raw', 'list', '--format', 'json'],
+                                  volume_mounts=mounts,
+                                  envs=ctx.env)
+    out, err, code = call_throws(ctx, c.run_cmd())
+    if code:
+        raise Error('failed to list raw osds')
+    try:
+        raw_ls = json.loads(out)
+    except ValueError as e:
+        raise Error(f'Invalid JSON in ceph-volume raw list: {e}')
+    if not isinstance(raw_ls, dict):
+        raise Error('Invalid JSON in ceph-volume raw list: expected object')
+
+    seen = set()
+    for details in raw_ls.values():
+        if not isinstance(details, dict) or details.get('ceph_fsid') != ctx.fsid:
+            continue
+        for key in ('device', 'device_db', 'device_wal'):
+            path = details.get(key)
+            if path and path not in seen:
+                seen.add(path)
+                _zap(ctx, path)
+
 
 def command_zap_osds(ctx: CephadmContext) -> None:
     if not ctx.force:

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -3466,3 +3466,128 @@ class TestRmClusterConfigCleanup(fake_filesystem_unittest.TestCase):
 
         assert os.path.exists('/etc/ceph/ceph.conf')
         assert os.path.isdir('/etc/ceph/ceph.conf')
+
+
+class TestZapOsds(object):
+    FSID = '50e242f4-59a8-11f1-b582-fa163efd19cc'
+    OTHER_FSID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+    def _ctx(self):
+        ctx = _cephadm.CephadmContext()
+        ctx.fsid = self.FSID
+        ctx.image = 'quay.io/ceph/ceph:test'
+        return ctx
+
+    def _run(self, inventory, raw_list):
+        zapped = []
+
+        def fake_container(ctx, args=None, **kwargs):
+            m = mock.Mock()
+            m.run_cmd.return_value = list(args or [])
+            return m
+
+        def fake_call_throws(ctx, cmd, **kwargs):
+            if cmd and cmd[0] == 'raw':
+                return json.dumps(raw_list), '', 0
+            return json.dumps(inventory), '', 0
+
+        with mock.patch('cephadm.get_container_mounts_for_type', return_value={}), \
+                mock.patch('cephadm.get_ceph_volume_container', side_effect=fake_container), \
+                mock.patch('cephadm.call_throws', side_effect=fake_call_throws), \
+                mock.patch('cephadm._zap', side_effect=lambda ctx, path: zapped.append(path)):
+            _cephadm._zap_osds(self._ctx())
+        return zapped
+
+    def test_zaps_raw_devices_matching_fsid(self):
+        zapped = self._run(
+            inventory=[],
+            raw_list={
+                'osd-1': {
+                    'ceph_fsid': self.FSID,
+                    'device': '/dev/vdb',
+                    'osd_id': 0,
+                },
+                'osd-2': {
+                    'ceph_fsid': self.FSID,
+                    'device': '/dev/vdc',
+                    'osd_id': 1,
+                },
+                'osd-other': {
+                    'ceph_fsid': self.OTHER_FSID,
+                    'device': '/dev/vdd',
+                    'osd_id': 2,
+                },
+            },
+        )
+        assert zapped == ['/dev/vdb', '/dev/vdc']
+
+    def test_zaps_raw_db_and_wal_devices(self):
+        zapped = self._run(
+            inventory=[],
+            raw_list={
+                'osd-1': {
+                    'ceph_fsid': self.FSID,
+                    'device': '/dev/sda',
+                    'device_db': '/dev/nvme0n1',
+                    'device_wal': '/dev/nvme1n1',
+                    'osd_id': 0,
+                },
+            },
+        )
+        assert zapped == ['/dev/sda', '/dev/nvme0n1', '/dev/nvme1n1']
+
+    def test_zaps_lvm_and_raw_devices(self):
+        zapped = self._run(
+            inventory=[
+                {
+                    'path': '/dev/vdb',
+                    'ceph_device_lvm': True,
+                    'lvs': [{'name': 'osd-block-1', 'cluster_fsid': self.FSID}],
+                },
+                {
+                    'path': '/dev/vdc',
+                    'ceph_device_lvm': False,
+                    'lvs': [],
+                },
+            ],
+            raw_list={
+                'osd-raw': {
+                    'ceph_fsid': self.FSID,
+                    'device': '/dev/vdc',
+                    'osd_id': 1,
+                },
+            },
+        )
+        assert zapped == ['/dev/vdb', '/dev/vdc']
+
+    def test_skips_lvm_only_when_no_raw_osds(self):
+        zapped = self._run(
+            inventory=[
+                {
+                    'path': '/dev/vdb',
+                    'ceph_device_lvm': True,
+                    'lvs': [{'name': 'osd-block-1', 'cluster_fsid': self.FSID}],
+                },
+            ],
+            raw_list={},
+        )
+        assert zapped == ['/dev/vdb']
+
+    def test_does_not_zap_when_no_matching_osds(self):
+        zapped = self._run(
+            inventory=[
+                {
+                    'path': '/dev/vdb',
+                    'ceph_device_lvm': False,
+                    'lvs': [],
+                },
+            ],
+            raw_list={
+                'osd-other': {
+                    'ceph_fsid': self.OTHER_FSID,
+                    'device': '/dev/vdb',
+                    'osd_id': 0,
+                },
+            },
+        )
+        assert zapped == []


### PR DESCRIPTION
_zap_osds() only looks at LVM inventory, so raw OSDs keep their bluestore label after `cephadm rm-cluster --zap-osds`. That's why the next deploy rejects the disks with "Has BlueStore device label".

Also, ceph-volume raw list used to overwrite the main device with the db/wal entry because they share the same osd_uuid. That drops ceph_fsid, so nothing gets zapped when db is on a separate disk.

Fixes: https://tracker.ceph.com/issues/80237

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
