### PR TITLE
tentacle: qa/cephadm: fix hardcoded 'sshd' unit name in setup_ca_signed_keys

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -583,12 +583,14 @@ def setup_ca_signed_keys(ctx, config):
             'sudo', 'tee', '-a', '/etc/ssh/ca-key.pub',
         ])
         # make sshd accept the CA signed key
+        # NOTE: the SSH server systemd unit is named 'ssh' on Debian/Ubuntu
+        # and 'sshd' on RHEL/CentOS/Rocky -- try both, but only after the
+        # config write itself has succeeded (grouped with parens so the
+        # restart fallback doesn't mask a failed config write).
         remote.run(args=[
-            'sudo', 'echo', 'TrustedUserCAKeys /etc/ssh/ca-key.pub',
-            run.Raw('|'),
-            'sudo', 'tee', '-a', '/etc/ssh/sshd_config',
-            run.Raw('&&'),
-            'sudo', 'systemctl', 'restart', 'sshd',
+            'sudo', 'sh', '-c',
+            "echo 'TrustedUserCAKeys /etc/ssh/ca-key.pub' | sudo tee -a /etc/ssh/sshd_config && "
+            "(sudo systemctl restart ssh || sudo systemctl restart sshd)"
         ])
 
     # generate a new key pair and sign the pub key to make a cert


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/78101

---

backport of https://github.com/ceph/ceph/pull/69998
parent tracker: https://tracker.ceph.com/issues/77991

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh