### PR TITLE
squid: radosgw-admin: 'account rm --purge-data' deletes oidc by account id

### DIFF
--- a/src/rgw/rgw_account.cc
+++ b/src/rgw/rgw_account.cc
@@ -422,13 +422,13 @@ int remove(const DoutPrefixProvider* dpp,
     return -ENOTEMPTY;
   }
 
-  for (const auto& info : providers) {
-    ret = driver->delete_oidc_provider(dpp, y, info.tenant, info.provider_url);
+  for (const auto& oidc : providers) {
+    ret = driver->delete_oidc_provider(dpp, y, info.id, oidc.provider_url);
     if (ret < 0) {
-      err_msg = fmt::format("unable to delete oidc provider {}", info.provider_url);
+      err_msg = fmt::format("unable to delete oidc provider {}", oidc.provider_url);
       return ret;
     }
-    ldpp_dout(dpp, 1) << "Deleted account oidc provider " << info.provider_url << dendl;
+    ldpp_dout(dpp, 1) << "Deleted account oidc provider " << oidc.provider_url << dendl;
   }
 
   rgw::sal::TopicList topics;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80253

---

backport of https://github.com/ceph/ceph/pull/71396
parent tracker: https://tracker.ceph.com/issues/80029

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh