### PR TITLE
umbrella: rgw: redirect to the endpoint of the bucket's zonegroup

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -628,12 +628,21 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::Driver* d
     s->bucket_owner = s->bucket_acl.get_owner();
     acct_acl_user = &s->bucket_owner;
 
-    s->zonegroup_endpoint = rgw::get_zonegroup_endpoint(zonegroup);
-    s->zonegroup_name = zonegroup.get_name();
+    const std::string& bucket_zonegroup_id = s->bucket->get_info().zonegroup;
 
-    if (!zonegroup.equals(s->bucket->get_info().zonegroup)) {
+    /* the zonegroup that holds the bucket, which is where any redirect has to
+     * point. using the local zonegroup here would send the client back to the
+     * endpoint it just used, and clients that follow redirects would loop */
+    const RGWZoneGroup* bucket_zonegroup = rgw::find_zonegroup_by_id(
+        zonegroup, s->penv.site->get_period(), bucket_zonegroup_id);
+    if (bucket_zonegroup) {
+      s->zonegroup_endpoint = rgw::get_zonegroup_endpoint(*bucket_zonegroup);
+      s->zonegroup_name = bucket_zonegroup->get_name();
+    }
+
+    if (!zonegroup.equals(bucket_zonegroup_id)) {
       ldpp_dout(dpp, 0) << "NOTICE: request for data in a different zonegroup ("
-          << s->bucket->get_info().zonegroup << " != "
+          << bucket_zonegroup_id << " != "
           << zonegroup.get_id() << ")" << dendl;
       /* we now need to make sure that the operation actually requires copy source, that is
        * it's a copy operation
@@ -645,6 +654,11 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::Driver* d
       } else if (!s->local_source ||
           (s->op != OP_PUT && s->op != OP_COPY) ||
           rgw::sal::Object::empty(s->object.get())) {
+        if (s->zonegroup_endpoint.empty()) {
+          ldpp_dout(dpp, 0) << "NOTICE: no endpoint found for zonegroup "
+              << bucket_zonegroup_id << ", responding without a redirect "
+              "location" << dendl;
+        }
         return -ERR_PERMANENT_REDIRECT;
       }
     }

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -941,6 +941,24 @@ std::string get_zonegroup_endpoint(const RGWZoneGroup& info)
   return "";
 }
 
+const RGWZoneGroup* find_zonegroup_by_id(const RGWZoneGroup& local_zonegroup,
+                                         const std::optional<RGWPeriod>& period,
+                                         const std::string& zonegroup_id)
+{
+  if (local_zonegroup.equals(zonegroup_id)) {
+    return &local_zonegroup;
+  }
+  if (!period) {
+    return nullptr;
+  }
+  const auto& zonegroups = period->period_map.zonegroups;
+  auto z = zonegroups.find(zonegroup_id);
+  if (z == zonegroups.end()) {
+    return nullptr;
+  }
+  return &z->second;
+}
+
 int add_zone_to_group(const DoutPrefixProvider* dpp, RGWZoneGroup& zonegroup,
                       const RGWZoneParams& zone_params,
                       const bool *pis_master, const bool *pread_only,

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -801,6 +801,13 @@ int set_default_zonegroup(const DoutPrefixProvider* dpp, optional_yield y,
 /// Return an endpoint from the zonegroup or its master zone.
 std::string get_zonegroup_endpoint(const RGWZoneGroup& info);
 
+/// Return the zonegroup with the given id, which may be the local zonegroup or
+/// any other zonegroup of the given period. Returns null if the id matches
+/// neither.
+const RGWZoneGroup* find_zonegroup_by_id(const RGWZoneGroup& local_zonegroup,
+                                         const std::optional<RGWPeriod>& period,
+                                         const std::string& zonegroup_id);
+
 /// Add a zone to the zonegroup, or update an existing zone entry.
 int add_zone_to_group(const DoutPrefixProvider* dpp,
                       RGWZoneGroup& zonegroup,

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -120,6 +120,11 @@ add_executable(unittest_rgw_period_history test_rgw_period_history.cc)
 add_ceph_unittest(unittest_rgw_period_history)
 target_link_libraries(unittest_rgw_period_history ${rgw_libs})
 
+# unittest_rgw_zone
+add_executable(unittest_rgw_zone test_rgw_zone.cc)
+add_ceph_unittest(unittest_rgw_zone)
+target_link_libraries(unittest_rgw_zone ${rgw_libs})
+
 # unittest_rgw_compression
 add_executable(unittest_rgw_compression
   test_rgw_compression.cc

--- a/src/test/rgw/test_rgw_zone.cc
+++ b/src/test/rgw/test_rgw_zone.cc
@@ -1,0 +1,143 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "rgw_zone.h"
+
+#include <list>
+#include <optional>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+const std::string local_id = "74506436-cfb6-4105-8a8c-edd0c62632b7";
+const std::string remote_id = "70271812-eb5c-472a-9050-16e289e78941";
+
+RGWZoneGroup make_zonegroup(const std::string& id, const std::string& name,
+                            std::list<std::string> endpoints)
+{
+  RGWZoneGroup zonegroup{id, name};
+  zonegroup.endpoints = std::move(endpoints);
+  return zonegroup;
+}
+
+void add_master_zone(RGWZoneGroup& zonegroup, const std::string& zone_id,
+                     std::list<std::string> endpoints)
+{
+  zonegroup.master_zone = zone_id;
+  RGWZone& zone = zonegroup.zones[zone_id];
+  zone.id = zone_id;
+  zone.endpoints = std::move(endpoints);
+}
+
+RGWPeriod make_period(std::initializer_list<RGWZoneGroup> zonegroups)
+{
+  RGWPeriod period{"period-id"};
+  for (const auto& zonegroup : zonegroups) {
+    period.period_map.zonegroups[zonegroup.id] = zonegroup;
+  }
+  return period;
+}
+
+} // anonymous namespace
+
+TEST(ZonegroupEndpoint, PrefersZonegroupEndpoint)
+{
+  auto zonegroup = make_zonegroup(local_id, "local", {"http://zg:80"});
+  add_master_zone(zonegroup, "zone-id", {"http://zone:80"});
+
+  EXPECT_EQ("http://zg:80", rgw::get_zonegroup_endpoint(zonegroup));
+}
+
+TEST(ZonegroupEndpoint, FallsBackToMasterZoneEndpoint)
+{
+  auto zonegroup = make_zonegroup(local_id, "local", {});
+  add_master_zone(zonegroup, "zone-id", {"http://zone:80"});
+
+  EXPECT_EQ("http://zone:80", rgw::get_zonegroup_endpoint(zonegroup));
+}
+
+TEST(ZonegroupEndpoint, EmptyWithoutAnyEndpoint)
+{
+  auto zonegroup = make_zonegroup(local_id, "local", {});
+  add_master_zone(zonegroup, "zone-id", {});
+
+  EXPECT_EQ("", rgw::get_zonegroup_endpoint(zonegroup));
+}
+
+TEST(FindZonegroupById, ReturnsLocalZonegroup)
+{
+  const auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  const std::optional<RGWPeriod> no_period;
+
+  EXPECT_EQ(&local, rgw::find_zonegroup_by_id(local, no_period, local_id));
+}
+
+TEST(FindZonegroupById, ReturnsLocalZonegroupForEmptyIdOnMaster)
+{
+  // buckets created before zonegroups existed have no zonegroup id, and
+  // RGWZoneGroup::equals() treats those as local on the master zonegroup
+  auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  local.is_master = true;
+  const std::optional<RGWPeriod> no_period;
+
+  EXPECT_EQ(&local, rgw::find_zonegroup_by_id(local, no_period, ""));
+}
+
+TEST(FindZonegroupById, ReturnsNullWithoutPeriod)
+{
+  const auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  const std::optional<RGWPeriod> no_period;
+
+  EXPECT_EQ(nullptr, rgw::find_zonegroup_by_id(local, no_period, remote_id));
+}
+
+TEST(FindZonegroupById, ReturnsNullForUnknownId)
+{
+  const auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  const std::optional<RGWPeriod> period = make_period({local});
+
+  EXPECT_EQ(nullptr, rgw::find_zonegroup_by_id(local, period, remote_id));
+}
+
+TEST(FindZonegroupById, ReturnsRemoteZonegroupFromPeriod)
+{
+  const auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  const auto remote = make_zonegroup(remote_id, "remote", {"http://remote:80"});
+  const std::optional<RGWPeriod> period = make_period({local, remote});
+
+  const RGWZoneGroup* found =
+      rgw::find_zonegroup_by_id(local, period, remote_id);
+  ASSERT_NE(nullptr, found);
+  EXPECT_EQ(remote_id, found->id);
+  EXPECT_EQ("remote", found->name);
+}
+
+// a request for a bucket in another zonegroup has to be redirected to that
+// zonegroup's endpoint. redirecting to the local endpoint sends the client
+// back to the gateway it just used, which loops forever
+TEST(FindZonegroupById, RedirectTargetIsNotTheLocalEndpoint)
+{
+  const auto local = make_zonegroup(local_id, "local", {"http://local:80"});
+  const auto remote = make_zonegroup(remote_id, "remote", {"http://remote:80"});
+  const std::optional<RGWPeriod> period = make_period({local, remote});
+
+  const RGWZoneGroup* bucket_zonegroup =
+      rgw::find_zonegroup_by_id(local, period, remote_id);
+  ASSERT_NE(nullptr, bucket_zonegroup);
+
+  const std::string endpoint = rgw::get_zonegroup_endpoint(*bucket_zonegroup);
+  EXPECT_EQ("http://remote:80", endpoint);
+  EXPECT_NE(rgw::get_zonegroup_endpoint(local), endpoint);
+}


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Summary

Backport of https://github.com/ceph/ceph/pull/70931 to **umbrella**.

In multi-zonegroup deployments, a request for a bucket that lives in another
zonegroup can reach a gateway that does not hold the bucket.
`rgw_build_bucket_policies()` returns `ERR_PERMANENT_REDIRECT`, but
`s->zonegroup_endpoint` was taken from the **local** zonegroup. The
`Location` header then pointed clients back at the same gateway, causing
redirect loops (see tracker #64983).

Add `rgw::find_zonegroup_by_id()` and use the bucket's zonegroup endpoint
for the redirect instead. If that zonegroup is not part of the current
period, leave the endpoint empty and log the reason.

**Why umbrella:** the regression (e2eb66a) is present on umbrella; the same
redirect loop fixed on main affects multi-zonegroup RGW deployments here.

**Minimal change:** cherry-pick of both commits from PR #70931 with
`git cherry-pick -x`. No manual conflict resolution was required.

Original bug: https://tracker.ceph.com/issues/64983
Main PR: https://github.com/ceph/ceph/pull/70931 (merged as ea93efc5777b)
Official backport tracker: https://tracker.ceph.com/issues/80267

## Testing

- Includes `unittest_rgw_zone` (cherry-picked from main PR)
- Jenkins `make check` passed (ceph-pr-pipeline/568)
- Not run locally on umbrella yet

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).
- If you are submitting a fix for a stable branch, please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/main/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

Fixes: https://tracker.ceph.com/issues/80267
