### PR TITLE
umbrella: client: add defensive checks for LRU pin counter drift

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -888,6 +888,7 @@ void Client::trim_cache(bool trim_kernel_dcache)
 {
   uint64_t max = cct->_conf->client_cache_size;
   ldout(cct, 20) << "trim_cache size " << lru.lru_get_size() << " max " << max << dendl;
+  assert_lru_num_pinned_sane("trim_cache start");
   unsigned last = 0;
   while (lru.lru_get_size() != last) {
     last = lru.lru_get_size();
@@ -899,8 +900,12 @@ void Client::trim_cache(bool trim_kernel_dcache)
     if (!dn)
       break;  // done
 
+    assert_lru_num_pinned_sane("trim_cache before evict", dn);
+
     trim_dentry(dn);
   }
+
+  assert_lru_num_pinned_sane("trim_cache end");
 
   if (trim_kernel_dcache && lru.lru_get_size() > max)
     _invalidate_kernel_dcache();
@@ -935,6 +940,8 @@ void Client::trim_cache_for_reconnect(MetaSession *s)
   for(list<Dentry*>::iterator p = skipped.begin(); p != skipped.end(); ++p)
     lru.lru_insert_mid(*p);
 
+  assert_lru_num_pinned_sane("trim_cache_for_reconnect end");
+
   ldout(cct, 20) << __func__ << " mds." << mds
 		 << " trimmed " << trimmed << " dentries" << dendl;
 
@@ -944,6 +951,12 @@ void Client::trim_cache_for_reconnect(MetaSession *s)
 
 void Client::trim_dentry(Dentry *dn)
 {
+  // dn come straight out of lru.lru_get_next_expire() in trim_cache(), it
+  // should still be attached to its dir. we touch dn->dir right below
+  // (before unlink() get a chance to check it itself), so better we assert
+  // it here too, otherwise we would just segfault on the dereference with
+  // no clue at all. See IBMCEPH-14337.
+  ceph_assert(dn->dir);
   ldout(cct, 15) << "trim_dentry unlinking dn " << dn->name 
 		 << " in dir "
 		 << std::hex << dn->dir->parent_inode->ino << std::dec
@@ -3734,8 +3747,23 @@ void Client::close_dir(Dir *dir)
   ceph_assert(dir->is_empty());
   ceph_assert(in->dir == dir);
   ceph_assert(in->dentries.size() < 2);     // dirs can't be hard-linked
-  if (!in->dentries.empty())
-    in->get_first_parent()->put();   // unpin dentry
+  if (!in->dentries.empty()) {
+    Dentry *pdn = in->get_first_parent();
+    // this will remove the "dir -> dn" pin from parent dentry. if that
+    // make its ref go down to 1, it become lru-unpinned and can be
+    // evicted on next trim_cache() run (may even happen inside same
+    // call, from _try_to_trim_inode() or from tick thread). we add log
+    // here so if "num_pinned" go wrong in some future crash dump, we
+    // have at least a clue what caused it.
+    // See: https://tracker.ceph.com/issues/74625, IBMCEPH-14337
+    ldout(cct, 15) << __func__ << " dropping dir pin on parent dn " << pdn->name
+		   << " (dn " << pdn << ") ref " << pdn->ref << " -> " << (pdn->ref - 1)
+		   << dendl;
+    pdn->put();   // unpin dentry, note: pdn could be freed by put() already,
+                  // do not touch it below this line.
+
+    assert_lru_num_pinned_sane("close_dir after parent unpin");
+  }
   
   delete in->dir;
   in->dir = 0;
@@ -3800,6 +3828,13 @@ void Client::unlink(Dentry *dn, bool keepdir, bool keepdentry)
   // See: https://tracker.ceph.com/issues/74625
   DentryRef dnref(dn);
 
+  // dn must be still linked into its dir at this point. this was a concern
+  // that came up during review of the DentryRef fix - in theory somebody
+  // could call us with a dn that close_dir()/detach() already unlinked.
+  // better to assert here than dereference a null dn->dir few lines below.
+  // See IBMCEPH-14337.
+  ceph_assert(dn->dir);
+
   ldout(cct, 15) << "unlink dir " << dn->dir->parent_inode << " '" << dn->name << "' dn " << dn
 		 << " inode " << dn->inode << dendl;
 
@@ -3819,8 +3854,9 @@ void Client::unlink(Dentry *dn, bool keepdir, bool keepdentry)
     // unlink from dir
     Dir *dir = dn->dir;
     dn->detach();
+    ceph_assert(dn->dir == nullptr);   // detach() must clear it
 
-    // delete den
+    assert_lru_num_pinned_sane("unlink before lru_remove", dn);
     lru.lru_remove(dn);
     dn->put();
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -955,7 +955,7 @@ void Client::trim_dentry(Dentry *dn)
   // should still be attached to its dir. we touch dn->dir right below
   // (before unlink() get a chance to check it itself), so better we assert
   // it here too, otherwise we would just segfault on the dereference with
-  // no clue at all. See IBMCEPH-14337.
+  // no clue at all. See https://tracker.ceph.com/issues/77947.
   ceph_assert(dn->dir);
   ldout(cct, 15) << "trim_dentry unlinking dn " << dn->name 
 		 << " in dir "
@@ -3755,7 +3755,8 @@ void Client::close_dir(Dir *dir)
     // call, from _try_to_trim_inode() or from tick thread). we add log
     // here so if "num_pinned" go wrong in some future crash dump, we
     // have at least a clue what caused it.
-    // See: https://tracker.ceph.com/issues/74625, IBMCEPH-14337
+    // See: https://tracker.ceph.com/issues/74625,
+    // https://tracker.ceph.com/issues/77947
     ldout(cct, 15) << __func__ << " dropping dir pin on parent dn " << pdn->name
 		   << " (dn " << pdn << ") ref " << pdn->ref << " -> " << (pdn->ref - 1)
 		   << dendl;
@@ -3832,7 +3833,7 @@ void Client::unlink(Dentry *dn, bool keepdir, bool keepdentry)
   // that came up during review of the DentryRef fix - in theory somebody
   // could call us with a dn that close_dir()/detach() already unlinked.
   // better to assert here than dereference a null dn->dir few lines below.
-  // See IBMCEPH-14337.
+  // See https://tracker.ceph.com/issues/77947.
   ceph_assert(dn->dir);
 
   ldout(cct, 15) << "unlink dir " << dn->dir->parent_inode << " '" << dn->name << "' dn " << dn

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -42,6 +42,7 @@
 #include "osdc/ObjectCacher.h"
 
 #include "RWRef.h"
+#include "Dentry.h"
 #include "DentryRef.h"
 #include "InodeRef.h"
 #include "MetaSession.h"
@@ -54,8 +55,10 @@
 #include <fstream>
 #include <locale>
 #include <map>
+#include <sstream>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -144,7 +147,6 @@ struct DirEntry {
 
 struct Cap;
 class Dir;
-class Dentry;
 struct SnapRealm;
 struct Fh;
 struct CapSnap;
@@ -1244,6 +1246,21 @@ protected:
   void trim_cache(bool trim_kernel_dcache=false);
   void trim_cache_for_reconnect(MetaSession *s);
   void trim_dentry(Dentry *dn);
+  void assert_lru_num_pinned_sane(const char *where, const Dentry *dn = nullptr) {
+    if (lru.lru_get_num_pinned() <= lru.lru_get_size())
+      return;
+    std::ostringstream oss;
+    oss << where << " LRU num_pinned drift: pinned="
+	<< lru.lru_get_num_pinned() << " size=" << lru.lru_get_size()
+	<< " (top=" << lru.lru_get_top() << " bot=" << lru.lru_get_bot()
+	<< " pintail=" << lru.lru_get_pintail() << ")";
+    if (dn)
+      oss << " dentry '" << dn->name << "' dn " << dn
+	  << " ref=" << dn->ref
+	  << " expireable=" << dn->lru_is_expireable();
+    lderr(cct) << oss.str() << dendl;
+    ceph_assert(lru.lru_get_num_pinned() <= lru.lru_get_size());
+  }
   void trim_caps(MetaSession *s, uint64_t max);
   void _invalidate_kernel_dcache();
   void _trim_negative_child_dentries(const InodeRef& in);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -55,7 +55,6 @@
 #include <fstream>
 #include <locale>
 #include <map>
-#include <sstream>
 #include <memory>
 #include <set>
 #include <sstream>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79670

---

backport of https://github.com/ceph/ceph/pull/69970
parent tracker: https://tracker.ceph.com/issues/77947

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh