### PR TITLE
test/mgr: start the messenger in the TestMgr fixture

### DIFF
--- a/src/test/mgr/TestMgr.h
+++ b/src/test/mgr/TestMgr.h
@@ -82,6 +82,12 @@ public:
     mc = std::make_unique<MonClient>(cct.get(), *icp);
     messenger.reset(
         Messenger::create_client_messenger(cct.get(), "unittest_mgr"));
+    // The messenger must be started for shutdown()/wait() in TearDown() to
+    // perform a full teardown: wait() returns early on a never-started
+    // messenger, skipping the final stack drain, so the loopback
+    // AsyncConnection's deferred cleanup would run on the msgr-worker
+    // thread after the messenger is destroyed and crash in ~AsyncConnection.
+    messenger->start();
     objecter =
         std::make_unique<Objecter>(cct.get(), messenger.get(), mc.get(), *icp);
 


### PR DESCRIPTION
Fixes the top flaky test in the ceph-pr-pipeline: `unittest_mgr_clusterstate` segfaulting intermittently in `TestMgr.ClusterState_LoadDigest` on both x86_64 and arm64 (6 of 11 flaky-failure runs between 2026-08-31 and 2026-09-02, e.g. [build 230](https://jenkins.ceph.com/job/ceph-pr-pipeline/230/testReport), also 221/241/284/329/419).

The crash is on `msgr-worker-0` in `SubsystemMap::should_gather` from `AsyncConnection::~AsyncConnection()` via `RefCountedObject::put()` / `C_clean_handler`. Root cause: the `TestMgr` fixture creates a client messenger but never calls `messenger->start()`. `AsyncMessenger::shutdown()` drains the stack and *then* marks down the loopback connection, queueing its deferred cleanup onto the msgr-worker; the subsequent `messenger->wait()` returns immediately (`started == false`), skipping `shutdown_connections()` and the final `stack->drain()`. `TearDown()` then destroys the messenger while the cleanup event is still pending. The NetworkStack worker threads are a per-CephContext singleton that outlives each test, so the worker later runs the cleanup — often mid-way through the next test — and `~AsyncConnection` dereferences the dangling `async_msgr` pointer in `ldout(async_msgr->cct, 20)`.

Starting the messenger in `SetUp()` (the standard client messenger lifecycle, cf. `RadosClient`) makes `wait()` perform the full teardown, so the deferred connection cleanup completes before the messenger is destroyed.

Fixes: https://tracker.ceph.com/issues/80257

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests