### PR TITLE
osd/PGLog: lower last_complete in reset_complete_to on an empty log

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1002,23 +1002,23 @@ public:
   }
 
   void reset_complete_to(pg_info_t *info, bool ec_optimizations_enabled) {
-    if (log.log.empty()) // caller is split_into()
-      return;
     log.complete_to = log.log.begin();
-    ceph_assert(log.complete_to != log.log.end());
     auto oldest_need = missing.get_oldest_need();
-    if (oldest_need != eversion_t()) {
-      while (log.complete_to->version < oldest_need) {
-        ++log.complete_to;
-	// partial writes allow a shard which did not participate in a write to
-	// have a missing version that is newer that the most recent log entry
-	if (log.complete_to == log.log.end()) {
-	  // keep complete_to one entry behind the end of the log to stop
-	  // code incorrectly using it to deduce that recovery has completed
-	  --log.complete_to;
-	  break;
-	}
-        ceph_assert(log.complete_to != log.log.end());
+    if (log.complete_to != log.log.end())
+    {
+      if (oldest_need != eversion_t()) {
+        while (log.complete_to->version < oldest_need) {
+          ++log.complete_to;
+          // partial writes allow a shard which did not participate in a write to
+          // have a missing version that is newer that the most recent log entry
+          if (log.complete_to == log.log.end()) {
+            // keep complete_to one entry behind the end of the log to stop
+            // code incorrectly using it to deduce that recovery has completed
+            --log.complete_to;
+            break;
+          }
+          ceph_assert(log.complete_to != log.log.end());
+        }
       }
     }
     if (!info)


### PR DESCRIPTION
reset_complete_to() returned early whenever the log was empty and never touched last_complete.  Its callers rely on it to do the opposite: PeeringState::activate() (via activate_not_complete) and split_into() provisionally leave last_complete == last_update and delegate to reset_complete_to() the job of pulling it back below the oldest missing version.  rewind_divergent_log() does the same - it only clamps last_complete down to the new (tail) head and adds the rewound objects to missing, expecting the later reset_complete_to() to lower it further.

So when a shard's log was rewound to empty (proc_replica_log discarding divergent entries) or a split handed a child an empty log, and the missing set was non-empty, last_complete was left equal to last_update. pg_info_t::has_missing() is last_complete != last_update, so it reported "no missing"; GetMissing's identical-log fast-path then discarded the peer's missing set and the primary activated the shard as up to date.  A subsequent clone was forwarded to that shard, which no longer had the object, and it crashed with ENOENT in BlueStore (tracker 68649).

Drop the empty-log early return and let the existing complete_to == log.begin() path handle it: for an empty log begin() == end(), so the oldest_need walk is skipped and last_complete is lowered below oldest_need just as in the non-empty case.  complete_to is left at end(), which is the only valid position for an empty log - the consumers that read complete_to == end() as "recovery complete" already special-case an empty log.

Recreate test harness (will never be backported): 
https://github.com/ceph/ceph/pull/71526

This likely does not need backporting - as its low probability, but it IS a bug in tentacle/umbrella, so we might change our mind. 

Assisted-by: Claude:Claude-Opus-4.8
Assisted-by: IBM Bob
Signed-off-by: Alex Ainscow <aainscow@uk.ibm.com>
Fixes: https://tracker.ceph.com/issues/68649

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
