### PR TITLE
rgw/lc: fixed the radosgw-admin lc list started epoch time

### DIFF
--- a/qa/suites/rgw/verify/tasks/lc-started.yaml
+++ b/qa/suites/rgw/verify/tasks/lc-started.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rgw/run-lc-started.sh

--- a/qa/workunits/rgw/run-lc-started.sh
+++ b/qa/workunits/rgw/run-lc-started.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -ex
+
+# assume working ceph environment (radosgw-admin in path) and rgw on localhost:80
+# localhost::443 for ssl
+
+mydir=`dirname $0`
+
+python3 -m venv $mydir
+source $mydir/bin/activate
+pip install pip --upgrade
+pip install boto3
+
+## run test
+$mydir/bin/python3 $mydir/test_rgw_lc_started.py
+
+deactivate
+echo OK.

--- a/qa/workunits/rgw/test_rgw_lc_started.py
+++ b/qa/workunits/rgw/test_rgw_lc_started.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import logging as log
+import json
+import time
+import botocore
+from common import exec_cmd, create_user, boto_connect
+from botocore.config import Config
+
+"""
+Tests the 'started' timestamp reported by 'radosgw-admin lc list'.
+
+The single-bucket lifecycle path used by 'radosgw-admin lc process
+--bucket' transitions the LC pool entry to PROCESSING. Historically it
+left start_time at its default-initialized value of 0, so 'lc list'
+reported "Thu, 01 Jan 1970 00:00:00 GMT" for buckets that had never
+been processed by the periodic LC worker.
+
+start_time is now initialized on that path when, and only when, it has
+never been set. An ad-hoc run must not overwrite a timestamp already
+recorded for the entry, because already_run_today() and
+expired_session() in the periodic-shard path read that value.
+"""
+
+""" Constants """
+USER = 'lc-started-tester'
+DISPLAY_NAME = 'LC Started Testing'
+ACCESS_KEY = 'LCSTARTED0123456789A'
+SECRET_KEY = 'lcstartedsecretkey0123456789abcdefghijklm'
+BUCKET_NAME = 'lc-started-bucket'
+RULE_ID = 'lc-started-expire'
+
+EPOCH_PREFIX = 'Thu, 01 Jan 1970'
+
+
+def get_lc_entry(bucket_name):
+    """
+    Return the 'lc list' entry for bucket_name, or None. Entries are
+    keyed as '<tenant>:<bucket>:<marker>'.
+    """
+    out = exec_cmd('radosgw-admin lc list')
+    for entry in json.loads(out):
+        if f':{bucket_name}:' in entry['bucket']:
+            return entry
+    return None
+
+
+def set_lifecycle(connection, bucket_name):
+    connection.meta.client.put_bucket_lifecycle_configuration(
+        Bucket=bucket_name,
+        LifecycleConfiguration={
+            'Rules': [
+                {
+                    'ID': RULE_ID,
+                    'Filter': {'Prefix': ''},
+                    'Status': 'Enabled',
+                    'Expiration': {'Days': 1},
+                }
+            ]
+        }
+    )
+    log.info(f'Set lifecycle rule {RULE_ID} on {bucket_name}')
+
+
+def main():
+    create_user(USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY)
+
+    connection = boto_connect(ACCESS_KEY, SECRET_KEY, Config(retries={
+        'total_max_attempts': 1,
+    }))
+
+    # pre-test cleanup
+    try:
+        bucket = connection.Bucket(BUCKET_NAME)
+        bucket.objects.all().delete()
+        bucket.delete()
+    except botocore.exceptions.ClientError as e:
+        if not e.response['Error']['Code'] == 'NoSuchBucket':
+            raise
+
+    bucket = connection.create_bucket(Bucket=BUCKET_NAME)
+    bucket.put_object(Key='obj', Body=b'some_data')
+
+    set_lifecycle(connection, BUCKET_NAME)
+
+    # TESTCASE 'an entry that has never been processed reports the epoch'
+    log.debug('TEST: an entry that has never been processed reports the epoch\n')
+    entry = get_lc_entry(BUCKET_NAME)
+    assert entry is not None, f'no lc list entry for {BUCKET_NAME}'
+    assert entry['started'].startswith(EPOCH_PREFIX), \
+        f"expected an unset 'started', got {entry['started']}"
+
+    # TESTCASE 'an ad-hoc run initializes started'
+    log.debug('TEST: an ad-hoc run initializes started\n')
+    exec_cmd(f'radosgw-admin lc process --bucket={BUCKET_NAME}'
+             ' --rgw-lc-debug-interval=10')
+    entry = get_lc_entry(BUCKET_NAME)
+    assert entry is not None, f'no lc list entry for {BUCKET_NAME}'
+    assert not entry['started'].startswith(EPOCH_PREFIX), \
+        f"'started' was not initialized, got {entry['started']}"
+    first_started = entry['started']
+    log.info(f'started initialized to {first_started}')
+
+    # 'started' has one-second resolution; sleep so that a second ad-hoc
+    # run would produce a visibly different timestamp if it overwrote it
+    time.sleep(2)
+
+    # TESTCASE 'a second ad-hoc run does not overwrite started'
+    log.debug('TEST: a second ad-hoc run does not overwrite started\n')
+    exec_cmd(f'radosgw-admin lc process --bucket={BUCKET_NAME}'
+             ' --rgw-lc-debug-interval=10')
+    entry = get_lc_entry(BUCKET_NAME)
+    assert entry is not None, f'no lc list entry for {BUCKET_NAME}'
+    assert entry['started'] == first_started, \
+        f"ad-hoc run overwrote 'started': {first_started} -> {entry['started']}"
+
+    # post-test cleanup
+    bucket.objects.all().delete()
+    bucket.delete()
+
+    log.info('OK')
+
+
+main()
+

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2651,6 +2651,10 @@ int RGWLC::process_bucket(int index, int max_lock_secs, LCWorker* worker,
 		     << dendl;
 
   entry.status = lc_processing;
+  /* only initialize start_time when it has never been set in an ad-hoc command */
+  if (entry.start_time == 0) {
+    entry.start_time = ceph_clock_now();
+  }
   ret = sal_lc->set_entry(this, null_yield, obj_names[index], entry);
   if (ret < 0) {
     ldpp_dout(this, 0) << "RGWLC::process_bucket() failed to set obj entry "


### PR DESCRIPTION
The single-bucket lifecycle path used by 'radosgw-admin lc process --bucket' writes the LC pool entry with only the status updated, leaving start_time at its default-initialized value of 0 for buckets that have never been processed by the periodic LC worker. As a result, 'radosgw-admin lc list' displays "started: Thu, 01 Jan 1970 00:00:00 GMT" for such entries, and stale-session detection in expired_session() compares against a bogus timestamp.

Stamp entry.start_time with the current time before writing the entry, matching RGWLC::process() for the periodic-shard path.

Before,
```
[
    {
        "bucket": ":mybucket:dc59444a-db3c-4b42-a029-1cc805136e06.4243.1",
        "started": "Thu, 01 Jan 1970 00:00:00 GMT",
        "status": "COMPLETE"
    }
]
```

After,
```
[
    {
        "bucket": ":mybucket:dc59444a-db3c-4b42-a029-1cc805136e06.4243.1",
        "started": "Thu, 03 Sep 2026 06:33:00 GMT",
        "status": "COMPLETE"
    }
]
```

Fixes: https://tracker.ceph.com/issues/80264





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
