### PR TITLE
[TESTING - DON'T MERGE] Mds snapdiff snapflush issue testing 1

### DIFF
--- a/qa/suites/fs/mirror/overrides/ignorelist_health.yaml
+++ b/qa/suites/fs/mirror/overrides/ignorelist_health.yaml
@@ -27,3 +27,5 @@ overrides:
       - experiencing slow operations in BlueStore
       - MGR_MODULE_ERROR
       - OSD_NEARFULL
+      # SIGKILL of cephfs-mirror leaves the MDS session until autoclose especially with test_cephfs_mirror_sigkill_during_sync_recovers
+      - evicting unresponsive client

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -2238,8 +2238,6 @@ class TestMirroring(CephFSTestCase):
     def test_cephfs_mirror_incremental_sync(self):
         """ Test incremental snapshot synchronization (based on mtime differences)."""
 
-        self.skipTest("temporarily disable test: snapdiff bug - see https://tracker.ceph.com/issues/74984")
-
         self.setup_mount_b(mds_perm='rw')
         repo = 'ceph-qa-suite'
         repo_dir = 'ceph_repo'
@@ -2289,7 +2287,9 @@ class TestMirroring(CephFSTestCase):
         vthird = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
         self.assertGreater(vthird["counters"]["snaps_synced"], vsecond["counters"]["snaps_synced"])
         inc_sync_duration1 = vthird["counters"]["last_synced_duration"]
-        self.assertGreaterEqual(float(full_sync_duration), float(inc_sync_duration1))
+        # For small number of files, incremental sync mostly takes more time because of snapdiff.
+        # This has become obvious after a separate crawler thread with multi-threaded mirroring
+        log.debug(f'full_sync_duration - {full_sync_duration}, inc_sync_duration1 - {inc_sync_duration1}')
 
         # diff again, this time back to HEAD
         log.debug('resetting to HEAD')
@@ -2304,7 +2304,9 @@ class TestMirroring(CephFSTestCase):
         vfourth = res[TestMirroring.PERF_COUNTER_KEY_NAME_CEPHFS_MIRROR_PEER][0]
         self.assertGreater(vfourth["counters"]["snaps_synced"], vthird["counters"]["snaps_synced"])
         inc_sync_duration2 = vfourth["counters"]["last_synced_duration"]
-        self.assertGreaterEqual(float(full_sync_duration), float(inc_sync_duration2))
+        # For small number of files, incremental sync mostly takes more time because of snapdiff.
+        # This has become obvious after a separate crawler thread with multi-threaded mirroring
+        log.debug(f'full_sync_duration - {full_sync_duration}, inc_sync_duration2 - {inc_sync_duration2}')
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
 
@@ -2389,8 +2391,6 @@ class TestMirroring(CephFSTestCase):
         mirror daemon should identify the purge and switch to using remote
         comparison to sync the snapshot (in the next iteration of course).
         """
-
-        self.skipTest("temporarily disable test: snapdiff bug - see https://tracker.ceph.com/issues/74984")
 
         self.setup_mount_b(mds_perm='rw')
         repo = 'ceph-qa-suite'

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -12356,6 +12356,7 @@ void Server::_readdir_diff(
   size_t rollback_pos = 0;
   size_t rollback_num = 0;
 
+  bool waiting = false;
   bool end = build_snap_diff(
     mdr,
     dir,
@@ -12427,7 +12428,11 @@ void Server::_readdir_diff(
       mdcache->lru.lru_touch(dn);
       ++numfiles;
       return true;
-    });
+    },
+    &waiting);
+
+  if (waiting)
+    return;
 
   __u16 flags = 0;
   if (req_flags & CEPH_READDIR_REPLY_BITFLAGS) {
@@ -12449,7 +12454,8 @@ bool Server::build_snap_diff(
   snapid_t snapid,
   unsigned diff_mask,
   const bufferlist& dnbl,
-  std::function<bool (CDentry*, CInode*, bool)> add_result_cb)
+  std::function<bool (CDentry*, CInode*, bool)> add_result_cb,
+  bool *waiting)
 {
   struct EntryInfo {
     CDentry* dn = nullptr;
@@ -12494,6 +12500,24 @@ bool Server::build_snap_diff(
       return res_mask != 0;
     }
   } before;
+
+
+  // rdlock filelock so pending snapflush completes before metadata is read.
+  auto rdlock_file_start = [&](CInode *in) -> bool {
+    if (!mds->locker->rdlock_start(&in->filelock, mdr)) {
+      dout(10) << __func__ << " waiting for snapflush, deferring readdir_snapdiff on "
+           << *in << " snap " << snapid_prev << " vs. " << snapid << dendl;
+      if (waiting)
+        *waiting = true;
+      return false;
+    }
+    return true;
+  };
+  auto rdlock_file_finish = [&](CInode *in) {
+    auto lit = mdr->locks.find(&in->filelock);
+    ceph_assert(lit != mdr->locks.end());
+    mds->locker->rdlock_finish(lit, mdr.get(), nullptr);
+  };
 
   auto insert_deleted = [&](EntryInfo& ei) {
     dout(20) << "build_snap_diff deleted file " << ei.dn->get_name() << " "
@@ -12628,11 +12652,27 @@ bool Server::build_snap_diff(
 		<< dendl;
 	      before.reset();
 	    } else {
-	      dout(0) << __func__ << " attrs not changed " << dn->get_name() << " "
-		<< dn->first << "/" << dn->last
-		<< dendl;
-	      before.reset();
-	      continue;
+	      /* If attrs match, rdlock the filelock which waits for pending snap
+	       * flush so that latest metadata is fetched under the lock.
+	       */
+	      if (!rdlock_file_start(in))
+		return false;
+	      bool differs = before.meta_differs(in, diff_mask, res_mask);
+	      rdlock_file_finish(in);
+	      if (differs) {
+		dout(0) << __func__ << " attrs changed " << dn->get_name() << " "
+		  << dn->first << "/" << dn->last
+		  << " result mask: 0x" << std::hex << res_mask << std::dec
+		  << " (after snapflush)"
+		  << dendl;
+		before.reset();
+	      } else {
+		dout(0) << __func__ << " attrs not changed " << dn->get_name() << " "
+		  << dn->first << "/" << dn->last
+		  << dendl;
+		before.reset();
+		continue;
+	      }
 	    }
 	  }
 	}

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -12501,6 +12501,18 @@ bool Server::build_snap_diff(
     }
   } before;
 
+  auto snapflush_pending = [&](CInode *in) -> bool {
+    if (!in->is_head() && !in->client_snap_caps.empty())
+      return true;
+    CInode *head = in->is_head() ? in : mdcache->get_inode(in->ino());
+    if (!head)
+      return true;
+    for (const auto& p : head->client_need_snapflush) {
+      if (p.first >= snapid_prev && p.first <= snapid && !p.second.empty())
+	return true;
+    }
+    return false;
+  };
 
   // rdlock filelock so pending snapflush completes before metadata is read.
   auto rdlock_file_start = [&](CInode *in) -> bool {
@@ -12614,8 +12626,42 @@ bool Server::build_snap_diff(
       }
     } else {
       if (snapid_prev >= dn->first && snapid <= dn->last) {
-	dout(20) << __func__ << " skipping unchanged " << dn->get_name() << " "
-	  << dn->first << "/" << dn->last << dendl;
+	if (!snapflush_pending(in)) {
+	  dout(20) << __func__ << " skipping unchanged " << dn->get_name() << " "
+	    << dn->first << "/" << dn->last << dendl;
+	  continue;
+	}
+	if (before.dn) {
+	  if (!insert_deleted(before)) {
+	    break;
+	  }
+	  before.reset();
+	}
+	CInode *head = in->is_head() ? in : mdcache->get_inode(in->ino());
+	if (!head) {
+	  dout(20) << __func__ << " skipping unchanged " << dn->get_name() << " "
+	    << dn->first << "/" << dn->last << dendl;
+	  continue;
+	}
+	unsigned res_mask = 0;
+	if (!rdlock_file_start(in))
+	  return false;
+	CInode *in_prev = mdcache->pick_inode_snap(head, snapid_prev);
+	CInode *in_snap = mdcache->pick_inode_snap(head, snapid);
+	EntryInfo prev_ei{dn, in_prev};
+	bool differs = prev_ei.meta_differs(in_snap, diff_mask, res_mask);
+	rdlock_file_finish(in);
+	if (differs) {
+	  dout(30) << __func__ << " attrs changed on unchanged span "
+	    << dn->get_name() << " " << dn->first << "/" << dn->last
+	    << " result mask: 0x" << std::hex << res_mask << std::dec << dendl;
+	  if (!add_result_cb(dn, in, true)) {
+	    break;
+	  }
+	  continue;
+	}
+	dout(20) << __func__ << " skipping unchanged after snapflush check "
+	  << dn->get_name() << " " << dn->first << "/" << dn->last << dendl;
 	continue;
       } else if (snapid_prev < dn->first && snapid > dn->last) {
 	dout(20) << __func__ << " skipping inner modification " << dn->get_name() << " "
@@ -12651,9 +12697,15 @@ bool Server::build_snap_diff(
 		<< " result mask: 0x" << std::hex << res_mask << std::dec
 		<< dendl;
 	      before.reset();
+	    } else if (!snapflush_pending(in)) {
+	      dout(0) << __func__ << " attrs not changed " << dn->get_name() << " "
+		<< dn->first << "/" << dn->last
+		<< dendl;
+	      before.reset();
+	      continue;
 	    } else {
-	      /* If attrs match, rdlock the filelock which waits for pending snap
-	       * flush so that latest metadata is fetched under the lock.
+	      /* attrs match but snapflush is pending; rdlock so metadata is
+	       * read after writeback completes.
 	       */
 	      if (!rdlock_file_start(in))
 		return false;
@@ -12669,6 +12721,7 @@ bool Server::build_snap_diff(
 	      } else {
 		dout(0) << __func__ << " attrs not changed " << dn->get_name() << " "
 		  << dn->first << "/" << dn->last
+		  << " (after snapflush)"
 		  << dendl;
 		before.reset();
 		continue;

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -584,7 +584,8 @@ private:
     snapid_t snapid,
     unsigned diff_mask,
     const bufferlist& dnbl,
-    std::function<bool(CDentry*, CInode*, bool)> add_result_cb);
+    std::function<bool(CDentry*, CInode*, bool)> add_result_cb,
+    bool *waiting = nullptr);
 
   MDSRank *mds;
   MDCache *mdcache;

--- a/src/test/libcephfs/snapdiff.cc
+++ b/src/test/libcephfs/snapdiff.cc
@@ -1963,7 +1963,12 @@ TEST(LibCephFS, HugeSnapDiffSmallDelta)
 {
   TestMount test_mount;
 
+#ifdef _WIN32
+  // Windows client is ~8x slower per file op; 10000 exceeds the test timeout
+  long int file_count = 10000 / 8;
+#else
   long int file_count = 10000;
+#endif
   printf("Seeding %ld files...\n", file_count);
 
   // Create simple directory tree with a couple of snapshots
@@ -2019,16 +2024,37 @@ TEST(LibCephFS, HugeSnapDiffLargeDelta)
 
   // Calculate amount of files required to have multiple directory fragments
   // using relevant config parameters.
-  // file_count = mds_bal_spli_size * mds_bal_fragment_fast_factor + 100
+  // file_count = mds_bal_split_size * mds_bal_fragment_fast_factor + 100
   char buf[256];
+  long int file_count;
+  double factor;
+#ifdef _WIN32
+  // Windows client is ~8x slower per file op; use a smaller split size so we
+  // still trigger directory fragmentation within the CI timeout.
+  struct Cleanup
+  {
+    TestMount &test_mount;
+    ~Cleanup()
+    {
+      test_mount.tell_rank0_config("mds_bal_split_size");
+      test_mount.tell_rank0_config("mds_bal_fragment_fast_factor");
+    }
+  } cleanup{test_mount};
+
+  ASSERT_TRUE(test_mount.tell_rank0_config("mds_bal_split_size", "800"));
+  ASSERT_TRUE(test_mount.tell_rank0_config("mds_bal_fragment_fast_factor", "1.5"));
+  factor = 1.5;
+  file_count = 800 * factor + 100;
+#else
   int r = test_mount.conf_get("mds_bal_split_size", buf, sizeof(buf));
   ASSERT_TRUE(r >= 0);
-  long int file_count = strtol(buf, nullptr, 10);
+  file_count = strtol(buf, nullptr, 10);
   r = test_mount.conf_get("mds_bal_fragment_fast_factor ", buf, sizeof(buf));
   ASSERT_TRUE(r >= 0);
-  double factor = strtod(buf, nullptr);
+  factor = strtod(buf, nullptr);
   file_count *= factor;
   file_count += 100;
+#endif
   printf("Seeding %ld files...\n", file_count);
 
   // Create simple directory tree with a couple of snapshots


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
