### PR TITLE
cephadm: fetch podman version when prepare-host is skipped

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3000,6 +3000,14 @@ def command_bootstrap(ctx):
     else:
         logger.info('Skip prepare_host')
 
+    # Ensure the container engine is ready and, for podman, that its
+    # version has been fetched. command_bootstrap is excluded from the
+    # check_container_engine() call in main() so that a missing engine can
+    # be installed by prepare_host, but with --skip-prepare-host nothing
+    # else populates Podman._version and daemon creation later fails with
+    # "Please call `get_version` first".
+    check_container_engine(ctx)
+
     logger.info('Cluster fsid: %s' % fsid)
     hostname = get_hostname()
     if '.' in hostname and not ctx.allow_fqdn_hostname:

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1981,6 +1981,27 @@ class TestBootstrap(object):
             retval = _cephadm.command_bootstrap(ctx)
             assert retval == 0
 
+    def test_skip_prepare_host_checks_container_engine(
+        self, cephadm_fs, funkypatch
+    ):
+        # command_bootstrap is excluded from the check_container_engine()
+        # call in main(), so bootstrap must call it itself. With
+        # --skip-prepare-host nothing else fetches the podman version, and
+        # daemon creation later fails with "Please call `get_version` first".
+        funkypatch.patch('cephadmlib.systemd.call')
+        check_container_engine = funkypatch.patch(
+            'cephadm.check_container_engine'
+        )
+
+        cmd = self._get_cmd(
+            '--mon-ip', '192.168.1.1', '--skip-mon-network'
+        )
+        with bootstrap_test_ctx(cmd) as ctx:
+            retval = _cephadm.command_bootstrap(ctx)
+            assert retval == 0
+
+        check_container_engine.assert_called_once_with(ctx)
+
     @pytest.mark.parametrize('mon_ip, list_networks, result',
         [
             # IPv4


### PR DESCRIPTION
`cephadm bootstrap` with podman fails at the "Creating mon..." step with`RuntimeError: Please call get_version first` when `--skip-prepare-host` is used.

`command_bootstrap` is excluded from the `check_container_engine()` call in`main()` so that a missing container engine can be installed by`prepare_host`. But `check_container_engine()` is the only caller of`Podman.get_version()`, so with `--skip-prepare-host` the podman version isnever fetched and `Podman._version` stays `None`. Daemon creation then fails in `should_log_to_journald()` -> `supports_split_cgroups` -> `version`.

This PR calls `check_container_engine()` from `command_bootstrap` after the
`prepare_host` step, so the engine is validated and the podman version is
fetched regardless of whether `prepare_host` was skipped.

Fixes: https://tracker.ceph.com/issues/80278

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
