### PR TITLE
cephadm: rank hosts by their most critical daemon at shutdown

### DIFF
--- a/src/cephadm/cephadmlib/cluster_ops.py
+++ b/src/cephadm/cephadmlib/cluster_ops.py
@@ -391,15 +391,23 @@ def get_daemon_type_priority(daemon_types: List[str]) -> int:
     Lower number = process earlier in shutdown.
 
     Monitoring/gateways first (low number), core services last (high number).
+
+    Stopping a host stops every daemon on it, so the host is ranked by the most
+    critical daemon it runs. Ranking it by the least critical one would stop a
+    host running a mon as early as a host running only node-exporter.
     """
-    min_priority = len(DAEMON_SHUTDOWN_ORDER)
+    max_priority = -1
 
     for dtype in daemon_types:
         if dtype in DAEMON_SHUTDOWN_ORDER:
             priority = DAEMON_SHUTDOWN_ORDER.index(dtype)
-            min_priority = min(min_priority, priority)
+            max_priority = max(max_priority, priority)
 
-    return min_priority
+    if max_priority < 0:
+        # nothing recognized: stop it last, the conservative choice
+        return len(DAEMON_SHUTDOWN_ORDER)
+
+    return max_priority
 
 
 def order_hosts_for_shutdown(

--- a/src/cephadm/tests/test_cluster_ops.py
+++ b/src/cephadm/tests/test_cluster_ops.py
@@ -192,6 +192,50 @@ class TestDaemonOrdering:
         # All hosts should be included
         assert set(ordered) == set(host_daemon_map.keys())
 
+    def test_priority_uses_most_critical_daemon(self):
+        """A host is ranked by its most critical daemon, not its least."""
+        # Stopping the host stops the mon too, so a host running a mon must
+        # rank with the mon, whatever else happens to run beside it.
+        assert cluster_ops.get_daemon_type_priority(
+            ['node-exporter', 'mon']
+        ) == cluster_ops.get_daemon_type_priority(['mon'])
+
+    def test_order_hosts_by_role_not_by_ubiquitous_daemons(self):
+        """crash and node-exporter run everywhere and must not flatten the order."""
+        # cephadm places crash and node-exporter on every host by default, so
+        # ranking a host by its least critical daemon gives every host the same
+        # priority and loses the ordering entirely.
+        host_daemon_map = {
+            'mon-host': ['mon', 'osd', 'crash', 'node-exporter'],
+            'osd-host': ['osd', 'crash', 'node-exporter'],
+            'grafana-host': ['grafana', 'prometheus', 'node-exporter'],
+        }
+
+        ordered = cluster_ops.order_hosts_for_shutdown(host_daemon_map, None)
+
+        # Monitoring first, then plain OSD hosts, then the host holding a mon.
+        assert ordered == ['grafana-host', 'osd-host', 'mon-host']
+
+    def test_order_hosts_stops_mon_host_after_osd_host(self):
+        """The documented guarantee: core services are stopped last."""
+        host_daemon_map = {
+            'node-1': ['mon', 'mgr', 'osd'],  # admin
+            'node-2': ['mon', 'osd', 'rgw'],
+            'node-3': ['osd'],
+        }
+
+        ordered = cluster_ops.order_hosts_for_shutdown(host_daemon_map, 'node-1')
+
+        # node-3 carries only OSDs, node-2 carries a mon: node-3 goes first.
+        assert ordered.index('node-3') < ordered.index('node-2')
+        assert ordered[-1] == 'node-1'
+
+    def test_priority_of_unknown_daemon_types(self):
+        """Unrecognized daemons are stopped last rather than first."""
+        assert cluster_ops.get_daemon_type_priority(
+            ['not-a-real-daemon']
+        ) == len(cluster_ops.DAEMON_SHUTDOWN_ORDER)
+
 
 class TestRemoteSystemctl:
     """Tests for remote systemctl operations."""


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/80276

`cephadm cluster-shutdown` ranks each host by the daemon that stops earliest on it rather than the one that stops last, so a host running a mon can be stopped before a host running only OSDs.

## Symptom

`order_hosts_for_shutdown()` documents "Monitoring hosts first, core (mon/mgr) hosts last". It does not do that. On main at 556acf470ea:

```
$ PYTHONPATH=src/cephadm:src/python-common python3 -c "
from cephadmlib import cluster_ops as c
m = {'node-1': ['mon','mgr','osd'], 'node-2': ['mon','osd','rgw'], 'node-3': ['osd']}
print(c.order_hosts_for_shutdown(m, 'node-1'))"
['node-2', 'node-3', 'node-1']
```

node-2 holds a mon and is stopped before node-3, which holds only OSDs.

On a default cluster it degrades further. cephadm places `crash` and `node-exporter` on every host, so every host collapses to `node-exporter`'s priority, the hosts tie, and the sort falls back to dictionary order. The ordering is then effectively arbitrary.

## Cause

`get_daemon_type_priority()` returns the minimum `DAEMON_SHUTDOWN_ORDER` index across a host's daemon types. Stopping a host stops every daemon on it, so a host has to be ranked by the daemon that must stop last, not the one that stops first.

## Fix

Rank each host by its most critical daemon. A host whose daemon types are all unrecognized keeps the previous behaviour and is stopped last.

## Testing

`src/cephadm/tests/` run before and after on an otherwise untouched checkout of 556acf470ea:

```
baseline   36 failed, 439 passed
with fix   36 failed, 443 passed    (+4 new tests)
```

The three new ordering tests fail before the change and pass after. The 36 pre-existing failures in `test_deploy.py` and `test_ingress.py` are unrelated to this change; the failing set is identical with and without it. `flake8 --config=tox.ini cephadm.py cephadm_invoker.py cephadmlib` is clean.

The existing tests could not detect this. `get_daemon_type_priority()` was only ever called with single-element lists, where the minimum and the maximum are the same value, and `test_order_hosts_for_shutdown()` asserted only that the admin host is last and that no host is dropped. Both still pass unchanged.

## Not tested

No live cluster shutdown. The change is confined to the ordering helper, but a reviewer with lab access may want to confirm the end-to-end sequencing.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket: https://tracker.ceph.com/issues/80276
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
