### PR TITLE
tentacle: rgw: Lua Package management fixes

### DIFF
--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -5573,7 +5573,9 @@ int RadosLuaManager::list_packages(const DoutPrefixProvider *dpp, optional_yield
     if (ret < 0) {
       return ret;
     }
-
+    if (more) {
+      start_after = *packages_chunk.rbegin();
+    }
     packages.merge(packages_chunk);
   }
 

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -194,9 +194,12 @@ void RGWRealmReloader::reload()
   if (env.lua.manager.get()) {
     env.lua.manager = env.driver->get_lua_manager(
         env.lua.manager->luarocks_path());
-    if (env.lua.background) {
-      env.lua.background->set_manager(env.lua.manager.get());
-      env.lua.manager.get()->set_lua_background(env.lua.background);
+    if (env.driver->get_name() == "rados") {
+      static_cast<rgw::sal::RadosLuaManager*>(env.lua.manager.get())->watch_reload(&dp);
+      if (env.lua.background) {
+        env.lua.background->set_manager(env.lua.manager.get());
+        env.lua.manager.get()->set_lua_background(env.lua.background);
+      }
     }
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/76199

---

backport of https://github.com/ceph/ceph/pull/67479
parent tracker: https://tracker.ceph.com/issues/75127

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh