### PR TITLE
mgr/cephadm: map an mds daemon to its filesystem by membership

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -789,6 +789,37 @@ def test_enough_mds_for_ok_to_stop(get, get_daemons_by_service, cephadm_module: 
         DaemonDescription(daemon_type='mds', daemon_id='myfs.test.host1.gfknd', service_name='mds.myfs.test'))
 
 
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch("cephadm.module.HostCache.get_daemons_by_service")
+@mock.patch("cephadm.CephadmOrchestrator.get")
+def test_enough_mds_for_ok_to_stop_uses_actual_membership(
+        get, get_daemons_by_service, cephadm_module: CephadmOrchestrator):
+    # mds_join_fs is a preference, not a constraint: a standby deployed by
+    # service mds.fsA can be promoted into a rank of fsB. The filesystem that
+    # lists the daemon has to win over the one its service name names,
+    # otherwise the wrong max_mds is compared and the ok-to-stop check is
+    # skipped for a daemon that is holding a rank.
+    mds = DaemonDescription(daemon_type='mds',
+                            daemon_id='fsA.host1.gfknd',
+                            service_name='mds.fsA')
+    get.side_effect = [{'filesystems': [
+        {'mdsmap': {'fs_name': 'fsA', 'max_mds': 3, 'info': {}}},
+        {'mdsmap': {'fs_name': 'fsB', 'max_mds': 2,
+                    'info': {'gid_1': {'name': 'fsA.host1.gfknd',
+                                       'state': 'up:active'}}}},
+    ]}]
+    get_daemons_by_service.side_effect = [[DaemonDescription()] * 3]
+    assert cephadm_module.upgrade._enough_mds_for_ok_to_stop(mds)
+
+    # with no membership recorded anywhere, the service naming convention is
+    # still used
+    get.side_effect = [{'filesystems': [
+        {'mdsmap': {'fs_name': 'fsA', 'max_mds': 2, 'info': {}}},
+    ]}]
+    get_daemons_by_service.side_effect = [[DaemonDescription()] * 3]
+    assert cephadm_module.upgrade._enough_mds_for_ok_to_stop(mds)
+
+
 def _mds_need_upgrade_entries() -> List[Tuple[DaemonDescription, bool]]:
     return [
         (DaemonDescription(

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1415,27 +1415,36 @@ class CephadmUpgrade:
     def _enough_mds_for_ok_to_stop(self, mds_daemon: DaemonDescription) -> bool:
         # type (DaemonDescription) -> bool
 
-        # find fs this mds daemon belongs to
+        assert mds_daemon.daemon_id
         fsmap = self.mgr.get("fs_map")
+
+        # Find the fs this mds daemon belongs to. mds_join_fs, which the mds
+        # service sets from the service name, is only a preference: a standby
+        # can be promoted into a rank of any filesystem that is short on MDS.
+        # Prefer the filesystem that actually lists this daemon and fall back
+        # to the service naming convention when none does.
+        by_membership = None
+        by_service_name = None
+        service_fs_name = mds_daemon.service_name().split('.', 1)[1]
         for fs in fsmap.get('filesystems', []):
             mdsmap = fs["mdsmap"]
-            fs_name = mdsmap["fs_name"]
+            if any(info.get('name') == mds_daemon.daemon_id
+                   for info in mdsmap.get('info', {}).values()):
+                by_membership = mdsmap
+                break
+            if by_service_name is None and mdsmap["fs_name"] == service_fs_name:
+                by_service_name = mdsmap
 
-            assert mds_daemon.daemon_id
-            if fs_name != mds_daemon.service_name().split('.', 1)[1]:
-                # wrong fs for this mds daemon
-                continue
+        mdsmap = by_membership if by_membership is not None else by_service_name
+        if mdsmap is None:
+            return True  # if mds has no fs it should pass ok-to-stop
 
-            # get number of mds daemons for this fs
-            mds_count = len(
-                [daemon for daemon in self.mgr.cache.get_daemons_by_service(mds_daemon.service_name())])
+        # get number of mds daemons for this fs
+        mds_count = len(
+            [daemon for daemon in self.mgr.cache.get_daemons_by_service(mds_daemon.service_name())])
 
-            # standby mds daemons for this fs?
-            if mdsmap["max_mds"] < mds_count:
-                return True
-            return False
-
-        return True  # if mds has no fs it should pass ok-to-stop
+        # standby mds daemons for this fs?
+        return mdsmap["max_mds"] < mds_count
 
     def _detect_need_upgrade(self, daemons: List[DaemonDescription], target_digests: Optional[List[str]] = None, target_name: Optional[str] = None) -> Tuple[bool, List[Tuple[DaemonDescription, bool]], List[Tuple[DaemonDescription, bool]], int]:
         # this function takes a list of daemons and container digests. The purpose


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/80088

`_enough_mds_for_ok_to_stop()` maps an mds daemon to a filesystem by
taking the part of its service name after the dot and matching it
against `fs_name`. `mds_join_fs` is only a preference, so a standby
deployed by service `mds.fsA` can be promoted into a rank of `fsB`, and
then the wrong `mdsmap` is evaluated.

The return value decides whether the caller runs the ok-to-stop check at
all, so returning `False` for the wrong filesystem means the upgrade
path (`upgrade.py:1590`) and the key rotation path (`upgrade.py:1709`)
can stop a daemon that is holding a rank without checking, causing an
unprepared failover on the filesystem it was actually serving.

Reproducer, as the added unit test: a daemon with `service_name`
`mds.fsA` listed in `fsB`'s `mdsmap['info']`, with `fsA` at `max_mds=3`,
`fsB` at `max_mds=2` and 3 daemons in the service. Before this change
the function evaluates `fsA` and returns `False`, skipping the check.
After it, it evaluates `fsB` and returns `True`.

The fallback to the service naming convention is kept for a daemon that
no filesystem claims, and is covered by the second half of the new test.
The pre-existing `test_enough_mds_for_ok_to_stop` still passes
unchanged.

Ran `pytest cephadm/tests/test_upgrade.py`: 73 passed. The 2 errors in
that file (`test_ok_to_upgrade_mon_report_*`) are present on unmodified
main in the same environment and are unrelated. flake8 clean.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
