### PR TITLE
mgr/cephadm: preserve nvmeof spec when scaling via CLI

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import enum
 import errno
 import json
@@ -2232,14 +2233,40 @@ Usage:
             nvmeof_pool_helper.create_pool_if_needed()
 
         cleanpool = pool.lstrip('.')
-        spec = NvmeofServiceSpec(
-            service_id=f'{cleanpool}.{group}' if group else cleanpool,
-            pool=pool,
-            group=group,
-            placement=PlacementSpec.from_string(placement),
-            unmanaged=unmanaged,
-            preview_only=dry_run
+        service_id = f'{cleanpool}.{group}' if group else cleanpool
+        service_name = f'nvmeof.{service_id}'
+        completion = self.describe_service(
+            service_type='nvmeof',
+            service_name=service_name,
+            refresh=False,
         )
+        raise_if_exception(completion)
+
+        if completion.result:
+            existing_spec = cast(
+                NvmeofServiceSpec,
+                completion.result[0].spec,
+            )
+            # This command scales an existing NVMe-oF service. Preserve the
+            # existing service configuration and only update fields controlled
+            # by this CLI path.
+            spec = deepcopy(existing_spec)
+            spec.placement = PlacementSpec.from_string(placement)
+            spec.unmanaged = unmanaged
+            spec.preview_only = dry_run
+        else:
+            spec = NvmeofServiceSpec(
+                service_id=f'{cleanpool}.{group}' if group else cleanpool,
+                pool=pool,
+                group=group,
+                placement=PlacementSpec.from_string(placement),
+                unmanaged=unmanaged,
+                preview_only=dry_run
+            )
+            self.log.debug(
+                'NVMeOF apply debug: newly generated CLI spec=%s',
+                spec.to_json(),
+            )
 
         spec.validate()  # force any validation exceptions to be caught correctly
 


### PR DESCRIPTION
mgr/cephadm: preserve nvmeof spec when scaling via CLI

ceph orch apply nvmeof creates a new NvmeofServiceSpec from the fields exposed by the shorthand CLI. When updating an existing service, this replaces the stored spec and drops fields that were originally configured through YAML, such as encryption_key.

Look up the exact existing NVMe-oF service before constructing a new spec. If it exists, reuse a copy of the stored spec and update only the placement-related fields handled by the CLI.

Keep the existing behavior for new services, where a fresh NvmeofServiceSpec is created.


Testing logs:
**1. Scale up scenario:**

Initial state -
```
[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT     
nvmeof.nvmeof.gw_group2    ?:4420,5500,8009,10008      1/1  45s ago    2m   ceph-node-0  
       
[ceph: root@ceph-node-0 ~]# ceph orch ls --export nvmeof
service_type: nvmeof
service_id: nvmeof.gw_group2
service_name: nvmeof.nvmeof.gw_group2
placement:
  hosts:
  - ceph-node-0
spec:
  abort_discovery_on_errors: true
  abort_on_errors: true
  abort_on_update_error: true
  allowed_consecutive_spdk_ping_failures: 1
  break_update_interval_sec: 25
  cluster_connections: 32
  cnc_chunk_blocks: 512
  cnc_enable: true
  cnc_parallel_chunks: 8
  cnc_rate_limiter_bytes: 100000000
  conn_retries: 10
  degrade_namespace_on_kmip_error: true
  discovery_bind_retries_limit: 10
  discovery_bind_sleep_interval: 0.5
  discovery_port: 8009
  enable_monitor_client: true
  enable_prometheus_exporter: true
  encryption_key: |
    <dummy encryption key>
  group: gw_group2

```

```
[ceph: root@ceph-node-0 ~]# ceph orch apply nvmeof \
  --group gw_group2 \
  --placement="ceph-node-0 ceph-node-1"
Scheduled nvmeof.nvmeof.gw_group2 update...

[ceph: root@ceph-node-0 ~]# ceph orch ls --export nvmeof
service_type: nvmeof
service_id: nvmeof.gw_group2
service_name: nvmeof.nvmeof.gw_group2
placement:
  hosts:
  - ceph-node-0
  - ceph-node-1
spec:
  abort_discovery_on_errors: true
  abort_on_errors: true
  abort_on_update_error: true
  allowed_consecutive_spdk_ping_failures: 1
  break_update_interval_sec: 25
  cluster_connections: 32
  cnc_chunk_blocks: 512
  cnc_enable: true
  cnc_parallel_chunks: 8
  cnc_rate_limiter_bytes: 100000000
  conn_retries: 10
  degrade_namespace_on_kmip_error: true
  discovery_bind_retries_limit: 10
  discovery_bind_sleep_interval: 0.5
  discovery_port: 8009
  enable_monitor_client: true
  enable_prometheus_exporter: true
  encryption_key: |
    <dummy encryption key>
  group: gw_group2

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT                          
nvmeof.nvmeof.gw_group2    ?:4420,5500,8009,10008      2/2  3m ago     2m   ceph-node-0;ceph-node-1  
```

**2. Apply new service:**

```
[ceph: root@ceph-node-0 ~]# ceph orch apply nvmeof \
  --group gw_group3 \
  --placement="ceph-node-2"
Scheduled nvmeof.nvmeof.gw_group3 update...

---
service_type: nvmeof
service_id: nvmeof.gw_group3
service_name: nvmeof.nvmeof.gw_group3
placement:
  hosts:
  - ceph-node-2
spec:
  abort_discovery_on_errors: true
  abort_on_errors: true
  abort_on_update_error: true
  allowed_consecutive_spdk_ping_failures: 1
  break_update_interval_sec: 25
  cluster_connections: 32


[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT                
nvmeof.nvmeof.gw_group2    ?:4420,5500,8009,10008      2/2  12m ago    10m  ceph-node-0;ceph-node-1  
nvmeof.nvmeof.gw_group3    ?:4420,5500,8009,10008      1/1  3m ago     5m   ceph-node-2   
```
 
**3. Scale down**

```
[ceph: root@ceph-node-0 ~]# ceph orch apply nvmeof \
  --group gw_group2 \
  --placement="ceph-node-0"
Scheduled nvmeof.nvmeof.gw_group2 update...

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT    
nvmeof.nvmeof.gw_group2    ?:4420,5500,8009,10008      2/1  9m ago     5s   ceph-node-0  
nvmeof.nvmeof.gw_group3    ?:4420,5500,8009,10008      1/1  3m ago     6m   ceph-node-2  

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT    

nvmeof.nvmeof.gw_group2    ?:4420,5500,8009,10008      1/1  19s ago    23s  ceph-node-0  
nvmeof.nvmeof.gw_group3    ?:4420,5500,8009,10008      1/1  4m ago     6m   ceph-node-2
```  


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
