### PR TITLE
test/osd: recreate corrupt last complete resulting in cloning of non-existing object

### DIFF
--- a/src/test/osd/ECPeeringTestFixture.cc
+++ b/src/test/osd/ECPeeringTestFixture.cc
@@ -18,10 +18,11 @@
 #include "test/osd/MockECReadPred.h"
 #include "crush/crush.h" // for CRUSH_ITEM_NONE
 
-// ShardDpp implementation
 std::ostream& ECPeeringTestFixture::ShardDpp::gen_prefix(std::ostream& out) const {
-  if (fixture->shard_peering_states.contains(shard)) {
-    PeeringState *ps = fixture->shard_peering_states[shard].get();
+  auto& states = is_child ? fixture->child_peering_states
+                          : fixture->shard_peering_states;
+  if (states.contains(shard)) {
+    PeeringState *ps = states[shard].get();
     out << *ps;
 
     // Add missing stats like PG::operator<< does (mimics production code)
@@ -97,16 +98,29 @@ void ECPeeringTestFixture::SetUp() {
 
     // Get the peering event from the message
     PGPeeringEventRef evt_ref(op->get_event());
-    
-    // Handle the event on the destination shard's peering state
-    PeeringCtx* ctx = get_peering_ctx(to_osd);
-    auto ps = get_peering_state(to_osd);
+
+    // Route to parent or child PG by spg_t.pgid; both exist after split_pg().
+    bool is_child = !child_peering_states.empty() &&
+                    op->get_spg().pgid == child_pgid;
+    PeeringCtx* ctx = is_child ? child_peering_ctxs.at(to_osd).get()
+                               : get_peering_ctx(to_osd);
+    PeeringState* ps = is_child ? child_peering_states.at(to_osd).get()
+                                : get_peering_state(to_osd);
     ps->handle_event(evt_ref, ctx);
 
     auto t = ctx->transaction.claim_and_reset();
-    int r = queue_transaction_helper(to_osd, std::move(t));
-    ceph_assert( r >= 0 );
-    return true;  // Message handled
+    int r;
+    if (is_child) {
+      if (!t.empty()) {
+        r = store->queue_transaction(child_chs.at(to_osd), std::move(t));
+      } else {
+        r = 0;
+      }
+    } else {
+      r = queue_transaction_helper(to_osd, std::move(t));
+    }
+    ceph_assert(r >= 0);
+    return true;
   };
   
   // Register the same handler for all peering message types
@@ -117,12 +131,20 @@ void ECPeeringTestFixture::SetUp() {
   messenger->register_typed_handler<MOSDPeeringOp>(MSG_OSD_PG_LEASE, peering_handler);
   messenger->register_typed_handler<MOSDPeeringOp>(MSG_OSD_PG_LEASE_ACK, peering_handler);
   messenger->register_typed_handler<MOSDPeeringOp>(MSG_OSD_RECOVERY_RESERVE, peering_handler);
+  messenger->register_typed_handler<MOSDPeeringOp>(MSG_OSD_PG_TRIM, peering_handler);
+  messenger->register_typed_handler<MOSDPeeringOp>(MSG_OSD_BACKFILL_RESERVE, peering_handler);
 
   // Register idle callback to check for buffered messages
   event_loop->register_idle_callback([this]() -> bool {
     bool found_messages = false;
     // Check all PeeringCtx objects for buffered messages
     for (auto& [osd, ctx] : shard_peering_ctxs) {
+      if (!ctx->message_map.empty()) {
+        dispatch_buffered_messages(osd, ctx.get());
+        found_messages = true;
+      }
+    }
+    for (auto& [osd, ctx] : child_peering_ctxs) {
       if (!ctx->message_map.empty()) {
         dispatch_buffered_messages(osd, ctx.get());
         found_messages = true;
@@ -136,6 +158,15 @@ void ECPeeringTestFixture::SetUp() {
 }
 
 void ECPeeringTestFixture::TearDown() {
+  // Tear down child state before parent: child collections were split from
+  // parent collections and hold handles into the same ObjectStore.
+  child_peering_states.clear();
+  child_peering_ctxs.clear();
+  child_peering_listeners.clear();
+  child_chs.clear();
+  child_colls.clear();
+  child_dpps.clear();
+
   shard_peering_states.clear();
   shard_peering_ctxs.clear();
   shard_peering_listeners.clear();
@@ -146,6 +177,61 @@ void ECPeeringTestFixture::TearDown() {
 void ECPeeringTestFixture::set_config(const std::string& option, const std::string& value) {
   g_ceph_context->_conf.set_val(option, value);
   g_ceph_context->_conf.apply_changes(nullptr);
+}
+
+void ECPeeringTestFixture::set_stall_recovery_reservations(bool v) {
+  stall_recovery_reservations = v;
+  for (auto& [shard, listener] : shard_peering_listeners) {
+    listener->inject_event_stall = v;
+  }
+  for (auto& [shard, listener] : child_peering_listeners) {
+    listener->inject_event_stall = v;
+  }
+}
+
+void ECPeeringTestFixture::set_target_pg_log_entries(unsigned n) {
+  for (auto& [shard, listener] : shard_peering_listeners) {
+    listener->target_pg_log_entries = n;
+  }
+  for (auto& [shard, listener] : child_peering_listeners) {
+    listener->target_pg_log_entries = n;
+  }
+}
+
+eversion_t ECPeeringTestFixture::compute_submit_trim_to() {
+  if (!enable_log_trimming) {
+    return eversion_t(0, 0);
+  }
+  int primary = get_primary_shard_from_osdmap();
+  if (primary < 0 || primary == CRUSH_ITEM_NONE) {
+    return eversion_t(0, 0);
+  }
+  auto* ps = get_peering_state(primary);
+  ps->update_trim_to();  // mirrors PrimaryLogPG pre-submit
+  return ps->get_pg_trim_to();
+}
+
+eversion_t ECPeeringTestFixture::compute_submit_pg_committed_to() {
+  if (!enable_log_trimming) {
+    return eversion_t(0, 0);
+  }
+  int primary = get_primary_shard_from_osdmap();
+  if (primary < 0 || primary == CRUSH_ITEM_NONE) {
+    return eversion_t(0, 0);
+  }
+  return get_peering_state(primary)->get_pg_committed_to();
+}
+
+void ECPeeringTestFixture::on_primary_write_committed(const eversion_t& at_version) {
+  if (!enable_log_trimming) {
+    return;
+  }
+  int primary = get_primary_shard_from_osdmap();
+  if (primary < 0 || primary == CRUSH_ITEM_NONE) {
+    return;
+  }
+  auto* ps = get_peering_state(primary);
+  ps->complete_write(at_version, at_version);  // mirrors PrimaryLogPG::repop_all_committed
 }
 
 PeeringState* ECPeeringTestFixture::get_peering_state(int shard) {
@@ -369,14 +455,11 @@ void ECPeeringTestFixture::inject_read_error_for_shard(const std::string& obj_na
 
 PeeringState* ECPeeringTestFixture::create_peering_state(int shard)
 {
-  const pg_pool_t& pi = get_pool();
   pg_shard_t pg_whoami(shard, shard_id_t(shard));
-  PGPool pool(osdmap, pool_id, pi, "test_pool");
 
   shard_dpps[shard] = std::make_unique<ShardDpp>(g_ceph_context, this, shard);
 
-  // Construct MockPeeringListener, transferring ownership of the backend
-  // listener created by setup_ec_pool() directly. No throw-away construction.
+  // Transfer ownership of the backend listener created by setup_ec_pool().
   shard_peering_listeners[shard] = std::make_unique<MockPeeringListener>(
     osdmap, pool_id, shard_dpps[shard].get(), pg_whoami,
     std::move(listeners[shard]),
@@ -386,7 +469,6 @@ PeeringState* ECPeeringTestFixture::create_peering_state(int shard)
   pl->current_epoch = osdmap->get_epoch();
   pl->set_messenger(messenger.get());
   pl->set_event_loop(event_loop.get());
-  pl->set_fixture(this);
   pl->backend_listener->set_messenger(messenger.get());
 
   pl->queue_transaction_callback =
@@ -394,7 +476,88 @@ PeeringState* ECPeeringTestFixture::create_peering_state(int shard)
       return queue_transaction_helper(shard, std::move(t));
     };
 
-  spg_t spgid(pgid, shard_id_t(shard));
+  return create_peering_state_common(
+    shard, spg_t(pgid, shard_id_t(shard)),
+    shard_peering_states, shard_peering_ctxs,
+    shard_peering_listeners, shard_dpps);
+}
+
+PeeringState* ECPeeringTestFixture::get_child_peering_state(int shard) {
+  auto it = child_peering_states.find(shard);
+  ceph_assert(it != child_peering_states.end());
+  return it->second.get();
+}
+
+// The child's log/missing/info are populated by the subsequent
+// PeeringState::split_into() call.
+PeeringState* ECPeeringTestFixture::create_child_peering_state(int shard)
+{
+  pg_shard_t pg_whoami(shard, shard_id_t(shard));
+  spg_t child_spgid(child_pgid, shard_id_t(shard));
+
+  coll_t child_coll(child_spgid);
+  auto child_ch = store->create_new_collection(child_coll);
+  {
+    ObjectStore::Transaction t;
+    // Create at the post-split bit depth; split_collection() asserts dest bits == split_bits.
+    t.create_collection(child_coll, child_split_bits);
+    store->queue_transaction(child_ch, std::move(t));
+  }
+  child_colls[shard] = child_coll;
+  child_chs[shard] = child_ch;
+
+  child_dpps[shard] = std::make_unique<ShardDpp>(g_ceph_context, this, shard,
+                                                 /*is_child=*/true);
+
+  auto child_bl = std::make_unique<MockPGBackendListener>(
+    osdmap, pool_id, child_dpps[shard].get(), pg_whoami);
+  child_bl->info.pgid = child_spgid;
+  for (int j = 0; j < k + m; j++) {
+    child_bl->shardset.insert(pg_shard_t(j, shard_id_t(j)));
+    child_bl->acting_recovery_backfill_shard_id_set.insert(shard_id_t(j));
+    pg_info_t shard_pg_info;
+    shard_pg_info.pgid = spg_t(child_pgid, shard_id_t(j));
+    child_bl->shard_info[pg_shard_t(j, shard_id_t(j))] = shard_pg_info;
+    child_bl->shard_missing[pg_shard_t(j, shard_id_t(j))] = pg_missing_t();
+  }
+  child_bl->set_store(store.get(), child_ch);
+  child_bl->set_event_loop(event_loop.get());
+
+  child_peering_listeners[shard] = std::make_unique<MockPeeringListener>(
+    osdmap, pool_id, child_dpps[shard].get(), pg_whoami,
+    std::move(child_bl),
+    store.get(), child_coll, child_ch);
+
+  auto& pl = child_peering_listeners[shard];
+  pl->current_epoch = osdmap->get_epoch();
+  pl->inject_event_stall = stall_recovery_reservations;
+  pl->set_messenger(messenger.get());
+  pl->set_event_loop(event_loop.get());
+  pl->backend_listener->set_messenger(messenger.get());
+  pl->queue_transaction_callback =
+    [this, shard](ObjectStore::Transaction&& t) -> int {
+      if (t.empty()) return 0;
+      return store->queue_transaction(child_chs.at(shard), std::move(t));
+    };
+
+  return create_peering_state_common(
+    shard, child_spgid,
+    child_peering_states, child_peering_ctxs,
+    child_peering_listeners, child_dpps);
+}
+
+PeeringState* ECPeeringTestFixture::create_peering_state_common(
+  int shard,
+  spg_t spgid,
+  std::map<int, std::unique_ptr<PeeringState>>& states,
+  std::map<int, std::unique_ptr<PeeringCtx>>& ctxs,
+  std::map<int, std::unique_ptr<MockPeeringListener>>& listeners_map,
+  std::map<int, std::unique_ptr<ShardDpp>>& dpps)
+{
+  pg_shard_t pg_whoami(shard, shard_id_t(shard));
+  PGPool pool(osdmap, pool_id, get_pool(), "test_pool");
+  auto& pl = listeners_map[shard];
+
   auto ps = std::make_unique<PeeringState>(
     g_ceph_context,
     pg_whoami,
@@ -402,7 +565,7 @@ PeeringState* ECPeeringTestFixture::create_peering_state(int shard)
     pool,
     osdmap,
     PG_FEATURE_CLASSIC_ALL,
-    shard_dpps[shard].get(),
+    dpps[shard].get(),
     pl.get());
 
   pl->ps = ps.get();
@@ -411,11 +574,167 @@ PeeringState* ECPeeringTestFixture::create_peering_state(int shard)
     get_is_readable_predicate(),
     get_is_recoverable_predicate());
 
-  shard_peering_states[shard] = std::move(ps);
-  pl->backend_listener->set_peering_state(shard_peering_states[shard].get());
-  shard_peering_ctxs[shard] = std::make_unique<PeeringCtx>();
+  states[shard] = std::move(ps);
+  pl->backend_listener->set_peering_state(states[shard].get());
+  ctxs[shard] = std::make_unique<PeeringCtx>();
+  pl->ctx = ctxs[shard].get();
 
-  return shard_peering_states[shard].get();
+  return states[shard].get();
+}
+
+pg_t ECPeeringTestFixture::split_pg()
+{
+  const unsigned new_pg_num = 2;
+  const unsigned split_bits = pgid.get_split_bits(new_pg_num);
+  child_pgid = pg_t(1, pool_id);  // seed 1 = child of seed 0 for pg_num 1 -> 2
+  child_split_bits = split_bits;
+
+  std::vector<int> acting;
+  for (int i = 0; i < k + m; i++) {
+    acting.push_back(i);
+  }
+
+  // 1. Bump pg_num to 2 and add upmaps for both parent and child.
+  auto new_osdmap = std::make_shared<OSDMap>();
+  new_osdmap->deepish_copy_from(*osdmap);
+  {
+    OSDMap::Incremental inc(new_osdmap->get_epoch() + 1);
+    inc.fsid = new_osdmap->get_fsid();
+    const pg_pool_t* cur = new_osdmap->get_pg_pool(pool_id);
+    ceph_assert(cur != nullptr);
+    pg_pool_t updated = *cur;
+    updated.set_pg_num(new_pg_num);
+    updated.set_pgp_num(new_pg_num);
+    inc.new_pools[pool_id] = updated;
+    inc.new_pg_upmap[pgid] =
+      mempool::osdmap::vector<int32_t>(acting.begin(), acting.end());
+    inc.new_pg_upmap[child_pgid] =
+      mempool::osdmap::vector<int32_t>(acting.begin(), acting.end());
+    new_osdmap->apply_incremental(inc);
+  }
+  // Advance each parent shard to the new osdmap so split_into() can resolve
+  // child_pgid.  Use a throwaway PeeringCtx to discard the new-interval peering
+  // queries — we must not re-peer the parent and overwrite the corrupt state.
+  osdmap = new_osdmap;
+  for (auto& [s, l] : shard_peering_listeners) {
+    l->current_epoch = osdmap->get_epoch();
+  }
+  {
+    std::vector<int> up_osds, acting_osds;
+    int up_primary = -1, acting_primary = -1;
+    osdmap->pg_to_up_acting_osds(pgid, &up_osds, &up_primary,
+                                 &acting_osds, &acting_primary);
+    for (int shard = 0; shard < k + m; shard++) {
+      PeeringState* ps = get_peering_state(shard);
+      OSDMapRef lastmap = ps->get_osdmap();
+      PeeringCtx throwaway;
+      ps->advance_map(osdmap, lastmap, up_osds, up_primary, acting_osds,
+                      acting_primary, throwaway);
+      (void)throwaway.transaction.claim_and_reset();
+    }
+  }
+
+  // 2. Split each shard: create the child state, run production split_into(),
+  //    then split the ObjectStore collection.
+  for (int shard = 0; shard < k + m; shard++) {
+    create_child_peering_state(shard);
+    auto* parent = get_peering_state(shard);
+    parent->split_into(child_pgid, get_child_peering_state(shard), split_bits);
+
+    ObjectStore::Transaction t;
+    t.split_collection(colls[shard], split_bits, child_pgid.ps(),
+                       child_colls[shard]);
+    store->queue_transaction(chs[shard], std::move(t));
+  }
+
+  // 3. Peer the child PG: advance_map/activate_map cycles, applying up_thru and
+  //    pg_temp as the monitor would.  The child primary requests pg_temp for EC
+  //    primaryfirst ordering and stalls in WaitActingChange without it.
+  for (int shard = 0; shard < k + m; shard++) {
+    auto evt = std::make_shared<PGPeeringEvent>(
+      osdmap->get_epoch(), osdmap->get_epoch(), PeeringState::Initialize());
+    get_child_peering_state(shard)->handle_event(
+      evt, child_peering_ctxs[shard].get());
+  }
+  event_loop->run_until_idle();
+
+  // Returns true if any up_thru or pg_temp was applied (more cycles needed).
+  auto child_apply_new_epoch = [this]() -> bool {
+    bool did_work = false;
+    epoch_t e = osdmap->get_epoch();
+    OSDMap::Incremental inc(e + 1);
+    inc.fsid = osdmap->get_fsid();
+
+    std::vector<int> acting_osds;
+    int acting_primary = -1;
+    osdmap->pg_to_acting_osds(child_pgid, &acting_osds, &acting_primary);
+    for (int shard : acting_osds) {
+      if (shard == CRUSH_ITEM_NONE) continue;
+      if (get_child_peering_state(shard)->get_need_up_thru()) {
+        inc.new_up_thru[shard] = e;
+        did_work = true;
+      }
+    }
+    if (acting_primary >= 0 && acting_primary != CRUSH_ITEM_NONE) {
+      auto& listener = child_peering_listeners.at(acting_primary);
+      if (listener->pg_temp_wanted) {
+        std::vector<int> up_osds;
+        int up_primary = -1;
+        osdmap->pg_to_up_acting_osds(child_pgid, &up_osds, &up_primary,
+                                     nullptr, nullptr);
+        std::vector<int> acting_temp = listener->next_acting;
+        if (acting_temp.empty()) {
+          acting_temp = up_osds;
+        }
+        const pg_pool_t* pool = osdmap->get_pg_pool(child_pgid.pool());
+        if (pool && pool->allows_ecoptimizations()) {
+          acting_temp = osdmap->pgtemp_primaryfirst(*pool, acting_temp);
+        }
+        inc.new_pg_temp[child_pgid] =
+          mempool::osdmap::vector<int32_t>(acting_temp.begin(), acting_temp.end());
+        listener->pg_temp_wanted = false;
+        did_work = true;
+      }
+    }
+    if (!did_work) {
+      return false;
+    }
+    osdmap->apply_incremental(inc);
+    for (auto& [shard, listener] : shard_peering_listeners) {
+      listener->current_epoch = osdmap->get_epoch();
+    }
+    for (auto& [shard, listener] : child_peering_listeners) {
+      listener->current_epoch = osdmap->get_epoch();
+    }
+    return true;
+  };
+
+  int max_cycles = 10;
+  bool more = true;
+  while (more && --max_cycles) {
+    for (int shard = 0; shard < k + m; shard++) {
+      PeeringState* ps = get_child_peering_state(shard);
+      OSDMapRef lastmap = ps->get_osdmap();
+      if (lastmap->get_epoch() == osdmap->get_epoch()) {
+          continue;
+        }
+      std::vector<int> up_osds, acting_osds;
+      int up_primary = -1, acting_primary = -1;
+      osdmap->pg_to_up_acting_osds(child_pgid, &up_osds, &up_primary,
+                                   &acting_osds, &acting_primary);
+      ps->advance_map(osdmap, lastmap, up_osds, up_primary, acting_osds,
+                      acting_primary, *child_peering_ctxs[shard]);
+    }
+    event_loop->run_until_idle();
+    for (int shard = 0; shard < k + m; shard++) {
+      get_child_peering_state(shard)->activate_map(*child_peering_ctxs[shard]);
+    }
+    event_loop->run_until_idle();
+
+    more = child_apply_new_epoch();
+  }
+
+  return child_pgid;
 }
 
 void ECPeeringTestFixture::init_peering(bool dne)

--- a/src/test/osd/ECPeeringTestFixture.cc
+++ b/src/test/osd/ECPeeringTestFixture.cc
@@ -584,6 +584,17 @@ PeeringState* ECPeeringTestFixture::create_peering_state_common(
 
 pg_t ECPeeringTestFixture::split_pg()
 {
+  // This harness supports exactly one 1→2 PG split.  Multiple splits or an
+  // N-way split are not modelled: child listeners/states/collections are stored
+  // in flat maps indexed by shard, so a second call would silently overwrite
+  // them.  A single 1→2 split is sufficient to reproduce all known split-
+  // related bugs; assert the pool is still at pg_num 1 to catch misuse.
+  {
+    const pg_pool_t* p = osdmap->get_pg_pool(pool_id);
+    ceph_assert(p != nullptr);
+    ceph_assert(p->get_pg_num() == 1 && "split_pg() supports only a single 1→2 split");
+  }
+
   const unsigned new_pg_num = 2;
   const unsigned split_bits = pgid.get_split_bits(new_pg_num);
   child_pgid = pg_t(1, pool_id);  // seed 1 = child of seed 0 for pg_num 1 -> 2

--- a/src/test/osd/ECPeeringTestFixture.cc
+++ b/src/test/osd/ECPeeringTestFixture.cc
@@ -600,9 +600,16 @@ pg_t ECPeeringTestFixture::split_pg()
   child_pgid = pg_t(1, pool_id);  // seed 1 = child of seed 0 for pg_num 1 -> 2
   child_split_bits = split_bits;
 
-  std::vector<int> acting;
-  for (int i = 0; i < k + m; i++) {
-    acting.push_back(i);
+  // Read the parent's current acting set from the osdmap so the new epoch
+  // preserves whatever acting set the test built before the split (e.g. after
+  // an OSD failure).  The child inherits the same set; a caller that needs a
+  // different child up-map can advance the epoch after the split.
+  std::vector<int> up_osds;
+  {
+    std::vector<int> acting_osds;
+    int up_primary = -1, acting_primary = -1;
+    osdmap->pg_to_up_acting_osds(pgid, &up_osds, &up_primary,
+                                 &acting_osds, &acting_primary);
   }
 
   // 1. Bump pg_num to 2 and add upmaps for both parent and child.
@@ -618,9 +625,9 @@ pg_t ECPeeringTestFixture::split_pg()
     updated.set_pgp_num(new_pg_num);
     inc.new_pools[pool_id] = updated;
     inc.new_pg_upmap[pgid] =
-      mempool::osdmap::vector<int32_t>(acting.begin(), acting.end());
+      mempool::osdmap::vector<int32_t>(up_osds.begin(), up_osds.end());
     inc.new_pg_upmap[child_pgid] =
-      mempool::osdmap::vector<int32_t>(acting.begin(), acting.end());
+      mempool::osdmap::vector<int32_t>(up_osds.begin(), up_osds.end());
     new_osdmap->apply_incremental(inc);
   }
   // Advance each parent shard to the new osdmap so split_into() can resolve

--- a/src/test/osd/ECPeeringTestFixture.cc
+++ b/src/test/osd/ECPeeringTestFixture.cc
@@ -490,7 +490,8 @@ PeeringState* ECPeeringTestFixture::get_child_peering_state(int shard) {
 
 // The child's log/missing/info are populated by the subsequent
 // PeeringState::split_into() call.
-PeeringState* ECPeeringTestFixture::create_child_peering_state(int shard)
+PeeringState* ECPeeringTestFixture::create_child_peering_state(int shard,
+                                                               unsigned split_bits)
 {
   pg_shard_t pg_whoami(shard, shard_id_t(shard));
   spg_t child_spgid(child_pgid, shard_id_t(shard));
@@ -500,7 +501,7 @@ PeeringState* ECPeeringTestFixture::create_child_peering_state(int shard)
   {
     ObjectStore::Transaction t;
     // Create at the post-split bit depth; split_collection() asserts dest bits == split_bits.
-    t.create_collection(child_coll, child_split_bits);
+    t.create_collection(child_coll, split_bits);
     store->queue_transaction(child_ch, std::move(t));
   }
   child_colls[shard] = child_coll;
@@ -598,7 +599,6 @@ pg_t ECPeeringTestFixture::split_pg()
   const unsigned new_pg_num = 2;
   const unsigned split_bits = pgid.get_split_bits(new_pg_num);
   child_pgid = pg_t(1, pool_id);  // seed 1 = child of seed 0 for pg_num 1 -> 2
-  child_split_bits = split_bits;
 
   // Read the parent's current acting set from the osdmap so the new epoch
   // preserves whatever acting set the test built before the split (e.g. after
@@ -655,7 +655,7 @@ pg_t ECPeeringTestFixture::split_pg()
   // 2. Split each shard: create the child state, run production split_into(),
   //    then split the ObjectStore collection.
   for (int shard = 0; shard < k + m; shard++) {
-    create_child_peering_state(shard);
+    create_child_peering_state(shard, split_bits);
     auto* parent = get_peering_state(shard);
     parent->split_into(child_pgid, get_child_peering_state(shard), split_bits);
 

--- a/src/test/osd/ECPeeringTestFixture.cc
+++ b/src/test/osd/ECPeeringTestFixture.cc
@@ -664,51 +664,9 @@ pg_t ECPeeringTestFixture::split_pg()
   event_loop->run_until_idle();
 
   // Returns true if any up_thru or pg_temp was applied (more cycles needed).
+  // Delegates to apply_new_epoch() which shares the implementation with new_epoch().
   auto child_apply_new_epoch = [this]() -> bool {
-    bool did_work = false;
-    epoch_t e = osdmap->get_epoch();
-    OSDMap::Incremental inc(e + 1);
-    inc.fsid = osdmap->get_fsid();
-
-    std::vector<int> acting_osds;
-    int acting_primary = -1;
-    osdmap->pg_to_acting_osds(child_pgid, &acting_osds, &acting_primary);
-    for (int shard : acting_osds) {
-      if (shard == CRUSH_ITEM_NONE) continue;
-      if (get_child_peering_state(shard)->get_need_up_thru()) {
-        inc.new_up_thru[shard] = e;
-        did_work = true;
-      }
-    }
-    if (acting_primary >= 0 && acting_primary != CRUSH_ITEM_NONE) {
-      auto& listener = pg_listeners.at(spg_t(child_pgid, shard_id_t(acting_primary)));
-      if (listener->pg_temp_wanted) {
-        std::vector<int> up_osds;
-        int up_primary = -1;
-        osdmap->pg_to_up_acting_osds(child_pgid, &up_osds, &up_primary,
-                                     nullptr, nullptr);
-        std::vector<int> acting_temp = listener->next_acting;
-        if (acting_temp.empty()) {
-          acting_temp = up_osds;
-        }
-        const pg_pool_t* pool = osdmap->get_pg_pool(child_pgid.pool());
-        if (pool && pool->allows_ecoptimizations()) {
-          acting_temp = osdmap->pgtemp_primaryfirst(*pool, acting_temp);
-        }
-        inc.new_pg_temp[child_pgid] =
-          mempool::osdmap::vector<int32_t>(acting_temp.begin(), acting_temp.end());
-        listener->pg_temp_wanted = false;
-        did_work = true;
-      }
-    }
-    if (!did_work) {
-      return false;
-    }
-    osdmap->apply_incremental(inc);
-    for (auto& [spgid, listener] : pg_listeners) {
-      listener->current_epoch = osdmap->get_epoch();
-    }
-    return true;
+    return apply_new_epoch(child_pgid, /*if_required=*/true);
   };
 
   int max_cycles = 10;
@@ -795,33 +753,38 @@ void ECPeeringTestFixture::new_epoch_loop() {
 
 bool ECPeeringTestFixture::new_epoch(bool if_required)
 {
+  return apply_new_epoch(this->pgid, if_required);
+}
+
+bool ECPeeringTestFixture::apply_new_epoch(pg_t which_pg, bool if_required)
+{
   bool did_work = false;
   epoch_t e = osdmap->get_epoch();
   OSDMap::Incremental pending_inc(e + 1);
   pending_inc.fsid = osdmap->get_fsid();
 
-  // Get acting set from OSDMap
   std::vector<int> acting_osds;
   int acting_primary = -1;
-  osdmap->pg_to_acting_osds(this->pgid, &acting_osds, &acting_primary);
+  osdmap->pg_to_acting_osds(which_pg, &acting_osds, &acting_primary);
 
   for (int shard : acting_osds) {
-    // Skip failed OSDs (marked as CRUSH_ITEM_NONE)
-    if (shard == CRUSH_ITEM_NONE) {
-      continue;
-    }
-    if (get_peering_state(shard)->get_need_up_thru()) {
+    if (shard == CRUSH_ITEM_NONE) continue;
+    spg_t key(which_pg, shard_id_t(shard));
+    auto it = pg_states.find(key);
+    if (it != pg_states.end() && it->second->get_need_up_thru()) {
       pending_inc.new_up_thru[shard] = e;
       did_work = true;
     }
   }
 
-  if (acting_primary >= 0) {
-    auto& listener = pg_listeners[spg_t(this->pgid, shard_id_t(acting_primary))];
-    if (listener->pg_temp_wanted) {
+  if (acting_primary >= 0 && acting_primary != CRUSH_ITEM_NONE) {
+    spg_t primary_key(which_pg, shard_id_t(acting_primary));
+    auto lit = pg_listeners.find(primary_key);
+    if (lit != pg_listeners.end() && lit->second->pg_temp_wanted) {
+      auto& listener = lit->second;
       std::vector<int> up_osds;
       int up_primary = -1;
-      osdmap->pg_to_up_acting_osds(this->pgid, &up_osds, &up_primary, nullptr, nullptr);
+      osdmap->pg_to_up_acting_osds(which_pg, &up_osds, &up_primary, nullptr, nullptr);
 
       std::vector<int> acting_temp = listener->next_acting;
       if (acting_temp.empty()) {
@@ -829,15 +792,15 @@ bool ECPeeringTestFixture::new_epoch(bool if_required)
       }
 
       // For EC pools with optimizations, transform to primaryfirst order before
-      // storing in pg_temp. This matches what the real monitor does and what
+      // storing in pg_temp.  This matches what the real monitor does and what
       // _get_temp_osds() expects when it calls pgtemp_undo_primaryfirst().
-      const pg_pool_t* pool = osdmap->get_pg_pool(this->pgid.pool());
+      const pg_pool_t* pool = osdmap->get_pg_pool(which_pg.pool());
       if (pool && pool->allows_ecoptimizations()) {
         acting_temp = osdmap->pgtemp_primaryfirst(*pool, acting_temp);
       }
 
-      pending_inc.new_pg_temp[this->pgid] =
-      mempool::osdmap::vector<int32_t>(acting_temp.begin(), acting_temp.end());
+      pending_inc.new_pg_temp[which_pg] =
+        mempool::osdmap::vector<int32_t>(acting_temp.begin(), acting_temp.end());
 
       listener->pg_temp_wanted = false;
       did_work = true;

--- a/src/test/osd/ECPeeringTestFixture.cc
+++ b/src/test/osd/ECPeeringTestFixture.cc
@@ -19,10 +19,9 @@
 #include "crush/crush.h" // for CRUSH_ITEM_NONE
 
 std::ostream& ECPeeringTestFixture::ShardDpp::gen_prefix(std::ostream& out) const {
-  auto& states = is_child ? fixture->child_peering_states
-                          : fixture->shard_peering_states;
-  if (states.contains(shard)) {
-    PeeringState *ps = states[shard].get();
+  auto it = fixture->pg_states.find(spgid);
+  if (it != fixture->pg_states.end()) {
+    PeeringState *ps = it->second.get();
     out << *ps;
 
     // Add missing stats like PG::operator<< does (mimics production code)
@@ -75,11 +74,12 @@ void ECPeeringTestFixture::SetUp() {
     create_peering_state(i);
   }
   
-  // Override epoch getter to use shard_peering_listeners instead of base class listeners
-  // (which are moved into shard_peering_listeners during create_peering_state)
+  // Override epoch getter to use pg_listeners instead of base class listeners
+  // (which are moved into pg_listeners during create_peering_state)
   messenger->set_epoch_getter([this](int osd) -> epoch_t {
-    auto it = shard_peering_listeners.find(osd);
-    if (it != shard_peering_listeners.end()) {
+    spg_t key(pgid, shard_id_t(osd));
+    auto it = pg_listeners.find(key);
+    if (it != pg_listeners.end()) {
       return it->second->get_osdmap_epoch();
     }
     // Fallback to test fixture's osdmap
@@ -99,27 +99,24 @@ void ECPeeringTestFixture::SetUp() {
     // Get the peering event from the message
     PGPeeringEventRef evt_ref(op->get_event());
 
-    // Route to parent or child PG by spg_t.pgid; both exist after split_pg().
-    bool is_child = !child_peering_states.empty() &&
-                    op->get_spg().pgid == child_pgid;
-    PeeringCtx* ctx = is_child ? child_peering_ctxs.at(to_osd).get()
-                               : get_peering_ctx(to_osd);
-    PeeringState* ps = is_child ? child_peering_states.at(to_osd).get()
-                                : get_peering_state(to_osd);
+    // Route to the correct PG shard using the spg_t from the message.
+    // Both parent and child shards are in the same pg_* maps.
+    spg_t key = op->get_spg();
+    auto ctx_it = pg_ctxs.find(key);
+    auto ps_it  = pg_states.find(key);
+    ceph_assert(ctx_it != pg_ctxs.end());
+    ceph_assert(ps_it  != pg_states.end());
+    PeeringCtx*  ctx = ctx_it->second.get();
+    PeeringState* ps = ps_it->second.get();
     ps->handle_event(evt_ref, ctx);
 
     auto t = ctx->transaction.claim_and_reset();
-    int r;
-    if (is_child) {
-      if (!t.empty()) {
-        r = store->queue_transaction(child_chs.at(to_osd), std::move(t));
-      } else {
-        r = 0;
-      }
-    } else {
-      r = queue_transaction_helper(to_osd, std::move(t));
+    if (!t.empty()) {
+      auto listener_it = pg_listeners.find(key);
+      ceph_assert(listener_it != pg_listeners.end());
+      int r = store->queue_transaction(listener_it->second->ch, std::move(t));
+      ceph_assert(r >= 0);
     }
-    ceph_assert(r >= 0);
     return true;
   };
   
@@ -138,15 +135,9 @@ void ECPeeringTestFixture::SetUp() {
   event_loop->register_idle_callback([this]() -> bool {
     bool found_messages = false;
     // Check all PeeringCtx objects for buffered messages
-    for (auto& [osd, ctx] : shard_peering_ctxs) {
+    for (auto& [spgid, ctx] : pg_ctxs) {
       if (!ctx->message_map.empty()) {
-        dispatch_buffered_messages(osd, ctx.get());
-        found_messages = true;
-      }
-    }
-    for (auto& [osd, ctx] : child_peering_ctxs) {
-      if (!ctx->message_map.empty()) {
-        dispatch_buffered_messages(osd, ctx.get());
+        dispatch_buffered_messages(spgid, ctx.get());
         found_messages = true;
       }
     }
@@ -158,19 +149,25 @@ void ECPeeringTestFixture::SetUp() {
 }
 
 void ECPeeringTestFixture::TearDown() {
-  // Tear down child state before parent: child collections were split from
-  // parent collections and hold handles into the same ObjectStore.
-  child_peering_states.clear();
-  child_peering_ctxs.clear();
-  child_peering_listeners.clear();
-  child_chs.clear();
-  child_colls.clear();
-  child_dpps.clear();
-
-  shard_peering_states.clear();
-  shard_peering_ctxs.clear();
-  shard_peering_listeners.clear();
-  shard_dpps.clear();
+  // Clear child PG shards before parent PG shards: child collections were
+  // split from parent collections and hold handles into the same ObjectStore.
+  // spg_t sorts by (pgid.pool, pgid.ps, shard), so child (ps=1) sorts after
+  // parent (ps=0).  When a split has been performed, erase child entries
+  // first so their collection handles are released before the parent
+  // collection handles are released.
+  if (child_pgid != pg_t()) {
+    for (int s = 0; s < k + m; s++) {
+      spg_t child_key(child_pgid, shard_id_t(s));
+      pg_states.erase(child_key);
+      pg_ctxs.erase(child_key);
+      pg_listeners.erase(child_key);
+      pg_dpps.erase(child_key);
+    }
+  }
+  pg_states.clear();
+  pg_ctxs.clear();
+  pg_listeners.clear();
+  pg_dpps.clear();
   PGBackendTestFixture::TearDown();
 }
 
@@ -181,19 +178,13 @@ void ECPeeringTestFixture::set_config(const std::string& option, const std::stri
 
 void ECPeeringTestFixture::set_stall_recovery_reservations(bool v) {
   stall_recovery_reservations = v;
-  for (auto& [shard, listener] : shard_peering_listeners) {
-    listener->inject_event_stall = v;
-  }
-  for (auto& [shard, listener] : child_peering_listeners) {
+  for (auto& [spgid, listener] : pg_listeners) {
     listener->inject_event_stall = v;
   }
 }
 
 void ECPeeringTestFixture::set_target_pg_log_entries(unsigned n) {
-  for (auto& [shard, listener] : shard_peering_listeners) {
-    listener->target_pg_log_entries = n;
-  }
-  for (auto& [shard, listener] : child_peering_listeners) {
+  for (auto& [spgid, listener] : pg_listeners) {
     listener->target_pg_log_entries = n;
   }
 }
@@ -236,24 +227,27 @@ void ECPeeringTestFixture::on_primary_write_committed(const eversion_t& at_versi
 
 PeeringState* ECPeeringTestFixture::get_peering_state(int shard) {
   ceph_assert(shard >= 0 && shard < k + m);
-  auto it = shard_peering_states.find(shard);
-  ceph_assert(it != shard_peering_states.end());
+  spg_t key(pgid, shard_id_t(shard));
+  auto it = pg_states.find(key);
+  ceph_assert(it != pg_states.end());
   ceph_assert(it->second != nullptr);
   return it->second.get();
 }
 
 PeeringCtx* ECPeeringTestFixture::get_peering_ctx(int shard) {
   ceph_assert(shard >= 0 && shard < k + m);
-  auto it = shard_peering_ctxs.find(shard);
-  ceph_assert(it != shard_peering_ctxs.end());
+  spg_t key(pgid, shard_id_t(shard));
+  auto it = pg_ctxs.find(key);
+  ceph_assert(it != pg_ctxs.end());
   ceph_assert(it->second != nullptr);
   return it->second.get();
 }
 
 MockPeeringListener* ECPeeringTestFixture::get_peering_listener(int shard) {
   ceph_assert(shard >= 0 && shard < k + m);
-  auto it = shard_peering_listeners.find(shard);
-  ceph_assert(it != shard_peering_listeners.end());
+  spg_t key(pgid, shard_id_t(shard));
+  auto it = pg_listeners.find(key);
+  ceph_assert(it != pg_listeners.end());
   ceph_assert(it->second != nullptr);
   return it->second.get();
 }
@@ -270,9 +264,9 @@ MockPGBackendListener* ECPeeringTestFixture::get_primary_listener() {
   if (primary_shard < 0) {
     return nullptr;
   }
-  
-  auto it = shard_peering_listeners.find(primary_shard);
-  if (it != shard_peering_listeners.end() && it->second &&
+  spg_t key(pgid, shard_id_t(primary_shard));
+  auto it = pg_listeners.find(key);
+  if (it != pg_listeners.end() && it->second &&
       it->second->backend_listener) {
     // Assert that the backend listener agrees it's primary
     ceph_assert(it->second->backend_listener->pgb_is_primary());
@@ -286,9 +280,9 @@ PGBackend* ECPeeringTestFixture::get_primary_backend() {
   if (primary_shard < 0) {
     return nullptr;
   }
-  
-  auto listener_it = shard_peering_listeners.find(primary_shard);
-  if (listener_it != shard_peering_listeners.end() && listener_it->second &&
+  spg_t key(pgid, shard_id_t(primary_shard));
+  auto listener_it = pg_listeners.find(key);
+  if (listener_it != pg_listeners.end() && listener_it->second &&
       listener_it->second->backend_listener) {
     // Assert that the backend listener agrees it's primary
     ceph_assert(listener_it->second->backend_listener->pgb_is_primary());
@@ -324,21 +318,24 @@ void ECPeeringTestFixture::event_initialize() {
 }
 
 void ECPeeringTestFixture::event_advance_map() {
-  // Capture the current osdmap and pgid for use in the lambda
+  // Capture the current osdmap for use in the lambda
   OSDMapRef current_osdmap = osdmap;
-  pg_t current_pgid = this->pgid;
 
-  // Schedule advance_map events for each shard instead of running directly
-  for (auto& [shard, ctx] : shard_peering_ctxs) {
-    PeeringState* ps = shard_peering_states.at(shard).get();
+  // Schedule advance_map events for each parent shard only.
+  // (The child PG is advanced separately during/after split_pg().)
+  for (auto& [spgid, ctx] : pg_ctxs) {
+    if (spgid.pgid != pgid) continue;  // skip child shards
+    PeeringState* ps = pg_states.at(spgid).get();
     OSDMapRef lastmap = ps->get_osdmap();
     PeeringCtx* peering_ctx = ctx.get();
+    pg_t cur_pgid = spgid.pgid;
+    int osd = spgid.shard.id;
     
-    event_loop->schedule_peering_event(shard, [ps, current_osdmap, lastmap, current_pgid, peering_ctx]() {
+    event_loop->schedule_peering_event(osd, [ps, current_osdmap, lastmap, cur_pgid, peering_ctx]() {
       // Get up/acting sets from OSDMap inside the lambda
       std::vector<int> up_osds, acting_osds;
       int up_primary = -1, acting_primary = -1;
-      current_osdmap->pg_to_up_acting_osds(current_pgid, &up_osds, &up_primary, &acting_osds, &acting_primary);
+      current_osdmap->pg_to_up_acting_osds(cur_pgid, &up_osds, &up_primary, &acting_osds, &acting_primary);
       
       ps->advance_map(
         current_osdmap, lastmap, up_osds, up_primary, acting_osds, acting_primary,
@@ -349,29 +346,29 @@ void ECPeeringTestFixture::event_advance_map() {
 }
 
 void ECPeeringTestFixture::event_activate_map() {
-  // Schedule activate_map events for each shard instead of running directly
-  for (auto& [shard, ctx] : shard_peering_ctxs) {
-    PeeringState* ps = shard_peering_states.at(shard).get();
+  // Schedule activate_map events for each parent shard only.
+  // (The child PG is activated separately during/after split_pg().)
+  for (auto& [spgid, ctx] : pg_ctxs) {
+    if (spgid.pgid != pgid) continue;  // skip child shards
+    PeeringState* ps = pg_states.at(spgid).get();
     PeeringCtx* peering_ctx = ctx.get();
+    int osd = spgid.shard.id;
     
-    event_loop->schedule_peering_event(shard, [ps, peering_ctx]() {
+    event_loop->schedule_peering_event(osd, [ps, peering_ctx]() {
       ps->activate_map(*peering_ctx);
     });
   }
   event_loop->run_until_idle();
 }
 
-void ECPeeringTestFixture::dispatch_buffered_messages(int from_shard, PeeringCtx* ctx) {
+void ECPeeringTestFixture::dispatch_buffered_messages(spg_t spgid, PeeringCtx* ctx) {
   ceph_assert(messenger);
   ceph_assert(ctx);
 
-  // Check if there are any buffered messages in the context
+  int from_osd = spgid.shard.id;
   for (auto& [target_osd, msg_list] : ctx->message_map) {
     for (auto& msg : msg_list) {
-      // Route the message through the messenger
-      // msg is a MessageRef (boost::intrusive_ptr<Message>), need to get raw pointer
-      // MockMessenger will set the connection when it processes the message
-      messenger->send_message(from_shard, target_osd, msg.get());
+      messenger->send_message(from_osd, target_osd, msg.get());
     }
     msg_list.clear();
   }
@@ -455,17 +452,18 @@ void ECPeeringTestFixture::inject_read_error_for_shard(const std::string& obj_na
 
 PeeringState* ECPeeringTestFixture::create_peering_state(int shard)
 {
+  spg_t spgid(pgid, shard_id_t(shard));
   pg_shard_t pg_whoami(shard, shard_id_t(shard));
 
-  shard_dpps[shard] = std::make_unique<ShardDpp>(g_ceph_context, this, shard);
+  pg_dpps[spgid] = std::make_unique<ShardDpp>(g_ceph_context, this, spgid);
 
   // Transfer ownership of the backend listener created by setup_ec_pool().
-  shard_peering_listeners[shard] = std::make_unique<MockPeeringListener>(
-    osdmap, pool_id, shard_dpps[shard].get(), pg_whoami,
+  pg_listeners[spgid] = std::make_unique<MockPeeringListener>(
+    osdmap, pool_id, pg_dpps[spgid].get(), pg_whoami,
     std::move(listeners[shard]),
     store.get(), colls[shard], chs[shard]);
 
-  auto& pl = shard_peering_listeners[shard];
+  auto& pl = pg_listeners[spgid];
   pl->current_epoch = osdmap->get_epoch();
   pl->set_messenger(messenger.get());
   pl->set_event_loop(event_loop.get());
@@ -476,15 +474,13 @@ PeeringState* ECPeeringTestFixture::create_peering_state(int shard)
       return queue_transaction_helper(shard, std::move(t));
     };
 
-  return create_peering_state_common(
-    shard, spg_t(pgid, shard_id_t(shard)),
-    shard_peering_states, shard_peering_ctxs,
-    shard_peering_listeners, shard_dpps);
+  return create_peering_state_common(spgid);
 }
 
 PeeringState* ECPeeringTestFixture::get_child_peering_state(int shard) {
-  auto it = child_peering_states.find(shard);
-  ceph_assert(it != child_peering_states.end());
+  spg_t key(child_pgid, shard_id_t(shard));
+  auto it = pg_states.find(key);
+  ceph_assert(it != pg_states.end());
   return it->second.get();
 }
 
@@ -493,8 +489,8 @@ PeeringState* ECPeeringTestFixture::get_child_peering_state(int shard) {
 PeeringState* ECPeeringTestFixture::create_child_peering_state(int shard,
                                                                unsigned split_bits)
 {
-  pg_shard_t pg_whoami(shard, shard_id_t(shard));
   spg_t child_spgid(child_pgid, shard_id_t(shard));
+  pg_shard_t pg_whoami(shard, shard_id_t(shard));
 
   coll_t child_coll(child_spgid);
   auto child_ch = store->create_new_collection(child_coll);
@@ -504,14 +500,11 @@ PeeringState* ECPeeringTestFixture::create_child_peering_state(int shard,
     t.create_collection(child_coll, split_bits);
     store->queue_transaction(child_ch, std::move(t));
   }
-  child_colls[shard] = child_coll;
-  child_chs[shard] = child_ch;
 
-  child_dpps[shard] = std::make_unique<ShardDpp>(g_ceph_context, this, shard,
-                                                 /*is_child=*/true);
+  pg_dpps[child_spgid] = std::make_unique<ShardDpp>(g_ceph_context, this, child_spgid);
 
   auto child_bl = std::make_unique<MockPGBackendListener>(
-    osdmap, pool_id, child_dpps[shard].get(), pg_whoami);
+    osdmap, pool_id, pg_dpps[child_spgid].get(), pg_whoami);
   child_bl->info.pgid = child_spgid;
   for (int j = 0; j < k + m; j++) {
     child_bl->shardset.insert(pg_shard_t(j, shard_id_t(j)));
@@ -524,40 +517,32 @@ PeeringState* ECPeeringTestFixture::create_child_peering_state(int shard,
   child_bl->set_store(store.get(), child_ch);
   child_bl->set_event_loop(event_loop.get());
 
-  child_peering_listeners[shard] = std::make_unique<MockPeeringListener>(
-    osdmap, pool_id, child_dpps[shard].get(), pg_whoami,
+  pg_listeners[child_spgid] = std::make_unique<MockPeeringListener>(
+    osdmap, pool_id, pg_dpps[child_spgid].get(), pg_whoami,
     std::move(child_bl),
     store.get(), child_coll, child_ch);
 
-  auto& pl = child_peering_listeners[shard];
+  auto& pl = pg_listeners[child_spgid];
   pl->current_epoch = osdmap->get_epoch();
   pl->inject_event_stall = stall_recovery_reservations;
   pl->set_messenger(messenger.get());
   pl->set_event_loop(event_loop.get());
   pl->backend_listener->set_messenger(messenger.get());
   pl->queue_transaction_callback =
-    [this, shard](ObjectStore::Transaction&& t) -> int {
+    [this, child_ch](ObjectStore::Transaction&& t) mutable -> int {
       if (t.empty()) return 0;
-      return store->queue_transaction(child_chs.at(shard), std::move(t));
+      return store->queue_transaction(child_ch, std::move(t));
     };
 
-  return create_peering_state_common(
-    shard, child_spgid,
-    child_peering_states, child_peering_ctxs,
-    child_peering_listeners, child_dpps);
+  return create_peering_state_common(child_spgid);
 }
 
-PeeringState* ECPeeringTestFixture::create_peering_state_common(
-  int shard,
-  spg_t spgid,
-  std::map<int, std::unique_ptr<PeeringState>>& states,
-  std::map<int, std::unique_ptr<PeeringCtx>>& ctxs,
-  std::map<int, std::unique_ptr<MockPeeringListener>>& listeners_map,
-  std::map<int, std::unique_ptr<ShardDpp>>& dpps)
+PeeringState* ECPeeringTestFixture::create_peering_state_common(spg_t spgid)
 {
+  int shard = spgid.shard.id;
   pg_shard_t pg_whoami(shard, shard_id_t(shard));
   PGPool pool(osdmap, pool_id, get_pool(), "test_pool");
-  auto& pl = listeners_map[shard];
+  auto& pl = pg_listeners[spgid];
 
   auto ps = std::make_unique<PeeringState>(
     g_ceph_context,
@@ -566,7 +551,7 @@ PeeringState* ECPeeringTestFixture::create_peering_state_common(
     pool,
     osdmap,
     PG_FEATURE_CLASSIC_ALL,
-    dpps[shard].get(),
+    pg_dpps[spgid].get(),
     pl.get());
 
   pl->ps = ps.get();
@@ -575,21 +560,21 @@ PeeringState* ECPeeringTestFixture::create_peering_state_common(
     get_is_readable_predicate(),
     get_is_recoverable_predicate());
 
-  states[shard] = std::move(ps);
-  pl->backend_listener->set_peering_state(states[shard].get());
-  ctxs[shard] = std::make_unique<PeeringCtx>();
-  pl->ctx = ctxs[shard].get();
+  pg_states[spgid] = std::move(ps);
+  pl->backend_listener->set_peering_state(pg_states[spgid].get());
+  pg_ctxs[spgid] = std::make_unique<PeeringCtx>();
+  pl->ctx = pg_ctxs[spgid].get();
 
-  return states[shard].get();
+  return pg_states[spgid].get();
 }
 
 pg_t ECPeeringTestFixture::split_pg()
 {
-  // This harness supports exactly one 1→2 PG split.  Multiple splits or an
-  // N-way split are not modelled: child listeners/states/collections are stored
-  // in flat maps indexed by shard, so a second call would silently overwrite
-  // them.  A single 1→2 split is sufficient to reproduce all known split-
-  // related bugs; assert the pool is still at pg_num 1 to catch misuse.
+  // This harness supports exactly one 1→2 PG split.  The child PG identity
+  // is stored in child_pgid and can only be set once; a second call would
+  // silently overwrite it and orphan all existing child state.  A single
+  // 1→2 split is sufficient to reproduce all known split-related bugs;
+  // assert the pool is still at pg_num 1 to catch misuse.
   {
     const pg_pool_t* p = osdmap->get_pg_pool(pool_id);
     ceph_assert(p != nullptr);
@@ -634,7 +619,7 @@ pg_t ECPeeringTestFixture::split_pg()
   // child_pgid.  Use a throwaway PeeringCtx to discard the new-interval peering
   // queries — we must not re-peer the parent and overwrite the corrupt state.
   osdmap = new_osdmap;
-  for (auto& [s, l] : shard_peering_listeners) {
+  for (auto& [spgid, l] : pg_listeners) {
     l->current_epoch = osdmap->get_epoch();
   }
   {
@@ -660,8 +645,9 @@ pg_t ECPeeringTestFixture::split_pg()
     parent->split_into(child_pgid, get_child_peering_state(shard), split_bits);
 
     ObjectStore::Transaction t;
+    spg_t child_key(child_pgid, shard_id_t(shard));
     t.split_collection(colls[shard], split_bits, child_pgid.ps(),
-                       child_colls[shard]);
+                       pg_listeners.at(child_key)->coll);
     store->queue_transaction(chs[shard], std::move(t));
   }
 
@@ -671,8 +657,9 @@ pg_t ECPeeringTestFixture::split_pg()
   for (int shard = 0; shard < k + m; shard++) {
     auto evt = std::make_shared<PGPeeringEvent>(
       osdmap->get_epoch(), osdmap->get_epoch(), PeeringState::Initialize());
+    spg_t child_key(child_pgid, shard_id_t(shard));
     get_child_peering_state(shard)->handle_event(
-      evt, child_peering_ctxs[shard].get());
+      evt, pg_ctxs.at(child_key).get());
   }
   event_loop->run_until_idle();
 
@@ -694,7 +681,7 @@ pg_t ECPeeringTestFixture::split_pg()
       }
     }
     if (acting_primary >= 0 && acting_primary != CRUSH_ITEM_NONE) {
-      auto& listener = child_peering_listeners.at(acting_primary);
+      auto& listener = pg_listeners.at(spg_t(child_pgid, shard_id_t(acting_primary)));
       if (listener->pg_temp_wanted) {
         std::vector<int> up_osds;
         int up_primary = -1;
@@ -718,10 +705,7 @@ pg_t ECPeeringTestFixture::split_pg()
       return false;
     }
     osdmap->apply_incremental(inc);
-    for (auto& [shard, listener] : shard_peering_listeners) {
-      listener->current_epoch = osdmap->get_epoch();
-    }
-    for (auto& [shard, listener] : child_peering_listeners) {
+    for (auto& [spgid, listener] : pg_listeners) {
       listener->current_epoch = osdmap->get_epoch();
     }
     return true;
@@ -740,12 +724,14 @@ pg_t ECPeeringTestFixture::split_pg()
       int up_primary = -1, acting_primary = -1;
       osdmap->pg_to_up_acting_osds(child_pgid, &up_osds, &up_primary,
                                    &acting_osds, &acting_primary);
+      spg_t child_key(child_pgid, shard_id_t(shard));
       ps->advance_map(osdmap, lastmap, up_osds, up_primary, acting_osds,
-                      acting_primary, *child_peering_ctxs[shard]);
+                      acting_primary, *pg_ctxs.at(child_key));
     }
     event_loop->run_until_idle();
     for (int shard = 0; shard < k + m; shard++) {
-      get_child_peering_state(shard)->activate_map(*child_peering_ctxs[shard]);
+      spg_t child_key(child_pgid, shard_id_t(shard));
+      get_child_peering_state(shard)->activate_map(*pg_ctxs.at(child_key));
     }
     event_loop->run_until_idle();
 
@@ -831,7 +817,7 @@ bool ECPeeringTestFixture::new_epoch(bool if_required)
   }
 
   if (acting_primary >= 0) {
-    auto& listener = shard_peering_listeners[acting_primary];
+    auto& listener = pg_listeners[spg_t(this->pgid, shard_id_t(acting_primary))];
     if (listener->pg_temp_wanted) {
       std::vector<int> up_osds;
       int up_primary = -1;
@@ -864,7 +850,7 @@ bool ECPeeringTestFixture::new_epoch(bool if_required)
 
   osdmap->apply_incremental(pending_inc);
 
-  for (auto& [shard, listener] : shard_peering_listeners) {
+  for (auto& [spgid, listener] : pg_listeners) {
     listener->current_epoch = osdmap->get_epoch();
   }
 

--- a/src/test/osd/ECPeeringTestFixture.h
+++ b/src/test/osd/ECPeeringTestFixture.h
@@ -24,35 +24,38 @@
 #include "messages/MOSDPGNotify2.h"
 #include "test/osd/MockMessenger.h"
 
-// Forward declaration
 class ECPeeringTestFixture;
 
-/**
- * ECPeeringTestFixture - EC test fixture with full peering infrastructure
- *
- * This fixture extends PGBackendTestFixture to add full PeeringState support
- * for each shard, enabling comprehensive testing of EC peering, recovery,
- * and failover scenarios. It combines the principles from TestPeeringState
- * with the EC backend infrastructure from PGBackendTestFixture.
- */
 class ECPeeringTestFixture : public PGBackendTestFixture {
 protected:
   std::map<int, std::unique_ptr<PeeringState>> shard_peering_states;
   std::map<int, std::unique_ptr<PeeringCtx>> shard_peering_ctxs;
   std::map<int, std::unique_ptr<MockPeeringListener>> shard_peering_listeners;
-  
+
   class ShardDpp : public NoDoutPrefix {
   public:
     ECPeeringTestFixture *fixture;
     int shard;
-    
-    ShardDpp(CephContext *cct, ECPeeringTestFixture *f, int s)
-      : NoDoutPrefix(cct, ceph_subsys_osd), fixture(f), shard(s) {}
-    
+    bool is_child;
+
+    ShardDpp(CephContext *cct, ECPeeringTestFixture *f, int s, bool child = false)
+      : NoDoutPrefix(cct, ceph_subsys_osd), fixture(f), shard(s), is_child(child) {}
+
     std::ostream& gen_prefix(std::ostream& out) const override;
   };
   std::map<int, std::unique_ptr<ShardDpp>> shard_dpps;
-  
+
+  // Child-PG state populated by split_pg().  Empty until a split is performed.
+  pg_t child_pgid;
+  unsigned child_split_bits = 0;
+  bool stall_recovery_reservations = false;
+  std::map<int, std::unique_ptr<PeeringState>> child_peering_states;
+  std::map<int, std::unique_ptr<PeeringCtx>> child_peering_ctxs;
+  std::map<int, std::unique_ptr<MockPeeringListener>> child_peering_listeners;
+  std::map<int, coll_t> child_colls;
+  std::map<int, ObjectStore::CollectionHandle> child_chs;
+  std::map<int, std::unique_ptr<ShardDpp>> child_dpps;
+
   IsPGRecoverablePredicate *get_is_recoverable_predicate();
   IsPGReadablePredicate *get_is_readable_predicate();
 
@@ -65,20 +68,14 @@ public:
   void TearDown() override;
   
   PeeringState* create_peering_state(int shard);
-  
+  PeeringState* create_child_peering_state(int shard);
+
   PeeringState* get_peering_state(int shard);
   PeeringCtx* get_peering_ctx(int shard);
   MockPeeringListener* get_peering_listener(int shard);
   
-  /**
-   * Query the OSDMap to determine which shard is the primary.
-   * This is the authoritative source of truth for primary determination.
-   *
-   * @return The shard ID of the primary, or -1 if no primary exists
-   */
   int get_primary_shard_from_osdmap() const;
-  
-  // Override base class methods to work with peering fixture's structure
+
   MockPGBackendListener* get_primary_listener() override;
   PGBackend* get_primary_backend() override;
   
@@ -87,28 +84,45 @@ public:
   void event_advance_map();
   void event_activate_map();
   
-  /**
-   * set_config - Set a configuration option for testing
-   *
-   * @param option The configuration option name
-   * @param value The value to set
-   */
   void set_config(const std::string& option, const std::string& value);
-  
+
+  // Set pg log target length on all listeners to drive log trimming.
+  // Combine with enable_log_trimming = true.
+  void set_target_pg_log_entries(unsigned n);
+
+  // Park recovery reservation grants so peering completes (peer_missing is
+  // populated) without launching recovery.  A grant delivered across a later
+  // interval change would hit a PeeringState in Reset and abort.
+  void set_stall_recovery_reservations(bool v);
+
+  eversion_t compute_submit_trim_to() override;
+  eversion_t compute_submit_pg_committed_to() override;
+  void on_primary_write_committed(const eversion_t& at_version) override;
+
+  // Double pg_num and split the fixture PG into itself (parent, seed 0) and a
+  // child (seed 1).  Objects route to parent or child by hash (set_object_hash()).
+  // Returns the child pg_t.
+  pg_t split_pg();
+
+  PeeringState* get_child_peering_state(int shard);
+  pg_t get_child_pgid() const { return child_pgid; }
+
 private:
-  /**
-   * dispatch_buffered_messages - Check for and dispatch any buffered messages
-   *
-   * After handling a peering event, PeeringState may have buffered messages
-   * in the PeeringCtx that need to be dispatched. This function checks for
-   * such messages and routes them through the messenger.
-   */
   void dispatch_buffered_messages(int from_shard, PeeringCtx* ctx);
+
+  // Shared tail of create_peering_state() and create_child_peering_state():
+  // constructs the PeeringState, wires pl->ps / pl->ctx, sets backend
+  // predicates, and stores everything in the supplied maps.
+  PeeringState* create_peering_state_common(
+    int shard,
+    spg_t spgid,
+    std::map<int, std::unique_ptr<PeeringState>>& states,
+    std::map<int, std::unique_ptr<PeeringCtx>>& ctxs,
+    std::map<int, std::unique_ptr<MockPeeringListener>>& listeners_map,
+    std::map<int, std::unique_ptr<ShardDpp>>& dpps);
 
 public:
 
-  // IMPORTANT: For EC pools, shard positions in acting array must be preserved.
-  // Failed OSDs should be replaced with CRUSH_ITEM_NONE, not removed.
   void update_osdmap_with_peering(
     std::shared_ptr<OSDMap> new_osdmap,
     std::optional<pg_shard_t> new_primary = std::nullopt);
@@ -118,139 +132,37 @@ public:
 
   void run_first_peering();
   
-  // OSDMap manipulation helpers - these create a new epoch and trigger peering
-  
-  /**
-   * Mark an OSD as down (exists but not UP).
-   * Creates a new OSDMap epoch and triggers peering.
-   */
   void mark_osd_down(int osd_id);
-  
-  /**
-   * Mark an OSD as up.
-   * Creates a new OSDMap epoch and triggers peering.
-   */
   void mark_osd_up(int osd_id);
-  
-  /**
-   * Mark multiple OSDs as down.
-   * Creates a new OSDMap epoch and triggers peering.
-   */
   void mark_osds_down(const std::vector<int>& osd_ids);
-  
-  /**
-   * Advance to a new epoch without changing OSD states.
-   * Useful for testing re-peering scenarios.
-   */
   void advance_epoch();
-  
+
   bool all_shards_active();
-  
-  // In EC pools, only the primary tracks PG_STATE_CLEAN.
-  bool all_shards_clean();
-  
+  bool all_shards_clean();  // only the primary tracks PG_STATE_CLEAN in EC pools
   std::string get_state_name(int shard);
 
-  /**
-   * Suspend an OSD - queues events for this OSD without executing them.
-   * This simulates an OSD being temporarily unavailable.
-   * Events remain queued and will be processed when the OSD is unsuspended.
-   *
-   * @param osd The OSD number to suspend
-   */
   void suspend_osd(int osd);
-
-  /**
-   * Unsuspend a previously suspended OSD.
-   * Queued events for this OSD will be processed on the next event loop iteration.
-   *
-   * @param osd The OSD number to unsuspend
-   */
   void unsuspend_osd(int osd);
-
-  /**
-   * Check if an OSD is currently suspended.
-   *
-   * @param osd The OSD number to check
-   * @return true if the OSD is suspended, false otherwise
-   */
   bool is_osd_suspended(int osd);
 
-  /**
-   * Suspend messages from the primary to a specific OSD.
-   * This blocks communication from the primary to the target OSD while
-   * allowing other communication to proceed normally.
-   *
-   * @param to_osd The OSD number to block messages to (from the primary)
-   */
   void suspend_primary_to_osd(int to_osd);
-
-  /**
-   * Unsuspend messages from the primary to a specific OSD.
-   * Queued messages will be processed on the next event loop iteration.
-   *
-   * @param to_osd The OSD number to unblock messages to (from the primary)
-   */
   void unsuspend_primary_to_osd(int to_osd);
 
-  /**
-   * Inject a read error for a specific object on a specific shard's store.
-   * The error will be returned on the next read() call for this object,
-   * then automatically cleared.
-   *
-   * @param obj_name The name of the object to inject an error for
-   * @param shard The shard number whose store should return the error
-   * @param error_code The error code to return (should be negative, e.g., -EIO)
-   */
+  // Inject a one-shot read error on the given shard's store for this object.
   void inject_read_error_for_shard(const std::string& obj_name, int shard, int error_code);
 
-  /**
-   * run_recovery_and_verify_callbacks - Run recovery for an object and verify callbacks
-   *
-   * This helper function encapsulates the complete EC recovery flow:
-   * 1. Verifies the object is in the peer's missing set
-   * 2. Runs the recovery operation
-   * 3. Verifies all recovery callbacks were invoked correctly
-   * 4. Verifies PeeringState was updated correctly
-   *
-   * @param obj_name The name of the object to recover
-   * @param removed_osd The OSD that was down and needs recovery
-   * @param expected_data The expected data content after recovery
-   */
   void run_recovery_and_verify_callbacks(
     const std::string& obj_name,
     int removed_osd,
     const std::string& expected_data);
 
-  /**
-   * run_parallel_recovery_and_verify_callbacks - Run parallel recovery for multiple objects
-   *
-   * This helper function recovers multiple objects in parallel within a single recovery
-   * operation. This is the key difference from run_recovery_and_verify_callbacks which
-   * recovers objects sequentially (one at a time).
-   *
-   * The parallel recovery flow:
-   * 1. Calls recover_object() for ALL objects first (queues them)
-   * 2. Calls run_recovery_op() ONCE to process all queued recoveries together
-   * 3. Verifies callbacks and data for all objects
-   *
-   * This reproduces Bug 75432 where multiple objects in a single operation can cause
-   * assertion failures when some complete while others need resend.
-   *
-   * @param obj_names Vector of object names to recover in parallel
-   * @param target_osd The OSD that was down and needs recovery
-   * @param expected_data Vector of expected data content (must match obj_names size)
-   */
+  // Recover multiple objects in a single parallel operation (reproduces bug 75432).
   void run_parallel_recovery_and_verify_callbacks(
     const std::vector<std::string>& obj_names,
     int target_osd,
     const std::vector<std::string>& expected_data);
 
 private:
-  /**
-   * Implementation function for parallel recovery that runs within event loop context.
-   * This is called by the public wrapper function after scheduling on the primary OSD.
-   */
   void do_run_parallel_recovery_and_verify_callbacks_impl(
     const std::vector<std::string>& obj_names,
     int target_osd,

--- a/src/test/osd/ECPeeringTestFixture.h
+++ b/src/test/osd/ECPeeringTestFixture.h
@@ -28,35 +28,32 @@ class ECPeeringTestFixture;
 
 class ECPeeringTestFixture : public PGBackendTestFixture {
 protected:
-  std::map<int, std::unique_ptr<PeeringState>> shard_peering_states;
-  std::map<int, std::unique_ptr<PeeringCtx>> shard_peering_ctxs;
-  std::map<int, std::unique_ptr<MockPeeringListener>> shard_peering_listeners;
-
   class ShardDpp : public NoDoutPrefix {
   public:
     ECPeeringTestFixture *fixture;
-    int shard;
-    bool is_child;
+    spg_t spgid;
 
-    ShardDpp(CephContext *cct, ECPeeringTestFixture *f, int s, bool child = false)
-      : NoDoutPrefix(cct, ceph_subsys_osd), fixture(f), shard(s), is_child(child) {}
+    ShardDpp(CephContext *cct, ECPeeringTestFixture *f, spg_t id)
+      : NoDoutPrefix(cct, ceph_subsys_osd), fixture(f), spgid(id) {}
 
     std::ostream& gen_prefix(std::ostream& out) const override;
   };
-  std::map<int, std::unique_ptr<ShardDpp>> shard_dpps;
+
+  // All peering state is stored in a single set of maps keyed by spg_t so
+  // that parent and child PG shards are handled uniformly (e.g. new_epoch()
+  // iterates once over all listeners regardless of which PG they belong to).
+  // The parent PG uses pgid; the child PG uses child_pgid (set by split_pg()).
+  std::map<spg_t, std::unique_ptr<PeeringState>>       pg_states;
+  std::map<spg_t, std::unique_ptr<PeeringCtx>>         pg_ctxs;
+  std::map<spg_t, std::unique_ptr<MockPeeringListener>> pg_listeners;
+  std::map<spg_t, std::unique_ptr<ShardDpp>>           pg_dpps;
 
   // Park recovery reservation grants so peering completes without launching
   // recovery (a grant delivered into a later interval hits Reset and aborts).
   bool stall_recovery_reservations = false;
 
-  // Child-PG state populated by split_pg().  Empty until a split is performed.
+  // Child-PG identity set by split_pg().  Zero until a split is performed.
   pg_t child_pgid;
-  std::map<int, std::unique_ptr<PeeringState>> child_peering_states;
-  std::map<int, std::unique_ptr<PeeringCtx>> child_peering_ctxs;
-  std::map<int, std::unique_ptr<MockPeeringListener>> child_peering_listeners;
-  std::map<int, coll_t> child_colls;
-  std::map<int, ObjectStore::CollectionHandle> child_chs;
-  std::map<int, std::unique_ptr<ShardDpp>> child_dpps;
 
   IsPGRecoverablePredicate *get_is_recoverable_predicate();
   IsPGReadablePredicate *get_is_readable_predicate();
@@ -110,18 +107,12 @@ public:
   pg_t get_child_pgid() const { return child_pgid; }
 
 private:
-  void dispatch_buffered_messages(int from_shard, PeeringCtx* ctx);
+  void dispatch_buffered_messages(spg_t spgid, PeeringCtx* ctx);
 
   // Shared tail of create_peering_state() and create_child_peering_state():
   // constructs the PeeringState, wires pl->ps / pl->ctx, sets backend
-  // predicates, and stores everything in the supplied maps.
-  PeeringState* create_peering_state_common(
-    int shard,
-    spg_t spgid,
-    std::map<int, std::unique_ptr<PeeringState>>& states,
-    std::map<int, std::unique_ptr<PeeringCtx>>& ctxs,
-    std::map<int, std::unique_ptr<MockPeeringListener>>& listeners_map,
-    std::map<int, std::unique_ptr<ShardDpp>>& dpps);
+  // predicates, and stores everything in the unified pg_* maps.
+  PeeringState* create_peering_state_common(spg_t spgid);
 
 public:
 

--- a/src/test/osd/ECPeeringTestFixture.h
+++ b/src/test/osd/ECPeeringTestFixture.h
@@ -45,9 +45,12 @@ protected:
   };
   std::map<int, std::unique_ptr<ShardDpp>> shard_dpps;
 
+  // Park recovery reservation grants so peering completes without launching
+  // recovery (a grant delivered into a later interval hits Reset and aborts).
+  bool stall_recovery_reservations = false;
+
   // Child-PG state populated by split_pg().  Empty until a split is performed.
   pg_t child_pgid;
-  bool stall_recovery_reservations = false;
   std::map<int, std::unique_ptr<PeeringState>> child_peering_states;
   std::map<int, std::unique_ptr<PeeringCtx>> child_peering_ctxs;
   std::map<int, std::unique_ptr<MockPeeringListener>> child_peering_listeners;

--- a/src/test/osd/ECPeeringTestFixture.h
+++ b/src/test/osd/ECPeeringTestFixture.h
@@ -114,6 +114,13 @@ private:
   // predicates, and stores everything in the unified pg_* maps.
   PeeringState* create_peering_state_common(spg_t spgid);
 
+  // Core of new_epoch(): checks up_thru/pg_temp for the given PG and, if any
+  // work was found (or if_required is false), bumps the osdmap epoch and
+  // updates all listener current_epochs.  Returns true iff a new epoch was
+  // applied.  Shared between new_epoch() (parent PG) and the child-peering
+  // loop inside split_pg() (child PG).
+  bool apply_new_epoch(pg_t which_pg, bool if_required);
+
 public:
 
   void update_osdmap_with_peering(

--- a/src/test/osd/ECPeeringTestFixture.h
+++ b/src/test/osd/ECPeeringTestFixture.h
@@ -47,7 +47,6 @@ protected:
 
   // Child-PG state populated by split_pg().  Empty until a split is performed.
   pg_t child_pgid;
-  unsigned child_split_bits = 0;
   bool stall_recovery_reservations = false;
   std::map<int, std::unique_ptr<PeeringState>> child_peering_states;
   std::map<int, std::unique_ptr<PeeringCtx>> child_peering_ctxs;
@@ -68,7 +67,7 @@ public:
   void TearDown() override;
   
   PeeringState* create_peering_state(int shard);
-  PeeringState* create_child_peering_state(int shard);
+  PeeringState* create_child_peering_state(int shard, unsigned split_bits);
 
   PeeringState* get_peering_state(int shard);
   PeeringCtx* get_peering_ctx(int shard);

--- a/src/test/osd/MockPeeringListener.cc
+++ b/src/test/osd/MockPeeringListener.cc
@@ -13,26 +13,23 @@
  */
 
 #include "test/osd/MockPeeringListener.h"
-#include "test/osd/ECPeeringTestFixture.h"
 #include "test/osd/EventLoop.h"
 
-// Implementation of MockPeeringListener::request_local_background_io_reservation
-// This must be defined after ECPeeringTestFixture is fully defined to avoid incomplete type errors
 void MockPeeringListener::request_local_background_io_reservation(
   unsigned priority,
   PGPeeringEventURef on_grant,
   PGPeeringEventURef on_preempt) {
-  // If the test has configured an event loop (i.e. ECPeeringTestFixture),
-  // then use the event loop to run this event, rather than putting it on the queue.
-  if (event_loop && fixture) {
-    // Schedule the event through the event loop for deterministic execution
+  // Check inject_event_stall first: a grant delivered across a later interval
+  // change would hit a PeeringState in Reset and abort.
+  if (inject_event_stall) {
+    stalled_events.push_back(std::move(on_grant));
+  } else if (event_loop) {
     PGPeeringEventRef evt_ref = std::move(on_grant);
     int shard = pg_whoami.osd;
-    event_loop->schedule_peering_event(shard, [this, evt_ref, shard]() {
-      fixture->get_peering_state(shard)->handle_event(evt_ref, fixture->get_peering_ctx(shard));
+    event_loop->schedule_peering_event(shard, [this, evt_ref]() {
+      if (!ps || !ctx) return;
+      ps->handle_event(evt_ref, ctx);
     });
-  } else if (inject_event_stall) {
-    stalled_events.push_back(std::move(on_grant));
   } else {
     events.push_back(std::move(on_grant));
   }
@@ -42,23 +39,19 @@ void MockPeeringListener::request_local_background_io_reservation(
   io_reservations_requested++;
 }
 
-// Implementation of MockPeeringListener::request_remote_recovery_reservation
-// This must be defined after ECPeeringTestFixture is fully defined to avoid incomplete type errors
 void MockPeeringListener::request_remote_recovery_reservation(
   unsigned priority,
   PGPeeringEventURef on_grant,
   PGPeeringEventURef on_preempt) {
-  // If the test has configured an event loop (i.e. ECPeeringTestFixture),
-  // then use the event loop to run this event, rather than putting it on the queue.
-  if (event_loop && fixture) {
-    // Schedule the event through the event loop for deterministic execution
+  if (inject_event_stall) {
+    stalled_events.push_back(std::move(on_grant));
+  } else if (event_loop) {
     PGPeeringEventRef evt_ref = std::move(on_grant);
     int shard = pg_whoami.osd;
-    event_loop->schedule_peering_event(shard, [this, evt_ref, shard]() {
-      fixture->get_peering_state(shard)->handle_event(evt_ref, fixture->get_peering_ctx(shard));
+    event_loop->schedule_peering_event(shard, [this, evt_ref]() {
+      if (!ps || !ctx) return;
+      ps->handle_event(evt_ref, ctx);
     });
-  } else if (inject_event_stall) {
-    stalled_events.push_back(std::move(on_grant));
   } else {
     events.push_back(std::move(on_grant));
   }
@@ -68,18 +61,19 @@ void MockPeeringListener::request_remote_recovery_reservation(
   remote_recovery_reservations_requested++;
 }
 
-// Implementation of MockPeeringListener::schedule_event_on_commit
-// This must be defined after ECPeeringTestFixture is fully defined to avoid incomplete type errors
 void MockPeeringListener::schedule_event_on_commit(
   ObjectStore::Transaction &t,
   PGPeeringEventRef on_commit) {
-  // If the test has configured an event loop (i.e. ECPeeringTestFixture),
-  // then use the event loop to run this event, rather than putting it on the queue.
-  if (event_loop && fixture) {
-    // Schedule the event through the event loop for deterministic execution
+  if (event_loop) {
+    // Gate on pg_has_reset_since for both epoch fields, mirroring
+    // PG::old_peering_evt -> old_peering_msg which discards an event when
+    // last_peering_reset > epoch_sent OR last_peering_reset > epoch_requested.
     int shard = pg_whoami.osd;
-    event_loop->schedule_peering_event(shard, [this, on_commit, shard]() {
-      fixture->get_peering_state(shard)->handle_event(on_commit, fixture->get_peering_ctx(shard));
+    event_loop->schedule_peering_event(shard, [this, on_commit]() {
+      if (!ps || !ctx) return;
+      if (ps->pg_has_reset_since(on_commit->get_epoch_sent()) ||
+          ps->pg_has_reset_since(on_commit->get_epoch_requested())) return;
+      ps->handle_event(on_commit, ctx);
     });
   } else if (inject_event_stall) {
     stalled_events.push_back(std::move(on_commit));
@@ -89,18 +83,18 @@ void MockPeeringListener::schedule_event_on_commit(
   events_on_commit_scheduled++;
 }
 
-// Implementation of MockPeeringListener::on_activate_complete
-// This must be defined after ECPeeringTestFixture is fully defined to avoid incomplete type errors
 void MockPeeringListener::on_activate_complete() {
   dout(0) << __func__ << dendl;
-  
-  // Helper lambda to schedule an event
+
   auto schedule_event = [this](PGPeeringEventRef evt) {
-    if (event_loop && fixture) {
-      // Use event loop for deterministic execution
+    if (event_loop) {
       int shard = pg_whoami.osd;
-      event_loop->schedule_peering_event(shard, [this, evt, shard]() {
-        fixture->get_peering_state(shard)->handle_event(evt, fixture->get_peering_ctx(shard));
+      // Gate on both epoch fields — mirrors PG::old_peering_evt -> old_peering_msg.
+      event_loop->schedule_peering_event(shard, [this, evt]() {
+        if (!ps || !ctx) return;
+        if (ps->pg_has_reset_since(evt->get_epoch_sent()) ||
+            ps->pg_has_reset_since(evt->get_epoch_requested())) return;
+        ps->handle_event(evt, ctx);
       });
     } else if (inject_event_stall) {
       stalled_events.push_back(evt);

--- a/src/test/osd/MockPeeringListener.h
+++ b/src/test/osd/MockPeeringListener.h
@@ -36,7 +36,6 @@
 
 // Forward declarations
 class EventLoop;
-class ECPeeringTestFixture;
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
@@ -47,6 +46,9 @@ class MockPeeringListener : public PeeringState::PeeringListener {
  public:
   pg_shard_t pg_whoami;
   PeeringState *ps;
+  // PeeringCtx paired with ps; ensures deferred events route to the correct PG
+  // (parent vs split child) when both coexist after split_pg().
+  PeeringCtx *ctx = nullptr;
   std::unique_ptr<MockPGBackendListener> backend_listener;
   coll_t coll;
   ObjectStore::CollectionHandle ch;
@@ -55,43 +57,20 @@ class MockPeeringListener : public PeeringState::PeeringListener {
   PerfCounters* logger_perf;
   std::vector<int> next_acting;
 
-  // MockMessenger for routing cluster messages (optional - used by ECPeeringTestFixture)
   MockMessenger* messenger = nullptr;
-  
-  // EventLoop for routing events (optional - used by ECPeeringTestFixture)
   class EventLoop* event_loop = nullptr;
-  
-  // Fixture pointer for accessing peering state and context (optional - used by ECPeeringTestFixture)
-  class ECPeeringTestFixture* fixture = nullptr;
 
 #ifdef WITH_CRIMSON
-  // Per OSD state - kept for backward compatibility with TestPeeringState
-  // When messenger is set, messages are routed through it instead
   std::map<int,std::list<MessageURef>> messages;
 #else
-  // Per OSD state - kept for backward compatibility with TestPeeringState
-  // When messenger is set, messages are routed through it instead
   std::map<int,std::list<MessageRef>> messages;
 #endif
   std::vector<HeartbeatStampsRef> hb_stamps;
   std::list<PGPeeringEventRef> events;
   std::list<PGPeeringEventRef> stalled_events;
 
-  // By default MockPeeringListener will add events to the event queue immediately
-  // simulating the responses that PrimaryLogPG normally generates. These inject
-  // booleans can change the behavior to test other code paths
-
-  // If inject_event_stall is true then events are added to the stalled_events list
-  // and the test case must manually dispatch the event
-  bool inject_event_stall = false;
-
-  // If inject_keep_preempt is true then the preempt event for a local/remote
-  // reservation is added to the stalled_events list so the test case can later
-  // dispatch this event to test a preempted reservation
-  bool inject_keep_preempt = false;
-
-  // If inject_fail_reserve_recovery_space is true then reject backfill/pool
-  // migration requests with too full
+  bool inject_event_stall = false;         // route grants to stalled_events
+  bool inject_keep_preempt = false;        // route preempt events to stalled_events
   bool inject_fail_reserve_recovery_space = false;
 
   std::function<int(ObjectStore::Transaction&&)> queue_transaction_callback;
@@ -107,9 +86,6 @@ class MockPeeringListener : public PeeringState::PeeringListener {
     logger_perf = build_osd_logger(g_ceph_context);
     g_ceph_context->get_perfcounters_collection()->add(logger_perf);
   }
-  /// Constructor for ECPeeringTestFixture: accepts a pre-created backend listener
-  /// instead of creating one internally. This avoids the throw-away construction
-  /// pattern where the internally-created listener would be immediately replaced.
   MockPeeringListener(OSDMapRef osdmap,
                       int64_t pool_id,
                       DoutPrefixProvider *dpp,
@@ -133,6 +109,9 @@ class MockPeeringListener : public PeeringState::PeeringListener {
 
 
   ~MockPeeringListener() {
+    // Zero ps/ctx before any scheduled lambdas can dereference them.
+    ps  = nullptr;
+    ctx = nullptr;
     if (recoverystate_perf) {
       g_ceph_context->get_perfcounters_collection()->remove(recoverystate_perf);
       delete recoverystate_perf;
@@ -149,7 +128,6 @@ class MockPeeringListener : public PeeringState::PeeringListener {
     return current_epoch;
   }
 
-  // PeeringListener interface
   void prepare_write(
     pg_info_t &info,
     pg_info_t &last_written_info,
@@ -218,10 +196,6 @@ class MockPeeringListener : public PeeringState::PeeringListener {
     event_loop = el;
   }
   
-  void set_fixture(ECPeeringTestFixture* f) {
-    fixture = f;
-  }
-
   void send_pg_created(pg_t pgid) override {
     pg_created_sent = true;
   }

--- a/src/test/osd/OSDMapTestHelpers.h
+++ b/src/test/osd/OSDMapTestHelpers.h
@@ -189,6 +189,8 @@ public:
     pool.crush_rule = 0;
     pool.erasure_code_profile = "default";
     pool.stripe_width = stripe_width;
+    pool.set_pg_num(1);
+    pool.set_pgp_num(1);
     
     // Set flags as specified by caller
     pool.flags = flags;

--- a/src/test/osd/PGBackendTestFixture.cc
+++ b/src/test/osd/PGBackendTestFixture.cc
@@ -355,8 +355,8 @@ int PGBackendTestFixture::do_transaction_and_complete(
   std::function<void(int)> on_write_complete,
   bool run)
 {
-  eversion_t trim_to(0, 0);
-  eversion_t pg_committed_to(0, 0);
+  eversion_t trim_to = compute_submit_trim_to();
+  eversion_t pg_committed_to = compute_submit_pg_committed_to();
   std::optional<pg_hit_set_history_t> hset_history;
 
   bool completed = false;
@@ -396,6 +396,8 @@ int PGBackendTestFixture::do_transaction_and_complete(
 
   if (!completed) {
     completion_result = -EINPROGRESS;
+  } else if (completion_result >= 0) {
+    on_primary_write_committed(at_version);
   }
 
   return completion_result;

--- a/src/test/osd/PGBackendTestFixture.h
+++ b/src/test/osd/PGBackendTestFixture.h
@@ -20,6 +20,7 @@
 #include <random>
 #include <sstream>
 #include <iomanip>
+#include <string>
 #include <gtest/gtest.h>
 #include "common/errno.h"
 #include "test/osd/MockErasureCode.h"
@@ -43,6 +44,47 @@
 #include "test/osd/ScrubTestFixture.h"
 #include "osd/scrubber/scrub_backend.h"
 #include "osd/scrubber/pg_scrubber.h"
+
+/**
+ * RAII helper that saves a ceph config option on construction and restores
+ * it on destruction.  Use this in tests instead of a bare set_config() call
+ * whenever the config change must be undone even if the test exits early
+ * via ASSERT_* or an exception.
+ *
+ * Usage:
+ *   {
+ *     ScopedConfig guard("osd_pg_log_trim_max", "1000");
+ *     // ... test body that relies on trim_max == 1000 ...
+ *   }  // original value is restored here regardless of how the block exits
+ *
+ * The guard reads the current live value from g_ceph_context->_conf at
+ * construction time, so it is correct even when the ceph default differs
+ * from the value this test file previously hardcoded as the "default".
+ */
+class ScopedConfig {
+public:
+  ScopedConfig(const std::string& key, const std::string& value)
+    : key_(key)
+  {
+    // Save the current value before we overwrite it.
+    g_ceph_context->_conf.get_val(key, &saved_);
+    g_ceph_context->_conf.set_val(key, value);
+    g_ceph_context->_conf.apply_changes(nullptr);
+  }
+
+  ~ScopedConfig() {
+    g_ceph_context->_conf.set_val(key_, saved_);
+    g_ceph_context->_conf.apply_changes(nullptr);
+  }
+
+  // Non-copyable, non-movable.
+  ScopedConfig(const ScopedConfig&) = delete;
+  ScopedConfig& operator=(const ScopedConfig&) = delete;
+
+private:
+  std::string key_;
+  std::string saved_;
+};
 
 // Unified test fixture for EC and Replicated backend tests with ObjectStore.
 // Uses PoolType to branch between EC (ECSwitch) and Replicated (ReplicatedBackend).
@@ -273,8 +315,21 @@ public:
     return nullptr;
   }
   
+  // Default hash 0 (all objects map to PG seed 0).  Override to steer an
+  // object into a specific child PG after a split.
+  std::map<std::string, uint32_t> object_hash_overrides;
+
+  void set_object_hash(const std::string& name, uint32_t hash) {
+    object_hash_overrides[name] = hash;
+  }
+
   hobject_t make_test_object(const std::string& name) const {
-    return hobject_t(object_t(name), "", CEPH_NOSNAP, 0, pool_id, "");
+    uint32_t hash = 0;
+    auto it = object_hash_overrides.find(name);
+    if (it != object_hash_overrides.end()) {
+      hash = it->second;
+    }
+    return hobject_t(object_t(name), "", CEPH_NOSNAP, hash, pool_id, "");
   }
   
   ObjectContextRef make_object_context(
@@ -290,51 +345,21 @@ public:
     return obc;
   }
     
-  /**
-   * Set the next version number for auto-generation.
-   * This can be used by tests after rollback to set the version to a specific value.
-   * The epoch will still come from the osdmap.
-   */
   void set_next_version(uint64_t version) {
     next_version = version;
   }
   
-  /**
-   * Get the next version as an eversion_t with epoch from osdmap.
-   * This auto-increments the version counter.
-   */
   eversion_t get_next_version() {
     epoch_t epoch = osdmap->get_epoch();
     return eversion_t(epoch, next_version++);
   }
   
-  /**
-   * Set an object context for the given object.
-   * This encapsulates access to the per-OSD object_contexts map.
-   * Must be called within event loop context.
-   *
-   * @param hoid The object to set context for
-   * @param obc The object context to cache
-   */
   void set_object_context(
     const hobject_t& hoid,
     ObjectContextRef obc);
 
-  /**
-   * Clear all object contexts for the current OSD.
-   * This encapsulates access to the per-OSD object_contexts map.
-   * Must be called within event loop context.
-   */
   void clear_object_contexts();
 
-  /**
-   * Get or create an object context for the given object.
-   * This matches PrimaryLogPG::get_object_context behavior.
-   *
-   * @param hoid The object to get context for
-   * @param can_create If true, create a new OBC if object doesn't exist
-   * @param attrs Optional attributes to use instead of reading from disk
-   */
   ObjectContextRef get_object_context(
     const hobject_t& hoid,
     bool can_create,
@@ -347,10 +372,14 @@ public:
     const eversion_t& at_version,
     std::vector<pg_log_entry_t> log_entries,
     std::function<void(int)> on_write_complete = nullptr,
-    bool run = true);
+bool run = true);
   
-  // Helper functions that perform the actual write logic
-  // Must be called within event loop context on the primary OSD
+  // Opt-in log trimming.  Default hooks return (0,0) so existing tests are
+  // unaffected.  ECPeeringTestFixture overrides these to mirror PrimaryLogPG.
+  bool enable_log_trimming = false;
+  virtual eversion_t compute_submit_trim_to() { return eversion_t(0, 0); }
+  virtual eversion_t compute_submit_pg_committed_to() { return eversion_t(0, 0); }
+  virtual void on_primary_write_committed(const eversion_t& at_version) {}
   int do_create_and_write_impl(
     const std::string& obj_name,
     const std::string& data);

--- a/src/test/osd/TestECFailoverWithPeering.cc
+++ b/src/test/osd/TestECFailoverWithPeering.cc
@@ -1018,6 +1018,286 @@ TEST_P(TestECFailoverWithPeering, ScrubPartialWrite) {
   std::cout << "=== ScrubPartialWrite test completed ===" << std::endl;
 }
 
+/**
+ * DivergentLogRewindThenSplit
+ *
+ * Organic reproduction of https://tracker.ceph.com/issues/68649.
+ * See debug_clone_issue/BUG_68649_TIMELINE.md for the incident log trace.
+ *
+ *  1. Trim the pg log to a high tail T (as teuthology's low osd_*_pg_log_entries
+ *     causes in the field).
+ *  2. Target misses a write and rejoins as an async-recovery target
+ *     (is_acting()==false, last_backfill==MAX) — the role in which append_log
+ *     rolls entries forward.  (The real incident used a post-backfill target,
+ *     which is equally !is_acting; async-recovery is the harness equivalent.)
+ *  3. Blocked (uncommitted, partial) writes to obj_head/obj_clone.  The
+ *     !is_acting target rolls them forward (crt→head), making them
+ *     non-rollbackable.
+ *  4. Recover the pre-existing missing (trigger) so last_complete climbs to
+ *     the head through the rolled-forward entries.
+ *  5. Interval change: proc_replica_log finds obj_head/obj_clone divergent with
+ *     prior_version ≤ log_tail, rewinds target to empty log + missing(2) with
+ *     last_complete == last_update == T.
+ *  6. PG split (pg_num 1→2): child inherits the empty log + missing(2).
+ *  7. Child's pg_notify carries last_complete == last_update; GetMissing's
+ *     identical-log fast-path clears peer_missing[target], hiding the missing
+ *     set.  A subsequent clone is forwarded to the target, which lacks the
+ *     object, and crashes with ENOENT in BlueStore.
+ *
+ * The test asserts the primary retains peer_missing[target].is_missing for
+ * obj_head/obj_clone after the split.  Fails without the reset_complete_to fix,
+ * passes with it.
+ */
+TEST_P(TestECFailoverWithPeering, DivergentLogRewindThenSplit) {
+  // Needs a coding shard (blocked) and an uninvolved data shard (failed) for
+  // the superseding interval; requires k>=3 and m>=2.
+  if (m < 2 || k < 3) {
+    GTEST_SKIP() << "DivergentLogRewindThenSplit requires k>=3 and m>=2";
+  }
+
+  ASSERT_TRUE(all_shards_active()) << "Initial peering must complete";
+
+  // ScopedConfig guards restore these to their original values on test exit,
+  // even if the test aborts early via ASSERT_*.
+  ScopedConfig cfg_async_recovery("osd_async_recovery_min_cost", "0");
+  ScopedConfig cfg_trim_min("osd_pg_log_trim_min", "1");
+  ScopedConfig cfg_trim_max("osd_pg_log_trim_max", "1000");
+  osdmap->set_flag(CEPH_OSDMAP_PGLOG_HARDLIMIT);
+
+  const int target = 1;
+  const pg_shard_t target_shard(target, shard_id_t(target));
+  const size_t data_size = stripe_unit * k;
+  const std::string pa(data_size, 'A'), pb(data_size, 'B');
+
+  // hash=1 routes obj_head/obj_clone into the child PG (seed 1) after the split.
+  set_object_hash("obj_head", 1);
+  set_object_hash("obj_clone", 1);
+
+  // Phase 1: commit the objects, then build a high log tail T.
+  create_and_write_verify("obj_head", pa);
+  create_and_write_verify("obj_clone", pa);
+  create_and_write_verify("trigger", pa);
+  enable_log_trimming = true;
+  set_target_pg_log_entries(1);
+  for (int i = 0; i < 10; ++i) {
+    write_verify("obj_head", 0, pa, data_size);
+    write_verify("obj_clone", 0, pa, data_size);
+  }
+
+  // Phase 2: target misses one "trigger" write; rejoins as async-recovery
+  // (is_acting()==false, last_backfill==MAX).
+  mark_osd_down(target);
+  write_verify("trigger", 0, pb, data_size);
+  mark_osd_up(target);
+  ASSERT_FALSE(get_peering_state(0)->is_acting(target_shard))
+    << "Target should rejoin as an async-recovery target (!is_acting)";
+  ASSERT_FALSE(get_peering_state(target)->get_info().is_incomplete())
+    << "Async-recovery target should be complete (last_backfill==MAX)";
+
+  // Phase 3: blocked writes to obj_head/obj_clone; target rolls them forward
+  // (crt→head), making them non-rollbackable.
+  const int blocked = k + 1;  // a coding shard
+  suspend_primary_to_osd(blocked);
+  ASSERT_EQ(-EINPROGRESS, write("obj_head", 0, pb, data_size));
+  ASSERT_EQ(-EINPROGRESS, write("obj_clone", 0, pb, data_size));
+  {
+    auto* t = get_peering_state(target);
+    ASSERT_EQ(t->get_pg_log().get_can_rollback_to(), t->get_pg_log().get_log().head)
+      << "Target must have rolled the partial writes forward (crt==head), "
+         "so they are non-rollbackable";
+  }
+
+  // Phase 4: recover "trigger" so last_complete climbs to the head through the
+  // rolled-forward entries.
+  run_recovery_and_verify_callbacks("trigger", target, pb);
+
+  // Stall reservation grants: the harness drives recovery directly, not through
+  // the reservation path.  Without stalling, a grant delivered across the split's
+  // interval change would hit a PeeringState in Reset and abort.
+  set_stall_recovery_reservations(true);
+
+  // Phase 5: interval change rewinds the target.  proc_replica_log finds
+  // obj_head/obj_clone divergent with prior_version <= log_tail and adds them
+  // to missing; the target ends up with an empty log and missing(2).
+  mark_osd_down(2);
+  unsuspend_primary_to_osd(blocked);
+  event_loop->run_until_idle();
+
+  {
+    auto* t = get_peering_state(target);
+    EXPECT_TRUE(t->get_pg_log().get_log().log.empty())
+      << "Target log should be rewound to empty";
+    EXPECT_EQ(t->get_pg_log().get_missing().num_missing(), 2u)
+      << "Target should be missing obj_head and obj_clone";
+    // reset_complete_to() on an empty-but-missing log must lower last_complete
+    // below last_update; this is the direct fix assertion (tracker 68649).
+    EXPECT_LT(t->get_info().last_complete, t->get_info().last_update)
+      << "bug 68649: reset_complete_to must lower last_complete on empty log";
+  }
+
+  // Raise the async-recovery cost so the child peers with the target as a full
+  // acting member; avoids pg_temp churn and matches the real incident (osd.11).
+  g_ceph_context->_conf.set_val("osd_async_recovery_min_cost", "100");
+  g_ceph_context->_conf.apply_changes(nullptr);
+
+  // Phase 6: PG split — child inherits the empty log + missing(2).
+  split_pg();
+
+  auto* child_target = get_child_peering_state(target);
+  EXPECT_TRUE(child_target->get_pg_log().get_log().log.empty())
+    << "Child target log should be empty after split";
+  EXPECT_EQ(child_target->get_pg_log().get_missing().num_missing(), 2u)
+    << "Child target should inherit missing(2)";
+
+  // Phase 7: assert that the primary retains peer_missing[target] entries for
+  // the two affected objects.  This is the shared precondition consulted by
+  // both is_degraded_or_backfilling_object() (which blocks the op for full
+  // acting peers) and should_send_op() (which ships an empty op to
+  // async-recovery targets).  Without the fix, GetMissing's identical-log
+  // fast-path clears peer_missing[target] and neither gate fires, causing a
+  // clone write to reach a shard that is missing the object → ENOENT.
+  auto* child_primary = get_child_peering_state(0);
+  auto primary_has_peer_missing_entry = [&](const hobject_t& soid) -> bool {
+    if (child_primary->get_pg_log().get_missing().get_items().count(soid)) {
+      return true;
+    }
+    for (const auto& peer : child_primary->get_acting_recovery_backfill()) {
+      if (peer == child_primary->get_primary()) {
+        continue;
+      }
+      auto pm = child_primary->get_peer_missing().find(peer);
+      if (pm != child_primary->get_peer_missing().end() &&
+          pm->second.is_missing(soid)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const hobject_t head = make_test_object("obj_head");
+  const hobject_t clone = make_test_object("obj_clone");
+  ASSERT_EQ(child_target->get_pg_log().get_missing().num_missing(), 2u);
+  EXPECT_TRUE(primary_has_peer_missing_entry(head))
+    << "bug 68649: peer_missing[target] cleared by GetMissing identical-log "
+       "fast-path; primary would forward a write to obj_head to a shard that "
+       "is missing the object -> ENOENT in BlueStore";
+  EXPECT_TRUE(primary_has_peer_missing_entry(clone))
+    << "bug 68649: peer_missing[target] cleared by GetMissing identical-log "
+       "fast-path; primary would forward a write to obj_clone to a shard that "
+       "is missing the object -> ENOENT in BlueStore";
+
+  // cfg_async_recovery, cfg_trim_min, and cfg_trim_max restore automatically
+  // via ScopedConfig destructors at function exit.
+}
+
+/**
+ * DivergentLogRewindThenNewInterval
+ *
+ * Companion to DivergentLogRewindThenSplit that confirms the bug is not
+ * specific to a PG split: any subsequent interval where the corrupt target
+ * re-advertises last_complete == last_update triggers the same GetMissing
+ * identical-log fast-path.
+ */
+TEST_P(TestECFailoverWithPeering, DivergentLogRewindThenNewInterval) {
+  if (m < 2 || k < 3) {
+    GTEST_SKIP() << "DivergentLogRewindThenNewInterval requires k>=3 and m>=2";
+  }
+
+  ASSERT_TRUE(all_shards_active()) << "Initial peering must complete";
+
+  // ScopedConfig guards restore these to their original values on test exit,
+  // even if the test aborts early via ASSERT_*.
+  ScopedConfig cfg_async_recovery("osd_async_recovery_min_cost", "0");
+  ScopedConfig cfg_trim_min("osd_pg_log_trim_min", "1");
+  ScopedConfig cfg_trim_max("osd_pg_log_trim_max", "1000");
+  osdmap->set_flag(CEPH_OSDMAP_PGLOG_HARDLIMIT);
+
+  const int target = 1;
+  const pg_shard_t target_shard(target, shard_id_t(target));
+  const size_t data_size = stripe_unit * k;
+  const std::string pa(data_size, 'A'), pb(data_size, 'B');
+
+  // Phase 1: commit the objects, then build a high log tail T.
+  create_and_write_verify("obj_head", pa);
+  create_and_write_verify("obj_clone", pa);
+  create_and_write_verify("trigger", pa);
+  enable_log_trimming = true;
+  set_target_pg_log_entries(1);
+  for (int i = 0; i < 10; ++i) {
+    write_verify("obj_head", 0, pa, data_size);
+    write_verify("obj_clone", 0, pa, data_size);
+  }
+
+  // Phase 2: target misses a trigger write; rejoins as async-recovery (!is_acting).
+  mark_osd_down(target);
+  write_verify("trigger", 0, pb, data_size);
+  mark_osd_up(target);
+  ASSERT_FALSE(get_peering_state(0)->is_acting(target_shard));
+
+  // Phase 3: blocked writes; target rolls them forward (crt→head), non-rollbackable.
+  const int blocked = k + 1;
+  suspend_primary_to_osd(blocked);
+  ASSERT_EQ(-EINPROGRESS, write("obj_head", 0, pb, data_size));
+  ASSERT_EQ(-EINPROGRESS, write("obj_clone", 0, pb, data_size));
+
+  // Phase 4: recover the pre-existing missing so last_complete reaches head.
+  run_recovery_and_verify_callbacks("trigger", target, pb);
+  set_stall_recovery_reservations(true);
+
+  // Phase 5: interval change rewinds the target to an empty log with missing(2).
+  mark_osd_down(2);
+  unsuspend_primary_to_osd(blocked);
+  event_loop->run_until_idle();
+  {
+    auto* t = get_peering_state(target);
+    ASSERT_TRUE(t->get_pg_log().get_log().log.empty());
+    ASSERT_EQ(t->get_pg_log().get_missing().num_missing(), 2u);
+  }
+
+  // Phase 6: plain new interval (no split).
+  g_ceph_context->_conf.set_val("osd_async_recovery_min_cost", "100");
+  g_ceph_context->_conf.apply_changes(nullptr);
+  advance_epoch();
+
+  // Phase 7: same peer_missing gate as DivergentLogRewindThenSplit.
+  // After raising osd_async_recovery_min_cost to 100 above, the target is
+  // a full acting peer (not async-recovery) in this interval, so
+  // is_degraded_or_backfilling_object() is what guards the write.  The
+  // underlying invariant in both cases is identical: peer_missing[target]
+  // must contain the soid.
+  auto* primary = get_peering_state(0);
+  auto primary_has_peer_missing_entry = [&](const hobject_t& soid) -> bool {
+    if (primary->get_pg_log().get_missing().get_items().count(soid)) {
+      return true;
+    }
+    for (const auto& peer : primary->get_acting_recovery_backfill()) {
+      if (peer == primary->get_primary()) {
+        continue;
+      }
+      auto pm = primary->get_peer_missing().find(peer);
+      if (pm != primary->get_peer_missing().end() &&
+          pm->second.is_missing(soid)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const hobject_t head = make_test_object("obj_head");
+  const hobject_t clone = make_test_object("obj_clone");
+  EXPECT_TRUE(primary_has_peer_missing_entry(head))
+    << "bug 68649: peer_missing[target] cleared by GetMissing identical-log "
+       "fast-path; primary would forward a write to obj_head to a shard that "
+       "is missing the object -> ENOENT in BlueStore";
+  EXPECT_TRUE(primary_has_peer_missing_entry(clone))
+    << "bug 68649: peer_missing[target] cleared by GetMissing identical-log "
+       "fast-path; primary would forward a write to obj_clone to a shard that "
+       "is missing the object -> ENOENT in BlueStore";
+
+  // cfg_async_recovery, cfg_trim_min, and cfg_trim_max restore automatically
+  // via ScopedConfig destructors at function exit.
+}
+
 // ---------------------------------------------------------------------------
 // Instantiate TestECFailoverWithPeering with EC configurations
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Before this change the EC peering unit-test fixture could drive recovery
and OSD failover, but had no way to reach the state behind tracker 68649:
a primary that believes a still-missing shard is up to date and forwards
a clone to it.  Reaching that needs aggressive PG-log trimming, control
over which child a PG split sends an object to, and an actual PG split -
none of which the fixture could do.

This adds that capability to ECPeeringTestFixture and friends:

- Opt-in aggressive log trimming on the write path (it now computes a
  real trim_to / pg_committed_to via update_trim_to()/complete_write(),
  as PrimaryLogPG does) so a shard's log can be driven to the trimmed and
  empty states that a low osd_*_pg_log_entries produces in the field.
- Per-object hash control, so an object can be steered into a chosen
  child PG when pg_num increases.
- A real PG split (split_pg): it bumps pg_num, runs the production
  PeeringState::split_into, splits the ObjectStore collection, and peers
  the child PG - including the pg_temp cycle the child primary needs to
  finish peering.
- Epoch-gated, correctly-routed delivery of deferred peering events in
  MockPeeringListener, matching PG::do_peering_event()/pg_has_reset_since:
  a deferred event (e.g. ActivateCommitted, DoRecovery) queued in a prior
  interval is now discarded rather than delivered into Reset, and is
  delivered to the listener's own PG (parent vs split child).  Without
  this the fixture aborted once the fix let recovery actually run.

Two tests are added.  DivergentLogRewindThenSplit builds the corrupt
state through the real code paths - trim to a high tail, an
async-recovery target that rolls forward uncommitted EC writes,
proc_replica_log's divergent rewind, then a real split - and asserts the
gate PrimaryLogPG uses before issuing a clone (is_degraded_or_backfilling
/ should_send_op, both of which need peer_missing[target].is_missing).
DivergentLogRewindThenNewInterval is a negative control: a plain interval
change instead of a split does not reproduce it (the primary re-requests
the target's log), showing the split is required.

DivergentLogRewindThenSplit fails on this commit alone and passes once
the following reset_complete_to fix is applied.

Assisted-by: Claude:Claude-opus-4.8(1M)
Assisted-by: IBM-Bob-v2.0.1
Signed-off-by: Alex Ainscow <aainscow@uk.ibm.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
