### PR TITLE
libfdb: staged proxy and internal shoring-up

### DIFF
--- a/src/rgw/ceph_fdb.h
+++ b/src/rgw/ceph_fdb.h
@@ -31,20 +31,6 @@ between FDB's types! If you have a user type to add, this is the place!
 
 /*** Conversions: */
 
-namespace ceph::libfdb::detail {
-
-auto as_fdb_span(ceph::buffer::list& bl)
-{
- // c_str() makes the buffer::list contiguous. Use length(), not C-string
- // rules, because buffer::list may contain arbitrary bytes:
- auto p = bl.c_str();
-
- return std::span<const std::uint8_t>(
-          reinterpret_cast<const std::uint8_t *>(p), bl.length());
-}
-
-} // namespace ceph::libfdb::detail
-
 namespace ceph::buffer {
 
 auto serialize(auto& archive, ceph::buffer::list& target)
@@ -86,9 +72,10 @@ auto serialize(auto& archive, const ceph::buffer::list& src)
 // is a non-owning structure. 
 auto serialize(auto& archive, const ceph::buffer::ptr& src)
 {
- std::span<std::uint8_t> src_span((std::uint8_t *)src.c_str(), src.length());
+ const auto bytes = ceph::libfdb::detail::as_byte_view(
+  std::string_view(src.c_str(), src.length()));
 
- return archive(src_span);
+ return archive(bytes);
 }
 
 } // namespace ceph::buffer

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -257,6 +257,7 @@ explicit open/closed boundaries.
 | Select an explicit half-open key interval | `q::between(begin, end)` | `lfdb::select` | Matches the usual FoundationDB `[begin, end)` range shape. |
 | Combine or subtract selections | `q::intersection()`, `q::set_union()`, `q::difference()` | query expression or selector | Lets the query compiler normalize intervals before execution. |
 | Run several dependent operations atomically | `lfdb::make_transactor(dbh)` | callable transaction runner | Replays retryable transactions while keeping user code explicit. |
+| Publish local output after a replayable transaction | `lfdb::staged(output)` | callback proxy | Prevents retries from applying the same local mutation more than once. |
 
 ### Managed Range Reads
 
@@ -956,6 +957,66 @@ txr([](auto& txn) {
   lfdb::set(txn, "person/eleanor-of-aquitaine/title", "Duchess of Aquitaine");
 });
 ```
+
+### Staged Proxies
+
+A transactor may run its body more than once. Mutating a captured output
+variable directly can therefore append or count the same result several times. 
+Staged Proxies talk with the transaction mechanisms to be sure that only attempts
+whos commits are confirmed get published to the `output`.
+
+```cpp
+// Recompute a D4N bucket's cached-byte count without counting a replay twice.
+std::uint64_t cached_bytes = 0; // <-- this is what we will pass by Staged Proxy
+auto txr = lfdb::make_transactor(dbh);
+
+txr([](auto& txn, auto& bytes, std::string_view bucket_id) {
+  bytes = 0;
+
+  for (const auto& block :
+       lfdb::scan<CacheBlock>(txn, object_range(bucket_id)) |
+         std::views::values) {
+    bytes += block.size;
+  }
+}, lfdb::staged(cached_bytes), bucket_id);
+```
+
+If you want to declare a proxy ahead of time, you should be sure to move() it into
+the Transactor becuse it represents exactly one invocation's staging state:
+
+```cpp
+// Replace a D4N block listing only after the transaction commits successfully.
+std::vector<CacheBlock> blocks;
+auto blocks_prx = lfdb::staged(blocks);
+auto txr = lfdb::make_transactor(dbh);
+
+txr([](auto& txn, auto& blocks, std::string_view bucket_id) {
+    /* do some operations */
+}, std::move(blocks_prx), bucket_id);
+```
+
+Prefer an ordinary return value when the callback produces one new value;
+staging is for output parameters or several existing local values.
+The proxy covers assignment, `+=`, common sequence updates, and
+`insert_or_assign()`; use `get_target()` for an uncommon operation.
+
+Gotchas:
+
+- The target must be copy-constructible, nothrow move-assignable, alive for the
+  call, and not accessed concurrently. Binding it twice is rejected with an exception;
+  overlapping targets are also invalid.
+
+- Accept the proxy by lvalue reference (`auto& output`, as above). Do not
+  capture and mutate the original target, or retain the proxy—or any
+  pointer, reference, or iterator obtained from it—after the callback.
+  Anything obtained through `get_target()` is still attempt-local.
+
+- Staging protects only the bound C++ value. Logging, I/O, other captured state,
+  and non-idempotent database writes after `commit_unknown_result` still need
+  their own replay-safe design.
+
+Any uncommitted outcome leaves the target unchanged. An ordinary transactor
+throws on retry exhaustion; `with_result` reports it with `committed == false`.
 
 ### Reporting replay results
 

--- a/src/rgw/fdb/EXAMPLES.md
+++ b/src/rgw/fdb/EXAMPLES.md
@@ -961,13 +961,31 @@ txr([](auto& txn) {
 ### Staged Proxies
 
 A transactor may run its body more than once. Mutating a captured output
-variable directly can therefore append or count the same result several times. 
-Staged Proxies talk with the transaction mechanisms to be sure that only attempts
-whos commits are confirmed get published to the `output`.
+variable directly can therefore append or count the same result several times.
+Staged Proxies give each attempt a private value and publish only the attempt
+whose commit is confirmed.
+
+Choose the parameter form according to its role:
+
+| Parameter | Use it for | Replay behavior |
+| --- | --- | --- |
+| `input` | An input that the transaction reads but does not modify. | The transactor copies it once and presents the same value to every attempt. |
+| `lfdb::staged(output)` | An output that modifies or extends its existing value. | Each attempt lazily copies the existing value before its first mutation. |
+| `lfdb::staged(output, std::in_place)` | An output rebuilt entirely from transaction results. | Each attempt starts with a fresh value; the previous contents are never copied. |
+
+Treat ordinary bound parameters as read-only. Mutating one changes only the
+transactor's private argument and that mutation carries into later attempts;
+it does not update the caller's object.
+
+In-place construction happens before each attempt, so a successful query that
+finds no values still replaces stale output with an empty value.
+
+Prefer an ordinary return value when the callback produces one new value.
+Staging is useful for output parameters or several existing local values.
 
 ```cpp
 // Recompute a D4N bucket's cached-byte count without counting a replay twice.
-std::uint64_t cached_bytes = 0; // <-- this is what we will pass by Staged Proxy
+std::uint64_t cached_bytes = 0;
 auto txr = lfdb::make_transactor(dbh);
 
 txr([](auto& txn, auto& bytes, std::string_view bucket_id) {
@@ -981,42 +999,46 @@ txr([](auto& txn, auto& bytes, std::string_view bucket_id) {
 }, lfdb::staged(cached_bytes), bucket_id);
 ```
 
-If you want to declare a proxy ahead of time, you should be sure to move() it into
-the Transactor becuse it represents exactly one invocation's staging state:
+If you declare a proxy ahead of time, move it into the transactor because it
+represents exactly one invocation's staging state:
 
 ```cpp
-// Replace a D4N block listing only after the transaction commits successfully.
+// Rebuild a D4N block listing without copying its previous contents.
 std::vector<CacheBlock> blocks;
-auto blocks_prx = lfdb::staged(blocks);
+auto blocks_prx = lfdb::staged(blocks, std::in_place);
 auto txr = lfdb::make_transactor(dbh);
 
 txr([](auto& txn, auto& blocks, std::string_view bucket_id) {
-    /* do some operations */
+  for (auto block : read_blocks(txn, bucket_id)) {
+    blocks.push_back(std::move(block));
+  }
 }, std::move(blocks_prx), bucket_id);
 ```
 
-Prefer an ordinary return value when the callback produces one new value;
-staging is for output parameters or several existing local values.
 The proxy covers assignment, `+=`, common sequence updates, and
-`insert_or_assign()`; use `get_target()` for an uncommon operation.
+`insert_or_assign()`; use `get_target()` for an uncommon operation. Mutating
+operations deliberately return no iterator or reference into attempt-local
+storage.
 
 Gotchas:
 
-- The target must be copy-constructible, nothrow move-assignable, alive for the
-  call, and not accessed concurrently. Binding it twice is rejected with an exception;
-  overlapping targets are also invalid.
+- An ordinarily staged target must be copy-constructible; an in-place target
+  must be default-initializable. Both must be nothrow move-assignable, alive for
+  the call, and not accessed concurrently. Binding the same target more than
+  once is rejected with an exception; overlapping targets are also invalid.
 
 - Accept the proxy by lvalue reference (`auto& output`, as above). Do not
-  capture and mutate the original target, or retain the proxy—or any
-  pointer, reference, or iterator obtained from it—after the callback.
-  Anything obtained through `get_target()` is still attempt-local.
+  capture and mutate the original target or retain the proxy after the callback.
+  Any pointer, reference, or iterator obtained through `get_target()` is
+  attempt-local and must not escape the callback.
 
 - Staging protects only the bound C++ value. Logging, I/O, other captured state,
   and non-idempotent database writes after `commit_unknown_result` still need
   their own replay-safe design.
 
-Any uncommitted outcome leaves the target unchanged. An ordinary transactor
-throws on retry exhaustion; `with_result` reports it with `committed == false`.
+Any outcome without a confirmed commit leaves the target unchanged. An ordinary
+transactor throws on retry exhaustion; `with_result` reports it with
+`committed == false`.
 
 ### Reporting replay results
 

--- a/src/rgw/fdb/NOTES.txt
+++ b/src/rgw/fdb/NOTES.txt
@@ -1,5 +1,8 @@
 
-* If you're looking for some information about how to use the library, interface.h is the "user interface".
+* Include fdb.h for the complete public interface. Lower-level ownership lives
+  in base.h; transactions, transactors, and staged output live in transaction.h;
+  direct key operations live in interface.h; and range traversal lives in
+  scan.h.
 
 ----
 Network and Database Options:

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -35,7 +35,6 @@
 #include <ranges>
 #include <iterator>
 #include <algorithm>
-#include <generator>
 
 #include <mutex>
 #include <thread>
@@ -51,9 +50,6 @@
 #include <stop_token>
 #include <filesystem>
 #include <type_traits>
-#include <initializer_list>
-
-#include "common/container_concepts.h"
 
 #ifdef __cpp_lib_flat_map
  #include <flat_map>
@@ -86,7 +82,6 @@ class transaction;
 using database_handle = std::shared_ptr<database>;
 using transaction_handle = std::shared_ptr<transaction>;
 
-extern transaction_handle make_transaction(database_handle dbh);
 [[nodiscard]] inline watch_handle make_watch(transaction_handle txn, std::string_view key);
 
 } // namespace ceph::libfdb
@@ -98,15 +93,10 @@ inline void convert(const std::span<const std::uint8_t>& from,
 
 } // namespace ceph::libfdb::from
 
-// MOAR forward declarations-- "pay no attention to that man behind the curtain":
+// Helpers used by the mostly opaque transaction type:
 namespace ceph::libfdb::detail {
 
 struct future_value;
-
-template <typename ValueT = std::string>
-std::pair<std::string, ValueT> to_decoded_kv_pair(const FDBKeyValue& kv);
-
-inline fdb_error_t do_commit(transaction_handle& txn);
 
 inline void transaction_set_kv_bytes(const transaction_handle& txn,
                                      std::span<const std::uint8_t> k,
@@ -119,16 +109,6 @@ inline void transaction_clear_range(const transaction_handle& txn,
 inline future_value block_until_ready(future_value&& fv);
 inline fdb_error_t get_future_error(const future_value& fv);
 inline future_value wait_for_on_error(FDBTransaction* txn, fdb_error_t original_error);
-inline future_value get_range_future_from_transaction(ceph::libfdb::transaction& txn, const ceph::libfdb::select& selection, int iteration);
-
-// A generator that produces successive spans for a range:
-inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(ceph::libfdb::transaction& txn, ceph::libfdb::select key_range);
-
-// Stores generated key/value pair results to an iterator and returns the
-// number of pairs emitted:
-template <typename OutIterT>
-requires std::output_iterator<OutIterT, std::pair<std::string, std::string>>
-inline std::size_t get_value_range_from_transaction(ceph::libfdb::transaction& txn, const ceph::libfdb::select& key_range, OutIterT& out_iter);
 
 } // namespace ceph::libfdb::detail
 
@@ -171,40 +151,6 @@ namespace ceph::libfdb::concepts {
 template <typename KeyT>
 concept libfdb_key = ceph::libfdb::detail::libfdb_key_like<KeyT>;
 
-template <typename IteratorT>
-concept key_value_iterator =
- std::input_iterator<IteratorT> and
- requires(std::iter_reference_t<IteratorT> kv) {
-  requires libfdb_key<decltype(kv.first)>;
-  requires std::is_object_v<std::remove_reference_t<decltype(kv.second)>>;
- };
-
-template <typename RangeT>
-concept key_value_range =
- std::ranges::input_range<RangeT> and
- key_value_iterator<std::ranges::iterator_t<RangeT>>;
-
-template <typename RangeT>
-concept key_value_forward_range =
- std::ranges::forward_range<RangeT> and
- key_value_iterator<std::ranges::iterator_t<RangeT>>;
-
-template <typename IteratorT>
-concept string_pair_output_iterator =
- std::output_iterator<IteratorT, std::pair<std::string, std::string>>;
-
-template <typename RangeT>
-concept string_pair_output_range =
- not std::is_array_v<std::remove_reference_t<RangeT>> and
- std::ranges::range<RangeT> and
- ceph::concepts::can_append<RangeT, std::pair<std::string, std::string>>;
-
-template <typename RangeT>
-concept materializable_string_pair_output_range =
- string_pair_output_range<RangeT> and
- std::default_initializable<std::remove_cvref_t<RangeT>> and
- std::move_constructible<std::remove_cvref_t<RangeT>>;
-
 template <typename FnT>
 concept value_invocable =
  std::invocable<FnT&, std::span<const std::uint8_t>>;
@@ -220,13 +166,6 @@ concept decoded_value_sink =
  std::is_lvalue_reference_v<T> and
  not std::is_const_v<std::remove_reference_t<T>> and
  std::is_object_v<std::remove_reference_t<T>>;
-
-template <typename T>
-concept supported_invocation_result =
- std::is_void_v<T> or
- (not std::is_reference_v<T> and
-  std::constructible_from<std::remove_cvref_t<T>, T> and
-  std::move_constructible<std::remove_cvref_t<T>>);
 
 } // namespace ceph::libfdb::concepts
 
@@ -798,12 +737,12 @@ class transaction final
 
  public:
  transaction(database_handle dbh_)
- : dbh(dbh_),
+ : dbh(std::move(dbh_)),
    txn_handle(dbh->create_transaction(), &fdb_transaction_destroy)
  {}
 
  transaction(database_handle dbh_, const transaction_options& opts) 
-  : transaction(dbh_)
+  : transaction(std::move(dbh_))
  {
   detail::apply_options(opts,
              [handle = raw_handle()](auto opt, auto val, auto sz) {
@@ -930,7 +869,6 @@ class transaction final
  friend inline commit_result commit(with_result_t, transaction_handle& txn);
  friend inline bool commit(transaction_handle& txn, const versionstamp& stamp);
  friend inline watch_handle make_watch(transaction_handle txn, std::string_view key);
- friend inline fdb_error_t ceph::libfdb::detail::do_commit(transaction_handle& txn);
  friend inline void ceph::libfdb::detail::transaction_set_kv_bytes(const transaction_handle&,
                                                                    std::span<const std::uint8_t>,
                                                                    std::span<const std::uint8_t>);
@@ -1133,292 +1071,6 @@ inline future_value await_future_of(FnT&& fn, XS&& ...params)
           std::invoke(std::forward<FnT>(fn), std::forward<XS>(params)...));
 }
 
-// Tracks a set of results and their corresponding Future:
-struct query_window final
-{
- future_value result_owner;
- std::span<const FDBKeyValue> result_pairs;
- bool more_available = false;
-};
-
-struct split_point_result final
-{
- future_value result_owner;
- std::span<const FDBKey> result_keys;
- fdb_error_t error = 0;
-};
-
-inline query_window extract_result_pairs(future_value result_owner)
-{
- int more_available = 0;
- int out_count = 0;
- const FDBKeyValue *out_kvs = nullptr;
-
- if (fdb_error_t r = fdb_future_get_keyvalue_array(result_owner.raw_ptr_or_throw(),
-                                                   &out_kvs,
-                                                   &out_count,
-                                                   &more_available); 0 != r) {
-  throw libfdb_exception(r);
- }
-
- return query_window {
-  .result_owner = std::move(result_owner),
-  .result_pairs = std::span<const FDBKeyValue>(out_kvs, out_count),
-  .more_available = 0 != more_available
- };
-}
-
-inline split_point_result extract_split_points(future_value result_owner)
-{
- const FDBKey *result_keys = nullptr;
- int result_count = 0;
-
- const auto error = fdb_future_get_key_array(result_owner.raw_ptr_or_throw(), &result_keys, &result_count);
-
- return split_point_result {
-  .result_owner = std::move(result_owner),
-  .result_keys = 0 == error ? std::span<const FDBKey>(result_keys, result_count)
-                            : std::span<const FDBKey>(),
-  .error = error
- };
-}
-
-inline query_window read_query_window(transaction& txn, const select& key_range, const int iteration)
-{
- return extract_result_pairs(await_future_of([&]() {
-  return get_range_future_from_transaction(txn, key_range, iteration);
- }));
-}
-
-inline std::optional<select> next_range_after(select key_range, const query_window& window)
-{
- if (not window.more_available or window.result_pairs.empty()) {
-  return std::nullopt;
- }
-
- const auto& last_key = window.result_pairs.back();
- auto cursor = std::string_view((const char *)last_key.key, last_key.key_length);
-
- if (key_range.options.reverse_order) {
-  key_range.end_key = cursor;
-  key_range.end_inclusive = false;
-  return key_range;
- }
-
- key_range.begin_key = cursor;
- key_range.begin_inclusive = false;
-
- return key_range;
-}
-
-template <typename ValueT = std::string>
-inline auto decode_pairs(std::span<const FDBKeyValue> pairs)
-{
- return pairs | std::views::transform(to_decoded_kv_pair<ValueT>);
-}
-
-template <typename ValueT, typename AssocT>
-inline AssocT collect_pairs(std::span<const FDBKeyValue> pairs)
-{
- return ceph::util::collect_as<AssocT>(decode_pairs<ValueT>(pairs));
-}
-
-template <typename AssocT>
-struct query_window_result final
-{
- AssocT result_block;
- std::optional<select> next_range;
-};
-
-template <typename ValueT, typename AssocT>
-inline query_window_result<AssocT> materialize_query_window(transaction& txn, select key_range, const int iteration = 1)
-{
- auto window = read_query_window(txn, key_range, iteration);
-
- return {
-  .result_block = collect_pairs<ValueT, AssocT>(window.result_pairs),
-  .next_range = next_range_after(std::move(key_range), window)
- };
-}
-
-inline std::size_t for_each_decoded_kv_pair(transaction& txn,
-                                            const select& key_range,
-                                            auto&& fn)
-{
- std::size_t nread = 0;
-
- for (const auto& kv : detail::generate_FDB_pairs(txn, key_range) | std::views::join) {
-  std::invoke(fn, to_decoded_kv_pair<std::string>(kv));
-  ++nread;
- }
-
- return nread;
-}
-
-template <typename OutIterT>
-requires std::output_iterator<OutIterT, std::pair<std::string, std::string>>
-inline std::size_t get_value_range_from_transaction(transaction& txn, const select& key_range, OutIterT& out_iter)
-{
- return for_each_decoded_kv_pair(txn, key_range,
-          [&out_iter](auto&& kv) {
-            *out_iter++ = std::forward<decltype(kv)>(kv);
-          });
-}
-
-inline std::size_t get_value_range_from_transaction(transaction& txn,
-                                                    const select& key_range,
-                                                    concepts::string_pair_output_range auto& out)
-{
- return for_each_decoded_kv_pair(txn, key_range,
-          [&out](auto&& kv) {
-            ceph::util::push_back(out, std::forward<decltype(kv)>(kv));
-          });
-}
-
-inline bool retry_after_error(ceph::libfdb::transaction_handle& txn, const fdb_error_t r)
-{
- if (0 == r) {
-  return false;
- }
-
- if (not fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, r)) {
-  // Non-retryable errors cannot be repaired by on_error():
-  throw ceph::libfdb::libfdb_exception(r);
- }
-
- if (fdb_error_t on_error_r = get_future_error(wait_for_on_error(txn->raw_handle(), r)); 0 != on_error_r) {
-  throw ceph::libfdb::libfdb_exception(r);
- }
-
- return true;
-}
-
-// Convert FDBKey array into something useful:
-inline std::vector<ceph::libfdb::select> as_select_seq(std::span<const FDBKey> xs,
-                                                       const ceph::libfdb::select& parent)
-{
- if (2 > xs.size()) {
-  return {};
- }
-
- // Gather the flattened list into *overlapping* libfdb::select pairs:
- return ceph::util::collect_as<std::vector<ceph::libfdb::select>>(
-          std::views::iota(std::size_t{0}, xs.size() - 1)
-        | std::views::transform([&parent, xs](const auto i) {
-           const auto& fst = xs[i];
-           const auto& snd = xs[i + 1];
-           const auto first_key = std::string_view((const char *)fst.key,
-                                                    static_cast<std::string::size_type>(fst.key_length));
-           const auto second_key = std::string_view((const char *)snd.key,
-                                                     static_cast<std::string::size_type>(snd.key_length));
-
-           ceph::libfdb::select split(first_key, second_key);
-
-           split.options = parent.options;
-           split.begin_inclusive = (0 == i) ? parent.begin_inclusive : true;
-           split.end_inclusive = (i + 2 == xs.size()) ? parent.end_inclusive : false;
-           return split;
-          }));
-}
-// Finding a clear example both in the samples and in the documentation is not very easy. The
-// statelessness of FDB requests bleeds into here with basically no hand-holding, but note for instance
-// that the call parameters have to change for subsequent reads.
-inline future_value get_range_future_from_transaction(ceph::libfdb::transaction& txn, const ceph::libfdb::select& selection, int iteration)
-{
-  const auto& begin_key  = selection.begin_key;
-  const auto& end_key    = selection.end_key;
-
-  const auto& options    = selection.options;
-
-  // The documentation makes this stuff about as clear as mud... read VERY carefully
-  // when you fiddle with these:
-  const bool continuing_forward = not options.reverse_order and 1 < iteration;
-  const bool continuing_reverse = options.reverse_order and 1 < iteration;
-
-  const int begin_or_eq = (continuing_forward or not selection.begin_inclusive) ? 1 : 0;
-  const int begin_offset = 1;
-  const int end_or_eq = (not continuing_reverse and selection.end_inclusive) ? 1 : 0;
-  const int end_offset = 1;
-
-  // See validate_and_update_parameters() in fdb_c.cpp (FDB source) if greater clarity is needed on
-  // the meaning of some of these, it can be hard to deduce from the documentation; Returns an
-  // FDBKeyValueArray in the future:
-  return future_value(fdb_transaction_get_range(txn.raw_handle(),
-                      (const uint8_t *)begin_key.data(), begin_key.size(),      // the reference-point key
-                      begin_or_eq,                                              // begin or eq
-                      begin_offset,                                             // begin offset
-
-                      (const uint8_t *)end_key.data(), end_key.size(),          // the end selector key
-                      end_or_eq,                                                // end or eq
-                      end_offset,                                               // end offset (a shift AFTER end is matched)
-
-                      // How should results be grouped/chunked:
-                      options.result_limit,                                     // FDB range-read limit (0 == unlimited)
-                      options.target_bytes,                                     // FDB range-read target bytes (0 == unlimited)
-                      options.streaming_mode,                                   // streaming mode (e.g.: FDB_STREAMING_MODE_WANT_ALL)
-                      iteration,                                                // iteration # (produced side effect)
-
-                      // Other options:
-                      0,                                                        // 0 unless this IS a snapshot read
-                      options.reverse_order                                     // should items come in reverse order?
-                    ));
-}
-
-inline std::vector<ceph::libfdb::select> plan_split_ranges(
-          ceph::libfdb::database_handle dbh, 
-          ceph::libfdb::select selector, 
-          const std::int64_t remote_chunk_size)
-{
- using ceph::libfdb::detail::wait_until_ready;
-
- auto txn = ceph::libfdb::make_transaction(dbh);
- auto split_selector = ceph::libfdb::detail::as_half_open_select(selector);
-
- for (bool should_retry = true; should_retry;) {
-  auto result_owner = wait_until_ready(future_value(fdb_transaction_get_range_split_points(
-                       txn->raw_handle(),
-                       (const std::uint8_t *)split_selector.begin_key.data(), static_cast<int>(split_selector.begin_key.length()),
-                       (const std::uint8_t *)split_selector.end_key.data(), static_cast<int>(split_selector.end_key.length()),
-                       remote_chunk_size)));
-
-  auto split_points = extract_split_points(std::move(result_owner));
-
-  should_retry = retry_after_error(txn, split_points.error);
-
-  if (not should_retry) {
-   return as_select_seq(split_points.result_keys, split_selector);
-  }
- }
-
- return {};
-}
-
-// Generators (internal guts):
-// The returned memory should be copied immediately as its lifetime will end once the Future is destroyed:
-// (This is pretty much why this is in the "detail" namespace-- we use this to implement the user-facing
-// stuff, it shouldn't really be touched outside.)
-inline std::generator<std::span<const FDBKeyValue>> generate_FDB_pairs(transaction& txn, select key_range)
-{
- // FDB uses iteration for FDB_STREAMING_MODE_ITERATOR (but, other streaming modes
- // just ignore it, per fdb_c's documentation. We do have to keep this state somewhere,
- // though. See: "https://apple.github.io/foundationdb/api-c.html".
- int iteration = 1;
-
- for (auto more_available = true; more_available; iteration++) {
-  auto window = read_query_window(txn, key_range, iteration);
-  auto next_range = next_range_after(key_range, window);
-
-  more_available = next_range.has_value();
-
-  co_yield window.result_pairs;
-
-  if (next_range) {
-   key_range = std::move(*next_range);
-  }
- }
-}
-
 } // namespace ceph::libfdb::detail
-
 
 #endif

--- a/src/rgw/fdb/base.h
+++ b/src/rgw/fdb/base.h
@@ -13,13 +13,13 @@
 */
 
 #ifndef CEPH_FDB_BASE_H
- #define CEPH_FDB_BASE_H
+#define CEPH_FDB_BASE_H
 
 // The API version we're writing against, which can (and probably does) differ
 // from the installed version. This must be defined before the FoundationDB header
 // is included (see fdb_c_apiversion.g.h):
 #define FDB_API_VERSION 730
-#include <foundationdb/fdb_c.h> 
+#include <foundationdb/fdb_c.h>
 
 // Ceph uses libfmt rather than <format>:
 #include <fmt/format.h>
@@ -36,9 +36,7 @@
 #include <iterator>
 #include <algorithm>
 
-#include <mutex>
-#include <thread>
-
+#include <bit>
 #include <memory>
 #include <cstdint>
 #include <utility>
@@ -50,6 +48,9 @@
 #include <stop_token>
 #include <filesystem>
 #include <type_traits>
+
+#include <mutex>
+#include <thread>
 
 #ifdef __cpp_lib_flat_map
  #include <flat_map>
@@ -96,19 +97,22 @@ inline void convert(const std::span<const std::uint8_t>& from,
 // Helpers used by the mostly opaque transaction type:
 namespace ceph::libfdb::detail {
 
+using byte_view = std::span<const std::uint8_t>;
+
 struct future_value;
 
 inline void transaction_set_kv_bytes(const transaction_handle& txn,
-                                     std::span<const std::uint8_t> k,
-                                     std::span<const std::uint8_t> v);
+                                     byte_view key,
+                                     byte_view value);
 inline void transaction_clear_key_bytes(const transaction_handle& txn,
-                                        std::span<const std::uint8_t> k);
+                                        byte_view key);
 inline void transaction_clear_range(const transaction_handle& txn,
                                     const ceph::libfdb::select& key_range);
 
 inline future_value block_until_ready(future_value&& fv);
 inline fdb_error_t get_future_error(const future_value& fv);
-inline future_value wait_for_on_error(FDBTransaction* txn, fdb_error_t original_error);
+inline future_value wait_for_on_error(FDBTransaction *txn,
+                                      fdb_error_t original_error);
 
 } // namespace ceph::libfdb::detail
 
@@ -225,6 +229,7 @@ inline constexpr fdb_error_t operation_cancelled_error = 1101;
 
 struct future_value final
 {
+ private:
  std::unique_ptr<FDBFuture, decltype(&fdb_future_destroy)> future_ptr;
 
  public:
@@ -232,7 +237,6 @@ struct future_value final
   : future_ptr(future_handle, &fdb_future_destroy)
  {}
 
- public:
  FDBFuture *raw_handle() const noexcept { return future_ptr.get(); }
 
  FDBFuture *raw_ptr_or_throw() const
@@ -246,25 +250,37 @@ struct future_value final
 
  private:
  void destroy() noexcept { future_ptr.reset(nullptr); }
- 
- private:
+
  friend class ceph::libfdb::transaction;
 };
 
-inline auto as_fdb_span(concepts::libfdb_key_view auto key)
+inline byte_view as_byte_view(concepts::libfdb_key_view auto key)
 {
- return std::span<const std::uint8_t>((const std::uint8_t *)key.data(), key.size());
+ return byte_view(reinterpret_cast<const std::uint8_t *>(key.data()), key.size());
 }
 
 } // namespace detail
 
 // watch_handle can only be constructed by calling make_watch():
-struct watch_handle final
+class watch_handle final
 {
+ private:
+ detail::future_value watch_future;
+
+ private:
+ explicit watch_handle(detail::future_value future)
+  : watch_future(std::move(future))
+ {}
+
+ watch_handle() = delete;
+ watch_handle(const watch_handle&) = delete;
+ watch_handle& operator=(const watch_handle&) = delete;
+
  public:
  watch_handle(watch_handle&&) noexcept = default;
  watch_handle& operator=(watch_handle&&) noexcept = default;
 
+ public:
  [[nodiscard]] bool ready() const noexcept
  {
   auto *future = watch_future.raw_handle();
@@ -327,28 +343,16 @@ struct watch_handle final
  }
 
  private:
- detail::future_value watch_future;
-
- private:
- explicit watch_handle(detail::future_value watch_future_)
-  : watch_future(std::move(watch_future_))
- {}
-
- watch_handle() = delete;
- watch_handle(const watch_handle&) = delete;
- watch_handle& operator=(const watch_handle&) = delete;
-
- private:
  friend watch_handle make_watch(transaction_handle txn, std::string_view key);
  friend class transaction;
 };
 
 namespace detail {
 
-inline auto as_fdb_span(const concepts::libfdb_key auto& key)
+inline byte_view as_byte_view(const concepts::libfdb_key auto& key)
 requires (!concepts::libfdb_key_view<decltype(key)>)
 {
- return as_fdb_span(as_libfdb_key_view(key));
+ return as_byte_view(as_libfdb_key_view(key));
 }
 
 } // namespace ceph::libfdb::detail
@@ -359,6 +363,13 @@ struct versionstamp final
  // database version followed by 2 bytes of transaction batch order.
  using versionstamp_data_t = std::array<std::uint8_t, 10>;
 
+ private:
+ std::shared_ptr<std::optional<versionstamp_data_t>> result =
+  std::make_shared<std::optional<versionstamp_data_t>>();
+
+ void store_result(const std::span<const std::uint8_t> versionstamp_result);
+
+ public:
  bool is_resolved() const noexcept
  {
   return result->has_value();
@@ -385,12 +396,6 @@ struct versionstamp final
  }
 
  private:
- std::shared_ptr<std::optional<versionstamp_data_t>> result =
-  std::make_shared<std::optional<versionstamp_data_t>>();
-
- void store_result(const std::span<const std::uint8_t> versionstamp_result);
-
- private:
  friend class transaction;
  friend void ceph::libfdb::from::convert(const std::span<const std::uint8_t>&,
                                          ceph::libfdb::versionstamp&);
@@ -400,22 +405,23 @@ struct versionstamp final
 // It carries data in transaction-correct version stamp encoding:
 struct versioned_bytes final
 {
+ private:
+ std::vector<std::uint8_t> encoding_buffer;
+ versionstamp stamp;
+
+ versioned_bytes(std::vector<std::uint8_t> buffer, versionstamp version)
+  : encoding_buffer(std::move(buffer)),
+    stamp(std::move(version))
+ {}
+
  public:
  versioned_bytes() = delete;
 
  versioned_bytes(const versioned_bytes&) = default;
  versioned_bytes(versioned_bytes&&) noexcept = default;
+
  versioned_bytes& operator=(const versioned_bytes&) = default;
  versioned_bytes& operator=(versioned_bytes&&) noexcept = default;
-
- private:
- std::vector<std::uint8_t> encoding_buffer;
- versionstamp stamp;
-
- versioned_bytes(std::vector<std::uint8_t> encoding_buffer_, versionstamp stamp_)
-  : encoding_buffer(std::move(encoding_buffer_)),
-    stamp(std::move(stamp_))
- {}
 
  private:
  friend class transaction;
@@ -429,13 +435,16 @@ struct versioned_bytes final
 
 namespace detail {
 
-// FDB version stamp mutations expect the final four bytes to be a little-endian uint32_t offset pointing at the 10-byte placeholder:
-inline void append_little_endian_u32(std::vector<std::uint8_t>& out, const std::uint32_t x)
+constexpr auto little_endian_bytes(std::integral auto value) noexcept
 {
- out.push_back(static_cast<std::uint8_t>(x));
- out.push_back(static_cast<std::uint8_t>(x >> 8));
- out.push_back(static_cast<std::uint8_t>(x >> 16));
- out.push_back(static_cast<std::uint8_t>(x >> 24));
+ static_assert(std::endian::little == std::endian::native or
+               std::endian::big == std::endian::native);
+
+ if constexpr (std::endian::big == std::endian::native) {
+  value = std::byteswap(value);
+ }
+
+ return std::bit_cast<std::array<std::uint8_t, sizeof value>>(value);
 }
 
 inline std::vector<std::uint8_t> make_versioned_encoding(std::string_view prefix, std::string_view suffix)
@@ -447,11 +456,18 @@ inline std::vector<std::uint8_t> make_versioned_encoding(std::string_view prefix
 
  std::ranges::copy(prefix, std::back_inserter(out));
 
+ if (not std::in_range<std::uint32_t>(out.size())) {
+  throw std::invalid_argument("version-stamped prefix is too large");
+ }
+
  const auto versionstamp_offset = static_cast<std::uint32_t>(out.size());
  out.resize(out.size() + versionstamp_byte_count);
 
  std::ranges::copy(suffix, std::back_inserter(out));
- detail::append_little_endian_u32(out, versionstamp_offset);
+
+ // FDB expects a little-endian uint32 offset to the 10-byte placeholder:
+ std::ranges::copy(little_endian_bytes(versionstamp_offset),
+                   std::back_inserter(out));
 
  return out;
 }
@@ -483,7 +499,7 @@ inline void versionstamp::store_result(const std::span<const std::uint8_t> versi
  std::ranges::copy(versionstamp_result, std::begin(result_value));
 
  if (not result->has_value()) {
-  result->emplace(std::move(result_value));
+  result->emplace(result_value);
   return;
  }
 
@@ -501,6 +517,7 @@ namespace ceph::libfdb {
 // Helpers for selectors:
 namespace detail {
 
+// ...i.e. the next FoundationDB key (lexicographical match):
 inline std::string key_after(std::string_view key)
 {
  return std::string(key) + '\0';
@@ -537,69 +554,155 @@ using transaction_options = option_map<FDBTransactionOption>;
 
 namespace detail {
 
-// Note that these are specific to FDB's needs (see return type, casts):
-inline const std::uint8_t *data_of(const std::vector<std::uint8_t>& xs) { return (const std::uint8_t *)xs.data(); }
-inline const std::uint8_t *data_of(const std::string& xs) { return (const std::uint8_t *)xs.data(); }
-inline const std::uint8_t *data_of(const std::int64_t& x) { return reinterpret_cast<const std::uint8_t *>(&x); }
-inline const std::uint8_t *data_of(const option_flag_t&) { return nullptr; }
-
-// Note that these are specific to FDB's needs (see return type, casts):
-constexpr int size_of(const std::vector<std::uint8_t>& xs) { return static_cast<int>(xs.size()); }
-constexpr int size_of(const std::string& xs) { return static_cast<int>(xs.size()); }
-constexpr int size_of(const std::int64_t) { return sizeof(std::int64_t); }
-constexpr int size_of(const option_flag_t&) { return 0; }
-
-// ...also used:
-inline const std::uint8_t *data_of(std::string_view xs) { return (const std::uint8_t *)xs.data(); }
-constexpr int size_of(std::string_view xs) { return static_cast<int>(xs.size()); }
-
-inline auto as_fdb_option_args(const auto& option)
+constexpr int checked_fdb_size(const std::size_t size)
 {
- auto [data, size] = std::visit([](const auto& x) {
-                         return std::tuple { data_of(x), size_of(x) };
-                       },
-                       option.second);
+ if (not std::in_range<int>(size)) {
+  throw libfdb_exception("value is too large for the FoundationDB C API");
+ }
 
- return std::tuple { option.first, data, size };
+ return static_cast<int>(size);
+}
+
+constexpr std::size_t checked_result_size(const int size)
+{
+ if (0 > size) {
+  throw libfdb_exception("FoundationDB returned a negative result size");
+ }
+
+ return static_cast<std::size_t>(size);
+}
+
+// FoundationDB's C interface represents every byte range as a pointer and a
+// checked int length:
+struct fdb_bytes final
+{
+ const std::uint8_t *data;
+ int length;
+};
+
+constexpr fdb_bytes as_fdb_bytes(const byte_view bytes)
+{
+ return {
+  .data = bytes.data(),
+  .length = checked_fdb_size(bytes.size())
+ };
+}
+
+inline fdb_bytes as_fdb_bytes(const concepts::libfdb_key auto& key)
+{
+ return as_fdb_bytes(as_byte_view(key));
+}
+
+constexpr byte_view result_bytes(const std::uint8_t *data, const int length)
+{
+ return byte_view(data, checked_result_size(length));
+}
+
+inline std::string_view as_string_view(const byte_view bytes) noexcept
+{
+ if (bytes.empty()) {
+  return {};
+ }
+
+ return std::string_view(
+  reinterpret_cast<const char *>(bytes.data()), bytes.size());
+}
+
+inline std::string_view key_view(const auto& result)
+{
+ return as_string_view(result_bytes(result.key, result.key_length));
+}
+
+inline byte_view value_view(const FDBKeyValue& pair)
+{
+ return result_bytes(pair.value, pair.value_length);
+}
+
+inline byte_view option_bytes(const std::vector<std::uint8_t>& value) noexcept
+{
+ return value;
+}
+
+inline byte_view option_bytes(const std::string& value) noexcept
+{
+ return as_byte_view(std::string_view(value));
+}
+
+inline byte_view option_bytes(const option_flag_t&) noexcept
+{
+ return {};
+}
+
+inline auto apply_option_value(auto& set_option,
+                               const auto code,
+                               const std::int64_t value)
+{
+ const auto bytes = little_endian_bytes(value);
+ const auto input = as_fdb_bytes(byte_view(bytes));
+
+ return std::invoke(set_option, code, input.data, input.length);
+}
+
+template <typename ValueT>
+requires (not std::same_as<std::int64_t, std::remove_cvref_t<ValueT>>)
+inline auto apply_option_value(auto& set_option,
+                               const auto code,
+                               const ValueT& value)
+{
+ const auto input = as_fdb_bytes(option_bytes(value));
+
+ return std::invoke(set_option, code, input.data, input.length);
 }
 
 inline void apply_options(const auto& option_map, auto&& set_option)
 {
  std::ranges::for_each(option_map, [&set_option](const auto& option) {
-    if (auto r = std::apply(set_option, as_fdb_option_args(option)); 0 != r) {
-      throw libfdb_exception(fmt::format("while setting option {}; {}",
-                             static_cast<int>(option.first),
-                             libfdb_exception::make_fdb_error_string(r)));
+    const auto apply = [&set_option, code = option.first](const auto& value) {
+      return apply_option_value(set_option, code, value);
+    };
+
+    if (const auto ec = std::visit(apply, option.second); 0 != ec) {
+      throw libfdb_exception(fmt::format(
+        "while setting option {}; {}", std::to_underlying(option.first),
+        libfdb_exception::make_fdb_error_string(ec)));
     }
   });
 }
 
 // The global DB state and management thread:
 // JFW: more user hooks that go into FDB system possible here
-namespace database_system
-{
+namespace database_system {
+
 inline bool was_initialized = false;
 inline bool was_shutdown = false;
 
 inline std::once_flag fdb_was_initialized;
+
 inline std::jthread fdb_network_thread;
+
+inline fdb_error_t fdb_network_error = 0;
 
 inline void initialize_fdb(const network_options& options)
 {
  // This must be called before ANY other API function-- the structure
  // of fdb_database_system accomplishes this:
- if (fdb_error_t r = fdb_select_api_version(FDB_API_VERSION); 0 != r)
-  throw libfdb_exception(r);
+ if (const auto ec = fdb_select_api_version(FDB_API_VERSION); 0 != ec) {
+  throw libfdb_exception(ec);
+ }
  
  // Zero or more calls to this may now be made:
  apply_options(options, fdb_network_set_option);
  
  // This must be called before any other API function (besides >= 0 calls to fdb_network_set_option()):
- if (fdb_error_t r = fdb_setup_network(); 0 != r)
-  throw libfdb_exception(r);
+ if (const auto ec = fdb_setup_network(); 0 != ec) {
+  throw libfdb_exception(ec);
+ }
  
  // Launch network thread:
- fdb_network_thread = std::jthread { &fdb_run_network };
+ fdb_network_error = 0;
+ fdb_network_thread = std::jthread {[] {
+  fdb_network_error = fdb_run_network();
+ }};
  
  // Okie-dokie, we're all set (distinct from fdb_was_initialized):
  was_initialized = true;
@@ -610,23 +713,11 @@ inline bool initialized() noexcept { return was_initialized; }
 
 inline void shutdown_fdb()
 {
- using namespace std::chrono_literals;
- 
  if (not initialized() or was_shutdown) {
    return;
  }
 
- // shut down network and database:
- if (int r = fdb_stop_network(); 0 != r)
-  {
-    // In this case, we likely don't want to throw from our dtor, but we may
-    // have something to log. As there's no higher-level hook for that, we
-    // have nothing to do right now.
-    // fmt::println("database::shutdown_fdb() error {}", r);
-  }
-
- // This may not actually be needed, but it's a traditional courtesy:
- std::this_thread::sleep_for(7ms);
+ const auto stop_error = fdb_stop_network();
  
  if (fdb_network_thread.joinable()) {
   fdb_network_thread.join();
@@ -634,6 +725,14 @@ inline void shutdown_fdb()
 
  was_shutdown = true;
  was_initialized = false;
+
+ if (0 != stop_error) {
+  throw libfdb_exception(stop_error);
+ }
+
+ if (0 != fdb_network_error) {
+  throw libfdb_exception(fdb_network_error);
+ }
 }
 
 } // namespace database_system
@@ -642,7 +741,6 @@ inline void shutdown_fdb()
 
 class database final
 {
- private:
  struct database_deleter final
  {
   void operator()(FDBDatabase *db) const noexcept
@@ -654,45 +752,53 @@ class database final
  std::unique_ptr<FDBDatabase, database_deleter> db_handle;
 
  static FDBDatabase *create_database_ptr(const std::filesystem::path& cluster_file_path,
-                                         const network_options& network_opts) {
-    std::call_once(detail::database_system::fdb_was_initialized,
-                   detail::database_system::initialize_fdb,
-                   network_opts);
+                                         const network_options& network_opts)
+ {
+  std::call_once(detail::database_system::fdb_was_initialized,
+                 detail::database_system::initialize_fdb,
+                 network_opts);
 
-    if (detail::database_system::was_shutdown) {
-      throw libfdb_exception("FoundationDB already shut down");
-    }
+  if (detail::database_system::was_shutdown) {
+   throw libfdb_exception("FoundationDB already shut down");
+  }
 
-    FDBDatabase *fdbp = nullptr;
+  FDBDatabase *database = nullptr;
 
-    if (fdb_error_t r = fdb_create_database(cluster_file_path.c_str(), &fdbp); 0 != r) {
-      throw libfdb_exception(r);
-    }
-    
-    return fdbp;
+  if (const auto ec = fdb_create_database(cluster_file_path.c_str(), &database);
+      0 != ec) {
+   throw libfdb_exception(ec);
+  }
+
+  return database;
  }
 
- FDBTransaction *create_transaction() {
-    FDBTransaction *txn_p = nullptr;
-    
-    if (fdb_error_t r = fdb_database_create_transaction(raw_handle(), &txn_p); 0 != r) {
-     throw libfdb_exception(r);
-    }
+ FDBTransaction *create_transaction()
+ {
+  FDBTransaction *txn = nullptr;
 
-    return txn_p;
+  if (const auto ec = fdb_database_create_transaction(raw_handle(), &txn);
+      0 != ec) {
+   throw libfdb_exception(ec);
+  }
+
+  return txn;
  }
 
  public:
- database(const std::filesystem::path cluster_file_path, const ceph::libfdb::database_options& db_opts, const network_options& network_opts)
+ database(const std::filesystem::path& cluster_file_path,
+          const ceph::libfdb::database_options& db_opts,
+          const network_options& network_opts)
   : db_handle(create_database_ptr(cluster_file_path, network_opts))
  {
-  detail::apply_options(db_opts,
-             [handle = raw_handle()](auto option_code, auto data, auto size) {
-               return fdb_database_set_option(handle, option_code, data, size);
-             });
+  detail::apply_options(
+    db_opts,
+    [handle = raw_handle()](auto option_code, auto data, auto size) {
+      return fdb_database_set_option(handle, option_code, data, size);
+    });
  }
 
- database(const std::filesystem::path cluster_file_path, const ceph::libfdb::database_options& db_opts)
+ database(const std::filesystem::path& cluster_file_path,
+          const ceph::libfdb::database_options& db_opts)
   : database(cluster_file_path, db_opts, {})
  {}
 
@@ -704,7 +810,7 @@ class database final
   : database("", db_opts, {})
  {}
 
- database(const std::filesystem::path cluster_file_path)
+ database(const std::filesystem::path& cluster_file_path)
   : database(cluster_file_path, {}, {})
  {}
 
@@ -712,55 +818,65 @@ class database final
   : database(std::filesystem::path {}, {}, {})
  {}
 
- public:
  explicit operator bool() const noexcept { return nullptr != raw_handle(); }
 
- public:
  FDBDatabase *raw_handle() const noexcept { return db_handle.get(); }
 
  private:
  friend transaction;
-
 };
 
 class transaction final
 {
  database_handle dbh;
-
  std::unique_ptr<FDBTransaction, decltype(&fdb_transaction_destroy)> txn_handle;
-
  std::vector<versionstamp> version_stamps;
 
- private:
- bool get_single_value_from_transaction(const std::span<const std::uint8_t>& key,
-                                        std::invocable<std::span<const std::uint8_t>> auto&& write_output_fn);
-
- public:
- transaction(database_handle dbh_)
- : dbh(std::move(dbh_)),
-   txn_handle(dbh->create_transaction(), &fdb_transaction_destroy)
- {}
-
- transaction(database_handle dbh_, const transaction_options& opts) 
-  : transaction(std::move(dbh_))
+ static database_handle require_database(database_handle dbh)
  {
-  detail::apply_options(opts,
-             [handle = raw_handle()](auto opt, auto val, auto sz) {
-               return fdb_transaction_set_option(handle, opt, val, sz);
-             });
+  if (not dbh) {
+   throw std::invalid_argument("transaction requires a database handle");
+  }
+
+  return dbh;
  }
 
- public:
- explicit operator bool() const noexcept { return dbh and nullptr != raw_handle(); }
+ bool get_single_value_from_transaction(detail::byte_view key,
+                                        std::invocable<std::span<const std::uint8_t>> auto&& write_output_fn);
+ void recover_from_commit_error(detail::future_value& commit_future,
+                                fdb_error_t error,
+                                fdb_error_t *replay_error);
+ void resolve_versionstamps(std::optional<detail::future_value>& versionstamp_future);
 
  public:
+ transaction(database_handle database)
+  : dbh(require_database(std::move(database))),
+    txn_handle(dbh->create_transaction(), &fdb_transaction_destroy)
+ {}
+
+ transaction(database_handle database, const transaction_options& opts)
+  : transaction(std::move(database))
+ {
+  detail::apply_options(
+    opts,
+    [handle = raw_handle()](auto option, auto data, auto size) {
+      return fdb_transaction_set_option(handle, option, data, size);
+    });
+ }
+
+ explicit operator bool() const noexcept { return dbh and nullptr != raw_handle(); }
+
  FDBTransaction *raw_handle() const noexcept { return txn_handle.get(); }
 
  private:
- void set(std::span<const std::uint8_t> k, std::span<const std::uint8_t> v) {
-    fdb_transaction_set(raw_handle(),
-                        (const uint8_t*)k.data(), k.size(),
-                        (const uint8_t*)v.data(), v.size());
+ void set(detail::byte_view key, detail::byte_view value)
+ {
+  const auto key_bytes = detail::as_fdb_bytes(key);
+  const auto value_bytes = detail::as_fdb_bytes(value);
+
+  fdb_transaction_set(raw_handle(),
+                      key_bytes.data, key_bytes.length,
+                      value_bytes.data, value_bytes.length);
  }
 
  void mark_version(const versionstamp& stamp)
@@ -773,69 +889,80 @@ class transaction final
  }
 
  template <FDBMutationType MutationKind>
- void set_versioned_data(std::span<const std::uint8_t> k,
-                         std::span<const std::uint8_t> v,
+ void set_versioned_data(detail::byte_view key,
+                         detail::byte_view value,
                          const versionstamp& stamp)
  {
+  const auto key_bytes = detail::as_fdb_bytes(key);
+  const auto value_bytes = detail::as_fdb_bytes(value);
+
   fdb_transaction_atomic_op(raw_handle(),
-                            (const std::uint8_t*)k.data(), k.size(),
-                            (const std::uint8_t*)v.data(), v.size(),
+                            key_bytes.data, key_bytes.length,
+                            value_bytes.data, value_bytes.length,
                             MutationKind);
 
   mark_version(stamp);
  }
 
- void set(const versioned_bytes& k, std::span<const std::uint8_t> v)
+ void set(const versioned_bytes& key, detail::byte_view value)
  {
   set_versioned_data<FDB_MUTATION_TYPE_SET_VERSIONSTAMPED_KEY>(
-    std::span<const std::uint8_t>(k.encoding_buffer), v, k.stamp);
+    detail::byte_view(key.encoding_buffer), value, key.stamp);
  }
 
- void set(std::span<const std::uint8_t> k, const versioned_bytes& v)
+ void set(detail::byte_view key, const versioned_bytes& value)
  {
   set_versioned_data<FDB_MUTATION_TYPE_SET_VERSIONSTAMPED_VALUE>(
-    k, std::span<const std::uint8_t>(v.encoding_buffer), v.stamp);
+    key, detail::byte_view(value.encoding_buffer), value.stamp);
  }
 
- bool get(const std::span<const std::uint8_t> k, concepts::value_callback auto&& val_collector) {
-    return get_single_value_from_transaction(k, val_collector);
- }
-
- void erase(std::span<const std::uint8_t> k) {
-    fdb_transaction_clear(raw_handle(),
-                          (const std::uint8_t *)k.data(), k.size());
- }
-
- void erase(const ceph::libfdb::select& key_range) {
-    const auto half_open_range = detail::as_half_open_select(key_range);
-
-    fdb_transaction_clear_range(raw_handle(),
-        (const uint8_t *)half_open_range.begin_key.data(), half_open_range.begin_key.size(),
-        (const uint8_t *)half_open_range.end_key.data(), half_open_range.end_key.size());
- }
-
- [[nodiscard]] watch_handle make_watch(std::span<const std::uint8_t> key)
+ bool get(const detail::byte_view key,
+          concepts::value_callback auto&& value_collector)
  {
+  return get_single_value_from_transaction(key, value_collector);
+ }
+
+ void erase(detail::byte_view key)
+ {
+  const auto key_bytes = detail::as_fdb_bytes(key);
+
+  fdb_transaction_clear(raw_handle(), key_bytes.data, key_bytes.length);
+ }
+
+ void erase(const ceph::libfdb::select& key_range)
+ {
+  const auto half_open_range = detail::as_half_open_select(key_range);
+  const auto begin = detail::as_fdb_bytes(half_open_range.begin_key);
+  const auto end = detail::as_fdb_bytes(half_open_range.end_key);
+
+  fdb_transaction_clear_range(
+    raw_handle(),
+    begin.data, begin.length,
+    end.data, end.length);
+ }
+
+ [[nodiscard]] watch_handle make_watch(detail::byte_view key)
+ {
+  const auto key_bytes = detail::as_fdb_bytes(key);
+
   return watch_handle {
    detail::future_value {
-    fdb_transaction_watch(raw_handle(), key.data(), key.size())
+    fdb_transaction_watch(raw_handle(), key_bytes.data, key_bytes.length)
    }
   };
  }
 
- bool key_exists(std::string_view k) {
-    return get_single_value_from_transaction(detail::as_fdb_span(k), [](auto) {});
+ bool key_exists(detail::byte_view key)
+ {
+  return get_single_value_from_transaction(key, [](auto) {});
  }
 
  bool commit();
  bool commit(fdb_error_t *replay_error);
  void destroy() noexcept { txn_handle.reset(); }
 
- // As you can see, friends are used extensively to implement the public interface; it would be nice to come up
- // with a strategy for making these "lists" a bit more managable, but for now it's what we have and it allows me ot
- // keep these handles mostly-opaque (this has proven to be a good idea as I've a few times shuffled internal details
- // with no disruption to the user interface surface):
- private:
+ // Friends implement the public free-function interface while keeping the
+ // transaction handle opaque:
  friend inline void set(transaction_handle,
                         const concepts::libfdb_key auto&,
                         const auto&,
@@ -870,10 +997,10 @@ class transaction final
  friend inline bool commit(transaction_handle& txn, const versionstamp& stamp);
  friend inline watch_handle make_watch(transaction_handle txn, std::string_view key);
  friend inline void ceph::libfdb::detail::transaction_set_kv_bytes(const transaction_handle&,
-                                                                   std::span<const std::uint8_t>,
-                                                                   std::span<const std::uint8_t>);
+                                                                   detail::byte_view,
+                                                                   detail::byte_view);
  friend inline void ceph::libfdb::detail::transaction_clear_key_bytes(const transaction_handle&,
-                                                                      std::span<const std::uint8_t>);
+                                                                      detail::byte_view);
  friend inline void ceph::libfdb::detail::transaction_clear_range(const transaction_handle&,
                                                                  const ceph::libfdb::select&);
 
@@ -883,16 +1010,16 @@ namespace detail {
 
 // Since lambdas cannot be friend-functions, we use a named helper:
 inline void transaction_set_kv_bytes(const transaction_handle& txn,
-                                     std::span<const std::uint8_t> k,
-                                     std::span<const std::uint8_t> v)
+                                     byte_view key,
+                                     byte_view value)
 {
- txn->set(k, v);
+ txn->set(key, value);
 }
 
 inline void transaction_clear_key_bytes(const transaction_handle& txn,
-                                        std::span<const std::uint8_t> k)
+                                        byte_view key)
 {
- txn->erase(k);
+ txn->erase(key);
 }
 
 inline void transaction_clear_range(const transaction_handle& txn,
@@ -903,33 +1030,96 @@ inline void transaction_clear_range(const transaction_handle& txn,
 
 } // namespace detail
 
-inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const std::span<const std::uint8_t>& key, std::invocable<std::span<const std::uint8_t>> auto&& write_output)
+inline bool ceph::libfdb::transaction::get_single_value_from_transaction(
+  const detail::byte_view key,
+  std::invocable<std::span<const std::uint8_t>> auto&& write_output)
 {
- const fdb_bool_t is_snapshot = false; 
+ const fdb_bool_t is_snapshot = false;
+ const auto key_bytes = detail::as_fdb_bytes(key);
 
- auto fv = detail::block_until_ready(detail::future_value(fdb_transaction_get(
-                                    raw_handle(),
-                                    (const uint8_t *)key.data(), key.size(),
-                                    is_snapshot)));
+ auto fv = detail::block_until_ready(detail::future_value(
+  fdb_transaction_get(raw_handle(),
+                      key_bytes.data,
+                      key_bytes.length,
+                      is_snapshot)));
  auto *future = fv.raw_ptr_or_throw();
- 
-  fdb_bool_t key_was_found = false;
-  const uint8_t *out_buffer = nullptr;
-  int out_len = 0;
 
-  if (fdb_error_t r = fdb_future_get_value(future, &key_was_found, &out_buffer, &out_len); 0 != r) {
-    throw libfdb_exception(r);
-  }
+ fdb_bool_t key_was_found = false;
+ const std::uint8_t *out_buffer = nullptr;
+ int out_len = 0;
 
-  // No errors, but no value was found:
-  if (0 == key_was_found) {
-    return false;
-  }
- 
-  write_output(std::span<const std::uint8_t>(out_buffer, out_len));
- 
-  // The happy path is the simple path:
-  return true; 
+ if (const auto ec = fdb_future_get_value(
+       future, &key_was_found, &out_buffer, &out_len);
+     0 != ec) {
+  throw libfdb_exception(ec);
+ }
+
+ if (0 == key_was_found) {
+  return false;
+ }
+
+ write_output(detail::result_bytes(out_buffer, out_len));
+
+ return true;
+}
+
+inline void ceph::libfdb::transaction::recover_from_commit_error(
+  detail::future_value& commit_result_future,
+  const fdb_error_t error,
+  fdb_error_t *replay_error)
+{
+ detail::future_value on_error_future =
+  detail::wait_for_on_error(raw_handle(), error);
+
+ if (0 != detail::get_future_error(on_error_future)) {
+  // These cleanup operations are one ordered action:
+  commit_result_future.destroy(), on_error_future.destroy(), destroy();
+
+  throw libfdb_exception(error);
+ }
+
+ if (nullptr != replay_error) {
+  *replay_error = error;
+ }
+
+ version_stamps.clear();
+}
+
+inline void ceph::libfdb::transaction::resolve_versionstamps(
+  std::optional<detail::future_value>& versionstamp_future)
+{
+ if (not versionstamp_future) {
+  return;
+ }
+
+ auto ready = detail::block_until_ready(std::move(*versionstamp_future));
+
+ const std::uint8_t *data = nullptr;
+ int size = 0;
+
+ if (const auto ec = fdb_future_get_key(ready.raw_handle(), &data, &size);
+     0 != ec) {
+  throw libfdb_exception(ec);
+ }
+
+ constexpr auto expected_size =
+  std::tuple_size_v<versionstamp::versionstamp_data_t>;
+
+ if (nullptr == data) {
+  throw libfdb_exception("invalid version stamp result");
+ }
+
+ const auto result = detail::result_bytes(data, size);
+
+ if (expected_size != result.size()) {
+  throw libfdb_exception("invalid version stamp result");
+ }
+
+ for (auto& stamp : version_stamps) {
+  stamp.store_result(result);
+ }
+
+ version_stamps.clear();
 }
 
 [[nodiscard]] inline bool ceph::libfdb::transaction::commit()
@@ -944,8 +1134,9 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
  }
 
  // We don't want to try to vivify for an "empty" commit:
- if (!*this)
+ if (not *this) {
   return false;
+ }
 
  std::optional<detail::future_value> versionstamp_future;
 
@@ -953,64 +1144,22 @@ inline bool ceph::libfdb::transaction::get_single_value_from_transaction(const s
   versionstamp_future.emplace(fdb_transaction_get_versionstamp(raw_handle()));
  }
 
- detail::future_value fv(fdb_transaction_commit(raw_handle()));
- auto *commit_future = fv.raw_ptr_or_throw();
+ detail::future_value commit_result_future(
+  fdb_transaction_commit(raw_handle()));
+ auto *commit_future = commit_result_future.raw_ptr_or_throw();
 
- if (fdb_error_t r = fdb_future_block_until_ready(commit_future); 0 != r) {
-  throw libfdb_exception(r);
+ if (const auto ec = fdb_future_block_until_ready(commit_future); 0 != ec) {
+  throw libfdb_exception(ec);
  }
 
- if (fdb_error_t r = fdb_future_get_error(commit_future); 0 != r) {
-  detail::future_value ferror_result = detail::wait_for_on_error(raw_handle(), r);
+ if (const auto ec = fdb_future_get_error(commit_future); 0 != ec) {
+  recover_from_commit_error(commit_result_future, ec, replay_error);
 
-  if (0 != detail::get_future_error(ferror_result)) {
-    // Destroy the futures AND be sure to invalidate the transaction-- according to the documentation,
-    // this must happen in the specified order (which /should/ currently match the dtor order, but I am
-    // not going to touch this any more right now):
-    fv.destroy(), ferror_result.destroy(), destroy();
-
-    // Again, use the original error:
-    throw libfdb_exception(r);
-  }
-
-  // A false result means on_error() succeeded; the caller should replay the transaction:
-  if (nullptr != replay_error) {
-   *replay_error = r;
-  }
-
-  version_stamps.clear();
   return false;
  }
 
- if (versionstamp_future) {
-  auto ready = detail::block_until_ready(std::move(*versionstamp_future));
+ resolve_versionstamps(versionstamp_future);
 
-  const uint8_t *out_versionstamp_data = nullptr;
-  int out_versionstamp_size = 0;
-
-  if (fdb_error_t r = fdb_future_get_key(ready.raw_handle(), &out_versionstamp_data, &out_versionstamp_size); 0 != r) {
-   throw libfdb_exception(r);
-  }
-
-  constexpr auto expected_versionstamp_size =
-   std::tuple_size_v<versionstamp::versionstamp_data_t>;
-
-  if (expected_versionstamp_size != static_cast<std::size_t>(out_versionstamp_size) ||
-      nullptr == out_versionstamp_data) {
-   throw libfdb_exception("invalid version stamp result");
-  }
-
-  const auto versionstamp_result =
-   std::span(out_versionstamp_data, expected_versionstamp_size);
-
-  for (auto& stamp : version_stamps) {
-   stamp.store_result(versionstamp_result);
-  }
-
-  version_stamps.clear();
- }
-
- // Ok:
  return true;
 }
 
@@ -1052,7 +1201,8 @@ inline fdb_error_t get_future_error(const future_value& fv)
  return fdb_future_get_error(fv.raw_ptr_or_throw());
 }
 
-inline future_value wait_for_on_error(FDBTransaction* txn, const fdb_error_t original_error)
+inline future_value wait_for_on_error(FDBTransaction *txn,
+                                      const fdb_error_t original_error)
 {
  future_value on_error_future(fdb_transaction_on_error(txn, original_error));
 

--- a/src/rgw/fdb/content.h
+++ b/src/rgw/fdb/content.h
@@ -18,12 +18,14 @@
 
 #include "base.h"
 
-#include <algorithm>
-#include <compare>
-#include <cstddef>
 #include <string>
 #include <string_view>
+
+#include <algorithm>
+
+#include <cstddef>
 #include <utility>
+#include <compare>
 
 namespace ceph::libfdb::layer::content {
 

--- a/src/rgw/fdb/content.h
+++ b/src/rgw/fdb/content.h
@@ -14,7 +14,7 @@
 */
 
 #ifndef CEPH_FDB_CONTENT_H
- #define CEPH_FDB_CONTENT_H
+#define CEPH_FDB_CONTENT_H
 
 #include "base.h"
 
@@ -37,7 +37,7 @@ constexpr std::size_t encoded_string_segment_size(const std::string_view segment
  const auto embedded_nuls =
   static_cast<std::size_t>(std::ranges::count(segment, '\0'));
 
- return std::size(segment) + embedded_nuls + 1;
+ return 1 + std::size(segment) + embedded_nuls;
 }
 
 constexpr void append_encoded_string_segment(std::string& out,
@@ -54,7 +54,7 @@ constexpr void append_encoded_string_segment(std::string& out,
   out.push_back(c);
 
   if ('\0' == c) {
-   out.push_back(static_cast<char>(0xFF));
+   out.push_back('\xFF');
   }
  }
 
@@ -67,7 +67,7 @@ constexpr void require_valid_keyspace_root(const std::string_view segment)
   throw ::ceph::libfdb::libfdb_exception("content key assembly requires a non-empty keyspace root");
  }
 
- if (static_cast<char>(0xFF) == segment.front()) {
+ if ('\xFF' == segment.front()) {
   throw ::ceph::libfdb::libfdb_exception("content keyspace root must not start with 0xFF");
  }
 }
@@ -123,25 +123,25 @@ constexpr compiled_key assemble(const Segments& ...segments);
 
 class compiled_key final
 {
- std::string bytes_;
+ std::string encoded_bytes;
 
  public:
  compiled_key() = delete;
 
  private:
  explicit constexpr compiled_key(std::string bytes)
-  : bytes_(std::move(bytes))
+  : encoded_bytes(std::move(bytes))
  {}
 
  public:
  constexpr std::size_t size() const noexcept
  {
-  return bytes_.size();
+  return encoded_bytes.size();
  }
 
  constexpr auto operator<=>(const compiled_key& rhs) const noexcept
  {
-  return bytes_ <=> rhs.bytes_;
+  return encoded_bytes <=> rhs.encoded_bytes;
  }
 
  constexpr bool operator==(const compiled_key& rhs) const noexcept = default;
@@ -152,15 +152,15 @@ class compiled_key final
  {
   const auto segment_bytes = detail::segment_view(segment);
 
-  detail::reserve_encoded_string_segments(lhs.bytes_, segment_bytes);
-  detail::append_encoded_string_segment(lhs.bytes_, segment_bytes);
+  detail::reserve_encoded_string_segments(lhs.encoded_bytes, segment_bytes);
+  detail::append_encoded_string_segment(lhs.encoded_bytes, segment_bytes);
 
   return lhs;
  }
 
  friend constexpr std::string_view libfdb_key_view(const compiled_key& key) noexcept
  {
-  return key.bytes_;
+  return key.encoded_bytes;
  }
 
  private:

--- a/src/rgw/fdb/conversion.h
+++ b/src/rgw/fdb/conversion.h
@@ -11,10 +11,10 @@
  * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
  *
-*/
+ */
 
 #ifndef CEPH_FDB_CONVERSION_H
- #define CEPH_FDB_CONVERSION_H
+#define CEPH_FDB_CONVERSION_H
 
 #include "base.h"
 
@@ -31,28 +31,20 @@
 #include <type_traits>
 #include <system_error>
 
-/* This module is the conversion boundary between C++ values and the byte buffers used by FoundationDB. Most of
-the serialization work is delegated to zpp_bits, but this layer has two jobs: it gives libfdb's gadgets a place
-to live (abstracting array/span behavior, callback outputs, error translation, etc.), and it provides a clean point
-for future features-- a good example would be caller-owned memory, which we currently don't support but certainly
-could. It also provides a fixed point where another serialization library could be swapped in. */
+/* This is the conversion boundary between C++ values and FoundationDB byte
+ * buffers. Serialization is delegated to zpp_bits; this layer adapts callback
+ * outputs, translates errors, and leaves a clean extension point for future
+ * caller-owned memory or a different serializer. */
 
 namespace ceph::libfdb::to {
 
-inline auto convert(const auto& from, std::vector<std::uint8_t>& out_data) -> std::span<const std::uint8_t>
+inline auto convert(const auto& from,
+                    std::vector<std::uint8_t>& out_data)
+ -> std::span<const std::uint8_t>
 {
  out_data.clear();
- 
+
  zpp::bits::out out(out_data);
-
- // zpp::bits won't write a size if we start with a fixed size array:
- // (see dynamic_extent):
- if constexpr (std::is_array_v<decltype(from)>) {
-     out(std::span(from, std::size(from))).or_throw();
-
-     return out_data;
- }
-
  out(from).or_throw();
 
  return out_data;
@@ -84,10 +76,13 @@ inline void convert(const std::span<const std::uint8_t>& from, auto& to)
  zpp_in(to).or_throw();
 }
 
-template <std::invocable<const char *, size_t> OutputFunction>
-inline void convert(const std::span<const std::uint8_t>& in, OutputFunction& write_output_fn)
+template <std::invocable<const char *, std::size_t> OutputFunction>
+inline void convert(const std::span<const std::uint8_t>& in,
+                    OutputFunction& write_output_fn)
 {
- write_output_fn((const char *)in.data(), in.size());
+ const auto input = detail::as_string_view(in);
+
+ write_output_fn(input.data(), input.size());
 }
 
 } // namespace ceph::libfdb::from
@@ -96,21 +91,19 @@ namespace ceph::libfdb::detail {
 
 template <typename ValueT>
 inline std::pair<std::string, ValueT> to_decoded_kv_pair(const FDBKeyValue& kv)
+try
 {
  std::pair<std::string, ValueT> r;
 
- r.first.assign((const char *)kv.key, static_cast<std::string::size_type>(kv.key_length));
-
- try 
-  {
-     ceph::libfdb::from::convert(std::span<const std::uint8_t>(kv.value, kv.value_length), r.second);
- }
- catch (const std::system_error& e) {
-     // Decode failures still surface as libfdb operation failures to callers.
-     throw ceph::libfdb::libfdb_exception(e.what());
-  }
+ r.first = key_view(kv);
+ ceph::libfdb::from::convert(value_view(kv), r.second);
 
  return r;
+}
+catch (const std::system_error& e)
+{
+ // Decode failures still surface as libfdb operation failures to callers:
+ throw ceph::libfdb::libfdb_exception(e.what());
 }
 
 } // namespace ceph::libfdb::detail

--- a/src/rgw/fdb/conversion.h
+++ b/src/rgw/fdb/conversion.h
@@ -23,10 +23,11 @@
 #include <span>
 #include <string>
 #include <vector>
+#include <string_view>
+
 #include <cstdint>
 #include <concepts>
 #include <functional>
-#include <string_view>
 #include <type_traits>
 #include <system_error>
 

--- a/src/rgw/fdb/fdb.h
+++ b/src/rgw/fdb/fdb.h
@@ -14,7 +14,7 @@
 */
 
 #ifndef CEPH_RGW_FDB_H
- #define CEPH_RGW_FDB_H
+#define CEPH_RGW_FDB_H
 
 #include "interface.h"
 #include "scan.h"

--- a/src/rgw/fdb/fdb.h
+++ b/src/rgw/fdb/fdb.h
@@ -17,6 +17,7 @@
  #define CEPH_RGW_FDB_H
 
 #include "interface.h"
+#include "scan.h"
 #include "content.h"
 
 #endif

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -12,7 +12,7 @@
 */
 
 #ifndef CEPH_FDB_INTERFACE_H
- #define CEPH_FDB_INTERFACE_H
+#define CEPH_FDB_INTERFACE_H
 
 #include "conversion.h"
 #include "transaction.h"
@@ -71,12 +71,12 @@ inline database_handle create_database()
  return std::make_shared<database>();
 }
 
-inline database_handle create_database(const std::filesystem::path dbfile)
+inline database_handle create_database(const std::filesystem::path& dbfile)
 {
  return std::make_shared<database>(dbfile);
 }
 
-inline database_handle create_database(const std::filesystem::path dbfile,
+inline database_handle create_database(const std::filesystem::path& dbfile,
                                        const database_options& dbopts,
                                        const network_options& netopts)
 {
@@ -94,15 +94,13 @@ inline database_handle create_database(const database_options& opts)
  return create_database(opts, network_options{});
 }
 
-inline database_handle create_database(const std::filesystem::path dbfile,
+inline database_handle create_database(const std::filesystem::path& dbfile,
                                        const database_options& dbopts)
 {
  return create_database(dbfile, dbopts, network_options{});
 }
 
-} // namespace ceph::libfdb
-
-namespace ceph::libfdb::detail {
+namespace detail {
 
 template <typename OutValuesT>
 struct value_collector_t final
@@ -129,9 +127,7 @@ auto get_output_for(OutputTargetOrFnT&& output_target_or_fn)
  return value_collector(output_target_or_fn);
 }
 
-} // namespace ceph::libfdb::detail
-
-namespace ceph::libfdb {
+} // namespace detail
 
 [[nodiscard]] inline watch_handle make_watch(database_handle dbh, std::string_view key)
 {
@@ -168,16 +164,12 @@ void watched_loop(database_handle dbh, std::string_view key, FnT&& fn)
  return watched_loop(dbh, key, std::stop_token{}, std::forward<FnT>(fn));
 }
 
-} // namespace ceph::libfdb
-
-namespace ceph::libfdb {
-
 inline void set(transaction_handle txn,
                 const concepts::libfdb_key auto& k, const auto& v,
                 const commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
-          [key = detail::as_fdb_span(k), &v](const transaction_handle& active_txn) {
+          [key = detail::as_byte_view(k), &v](const transaction_handle& active_txn) {
             return detail::transaction_set_kv_bytes(active_txn, key, ceph::libfdb::to::convert(v));
           });
 }
@@ -213,7 +205,7 @@ inline void set(transaction_handle txn,
             std::ranges::for_each(std::ranges::subrange(b, e),
                       [&active_txn, &fixed_buffer](const auto& kv) {
                         detail::transaction_set_kv_bytes(active_txn,
-                                  detail::as_fdb_span(kv.first),
+                                  detail::as_byte_view(kv.first),
                                   ceph::libfdb::to::convert(kv.second, fixed_buffer));
                       });
           });
@@ -260,7 +252,7 @@ inline void set(transaction_handle txn,
                 const commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
-          [key = detail::as_fdb_span(k), value = std::string_view(v)](const transaction_handle& active_txn) {
+          [key = detail::as_byte_view(k), value = std::string_view(v)](const transaction_handle& active_txn) {
             return detail::transaction_set_kv_bytes(active_txn, key, ceph::libfdb::to::convert(value));
           });
 }
@@ -288,8 +280,8 @@ inline void set(transaction_handle txn,
                 const commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
-          [&k, &v](const transaction_handle& txn) {
-            return txn->set(k, ceph::libfdb::to::convert(v));
+          [&k, &v](const transaction_handle& active_txn) {
+            return active_txn->set(k, ceph::libfdb::to::convert(v));
           });
 }
 
@@ -330,8 +322,8 @@ inline void set(transaction_handle txn,
                 const commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
-          [key = detail::as_fdb_span(k), &v](const transaction_handle& txn) {
-            return txn->set(key, v);
+          [key = detail::as_byte_view(k), &v](const transaction_handle& active_txn) {
+            return active_txn->set(key, v);
           });
 }
 
@@ -351,10 +343,6 @@ inline void set(database_handle dbh,
             return set(txn, k, v, commit_after_op::no_commit);
           });
 }
-
-} // namespace ceph::libfdb
-
-namespace ceph::libfdb {
 
 // erase() in libfdb is clear() in FDB parlance:
 inline void erase(ceph::libfdb::transaction_handle txn,
@@ -388,7 +376,7 @@ inline void erase(ceph::libfdb::transaction_handle txn,
                   const commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
-          [key = detail::as_fdb_span(k)](const transaction_handle& active_txn) {
+          [key = detail::as_byte_view(k)](const transaction_handle& active_txn) {
             return detail::transaction_clear_key_bytes(active_txn, key);
           });
 }
@@ -406,10 +394,6 @@ inline void erase(ceph::libfdb::database_handle dbh, const concepts::libfdb_key 
           });
 }
 
-} // namespace ceph::libfdb
-
-namespace ceph::libfdb {
-
 template <typename OutputTargetOrFnT>
 requires concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>> or
          concepts::decoded_value_sink<OutputTargetOrFnT&&>
@@ -419,7 +403,7 @@ inline bool get(ceph::libfdb::transaction_handle txn,
                 const commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
-          [key = detail::as_fdb_span(key), &output_target_or_fn](const transaction_handle& active_txn) {
+          [key = detail::as_byte_view(key), &output_target_or_fn](const transaction_handle& active_txn) {
             return active_txn->get(key,
                                    detail::get_output_for(output_target_or_fn));
           });
@@ -448,17 +432,13 @@ inline bool get(ceph::libfdb::database_handle dbh,
           });
 }
 
-} // namespace ceph::libfdb
-
-namespace ceph::libfdb {
-
 // Does a key exist?
 inline bool key_exists(transaction_handle txn,
                        const concepts::libfdb_key auto& k,
                        const commit_after_op commit_after)
 {
  return detail::commit_noreplay(txn, commit_after,
-          [key = detail::as_libfdb_key_view(k)](const transaction_handle& active_txn) {
+          [key = detail::as_byte_view(k)](const transaction_handle& active_txn) {
             return active_txn->key_exists(key);
           });
 }
@@ -476,9 +456,7 @@ inline bool key_exists(database_handle dbh, const concepts::libfdb_key auto& k)
           });
 }
 
-} // namespace ceph::libfdb
-
-namespace ceph::libfdb::detail {
+namespace detail {
 
 template <typename OutValuesT>
 void value_collector_t<OutValuesT>::operator()(std::span<const std::uint8_t> out_data) const
@@ -492,6 +470,8 @@ auto value_collector(OutValuesT& out_values) -> value_collector_t<OutValuesT>
  return { out_values };
 }
 
-} // namespace ceph::libfdb::detail
+} // namespace detail
+
+} // namespace ceph::libfdb
 
 #endif

--- a/src/rgw/fdb/interface.h
+++ b/src/rgw/fdb/interface.h
@@ -11,36 +11,53 @@
  *
 */
 
-#ifndef CEPH_FDB_BINDINGS_H
- #define CEPH_FDB_BINDINGS_H
+#ifndef CEPH_FDB_INTERFACE_H
+ #define CEPH_FDB_INTERFACE_H
 
-#include "base.h"
 #include "conversion.h"
+#include "transaction.h"
 
-#include <tuple>
+#include <span>
+#include <string>
+#include <vector>
+#include <string_view>
+
+#include <ranges>
+#include <iterator>
+#include <algorithm>
+
+#include <memory>
+#include <cstdint>
+#include <utility>
+#include <concepts>
+#include <functional>
+#include <stop_token>
+#include <filesystem>
+#include <type_traits>
 
 namespace ceph::libfdb {
 
-// Overload tag for transactors that should report replay/commit metadata:
-struct with_result_t final {};
-inline constexpr with_result_t with_result;
+namespace concepts {
 
-// Describes replay/commit work performed by result-reporting transactors.
-struct transaction_result final {
- bool committed = false;
- std::size_t attempts = 0;
+template <typename IteratorT>
+concept key_value_iterator =
+ std::input_iterator<IteratorT> and
+ requires(std::iter_reference_t<IteratorT> kv) {
+  requires libfdb_key<decltype(kv.first)>;
+  requires std::is_object_v<std::remove_reference_t<decltype(kv.second)>>;
+ };
 
- // Replays prepared after retryable failures; excludes a final exhausted attempt:
- std::size_t replay_count = 0;
+template <typename RangeT>
+concept key_value_range =
+ std::ranges::input_range<RangeT> and
+ key_value_iterator<std::ranges::iterator_t<RangeT>>;
 
- fdb_error_t last_error = 0;
-};
+template <typename RangeT>
+concept key_value_forward_range =
+ std::ranges::forward_range<RangeT> and
+ key_value_iterator<std::ranges::iterator_t<RangeT>>;
 
-// Describes a commit attempt when the caller owns transaction replay.
-struct commit_result final {
- bool committed = false;
- fdb_error_t replay_error = 0;
-};
+} // namespace concepts
 
 /* This should be called when the application is all done with FoundationDB: */
 inline void shutdown_libfdb()
@@ -83,79 +100,9 @@ inline database_handle create_database(const std::filesystem::path dbfile,
  return create_database(dbfile, dbopts, network_options{});
 }
 
-inline transaction_handle make_transaction(database_handle dbh)
-{
- if (!dbh) {
-  throw std::invalid_argument("make_transaction() requires database handle");
- }
-
- return std::make_shared<transaction>(dbh);
-}
-
-inline transaction_handle make_transaction(database_handle dbh, const transaction_options& opts)
-{
- return std::make_shared<transaction>(dbh, opts);
-}
-
-// Note: only rarely is a direct call to this needed. You can use transactors or pass database_handles
-// to get automagic.
-// Note: after a transaction is committed, it cannot be used again.
-// On false, the client should retry the transaction:
-[[nodiscard]] inline bool commit(transaction_handle& txn)
-{
- return txn->commit();
-}
-
-// Prepare a transaction to replay after a retryable operation-body error:
-void prepare_replay(transaction_handle& txn, fdb_error_t error);
-
-[[nodiscard]] commit_result commit(with_result_t, transaction_handle& txn);
-
-[[nodiscard]] inline bool commit(transaction_handle& txn,
-                                 const versionstamp& stamp)
-{
- txn->mark_version(stamp);
- return commit(txn);
-}
-
-[[nodiscard]] inline watch_handle make_watch(transaction_handle txn, std::string_view key)
-{
- return txn->make_watch(detail::as_fdb_span(key));
-}
-
 } // namespace ceph::libfdb
 
 namespace ceph::libfdb::detail {
-
-// Forward declarations:
-template <typename FnT, typename ...ArgTs>
-using transaction_invocation_result_t =
- std::invoke_result_t<FnT&, transaction_handle&, ArgTs&...>;
-
-template <typename FnT, typename ...ArgTs>
-concept transaction_op =
- std::invocable<FnT&, transaction_handle&, ArgTs&...> &&
- concepts::supported_invocation_result<transaction_invocation_result_t<FnT, ArgTs...>>;
-
-template <typename FnT, typename ...ArgTs>
-concept result_reporting_transaction_op =
- transaction_op<FnT, ArgTs...> &&
- std::is_void_v<transaction_invocation_result_t<FnT, ArgTs...>>;
-
-template <typename FnT, typename ...ArgTs>
-concept bound_transaction_op =
- std::constructible_from<std::decay_t<FnT>, FnT> &&
- (std::constructible_from<std::decay_t<ArgTs>, ArgTs> && ...) &&
- transaction_op<std::decay_t<FnT>, std::decay_t<ArgTs>...>;
-
-template <typename FnT>
-using operation_result_t =
- std::conditional_t<std::is_void_v<transaction_invocation_result_t<FnT>>,
-                    void,
-                    std::remove_cvref_t<transaction_invocation_result_t<FnT>>>;
-
-template <result_reporting_transaction_op FnT>
-transaction_result maybe_retry_with_result(transaction_handle txn, FnT&& fn);
 
 template <typename OutValuesT>
 struct value_collector_t final
@@ -181,17 +128,6 @@ auto get_output_for(OutputTargetOrFnT&& output_target_or_fn)
 {
  return value_collector(output_target_or_fn);
 }
-
-template <transaction_op FnT>
-auto maybe_retry(transaction_handle txn, FnT&& fn) -> operation_result_t<FnT>;
-
-template <transaction_op FnT>
-auto commit_noreplay(transaction_handle txn, const commit_after_op commit_after, FnT&& fn)
- -> operation_result_t<FnT>;
-
-template <transaction_op FnT>
-auto in_transaction(database_handle dbh, FnT&& fn)
- -> operation_result_t<FnT>;
 
 } // namespace ceph::libfdb::detail
 
@@ -474,180 +410,6 @@ inline void erase(ceph::libfdb::database_handle dbh, const concepts::libfdb_key 
 
 namespace ceph::libfdb {
 
-namespace detail {
-
-inline select select_from_initializer_list(std::initializer_list<std::string_view> keys)
-{
- const auto first = std::begin(keys);
-
- if (1 == std::size(keys)) {
-  return select(*first);
- }
-
- if (2 == std::size(keys)) {
-  return select(*first, *std::next(first));
- }
-
- throw libfdb_exception("range selection initializer list requires one or two keys");
-}
-
-template <typename OutT>
-struct materialized_string_pair_output final
-{
- OutT values;
- std::size_t nread = 0;
-};
-
-template <typename RangeT>
-inline auto move_range(RangeT& range)
-{
- return std::ranges::subrange(std::make_move_iterator(std::begin(range)),
-                              std::make_move_iterator(std::end(range)));
-}
-
-template <typename ContainerT>
-inline void publish_string_pair_results(ContainerT& out, ContainerT&& tmp)
-{
- if constexpr (ceph::concepts::has_empty<ContainerT> &&
-               std::assignable_from<ContainerT&, ContainerT&&>) {
-  if (out.empty()) {
-   out = std::move(tmp);
-   return;
-  }
- }
-
- if constexpr (requires { out.merge(tmp); }) {
-  out.merge(tmp);
-  return;
- }
-
- ceph::util::append_range(out, move_range(tmp));
-}
-
-template <query::expression SelectionT, typename OutT>
-requires concepts::string_pair_output_iterator<OutT> ||
-         concepts::string_pair_output_range<OutT>
-inline std::size_t get_value_selection_from_transaction(transaction& txn,
-                                                        const SelectionT& selection,
-                                                        OutT& out)
-{
- std::size_t nread = 0;
-
- query::for_each_interval(selection, [&](const ceph::libfdb::select& interval) {
-  nread += detail::get_value_range_from_transaction(txn, interval, out);
- });
-
- return nread;
-}
-
-template <typename OutT, query::expression SelectionT>
-requires concepts::materializable_string_pair_output_range<OutT>
-inline auto materialize_string_pair_selection(transaction& txn,
-                                              const SelectionT& selection)
- -> materialized_string_pair_output<OutT>
-{
- OutT tmp;
- const auto nread = get_value_selection_from_transaction(txn, selection, tmp);
-
- return {
-  .values = std::move(tmp),
-  .nread = nread
- };
-}
-
-} // namespace detail
-
-// get() with a selector writes key/value pairs to out_iter and returns the
-// number of pairs emitted:
-// JFW: Satisfying output_iterator is not as straightforward as it appears, I need to look at this mechanism again; meanwhile, the template doesn't
-// /prevent/ future type narrowing, but I'm forcing it to std::string for now:
-inline std::size_t get(ceph::libfdb::transaction_handle txn,
-                       const query::expression auto& selection,
-                       concepts::string_pair_output_iterator auto out_iter,
-                       const ceph::libfdb::commit_after_op commit_after)
-{
- return detail::commit_noreplay(txn, commit_after,
-          [&selection, out_iter](const transaction_handle& active_txn) mutable {
-            return detail::get_value_selection_from_transaction(*active_txn, selection, out_iter);
-          });
-}
-
-inline std::size_t get(ceph::libfdb::transaction_handle txn,
-                       const query::expression auto& selection,
-                       concepts::string_pair_output_iterator auto out_iter)
-{
- return get(txn, selection, out_iter, commit_after_op::no_commit);
-}
-
-inline std::size_t get(ceph::libfdb::database_handle dbh,
-                       const query::expression auto& selection,
-                       concepts::string_pair_output_iterator auto out_iter)
-{
- auto result = detail::in_transaction(dbh,
-          [&selection](transaction_handle& txn) {
-            using out_t = std::vector<std::pair<std::string, std::string>>;
-            return detail::materialize_string_pair_selection<out_t>(*txn, selection);
-          });
-
- std::ranges::move(result.values, out_iter);
- return result.nread;
-}
-
-inline std::size_t get(ceph::libfdb::transaction_handle txn,
-                       const query::expression auto& selection,
-                       concepts::string_pair_output_range auto& out,
-                       const ceph::libfdb::commit_after_op commit_after)
-{
- return detail::commit_noreplay(txn, commit_after,
-          [&selection, &out](const transaction_handle& active_txn) {
-            return detail::get_value_selection_from_transaction(*active_txn, selection, out);
-          });
-}
-
-inline std::size_t get(ceph::libfdb::transaction_handle txn,
-                       const query::expression auto& selection,
-                       concepts::string_pair_output_range auto& out)
-{
- return get(txn, selection, out, commit_after_op::no_commit);
-}
-
-inline std::size_t get(ceph::libfdb::database_handle dbh,
-                       const query::expression auto& selection,
-                       concepts::materializable_string_pair_output_range auto& out)
-{
- using out_t = std::remove_cvref_t<decltype(out)>;
-
- auto result = detail::in_transaction(dbh,
-          [&selection](transaction_handle& txn) {
-            return detail::materialize_string_pair_selection<out_t>(*txn, selection);
-          });
-
- detail::publish_string_pair_results(out, std::move(result.values));
- return result.nread;
-}
-
-inline std::size_t get(ceph::libfdb::transaction_handle txn,
-                       std::initializer_list<std::string_view> keys,
-                       concepts::string_pair_output_range auto& out,
-                       const ceph::libfdb::commit_after_op commit_after)
-{
- return get(txn, detail::select_from_initializer_list(keys), out, commit_after);
-}
-
-inline std::size_t get(ceph::libfdb::transaction_handle txn,
-                       std::initializer_list<std::string_view> keys,
-                       concepts::string_pair_output_range auto& out)
-{
- return get(txn, keys, out, commit_after_op::no_commit);
-}
-
-inline std::size_t get(ceph::libfdb::database_handle dbh,
-                       std::initializer_list<std::string_view> keys,
-                       concepts::materializable_string_pair_output_range auto& out)
-{
- return get(dbh, detail::select_from_initializer_list(keys), out);
-}
-
 template <typename OutputTargetOrFnT>
 requires concepts::value_callback<std::remove_reference_t<OutputTargetOrFnT>> or
          concepts::decoded_value_sink<OutputTargetOrFnT&&>
@@ -716,340 +478,6 @@ inline bool key_exists(database_handle dbh, const concepts::libfdb_key auto& k)
 
 } // namespace ceph::libfdb
 
-namespace ceph::libfdb {
-
-/* A "transactor" is a function-like wrapper for running replayable transactions.
- * It defers transaction creation until called, commits after the user function
- * returns, replays when FoundationDB requests replay, and throws when recovery
- * fails or retry attempts are exhausted. Plus, the name is pretty cool. */
-class transactor final
-{
- database_handle dbh;
-
- std::optional<transaction_options> opts;
-
- private:
- explicit transactor(database_handle dbh_)
-  : dbh(dbh_)
- {}
-
- transactor(database_handle dbh_, const transaction_options& opts_)
-  : dbh(dbh_),
-    opts(opts_)
- {}
-
- // Bind the callable and arguments once so replays see stable state:
- template <typename FnT, typename ...ArgTs>
- static auto bind_invocation(FnT&& fn, ArgTs&& ...args)
- {
-  return [frame = std::tuple<std::decay_t<FnT>, std::decay_t<ArgTs>...> {
-            std::forward<FnT>(fn), std::forward<ArgTs>(args)...
-          }](transaction_handle& txn) mutable -> decltype(auto) {
-    return std::apply([&txn](auto& active_fn, auto& ...active_args) -> decltype(auto) {
-      return std::invoke(active_fn, txn, active_args...);
-    }, frame);
-  };
- }
-
- transaction_handle make_transaction_for_call() const
- {
-  return opts ? make_transaction(dbh, *opts) : make_transaction(dbh);
- }
-
- public:
- template <typename FnT>
- requires detail::transaction_op<FnT>
- decltype(auto) operator()(FnT&& fn) const
- {
-  return detail::maybe_retry(make_transaction_for_call(), std::forward<FnT>(fn));
- }
-
- template <typename FnT, typename ...ArgTs>
- requires (sizeof...(ArgTs) > 0 && detail::bound_transaction_op<FnT, ArgTs...>)
- decltype(auto) operator()(FnT&& fn, ArgTs&& ...args) const
- {
-  auto bound = bind_invocation(std::forward<FnT>(fn), std::forward<ArgTs>(args)...);
-
-  return (*this)(bound);
- }
-
- template <typename FnT>
- requires detail::result_reporting_transaction_op<FnT>
- transaction_result operator()(with_result_t, FnT&& fn) const
- {
-  return detail::maybe_retry_with_result(make_transaction_for_call(), std::forward<FnT>(fn));
- }
-
- template <typename FnT, typename ...ArgTs>
- requires (sizeof...(ArgTs) > 0 &&
-           detail::bound_transaction_op<FnT, ArgTs...> &&
-           detail::result_reporting_transaction_op<
-             std::decay_t<FnT>, std::decay_t<ArgTs>...>)
- transaction_result operator()(with_result_t, FnT&& fn, ArgTs&& ...args) const
- {
-  auto bound = bind_invocation(std::forward<FnT>(fn), std::forward<ArgTs>(args)...);
-
-  return (*this)(with_result, bound);
- }
-
- private:
- friend inline transactor make_transactor(database_handle dbh);
- friend inline transactor make_transactor(database_handle dbh, const transaction_options& opts);
-};
-
-inline transactor make_transactor(database_handle dbh)
-{
- return transactor(dbh);
-}
-
-inline transactor make_transactor(database_handle dbh, const transaction_options& opts)
-{
- return transactor(dbh, opts);
-}
-
-} // namespace ceph::libfdb
-
-// Scan and block traversal:
-namespace ceph::libfdb {
-
-namespace detail {
-
-inline auto intervals(ceph::libfdb::select selection)
-{
- // Raw selectors keep select compatibility but still execute in ordinary FDB keyspace:
- return std::views::single(query::intersection(std::move(selection), query::universal()))
-      | std::views::filter([](const ceph::libfdb::select& range) {
-         return not query::is_empty(range);
-        });
-}
-
-template <query::non_interval_expression QueryT>
-inline auto intervals(const QueryT& query)
-{
- std::vector<ceph::libfdb::select> out;
-
- query::for_each_interval(query, [&out](ceph::libfdb::select interval) {
-  out.push_back(std::move(interval));
- });
-
- return out;
-}
-
-template <typename AssocT, typename RangeT>
-inline AssocT collect_range(RangeT&& range)
-{
- AssocT out;
- std::ranges::copy(std::forward<RangeT>(range),
-                   std::inserter(out, std::end(out)));
- return out;
-}
-
-template <typename ValueT = std::string>
-inline auto scan_selector(ceph::libfdb::transaction_handle txn, ceph::libfdb::select key_range)
-  -> std::generator<std::pair<std::string, ValueT>>
-{
- auto decoded_pairs = ceph::libfdb::detail::generate_FDB_pairs(*txn, key_range)
-                    | std::views::join
-                    | std::views::transform(ceph::libfdb::detail::to_decoded_kv_pair<ValueT>);
-
- co_yield std::ranges::elements_of(decoded_pairs);
-}
-
-template <typename ValueT, typename BlockRangeT>
-inline auto flatten_blocks(BlockRangeT block_range)
-  -> std::generator<std::pair<std::string, ValueT>>
-{
- for (auto block : block_range) {
-  for (auto& pair : block) {
-   co_yield std::move(pair);
-  }
- }
-}
-
-} // namespace detail
-
-// For ordinary range scans inside one explicit transaction, scan() is usually
-// the right default:
-template <typename ValueT = std::string,
-          query::expression SelectionT>
-inline auto scan(ceph::libfdb::transaction_handle txn, SelectionT selection)
-  -> std::generator<std::pair<std::string, ValueT>>
-{
- for (auto& interval : detail::intervals(selection)) {
-  co_yield std::ranges::elements_of(
-   detail::scan_selector<ValueT>(txn, std::move(interval)));
- }
-}
-
-// Legacy name retained for compatibility:
-template <typename ValueT = std::string,
-          query::expression SelectionT>
-inline auto pair_generator(ceph::libfdb::transaction_handle txn,
-                           SelectionT selection)
-  -> std::generator<std::pair<std::string, ValueT>>
-{
- return scan<ValueT>(txn, std::move(selection));
-}
-
-// Note: blocks() uses split planning to tackle large sets; use scan(txn, ...)
-// for direct scans in a caller-owned transaction.
-//
-// What blocks() gives you:
-// - avoids one huge transaction getting too old
-// - gives caller block-at-a-time processing
-// - can bound memory and transaction duration better than a monolithic scan
-//
-// Note: blocks() was originally parallel, and could be again, but preliminary
-// benchmarking showed it to be a significant performance impediment. The
-// database must be truly large to see benefits.
-//
-// Note: This is meant to be straightforward and easy-to-understand-- hence, there's not
-// a recovery strategy or other things (you can replay the entire query)-- as new needs arise, this
-// can be made more flexible via selector options, dynamic range-splitting, etc., but so far there
-// has been no need:
-namespace detail {
-
-template <typename ValueT = std::string,
-          typename AssocT = std::vector<std::pair<std::string, ValueT>>>
-auto blocks_selector(ceph::libfdb::database_handle dbh, ceph::libfdb::select selector)
- -> std::generator<AssocT>
-{
- if (0 == selector.options.result_limit) {
-  selector.options.result_limit = 4096;
- }
-
- // JFW: Although this is tunable, in my measurement it isn't a large factor so far-- likely 
- // these can move into the select instance itself (this is hard to measure in tests-- N
- // has to be pretty big; I've adjusted chunk_size to where I guesstimate it needs to be,
- // we need real-world experience to tweak this further):
- const auto chunk_size = 4 * 1024 * 1024;
-
- auto split_ranges = detail::plan_split_ranges(dbh, selector, chunk_size);
-
- auto read_blocks = [txr = make_transactor(dbh)](this auto& self, ceph::libfdb::select range, const int iteration)
- -> std::generator<AssocT> {
-  auto read_result = txr([](auto& txn, ceph::libfdb::select range, const int iteration) {
-   return detail::materialize_query_window<ValueT, AssocT>(*txn, std::move(range), iteration);
-  }, std::move(range), iteration);
-
-  auto next_range = std::move(read_result.next_range);
-
-  if (read_result.result_block.empty()) {
-   co_return;
-  }
-
-  co_yield std::move(read_result.result_block);
-
-  if (next_range) {
-   co_yield std::ranges::elements_of(self(std::move(*next_range), iteration + 1));
-  }
- };
-
- auto expand_range = [&read_blocks](ceph::libfdb::select range) {
-  return read_blocks(std::move(range), 1);
- };
-
- co_yield std::ranges::elements_of(split_ranges
-                                 | std::views::transform(expand_range)
-                                 | std::views::join);
-}
-
-} // namespace detail
-
-template <typename ValueT = std::string,
-          typename AssocT = std::vector<std::pair<std::string, ValueT>>,
-          query::expression SelectionT>
-auto blocks(ceph::libfdb::database_handle dbh, SelectionT selection)
- -> std::generator<AssocT>
-{
- for (auto& interval : detail::intervals(selection)) {
-  co_yield std::ranges::elements_of(
-   detail::blocks_selector<ValueT, AssocT>(dbh, std::move(interval)));
- }
-}
-
-// Legacy name retained for compatibility:
-template <typename ValueT = std::string,
-          typename AssocT = std::vector<std::pair<std::string, ValueT>>,
-          query::expression SelectionT>
-auto block_generator(ceph::libfdb::database_handle dbh, SelectionT selection)
- -> std::generator<AssocT>
-{
- return blocks<ValueT, AssocT>(dbh, std::move(selection));
-}
-
-// Managed scans flatten the blocks() stream into key/value pairs.
-template <typename ValueT = std::string,
-          query::expression SelectionT>
-inline auto scan(ceph::libfdb::database_handle dbh, SelectionT selection)
-  -> std::generator<std::pair<std::string, ValueT>>
-{
- return detail::flatten_blocks<ValueT>(blocks<ValueT>(dbh, std::move(selection)));
-}
-
-template <typename ValueT = std::string,
-          typename AssocT = std::vector<std::pair<std::string, ValueT>>,
-          query::expression SelectionT>
-inline AssocT collect(ceph::libfdb::transaction_handle txn, SelectionT selection)
-{
- return detail::collect_range<AssocT>(scan<ValueT>(txn, std::move(selection)));
-}
-
-template <typename ValueT = std::string,
-          typename AssocT = std::vector<std::pair<std::string, ValueT>>,
-          query::expression SelectionT>
-inline AssocT collect(ceph::libfdb::database_handle dbh, SelectionT selection)
-{
- return detail::collect_range<AssocT>(scan<ValueT>(dbh, std::move(selection)));
-}
-
-} // namespace ceph::libfdb
-
-namespace ceph::libfdb::detail {
-
-// Helper implementations:
-inline fdb_error_t do_commit(transaction_handle& txn)
-{
- if (fdb_error_t r = 0; !txn->commit(&r)) {
-  return r;
- }
-
- return 0;
-}
-
-inline bool commit_or_throw(transaction_handle& txn)
-{
- if (fdb_error_t r = do_commit(txn); 0 != r) {
-  throw ceph::libfdb::libfdb_exception(r);
- }
-
- return true;
-}
-
-} // namespace ceph::libfdb::detail
-
-namespace ceph::libfdb {
-
-inline void prepare_replay(transaction_handle& txn, const fdb_error_t error)
-{
- if (not detail::retry_after_error(txn, error)) {
-  throw libfdb_exception(error);
- }
-}
-
-[[nodiscard]] inline commit_result commit(with_result_t, transaction_handle& txn)
-{
- fdb_error_t replay_error = 0;
- const auto committed = txn->commit(&replay_error);
-
- return {
-  .committed = committed,
-  .replay_error = replay_error,
- };
-}
-
-} // namespace ceph::libfdb
-
 namespace ceph::libfdb::detail {
 
 template <typename OutValuesT>
@@ -1062,192 +490,6 @@ template <typename OutValuesT>
 auto value_collector(OutValuesT& out_values) -> value_collector_t<OutValuesT>
 {
  return { out_values };
-}
-
-enum struct invocation_failure_policy { no_retry, retry };
-
-struct no_invocation_result final {};
-
-// Keep the existing transactor retry behavior in one place.
-constexpr std::size_t transaction_retry_attempts = 10;
-
-inline void record_transaction_replay(transaction_result& result,
-                                      const fdb_error_t r,
-                                      const bool can_replay)
-{
- result.last_error = r;
-
- if (can_replay) {
-  ++result.replay_count;
- }
-}
-
-template <typename ResultT>
-struct invocation_result_traits final {
- using stored_t = std::remove_cvref_t<ResultT>;
-
- template <typename FnT>
- static stored_t store(transaction_handle& txn, FnT&& fn)
- {
-  return std::invoke(std::forward<FnT>(fn), txn);
- }
-
- static stored_t take(std::optional<stored_t>&& result)
- {
-  return *std::move(result);
- }
-};
-
-template <>
-struct invocation_result_traits<void> final {
- using stored_t = no_invocation_result;
-
- template <typename FnT>
- static stored_t store(transaction_handle& txn, FnT&& fn)
- {
-  std::invoke(std::forward<FnT>(fn), txn);
-
-  return {};
- }
-
- static void take(std::optional<stored_t>&&)
- {}
-};
-
-template <typename ResultT>
-using stored_invocation_result_t = typename invocation_result_traits<ResultT>::stored_t;
-
-template <typename ResultT, typename FnT>
-auto store_invocation_result(transaction_handle& txn, FnT&& fn)
- -> stored_invocation_result_t<ResultT>
-{
- return invocation_result_traits<ResultT>::store(txn, std::forward<FnT>(fn));
-}
-
-template <typename ResultT, typename StoredT>
-decltype(auto) invocation_value_from_result(std::optional<StoredT>&& result)
-{
- return invocation_result_traits<ResultT>::take(std::move(result));
-}
-
-template <invocation_failure_policy FailurePolicy,
-          typename FnT,
-          typename CommitFnT,
-          typename ResultT = std::invoke_result_t<FnT&, transaction_handle&>>
-auto attempt_invocation(transaction_handle& txn, FnT&& fn, CommitFnT&& commit_fn)
- -> std::optional<stored_invocation_result_t<ResultT>>
-{
- using stored_result_t = stored_invocation_result_t<ResultT>;
-
- std::optional<stored_result_t> result;
-
- try {
-  result.emplace(store_invocation_result<ResultT>(txn, fn));
- }
- catch (const libfdb_exception& e) {
-  // Figure out how to recover from invocation failure:
-
-  if constexpr (invocation_failure_policy::no_retry == FailurePolicy) {
-   throw;
-  }
-
-  if (not e.retryable()) {
-   throw;
-  }
-
-  prepare_replay(txn, e.fdb_error_value);
-  return std::nullopt;
- }
-
- if (!std::invoke(commit_fn, txn)) {
-  return std::nullopt;
- }
-
- return result;
-}
-
-template <invocation_failure_policy FailurePolicy,
-          typename FnT,
-          typename CommitFnT,
-          typename ResultT = std::invoke_result_t<FnT&, transaction_handle&>>
-decltype(auto) invoke_with_retry(transaction_handle& txn, FnT&& fn, CommitFnT&& commit_fn)
-{
- for (auto tries = transaction_retry_attempts; tries; --tries) {
-  if (auto result = attempt_invocation<FailurePolicy>(txn, fn, commit_fn)) {
-   return invocation_value_from_result<ResultT>(std::move(result));
-  }
- }
-
- throw libfdb_exception("transaction retry limit exceeded");
-}
-
-template <transaction_op FnT>
-auto maybe_retry(transaction_handle txn, FnT&& fn) -> operation_result_t<FnT>
-{
- return invoke_with_retry<invocation_failure_policy::retry>(
-          txn, std::forward<FnT>(fn),
-          [](transaction_handle& active_txn) {
-            return ceph::libfdb::commit(active_txn);
-          });
-}
-
-template <result_reporting_transaction_op FnT>
-transaction_result maybe_retry_with_result(transaction_handle txn, FnT&& fn)
-{
- transaction_result result;
-
- for (auto attempts_left = transaction_retry_attempts; attempts_left; --attempts_left) {
-  ++result.attempts;
-
-  try {
-   std::invoke(fn, txn);
-  } catch (const libfdb_exception& e) {
-   if (not e.retryable()) {
-    throw;
-   }
-
-   prepare_replay(txn, e.fdb_error_value);
-   record_transaction_replay(result, e.fdb_error_value, 1 < attempts_left);
-
-   continue;
-  }
-
-  const auto commit_state = commit(with_result, txn);
-  if (not commit_state.committed and 0 == commit_state.replay_error) {
-   throw libfdb_exception("transactor commit did not start");
-  }
-
-  if (not commit_state.committed) {
-   record_transaction_replay(result, commit_state.replay_error, 1 < attempts_left);
-
-   continue;
-  }
-
-  result.committed = true;
-  return result;
- }
-
- return result;
-}
-
-template <transaction_op FnT>
-auto in_transaction(database_handle dbh, FnT&& fn)
- -> operation_result_t<FnT>
-{
- return maybe_retry(make_transaction(dbh), std::forward<FnT>(fn));
-}
-
-// Commit only once; the caller is responsible for transaction replay:
-template <transaction_op FnT>
-auto commit_noreplay(transaction_handle txn, const commit_after_op commit_after, FnT&& fn)
- -> operation_result_t<FnT>
-{
- if (commit_after_op::commit != commit_after) {
-  return std::invoke(fn, txn);
- }
-
- return invoke_with_retry<invocation_failure_policy::no_retry>(
-          txn, std::forward<FnT>(fn), commit_or_throw);
 }
 
 } // namespace ceph::libfdb::detail

--- a/src/rgw/fdb/interval.h
+++ b/src/rgw/fdb/interval.h
@@ -14,7 +14,7 @@
 */
 
 #ifndef CEPH_FDB_INTERVAL_H
- #define CEPH_FDB_INTERVAL_H
+#define CEPH_FDB_INTERVAL_H
 
 #include "common/container_concepts.h"
 
@@ -158,6 +158,12 @@ class boundary final : public detail::boundary_view_ops
  using domain_type = DomainT;
  using value_type = typename DomainT::value_type;
 
+ private:
+ boundary_kind bound_kind = boundary_kind::finite;
+ std::optional<value_type> key;
+ bool includes_key = false;
+
+ public:
  static constexpr boundary negative_infinity() noexcept
  {
   return boundary(boundary_kind::negative_infinity, std::nullopt, false);
@@ -180,33 +186,29 @@ class boundary final : public detail::boundary_view_ops
 
  constexpr boundary_kind kind() const noexcept
  {
-  return kind_;
+  return bound_kind;
  }
 
  constexpr const value_type& finite_key() const noexcept
  {
-  return *key_;
+  return *key;
  }
 
  constexpr bool inclusive() const noexcept
  {
-  return inclusive_;
+  return includes_key;
  }
 
  constexpr bool operator==(const boundary&) const = default;
 
  private:
  constexpr boundary(const boundary_kind kind,
-                    std::optional<value_type> key,
+                    std::optional<value_type> key_value,
                     const bool inclusive)
-  : kind_(kind),
-    key_(std::move(key)),
-    inclusive_(inclusive)
+  : bound_kind(kind),
+    key(std::move(key_value)),
+    includes_key(inclusive)
  {}
-
- boundary_kind kind_ = boundary_kind::finite;
- std::optional<value_type> key_;
- bool inclusive_ = false;
 };
 
 template <ordered_domain DomainT>
@@ -216,6 +218,15 @@ class boundary_ref final : public detail::boundary_view_ops
  using domain_type = DomainT;
  using value_type = typename DomainT::value_type;
 
+ private:
+ boundary_kind bound_kind = boundary_kind::finite;
+
+ // Infinities cannot be keys, so the non-owning pointer is NULL for them.
+ const value_type *key = nullptr;
+
+ bool includes_key = false;
+
+ public:
  static constexpr boundary_ref negative_infinity() noexcept
  {
   return boundary_ref(boundary_kind::negative_infinity, nullptr, false);
@@ -241,34 +252,27 @@ class boundary_ref final : public detail::boundary_view_ops
 
  constexpr boundary_kind kind() const noexcept
  {
-  return kind_;
+  return bound_kind;
  }
 
  constexpr const value_type& finite_key() const noexcept
  {
-  return *key_;
+  return *key;
  }
 
  constexpr bool inclusive() const noexcept
  {
-  return inclusive_;
+  return includes_key;
  }
 
  private:
  constexpr boundary_ref(const boundary_kind kind,
-                        const value_type* key,
+                        const value_type *key_value,
                         const bool inclusive) noexcept
-  : kind_(kind),
-    key_(key),
-    inclusive_(boundary_kind::finite == kind && inclusive)
+  : bound_kind(kind),
+    key(key_value),
+    includes_key(boundary_kind::finite == kind and inclusive)
  {}
-
- boundary_kind kind_ = boundary_kind::finite;
-
- // Infinities cannot be keys, so the non-owning pointer uses null for that state.
- const value_type *key_ = nullptr;
-
- bool inclusive_ = false;
 };
 
 template <typename BoundT, typename DomainT>
@@ -339,17 +343,23 @@ class query final : public detail::expression_tag
  using value_type = typename DomainT::value_type;
  using boundary_type = boundary<DomainT>;
 
+ private:
+ boundary_type begin_bound = boundary_type::negative_infinity();
+ boundary_type end_bound = boundary_type::positive_infinity();
+ bool is_empty = false;
+
+ public:
  constexpr query() = default;
 
  constexpr query(boundary_type begin, boundary_type end)
-  : begin_(std::move(begin)),
-    end_(std::move(end))
+  : begin_bound(std::move(begin)),
+    end_bound(std::move(end))
  {}
 
  static constexpr query empty() noexcept
  {
   query out;
-  out.empty_ = true;
+  out.is_empty = true;
 
   return out;
  }
@@ -411,30 +421,25 @@ class query final : public detail::expression_tag
 
  constexpr const boundary_type& lower() const noexcept
  {
-  return begin_;
+  return begin_bound;
  }
 
  constexpr const boundary_type& upper() const noexcept
  {
-  return end_;
+  return end_bound;
  }
 
  constexpr bool explicitly_empty() const noexcept
  {
-  return empty_;
+  return is_empty;
  }
 
  constexpr bool operator==(const query& rhs) const
  {
-  return begin_ == rhs.begin_ &&
-         end_ == rhs.end_ &&
-         empty_ == rhs.empty_;
+  return begin_bound == rhs.begin_bound and
+         end_bound == rhs.end_bound and
+         is_empty == rhs.is_empty;
  }
-
- private:
- boundary_type begin_ = boundary_type::negative_infinity();
- boundary_type end_ = boundary_type::positive_infinity();
- bool empty_ = false;
 };
 
 template <ordered_domain DomainT, std::size_t Capacity>
@@ -444,39 +449,44 @@ class static_interval_set final
  using value_type = query<DomainT>;
  using const_iterator = typename std::array<value_type, Capacity>::const_iterator;
 
+ private:
+ std::array<value_type, Capacity> intervals {};
+ std::size_t interval_count = 0;
+
+ public:
  constexpr void push_back(value_type value)
  {
-  if (Capacity == size_) {
+  if (Capacity == interval_count) {
    throw std::length_error { "static interval set capacity exceeded" };
   }
 
-  intervals_[size_++] = std::move(value);
+  intervals[interval_count++] = std::move(value);
  }
 
  constexpr bool empty() const noexcept
  {
-  return 0 == size_;
+  return 0 == interval_count;
  }
 
  constexpr std::size_t size() const noexcept
  {
-  return size_;
+  return interval_count;
  }
 
  constexpr const value_type& operator[](const std::size_t index) const noexcept
  {
-  return intervals_[index];
+  return intervals[index];
  }
 
  constexpr const_iterator begin() const noexcept
  {
-  return std::begin(intervals_);
+  return std::begin(intervals);
  }
 
  constexpr const_iterator end() const noexcept
  {
-  return std::next(std::begin(intervals_),
-                   static_cast<std::ptrdiff_t>(size_));
+  return std::next(std::begin(intervals),
+                   static_cast<std::ptrdiff_t>(interval_count));
  }
 
  constexpr bool operator==(const static_interval_set& rhs) const
@@ -484,9 +494,6 @@ class static_interval_set final
   return std::ranges::equal(*this, rhs);
  }
 
- private:
- std::array<value_type, Capacity> intervals_ {};
- std::size_t size_ = 0;
 };
 
 namespace detail {
@@ -514,24 +521,25 @@ struct interval_bounds final
  using lower_result = decltype(std::declval<const IntervalT&>().lower());
  using upper_result = decltype(std::declval<const IntervalT&>().upper());
 
+ private:
+ boundary_storage<lower_result> lower_bound;
+ boundary_storage<upper_result> upper_bound;
+
+ public:
  constexpr explicit interval_bounds(const IntervalT& interval)
-  : lower_(interval.lower()),
-    upper_(interval.upper())
+  : lower_bound(interval.lower()),
+    upper_bound(interval.upper())
  {}
 
  constexpr const auto& lower() const noexcept
  {
-  return lower_;
+  return lower_bound;
  }
 
  constexpr const auto& upper() const noexcept
  {
-  return upper_;
+  return upper_bound;
  }
-
- private:
- boundary_storage<lower_result> lower_;
- boundary_storage<upper_result> upper_;
 };
 
 template <typename IntervalT>
@@ -698,10 +706,11 @@ constexpr void emit_bounds(SinkT&& sink, const LowerT& lower, const UpperT& uppe
                 std::forward<SinkT>(s).emit_interval(lower, upper);
                }) {
   std::forward<SinkT>(sink).emit_interval(lower, upper);
- } else {
-  std::invoke(std::forward<SinkT>(sink),
-              query<domain_type>::between(lower, upper));
+  return;
  }
+
+ std::invoke(std::forward<SinkT>(sink),
+             query<domain_type>::between(lower, upper));
 }
 
 template <boundary_view LhsT, boundary_view RhsT>
@@ -1083,35 +1092,39 @@ template <expression LhsT, expression RhsT, typename SinkT>
 constexpr void for_each_interval(const detail::intersection_expr<LhsT, RhsT>& expression,
                                  SinkT&& sink)
 {
- if constexpr (interval_view<RhsT> && !canonical_interval<RhsT>) {
+ if constexpr (interval_view<RhsT>) {
+  if constexpr (canonical_interval<RhsT>) {
+   ::ceph::libfdb::interval::for_each_interval(expression.lhs, [&sink, &expression](const auto& lhs) {
+    detail::emit_intersection(lhs, expression.rhs, sink);
+   });
+
+   return;
+  }
+
   ::ceph::libfdb::interval::for_each_interval(expression.rhs, [&sink, &expression](const auto& rhs) {
    ::ceph::libfdb::interval::for_each_interval(expression.lhs, [&sink, &rhs](const auto& lhs) {
     detail::emit_intersection(lhs, rhs, sink);
    });
   });
+
   return;
  }
 
- if constexpr (interval_view<RhsT>) {
-  ::ceph::libfdb::interval::for_each_interval(expression.lhs, [&sink, &expression](const auto& lhs) {
-   detail::emit_intersection(lhs, expression.rhs, sink);
-  });
-  return;
- }
+ if constexpr (interval_view<LhsT>) {
+  if constexpr (canonical_interval<LhsT>) {
+   ::ceph::libfdb::interval::for_each_interval(expression.rhs, [&sink, &expression](const auto& rhs) {
+    detail::emit_intersection(expression.lhs, rhs, sink);
+   });
 
- if constexpr (interval_view<LhsT> && !canonical_interval<LhsT>) {
+   return;
+  }
+
   ::ceph::libfdb::interval::for_each_interval(expression.lhs, [&sink, &expression](const auto& lhs) {
    ::ceph::libfdb::interval::for_each_interval(expression.rhs, [&sink, &lhs](const auto& rhs) {
     detail::emit_intersection(lhs, rhs, sink);
    });
   });
-  return;
- }
 
- if constexpr (interval_view<LhsT>) {
-  ::ceph::libfdb::interval::for_each_interval(expression.rhs, [&sink, &expression](const auto& rhs) {
-   detail::emit_intersection(expression.lhs, rhs, sink);
-  });
   return;
  }
 

--- a/src/rgw/fdb/interval.h
+++ b/src/rgw/fdb/interval.h
@@ -18,20 +18,22 @@
 
 #include "common/container_concepts.h"
 
-#include <algorithm>
 #include <array>
-#include <compare>
-#include <concepts>
+#include <vector>
+#include <optional>
+
+#include <ranges>
+#include <iterator>
+#include <algorithm>
+
 #include <cstddef>
 #include <cstdint>
-#include <functional>
-#include <iterator>
-#include <optional>
-#include <ranges>
-#include <stdexcept>
-#include <type_traits>
 #include <utility>
-#include <vector>
+#include <compare>
+#include <concepts>
+#include <stdexcept>
+#include <functional>
+#include <type_traits>
 
 // Defines a pure interval algebra used to wrangle ranges over ordered domains; the
 // query layer supplies the FoundationDB-specific key domain:

--- a/src/rgw/fdb/query.h
+++ b/src/rgw/fdb/query.h
@@ -19,16 +19,17 @@
 #include "common/container_concepts.h"
 #include "interval.h"
 
+#include <string>
+#include <vector>
+#include <optional>
+#include <string_view>
+
+#include <cstddef>
+#include <utility>
 #include <compare>
 #include <concepts>
-#include <cstddef>
 #include <functional>
-#include <optional>
-#include <string>
-#include <string_view>
 #include <type_traits>
-#include <utility>
-#include <vector>
 
 /* libfdb queries are small expression trees over FoundationDB's lexicographic
  * keyspace. The interval algebra is generic and option-free; this header adapts

--- a/src/rgw/fdb/query.h
+++ b/src/rgw/fdb/query.h
@@ -14,7 +14,7 @@
 */
 
 #ifndef CEPH_FDB_QUERY_H
- #define CEPH_FDB_QUERY_H
+#define CEPH_FDB_QUERY_H
 
 #include "common/container_concepts.h"
 #include "interval.h"
@@ -50,7 +50,6 @@ struct query_options final
 
  FDBStreamingMode streaming_mode = FDB_STREAMING_MODE_ITERATOR;
 
- public:
  constexpr bool operator==(const query_options&) const noexcept = default;
 };
 
@@ -74,6 +73,12 @@ struct byte_string_domain final
   return std::string(keyspace_limit_view());
  }
 
+ // Keys beginning with 0xFF belong to FoundationDB's reserved keyspace:
+ static constexpr bool is_reserved_key(const std::string_view key) noexcept
+ {
+  return key.starts_with('\xFF');
+ }
+
  static constexpr std::strong_ordering compare(const std::string_view lhs,
                                                const std::string_view rhs) noexcept
  {
@@ -87,7 +92,7 @@ struct byte_string_domain final
 
  static constexpr std::optional<std::string> successor(const std::string_view prefix)
  {
-  constexpr auto max_byte = static_cast<unsigned char>(0xFF);
+  constexpr unsigned char max_byte = 0xFF;
 
   for (auto i = prefix.rbegin(); i != prefix.rend(); ++i) {
    const auto byte = static_cast<unsigned char>(*i);
@@ -136,10 +141,10 @@ struct interval_bound final
  std::string key;
  bool inclusive;
 
- explicit constexpr interval_bound(const concepts::libfdb_key auto& key_,
-                                   const bool inclusive_)
-  : key(detail::as_libfdb_key_view(key_)),
-    inclusive(inclusive_)
+ explicit constexpr interval_bound(const concepts::libfdb_key auto& key_value,
+                                   const bool is_inclusive)
+  : key(::ceph::libfdb::detail::as_libfdb_key_view(key_value)),
+    inclusive(is_inclusive)
  {}
 
  constexpr bool operator==(const interval_bound&) const noexcept = default;
@@ -173,14 +178,14 @@ struct interval final
  bool end_inclusive = false;
  query_options options;
 
- constexpr interval(std::string begin_key_,
-                    std::string end_key_,
-                    const bool begin_inclusive_,
-                    const bool end_inclusive_)
-  : begin_key(std::move(begin_key_)),
-    end_key(std::move(end_key_)),
-    begin_inclusive(begin_inclusive_),
-    end_inclusive(end_inclusive_)
+ constexpr interval(std::string begin,
+                    std::string end,
+                    const bool includes_begin,
+                    const bool includes_end)
+  : begin_key(std::move(begin)),
+    end_key(std::move(end)),
+    begin_inclusive(includes_begin),
+    end_inclusive(includes_end)
  {
   normalize_keyspace();
  }
@@ -194,29 +199,29 @@ struct interval final
   normalize_keyspace();
  }
 
- constexpr interval(const concepts::libfdb_key auto& begin_key_,
-                    const concepts::libfdb_key auto& end_key_)
-  : interval(closed(begin_key_), open(end_key_))
+ constexpr interval(const concepts::libfdb_key auto& begin,
+                    const concepts::libfdb_key auto& end)
+  : interval(closed(begin), open(end))
  {}
 
- constexpr interval(const concepts::libfdb_key auto& begin_key_,
+ constexpr interval(const concepts::libfdb_key auto& begin,
                     interval_bound end)
-  : interval(closed(begin_key_), std::move(end))
+  : interval(closed(begin), std::move(end))
  {}
 
  constexpr interval(interval_bound begin,
-                    const concepts::libfdb_key auto& end_key_)
-  : interval(std::move(begin), open(end_key_))
+                    const concepts::libfdb_key auto& end)
+  : interval(std::move(begin), open(end))
  {}
 
  constexpr explicit interval(const concepts::libfdb_key auto& prefix)
-  : begin_key(detail::as_libfdb_key_view(prefix)),
-    end_key(successor(detail::as_libfdb_key_view(prefix)))
+  : begin_key(::ceph::libfdb::detail::as_libfdb_key_view(prefix)),
+    end_key(successor(::ceph::libfdb::detail::as_libfdb_key_view(prefix)))
  {
   normalize_keyspace();
  }
 
- constexpr boundary_ref lower() const noexcept
+ constexpr boundary_ref lower() const& noexcept
  {
   if (begin_inclusive) {
    return boundary_ref::closed(begin_key);
@@ -225,7 +230,9 @@ struct interval final
   return boundary_ref::open(begin_key);
  }
 
- constexpr boundary_ref upper() const noexcept
+ boundary_ref lower() const&& = delete;
+
+ constexpr boundary_ref upper() const& noexcept
  {
   if (end_inclusive) {
    return boundary_ref::closed(end_key);
@@ -233,6 +240,8 @@ struct interval final
 
   return boundary_ref::open(end_key);
  }
+
+ boundary_ref upper() const&& = delete;
 
  constexpr bool operator==(const interval& rhs) const noexcept
  {
@@ -247,31 +256,31 @@ struct interval final
  struct unchecked_select_t final {};
 
  constexpr interval(unchecked_select_t,
-                    std::string begin_key_,
-                    std::string end_key_,
-                    const bool begin_inclusive_,
-                    const bool end_inclusive_)
-  : begin_key(std::move(begin_key_)),
-    end_key(std::move(end_key_)),
-    begin_inclusive(begin_inclusive_),
-    end_inclusive(end_inclusive_)
+                    std::string begin,
+                    std::string end,
+                    const bool includes_begin,
+                    const bool includes_end)
+  : begin_key(std::move(begin)),
+    end_key(std::move(end)),
+    begin_inclusive(includes_begin),
+    end_inclusive(includes_end)
  {}
 
- friend constexpr interval detail_make_interval(std::string begin_key_,
-                                                std::string end_key_,
-                                                bool begin_inclusive_,
-                                                bool end_inclusive_)
+ friend constexpr interval detail_make_interval(std::string begin,
+                                                std::string end,
+                                                bool includes_begin,
+                                                bool includes_end)
  {
   return interval(unchecked_select_t {},
-                  std::move(begin_key_),
-                  std::move(end_key_),
-                  begin_inclusive_,
-                  end_inclusive_);
+                  std::move(begin),
+                  std::move(end),
+                  includes_begin,
+                  includes_end);
  }
 
  constexpr void normalize_keyspace()
  {
-  if (not end_key.empty() && 0xFF == static_cast<unsigned char>(end_key.front())) {
+  if (byte_string_domain::is_reserved_key(end_key)) {
    end_key = byte_string_domain::keyspace_limit();
    end_inclusive = false;
   }
@@ -331,15 +340,10 @@ constexpr std::string key_string(const concepts::libfdb_key auto& key)
  return std::string(key_view(key));
 }
 
-constexpr bool at_or_after_keyspace_limit(const std::string_view key) noexcept
-{
- return not key.empty() && 0xFF == static_cast<unsigned char>(key.front());
-}
-
 // Clamp an executable selector to ordinary FDB keyspace:
 constexpr interval clamp_to_keyspace(interval x)
 {
- if (at_or_after_keyspace_limit(x.end_key)) {
+ if (byte_string_domain::is_reserved_key(x.end_key)) {
   x.end_key = byte_string_domain::keyspace_limit();
   x.end_inclusive = false;
  }
@@ -394,12 +398,6 @@ constexpr interval to_select(const IntervalT& x, const query_options& options)
  }
 
  return to_select(x.lower(), x.upper(), options);
-}
-
-template <core::interval_view IntervalT>
-constexpr interval to_keyspace_select(const IntervalT& x, const query_options& options)
-{
- return to_select(x, options);
 }
 
 template <expression ExprT>
@@ -504,7 +502,7 @@ constexpr interval singleton(const concepts::libfdb_key auto& key)
 {
  const auto key_view = detail::key_view(key);
 
- if (detail::at_or_after_keyspace_limit(key_view)) {
+ if (byte_string_domain::is_reserved_key(key_view)) {
   return empty();
  }
 
@@ -519,7 +517,7 @@ constexpr interval prefix(const concepts::libfdb_key auto& key)
   return universal();
  }
 
- if (detail::at_or_after_keyspace_limit(key_view)) {
+ if (byte_string_domain::is_reserved_key(key_view)) {
   return empty();
  }
 
@@ -533,9 +531,7 @@ constexpr interval prefix(const concepts::libfdb_key auto& key)
 
 constexpr interval between(interval_bound begin, interval_bound end)
 {
- auto bounded = interval(std::move(begin), std::move(end));
-
- return detail::to_keyspace_select(bounded, {});
+ return detail::to_select(interval(std::move(begin), std::move(end)), {});
 }
 
 constexpr interval between(const concepts::libfdb_key auto& begin_key,
@@ -559,7 +555,7 @@ constexpr auto with_options(ExprT&& expr, const query_options& options)
 
 constexpr interval intersection(interval lhs, const interval& rhs)
 {
- return detail::to_keyspace_select(core::intersection(lhs, rhs), lhs.options);
+ return detail::to_select(core::intersection(lhs, rhs), lhs.options);
 }
 
 template <typename LhsT, typename RhsT>
@@ -669,17 +665,9 @@ template <expression ExprT>
 constexpr bool contains(const ExprT& expr, const concepts::libfdb_key auto& key)
 {
  const auto key_view = detail::key_view(key);
- bool found = false;
 
- for_each_interval(expr, [&found, key_view](const interval& x) {
-  if (found) {
-   return;
-  }
-
-  found = core::contains(x, key_view);
- });
-
- return found;
+ return not byte_string_domain::is_reserved_key(key_view) and
+        core::contains(detail::core_expression_of(expr), key_view);
 }
 
 template <expression LhsT, expression RhsT>
@@ -733,19 +721,19 @@ constexpr auto upper_before(const concepts::libfdb_key auto& key)
 constexpr auto between(core::lower_endpoint<byte_string_domain> lower,
                        core::upper_endpoint<byte_string_domain> upper)
 {
- return detail::to_keyspace_select(core::between(std::move(lower), std::move(upper)), {});
+ return detail::to_select(core::between(std::move(lower), std::move(upper)), {});
 }
 
 constexpr auto from(core::lower_endpoint<byte_string_domain> lower)
 {
  // The missing upper side means public libfdb universal, not algebraic +infinity.
- return detail::to_keyspace_select(core::from(std::move(lower)), {});
+ return detail::to_select(core::from(std::move(lower)), {});
 }
 
 constexpr auto until(core::upper_endpoint<byte_string_domain> upper)
 {
  // The missing lower side means public libfdb universal, not algebraic -infinity.
- return detail::to_keyspace_select(core::until(std::move(upper)), {});
+ return detail::to_select(core::until(std::move(upper)), {});
 }
 
 constexpr auto at(const concepts::libfdb_key auto& key)

--- a/src/rgw/fdb/scan.h
+++ b/src/rgw/fdb/scan.h
@@ -1,0 +1,733 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025-2026 International Business Machines Corp. (IBM)
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_FDB_SCAN_H
+ #define CEPH_FDB_SCAN_H
+
+#include "conversion.h"
+#include "transaction.h"
+
+#include "common/container_concepts.h"
+
+#include <span>
+#include <string>
+#include <vector>
+#include <optional>
+#include <string_view>
+#include <initializer_list>
+
+#include <ranges>
+#include <iterator>
+#include <generator>
+#include <algorithm>
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <concepts>
+#include <functional>
+#include <type_traits>
+
+namespace ceph::libfdb {
+
+namespace concepts {
+
+template <typename IteratorT>
+concept string_pair_output_iterator =
+ std::output_iterator<IteratorT, std::pair<std::string, std::string>>;
+
+template <typename RangeT>
+concept string_pair_output_range =
+ not std::is_array_v<std::remove_reference_t<RangeT>> and
+ std::ranges::range<RangeT> and
+ ceph::concepts::can_append<RangeT, std::pair<std::string, std::string>>;
+
+template <typename RangeT>
+concept materializable_string_pair_output_range =
+ string_pair_output_range<RangeT> and
+ std::default_initializable<std::remove_cvref_t<RangeT>> and
+ std::move_constructible<std::remove_cvref_t<RangeT>>;
+
+} // namespace concepts
+
+namespace detail {
+
+// Owns an FDB range result while exposing the returned key/value array:
+struct query_window final
+{
+ future_value result_owner;
+
+ std::span<const FDBKeyValue> result_pairs;
+
+ bool more_available = false;
+};
+
+// Owns an FDB split-point result while exposing the returned keys:
+struct split_point_result final
+{
+ future_value result_owner;
+
+ std::span<const FDBKey> result_keys;
+
+ fdb_error_t error = 0;
+};
+
+inline query_window extract_result_pairs(future_value result_owner)
+{
+ int more_available = 0;
+ int out_count = 0;
+ const FDBKeyValue *out_kvs = nullptr;
+
+ if (fdb_error_t r =
+       fdb_future_get_keyvalue_array(result_owner.raw_ptr_or_throw(),
+                                     &out_kvs,
+                                     &out_count,
+                                     &more_available);
+     0 != r) {
+  throw libfdb_exception(r);
+ }
+
+ return query_window {
+  .result_owner = std::move(result_owner),
+  .result_pairs = std::span<const FDBKeyValue>(out_kvs, out_count),
+  .more_available = 0 != more_available
+ };
+}
+
+inline split_point_result extract_split_points(future_value result_owner)
+{
+ const FDBKey *result_keys = nullptr;
+ int result_count = 0;
+
+ const auto error = fdb_future_get_key_array(
+   result_owner.raw_ptr_or_throw(), &result_keys, &result_count);
+
+ return split_point_result {
+  .result_owner = std::move(result_owner),
+  .result_keys = 0 == error
+    ? std::span<const FDBKey>(result_keys, result_count)
+    : std::span<const FDBKey>(),
+  .error = error
+ };
+}
+
+/* FoundationDB range reads are stateless requests: callers must advance their
+ * selectors and iteration number between requests. See
+ * validate_and_update_parameters() in FoundationDB's fdb_c.cpp for the exact
+ * selector interpretation: */
+inline future_value get_range_future_from_transaction(
+  transaction& txn,
+  const select& selection,
+  const int iteration)
+{
+ const auto& begin_key = selection.begin_key;
+ const auto& end_key = selection.end_key;
+ const auto& options = selection.options;
+
+ const bool continuing_forward = !options.reverse_order && 1 < iteration;
+ const bool continuing_reverse = options.reverse_order && 1 < iteration;
+
+ const int begin_or_eq = continuing_forward || !selection.begin_inclusive ? 1 : 0;
+ const int begin_offset = 1;
+ const int end_or_eq = !continuing_reverse && selection.end_inclusive ? 1 : 0;
+ const int end_offset = 1;
+
+ // Hold your breath-- this call is a bit of a Swiss army knife!
+ // It really helps to see the fdb_c reference, some of these are gnarly.
+ return future_value(fdb_transaction_get_range(
+   txn.raw_handle(),
+   reinterpret_cast<const std::uint8_t *>(begin_key.data()),
+   static_cast<int>(begin_key.size()),
+   begin_or_eq,
+   begin_offset,
+   reinterpret_cast<const std::uint8_t *>(end_key.data()),
+   static_cast<int>(end_key.size()),
+   end_or_eq,
+   end_offset,
+   options.result_limit,
+   options.target_bytes,
+   options.streaming_mode,
+   iteration,
+   0,   // this is not a snapshot read
+   options.reverse_order));
+}
+
+inline query_window read_query_window(transaction& txn,
+                                      const select& key_range,
+                                      const int iteration)
+{
+ return extract_result_pairs(await_future_of([&] {
+  return get_range_future_from_transaction(txn, key_range, iteration);
+ }));
+}
+
+inline std::optional<select> next_range_after(select key_range,
+                                              const query_window& window)
+{
+ if (not window.more_available || window.result_pairs.empty()) {
+  return std::nullopt;
+ }
+
+ const auto& last_key = window.result_pairs.back();
+ auto cursor = std::string_view(
+                reinterpret_cast<const char *>(last_key.key), last_key.key_length);
+
+ if (key_range.options.reverse_order) {
+  key_range.end_key = cursor;
+  key_range.end_inclusive = false;
+  return key_range;
+ }
+
+ key_range.begin_key = cursor;
+ key_range.begin_inclusive = false;
+
+ return key_range;
+}
+
+/* Returned spans remain valid only while the coroutine retains the owning FDB
+ * future. Consumers must copy their contents before advancing the generator: */
+inline auto generate_FDB_pairs(transaction& txn, select key_range)
+ -> std::generator<std::span<const FDBKeyValue>>
+{
+ int iteration = 1;
+
+ for (auto more_available = true; more_available; ++iteration) {
+  auto window = read_query_window(txn, key_range, iteration);
+  auto next_range = next_range_after(key_range, window);
+
+  more_available = next_range.has_value();
+
+  co_yield window.result_pairs;
+
+  if (next_range) {
+   key_range = std::move(*next_range);
+  }
+ }
+}
+
+template <typename ValueT = std::string>
+inline auto decode_pairs(std::span<const FDBKeyValue> pairs)
+{
+ return pairs | std::views::transform(to_decoded_kv_pair<ValueT>);
+}
+
+template <typename ValueT, typename AssocT>
+inline AssocT collect_pairs(std::span<const FDBKeyValue> pairs)
+{
+ return ceph::util::collect_as<AssocT>(decode_pairs<ValueT>(pairs));
+}
+
+template <typename AssocT>
+struct query_window_result final
+{
+ AssocT result_block;
+ std::optional<select> next_range;
+};
+
+template <typename ValueT, typename AssocT>
+inline auto materialize_query_window(transaction& txn,
+                                     select key_range,
+                                     const int iteration = 1)
+ -> query_window_result<AssocT>
+{
+ auto window = read_query_window(txn, key_range, iteration);
+
+ return {
+  .result_block = collect_pairs<ValueT, AssocT>(window.result_pairs),
+  .next_range = next_range_after(std::move(key_range), window)
+ };
+}
+
+inline std::size_t for_each_decoded_kv_pair(transaction& txn,
+                                            const select& key_range,
+                                            auto&& fn)
+{
+ std::size_t nread = 0;
+
+ for (const auto& kv : generate_FDB_pairs(txn, key_range)
+                     | std::views::join) {
+  std::invoke(fn, to_decoded_kv_pair<std::string>(kv));
+  ++nread;
+ }
+
+ return nread;
+}
+
+template <typename OutIterT>
+requires std::output_iterator<OutIterT,
+                              std::pair<std::string, std::string>>
+inline std::size_t get_value_range_from_transaction(
+  transaction& txn,
+  const select& key_range,
+  OutIterT& out_iter)
+{
+ return for_each_decoded_kv_pair(
+   txn, key_range,
+   [&out_iter](auto&& kv) {
+     *out_iter++ = std::forward<decltype(kv)>(kv);
+   });
+}
+
+inline std::size_t get_value_range_from_transaction(
+  transaction& txn,
+  const select& key_range,
+  concepts::string_pair_output_range auto& out)
+{
+ return for_each_decoded_kv_pair(
+   txn, key_range,
+   [&out](auto&& kv) {
+     ceph::util::push_back(out, std::forward<decltype(kv)>(kv));
+   });
+}
+
+inline std::vector<select> select_ranges_from_split_points(
+  std::span<const FDBKey> keys,
+  const select& parent)
+{
+ if (2 > keys.size()) {
+  return {};
+ }
+
+ // Gather the flattened list into overlapping libfdb::select pairs:
+ return ceph::util::collect_as<std::vector<select>>(
+   std::views::iota(std::size_t {0}, keys.size() - 1)
+   | std::views::transform([&parent, keys](const auto i) {
+       const auto& first = keys[i];
+       const auto& second = keys[1 + i];
+
+       const auto first_key = std::string_view(
+         reinterpret_cast<const char *>(first.key),
+         static_cast<std::string::size_type>(first.key_length));
+
+       const auto second_key = std::string_view(
+         reinterpret_cast<const char *>(second.key),
+         static_cast<std::string::size_type>(second.key_length));
+
+       select split(first_key, second_key);
+
+       split.options = parent.options;
+
+       split.begin_inclusive = 0 == i ? parent.begin_inclusive : true;
+       split.end_inclusive = 2 + i == keys.size()
+        ? parent.end_inclusive
+        : false;
+
+       return split;
+     }));
+}
+
+inline std::vector<select> plan_split_ranges(
+  database_handle dbh,
+  select selector,
+  const std::int64_t remote_chunk_size)
+{
+ auto txn = make_transaction(std::move(dbh));
+ auto split_selector = as_half_open_select(selector);
+
+ for (;;) {
+  auto result_owner = wait_until_ready(future_value(
+    fdb_transaction_get_range_split_points(
+      txn->raw_handle(),
+      reinterpret_cast<const std::uint8_t *>(split_selector.begin_key.data()),
+      static_cast<int>(split_selector.begin_key.length()),
+      reinterpret_cast<const std::uint8_t *>(split_selector.end_key.data()),
+      static_cast<int>(split_selector.end_key.length()),
+      remote_chunk_size)));
+
+  auto split_points = extract_split_points(std::move(result_owner));
+
+  if (not retry_after_error(txn, split_points.error)) {
+   return select_ranges_from_split_points(split_points.result_keys, split_selector);
+  }
+ }
+}
+
+inline select select_from_initializer_list(
+  std::initializer_list<std::string_view> keys)
+{
+ const auto first = std::begin(keys);
+
+ if (1 == std::size(keys)) {
+  return select(*first);
+ }
+
+ if (2 == std::size(keys)) {
+  return select(*first, *std::next(first));
+ }
+
+ // You might except that std::invalid_argument should be thrown... and you would
+ // be correct. However, we also don't want to make callers catch a zillion different
+ // exceptions:
+ throw libfdb_exception("range selection initializer list requires one or two keys");
+}
+
+template <typename OutT>
+struct materialized_string_pair_output final
+{
+ OutT values;
+ std::size_t nread = 0;
+};
+
+template <typename RangeT>
+inline auto move_range(RangeT& range)
+{
+ return std::ranges::subrange(std::make_move_iterator(std::begin(range)),
+                              std::make_move_iterator(std::end(range)));
+}
+
+template <typename ContainerT>
+inline void publish_string_pair_results(ContainerT& out, ContainerT&& tmp)
+{
+ if constexpr (ceph::concepts::has_empty<ContainerT> &&
+               std::assignable_from<ContainerT&, ContainerT&&>) {
+  if (out.empty()) {
+   out = std::move(tmp);
+   return;
+  }
+ }
+
+ if constexpr (requires { out.merge(tmp); }) {
+  out.merge(tmp);
+  return;
+ }
+
+ ceph::util::append_range(out, move_range(tmp));
+}
+
+template <query::expression SelectionT, typename OutT>
+requires concepts::string_pair_output_iterator<OutT> ||
+         concepts::string_pair_output_range<OutT>
+inline std::size_t get_value_selection_from_transaction(
+  transaction& txn,
+  const SelectionT& selection,
+  OutT& out)
+{
+ std::size_t nread = 0;
+
+ query::for_each_interval(selection,
+   [&](const select& interval) {
+     nread += get_value_range_from_transaction(txn, interval, out);
+   });
+
+ return nread;
+}
+
+template <typename OutT, query::expression SelectionT>
+requires concepts::materializable_string_pair_output_range<OutT>
+inline auto materialize_string_pair_selection(
+  transaction& txn,
+  const SelectionT& selection) -> materialized_string_pair_output<OutT>
+{
+ materialized_string_pair_output<OutT> result;
+ result.nread = get_value_selection_from_transaction(txn, selection, result.values);
+
+ return result;
+}
+
+} // namespace detail
+
+// get() with a selector writes key/value pairs to its output and returns the
+// number of pairs emitted:
+inline std::size_t get(transaction_handle txn,
+                       const query::expression auto& selection,
+                       concepts::string_pair_output_iterator auto out_iter,
+                       const commit_after_op commit_after)
+{
+ return detail::commit_noreplay(
+   txn, commit_after,
+   [&selection, out_iter](const transaction_handle& active_txn) mutable {
+     return detail::get_value_selection_from_transaction(
+       *active_txn, selection, out_iter);
+   });
+}
+
+inline std::size_t get(transaction_handle txn,
+                       const query::expression auto& selection,
+                       concepts::string_pair_output_iterator auto out_iter)
+{
+ return get(txn, selection, out_iter, commit_after_op::no_commit);
+}
+
+inline std::size_t get(database_handle dbh,
+                       const query::expression auto& selection,
+                       concepts::string_pair_output_iterator auto out_iter)
+{
+ auto result = detail::in_transaction(
+   std::move(dbh),
+   [&selection](transaction_handle& txn) {
+     using out_t = std::vector<std::pair<std::string, std::string>>;
+
+     return detail::materialize_string_pair_selection<out_t>(
+       *txn, selection);
+   });
+
+ std::ranges::move(result.values, out_iter);
+
+ return result.nread;
+}
+
+inline std::size_t get(transaction_handle txn,
+                       const query::expression auto& selection,
+                       concepts::string_pair_output_range auto& out,
+                       const commit_after_op commit_after)
+{
+ return detail::commit_noreplay(
+   txn, commit_after,
+   [&selection, &out](const transaction_handle& active_txn) {
+     return detail::get_value_selection_from_transaction(
+       *active_txn, selection, out);
+   });
+}
+
+inline std::size_t get(transaction_handle txn,
+                       const query::expression auto& selection,
+                       concepts::string_pair_output_range auto& out)
+{
+ return get(txn, selection, out, commit_after_op::no_commit);
+}
+
+inline std::size_t get(database_handle dbh,
+                       const query::expression auto& selection,
+                       concepts::materializable_string_pair_output_range auto& out)
+{
+ using out_t = std::remove_cvref_t<decltype(out)>;
+
+ auto result = detail::in_transaction(
+   std::move(dbh),
+   [&selection](transaction_handle& txn) {
+     return detail::materialize_string_pair_selection<out_t>(
+       *txn, selection);
+   });
+
+ detail::publish_string_pair_results(out, std::move(result.values));
+
+ return result.nread;
+}
+
+inline std::size_t get(transaction_handle txn,
+                       std::initializer_list<std::string_view> keys,
+                       concepts::string_pair_output_range auto& out,
+                       const commit_after_op commit_after)
+{
+ return get(txn, detail::select_from_initializer_list(keys), out,
+            commit_after);
+}
+
+inline std::size_t get(transaction_handle txn,
+                       std::initializer_list<std::string_view> keys,
+                       concepts::string_pair_output_range auto& out)
+{
+ return get(txn, keys, out, commit_after_op::no_commit);
+}
+
+inline std::size_t get(database_handle dbh,
+                       std::initializer_list<std::string_view> keys,
+                       concepts::materializable_string_pair_output_range auto& out)
+{
+ return get(std::move(dbh), detail::select_from_initializer_list(keys), out);
+}
+
+namespace detail {
+
+inline auto intervals(select selection)
+{
+ // Raw selectors still execute in the ordinary FDB keyspace:
+ return std::views::single(
+          query::intersection(std::move(selection), query::universal()))
+      | std::views::filter([](const select& range) {
+          return not query::is_empty(range);
+        });
+}
+
+template <query::non_interval_expression QueryT>
+inline auto intervals(const QueryT& query)
+{
+ std::vector<select> out;
+
+ query::for_each_interval(query, [&out](select interval) {
+  out.push_back(std::move(interval));
+ });
+
+ return out;
+}
+
+template <typename AssocT, typename RangeT>
+inline AssocT collect_range(RangeT&& range)
+{
+ AssocT out;
+ std::ranges::copy(std::forward<RangeT>(range),
+                   std::inserter(out, std::end(out)));
+
+ return out;
+}
+
+template <typename ValueT = std::string>
+inline auto scan_selector(transaction_handle txn, select key_range)
+ -> std::generator<std::pair<std::string, ValueT>>
+{
+ auto decoded_pairs = generate_FDB_pairs(*txn, std::move(key_range))
+                    | std::views::join
+                    | std::views::transform(to_decoded_kv_pair<ValueT>);
+
+ co_yield std::ranges::elements_of(decoded_pairs);
+}
+
+template <typename ValueT, typename BlockRangeT>
+inline auto flatten_blocks(BlockRangeT block_range)
+ -> std::generator<std::pair<std::string, ValueT>>
+{
+ for (auto block : block_range) {
+  for (auto& pair : block) {
+   co_yield std::move(pair);
+  }
+ }
+}
+
+template <typename ValueT = std::string,
+          typename AssocT = std::vector<std::pair<std::string, ValueT>>>
+auto blocks_selector(database_handle dbh, select selector)
+ -> std::generator<AssocT>
+{
+ if (0 == selector.options.result_limit) {
+  selector.options.result_limit = 4096;
+ }
+
+ /* Although this is tunable, early measurements show that it is not yet a
+  * large factor. Real-world experience should guide further adjustment: */
+ constexpr auto chunk_size = 4 * 1024 * 1024;
+
+ auto split_ranges = plan_split_ranges(dbh, selector, chunk_size);
+
+ auto read_blocks =
+  [txr = make_transactor(dbh)](this auto& self,
+                               select range,
+                               const int iteration) -> std::generator<AssocT> {
+   auto read_result = txr(
+     [](auto& txn, select range, const int iteration) {
+       return materialize_query_window<ValueT, AssocT>(
+         *txn, std::move(range), iteration);
+     }, std::move(range), iteration);
+
+   auto next_range = std::move(read_result.next_range);
+
+   if (read_result.result_block.empty()) {
+    co_return;
+   }
+
+   co_yield std::move(read_result.result_block);
+
+   if (next_range) {
+    co_yield std::ranges::elements_of(
+      self(std::move(*next_range), 1 + iteration));
+   }
+  };
+
+ auto expand_range = [&read_blocks](select range) {
+  return read_blocks(std::move(range), 1);
+ };
+
+ co_yield std::ranges::elements_of(split_ranges
+                                 | std::views::transform(expand_range)
+                                 | std::views::join);
+}
+
+} // namespace detail
+
+/* blocks() uses split planning to tackle large sets; use scan(txn, ...) for
+ * direct scans in a caller-owned transaction.
+ *
+ * What blocks() provides:
+ * - avoids one large transaction getting too old
+ * - gives the caller block-at-a-time processing
+ * - bounds memory and transaction duration more readily than a monolithic scan
+ *
+ * blocks() was originally parallel, and could be again, but preliminary
+ * benchmarking showed a significant performance penalty. The database must be
+ * truly large before parallelism is expected to help. */
+template <typename ValueT = std::string,
+          typename AssocT = std::vector<std::pair<std::string, ValueT>>,
+          query::expression SelectionT>
+auto blocks(database_handle dbh, SelectionT selection)
+ -> std::generator<AssocT>
+{
+ for (auto& interval : detail::intervals(selection)) {
+  co_yield std::ranges::elements_of(
+    detail::blocks_selector<ValueT, AssocT>(dbh, std::move(interval)));
+ }
+}
+
+// Legacy name retained for compatibility:
+template <typename ValueT = std::string,
+          typename AssocT = std::vector<std::pair<std::string, ValueT>>,
+          query::expression SelectionT>
+auto block_generator(database_handle dbh, SelectionT selection)
+ -> std::generator<AssocT>
+{
+ return blocks<ValueT, AssocT>(std::move(dbh), std::move(selection));
+}
+
+// For ordinary range scans inside one explicit transaction, scan() is usually
+// the right default:
+template <typename ValueT = std::string,
+          query::expression SelectionT>
+inline auto scan(transaction_handle txn, SelectionT selection)
+ -> std::generator<std::pair<std::string, ValueT>>
+{
+ for (auto& interval : detail::intervals(selection)) {
+  co_yield std::ranges::elements_of(
+    detail::scan_selector<ValueT>(txn, std::move(interval)));
+ }
+}
+
+// Managed scans flatten the blocks() stream into key/value pairs.
+template <typename ValueT = std::string,
+          query::expression SelectionT>
+inline auto scan(database_handle dbh, SelectionT selection)
+ -> std::generator<std::pair<std::string, ValueT>>
+{
+ return detail::flatten_blocks<ValueT>(
+   blocks<ValueT>(std::move(dbh), std::move(selection)));
+}
+
+// Legacy name retained for compatibility:
+template <typename ValueT = std::string,
+          query::expression SelectionT>
+inline auto pair_generator(transaction_handle txn, SelectionT selection)
+ -> std::generator<std::pair<std::string, ValueT>>
+{
+ return scan<ValueT>(txn, std::move(selection));
+}
+
+template <typename ValueT = std::string,
+          typename AssocT = std::vector<std::pair<std::string, ValueT>>,
+          query::expression SelectionT>
+inline AssocT collect(transaction_handle txn, SelectionT selection)
+{
+ return detail::collect_range<AssocT>(
+   scan<ValueT>(txn, std::move(selection)));
+}
+
+template <typename ValueT = std::string,
+          typename AssocT = std::vector<std::pair<std::string, ValueT>>,
+          query::expression SelectionT>
+inline AssocT collect(database_handle dbh, SelectionT selection)
+{
+ return detail::collect_range<AssocT>(
+   scan<ValueT>(std::move(dbh), std::move(selection)));
+}
+
+} // namespace ceph::libfdb
+
+#endif

--- a/src/rgw/fdb/scan.h
+++ b/src/rgw/fdb/scan.h
@@ -14,7 +14,7 @@
  */
 
 #ifndef CEPH_FDB_SCAN_H
- #define CEPH_FDB_SCAN_H
+#define CEPH_FDB_SCAN_H
 
 #include "conversion.h"
 #include "transaction.h"
@@ -86,7 +86,7 @@ struct split_point_result final
 
 inline query_window extract_result_pairs(future_value result_owner)
 {
- int more_available = 0;
+ fdb_bool_t more_available = false;
  int out_count = 0;
  const FDBKeyValue *out_kvs = nullptr;
 
@@ -101,7 +101,8 @@ inline query_window extract_result_pairs(future_value result_owner)
 
  return query_window {
   .result_owner = std::move(result_owner),
-  .result_pairs = std::span<const FDBKeyValue>(out_kvs, out_count),
+  .result_pairs = std::span<const FDBKeyValue>(
+    out_kvs, checked_result_size(out_count)),
   .more_available = 0 != more_available
  };
 }
@@ -117,7 +118,7 @@ inline split_point_result extract_split_points(future_value result_owner)
  return split_point_result {
   .result_owner = std::move(result_owner),
   .result_keys = 0 == error
-    ? std::span<const FDBKey>(result_keys, result_count)
+    ? std::span<const FDBKey>(result_keys, checked_result_size(result_count))
     : std::span<const FDBKey>(),
   .error = error
  };
@@ -132,35 +133,36 @@ inline future_value get_range_future_from_transaction(
   const select& selection,
   const int iteration)
 {
- const auto& begin_key = selection.begin_key;
- const auto& end_key = selection.end_key;
  const auto& options = selection.options;
+ const auto begin = as_fdb_bytes(selection.begin_key);
+ const auto end = as_fdb_bytes(selection.end_key);
 
  const bool continuing_forward = !options.reverse_order && 1 < iteration;
  const bool continuing_reverse = options.reverse_order && 1 < iteration;
 
- const int begin_or_eq = continuing_forward || !selection.begin_inclusive ? 1 : 0;
+ const fdb_bool_t begin_or_eq = continuing_forward || !selection.begin_inclusive;
  const int begin_offset = 1;
- const int end_or_eq = !continuing_reverse && selection.end_inclusive ? 1 : 0;
+ const fdb_bool_t end_or_eq = !continuing_reverse && selection.end_inclusive;
  const int end_offset = 1;
+ const fdb_bool_t is_snapshot = false;
 
  // Hold your breath-- this call is a bit of a Swiss army knife!
  // It really helps to see the fdb_c reference, some of these are gnarly.
  return future_value(fdb_transaction_get_range(
    txn.raw_handle(),
-   reinterpret_cast<const std::uint8_t *>(begin_key.data()),
-   static_cast<int>(begin_key.size()),
+   begin.data,
+   begin.length,
    begin_or_eq,
    begin_offset,
-   reinterpret_cast<const std::uint8_t *>(end_key.data()),
-   static_cast<int>(end_key.size()),
+   end.data,
+   end.length,
    end_or_eq,
    end_offset,
    options.result_limit,
    options.target_bytes,
    options.streaming_mode,
    iteration,
-   0,   // this is not a snapshot read
+   is_snapshot,
    options.reverse_order));
 }
 
@@ -181,8 +183,7 @@ inline std::optional<select> next_range_after(select key_range,
  }
 
  const auto& last_key = window.result_pairs.back();
- auto cursor = std::string_view(
-                reinterpret_cast<const char *>(last_key.key), last_key.key_length);
+ const auto cursor = key_view(last_key);
 
  if (key_range.options.reverse_order) {
   key_range.end_key = cursor;
@@ -307,13 +308,8 @@ inline std::vector<select> select_ranges_from_split_points(
        const auto& first = keys[i];
        const auto& second = keys[1 + i];
 
-       const auto first_key = std::string_view(
-         reinterpret_cast<const char *>(first.key),
-         static_cast<std::string::size_type>(first.key_length));
-
-       const auto second_key = std::string_view(
-         reinterpret_cast<const char *>(second.key),
-         static_cast<std::string::size_type>(second.key_length));
+       const auto first_key = key_view(first);
+       const auto second_key = key_view(second);
 
        select split(first_key, second_key);
 
@@ -333,25 +329,33 @@ inline std::vector<select> plan_split_ranges(
   select selector,
   const std::int64_t remote_chunk_size)
 {
- auto txn = make_transaction(std::move(dbh));
  auto split_selector = as_half_open_select(selector);
 
- for (;;) {
-  auto result_owner = wait_until_ready(future_value(
-    fdb_transaction_get_range_split_points(
+ return retry_without_commit(
+  make_transaction(std::move(dbh)),
+  [split_selector = std::move(split_selector), remote_chunk_size](
+    transaction_handle& txn) {
+    const auto begin = as_fdb_bytes(split_selector.begin_key);
+    const auto end = as_fdb_bytes(split_selector.end_key);
+
+    auto result_owner = wait_until_ready(future_value(
+     fdb_transaction_get_range_split_points(
       txn->raw_handle(),
-      reinterpret_cast<const std::uint8_t *>(split_selector.begin_key.data()),
-      static_cast<int>(split_selector.begin_key.length()),
-      reinterpret_cast<const std::uint8_t *>(split_selector.end_key.data()),
-      static_cast<int>(split_selector.end_key.length()),
+      begin.data,
+      begin.length,
+      end.data,
+      end.length,
       remote_chunk_size)));
 
-  auto split_points = extract_split_points(std::move(result_owner));
+    auto split_points = extract_split_points(std::move(result_owner));
 
-  if (not retry_after_error(txn, split_points.error)) {
-   return select_ranges_from_split_points(split_points.result_keys, split_selector);
-  }
- }
+    if (0 != split_points.error) {
+     throw libfdb_exception(split_points.error);
+    }
+
+    return select_ranges_from_split_points(
+      split_points.result_keys, split_selector);
+  });
 }
 
 inline select select_from_initializer_list(
@@ -554,13 +558,7 @@ inline auto intervals(select selection)
 template <query::non_interval_expression QueryT>
 inline auto intervals(const QueryT& query)
 {
- std::vector<select> out;
-
- query::for_each_interval(query, [&out](select interval) {
-  out.push_back(std::move(interval));
- });
-
- return out;
+ return query::compile_intervals(query);
 }
 
 template <typename AssocT, typename RangeT>
@@ -609,38 +607,31 @@ auto blocks_selector(database_handle dbh, select selector)
  constexpr auto chunk_size = 4 * 1024 * 1024;
 
  auto split_ranges = plan_split_ranges(dbh, selector, chunk_size);
+ auto txr = make_transactor(dbh);
 
- auto read_blocks =
-  [txr = make_transactor(dbh)](this auto& self,
-                               select range,
-                               const int iteration) -> std::generator<AssocT> {
+ for (auto split_range : split_ranges) {
+  for (int page = 1;; ++page) {
    auto read_result = txr(
-     [](auto& txn, select range, const int iteration) {
-       return materialize_query_window<ValueT, AssocT>(
-         *txn, std::move(range), iteration);
-     }, std::move(range), iteration);
+    [](auto& txn, select range, const int iteration) {
+      return materialize_query_window<ValueT, AssocT>(
+        *txn, std::move(range), iteration);
+    }, std::move(split_range), page);
 
    auto next_range = std::move(read_result.next_range);
 
    if (read_result.result_block.empty()) {
-    co_return;
+    break;
    }
 
    co_yield std::move(read_result.result_block);
 
-   if (next_range) {
-    co_yield std::ranges::elements_of(
-      self(std::move(*next_range), 1 + iteration));
+   if (not next_range) {
+    break;
    }
-  };
 
- auto expand_range = [&read_blocks](select range) {
-  return read_blocks(std::move(range), 1);
- };
-
- co_yield std::ranges::elements_of(split_ranges
-                                 | std::views::transform(expand_range)
-                                 | std::views::join);
+   split_range = std::move(*next_range);
+  }
+ }
 }
 
 } // namespace detail

--- a/src/rgw/fdb/transaction.h
+++ b/src/rgw/fdb/transaction.h
@@ -40,29 +40,55 @@ namespace detail {
 template <typename T>
 inline constexpr bool is_staged_proxy = false;
 
+enum struct staged_initialization { copy_target, in_place };
+
 struct staged_access;
 
 } // namespace detail
 
 namespace concepts {
 
-// Staged values use attempt-local storage and move into place only after a
-// confirmed commit. Publication must not fail after the database commits:
+// Publication must not fail after the database commits:
 template <typename T>
 concept stageable =
- std::copy_constructible<T> and std::is_nothrow_move_assignable_v<T>;
+ std::copy_constructible<T> and
+ std::is_nothrow_move_assignable_v<T>;
+
+template <typename T>
+concept in_place_stageable =
+ std::move_constructible<T> and std::default_initializable<T> and
+ std::is_nothrow_move_assignable_v<T>;
 
 } // namespace concepts
 
-template <concepts::stageable T>
+namespace detail {
+
+template <typename T, staged_initialization Initialization>
+concept stageable_with =
+ (staged_initialization::copy_target == Initialization and
+  concepts::stageable<T>) or
+ (staged_initialization::in_place == Initialization and
+  concepts::in_place_stageable<T>);
+
+} // namespace detail
+
+template <typename T,
+          detail::staged_initialization Initialization =
+            detail::staged_initialization::copy_target>
+requires detail::stageable_with<T, Initialization>
 class staged_proxy;
 
 template <concepts::stageable T>
 [[nodiscard]] staged_proxy<T> staged(T& target);
 
+template <concepts::in_place_stageable T>
+[[nodiscard]] auto staged(T& target, std::in_place_t)
+ -> staged_proxy<T, detail::staged_initialization::in_place>;
+
 // A transaction-attempt-local view of a value supplied through staged(). It is
 // also the compile-time binding stored by a transactor invocation.
-template <concepts::stageable T>
+template <typename T, detail::staged_initialization Initialization>
+requires detail::stageable_with<T, Initialization>
 class staged_proxy final
 {
  std::reference_wrapper<T> target;
@@ -71,19 +97,36 @@ class staged_proxy final
  T& materialize()
  {
   if (not attempt_value) {
-   attempt_value.emplace(target.get());
+   if constexpr (detail::staged_initialization::copy_target == Initialization) {
+    attempt_value.emplace(target.get());
+   }
+
+   if constexpr (detail::staged_initialization::in_place == Initialization) {
+    attempt_value.emplace();
+   }
   }
 
   return *attempt_value;
  }
 
- explicit staged_proxy(T& target_)
-  : target(target_)
+ void prepare_attempt()
+ noexcept(detail::staged_initialization::copy_target == Initialization or
+          std::is_nothrow_default_constructible_v<T>)
+ {
+  attempt_value.reset();
+
+  if constexpr (detail::staged_initialization::in_place == Initialization) {
+   attempt_value.emplace();
+  }
+ }
+
+ explicit staged_proxy(T& value)
+  : target(value)
  {}
 
  public:
  staged_proxy(const staged_proxy&) = delete;
- staged_proxy(staged_proxy&&) noexcept = default;
+ staged_proxy(staged_proxy&&) noexcept(std::is_nothrow_move_constructible_v<T>) = default;
 
  staged_proxy& operator=(const staged_proxy&) = delete;
  staged_proxy& operator=(staged_proxy&&) = delete;
@@ -116,18 +159,18 @@ class staged_proxy final
  requires requires(T& active_target, U&& value) {
   active_target.push_back(std::forward<U>(value));
  }
- decltype(auto) push_back(U&& value)
+ void push_back(U&& value)
  {
-  return materialize().push_back(std::forward<U>(value));
+  materialize().push_back(std::forward<U>(value));
  }
 
  template <typename ...ArgTs>
  requires requires(T& active_target, ArgTs&& ...args) {
   active_target.emplace_back(std::forward<ArgTs>(args)...);
  }
- decltype(auto) emplace_back(ArgTs&& ...args)
+ void emplace_back(ArgTs&& ...args)
  {
-  return materialize().emplace_back(std::forward<ArgTs>(args)...);
+  materialize().emplace_back(std::forward<ArgTs>(args)...);
  }
 
  template <typename KeyT, typename ValueT>
@@ -135,10 +178,10 @@ class staged_proxy final
   active_target.insert_or_assign(std::forward<KeyT>(key),
                                  std::forward<ValueT>(value));
  }
- decltype(auto) insert_or_assign(KeyT&& key, ValueT&& value)
+ void insert_or_assign(KeyT&& key, ValueT&& value)
  {
-  return materialize().insert_or_assign(std::forward<KeyT>(key),
-                                        std::forward<ValueT>(value));
+  materialize().insert_or_assign(std::forward<KeyT>(key),
+                                 std::forward<ValueT>(value));
  }
 
  // Escape hatch for an operation outside the intentionally small proxy API;
@@ -152,24 +195,35 @@ class staged_proxy final
 
  private:
  friend struct detail::staged_access;
- friend staged_proxy<T> staged<T>(T& target);
+
+ template <concepts::stageable U>
+ friend staged_proxy<U> staged(U& target);
+
+ template <concepts::in_place_stageable U>
+ friend auto staged(U& target, std::in_place_t)
+  -> staged_proxy<U, detail::staged_initialization::in_place>;
 };
 
 namespace detail {
 
-template <concepts::stageable T>
-inline constexpr bool is_staged_proxy<staged_proxy<T>> = true;
+template <typename T, staged_initialization Initialization>
+requires stageable_with<T, Initialization>
+inline constexpr bool is_staged_proxy<staged_proxy<T, Initialization>> = true;
+
+template <typename T>
+concept staged_argument = is_staged_proxy<std::remove_cvref_t<T>>;
 
 struct staged_access final
 {
- template <concepts::stageable T>
- static void prepare_attempt(staged_proxy<T>& proxy) noexcept
+ template <staged_argument ProxyT>
+ static void prepare_attempt(ProxyT& proxy)
+ noexcept(noexcept(proxy.prepare_attempt()))
  {
-  proxy.attempt_value.reset();
+  proxy.prepare_attempt();
  }
 
- template <concepts::stageable T>
- static void publish(staged_proxy<T>& proxy) noexcept
+ template <staged_argument ProxyT>
+ static void publish(ProxyT& proxy) noexcept
  {
   if (not proxy.attempt_value) {
    return;
@@ -179,9 +233,9 @@ struct staged_access final
   proxy.attempt_value.reset();
  }
 
- template <concepts::stageable T>
+ template <staged_argument ProxyT>
  [[nodiscard]] static const void *target_address(
-   const staged_proxy<T>& proxy) noexcept
+   const ProxyT& proxy) noexcept
  {
   return std::addressof(proxy.target.get());
  }
@@ -208,8 +262,8 @@ inline const void *staged_target_address(const auto&) noexcept
  return nullptr;
 }
 
-template <concepts::stageable T>
-const void *staged_target_address(const staged_proxy<T>& proxy) noexcept
+template <staged_argument ProxyT>
+const void *staged_target_address(const ProxyT& proxy) noexcept
 {
  return staged_access::target_address(proxy);
 }
@@ -218,22 +272,24 @@ template <typename ...ArgTs>
 void validate_staged_arguments(const ArgTs& ...arguments)
 {
  if constexpr ((is_staged_proxy<std::remove_cvref_t<ArgTs>> or ...)) {
-  const std::array addresses {staged_target_address(arguments)...};
-  const auto is_repeated = [&addresses](const void *address) {
-   return nullptr != address && 1 < std::ranges::count(addresses, address);
+  std::array addresses {staged_target_address(arguments)...};
+  std::ranges::sort(addresses);
+  const auto same_target = [](const void *lhs, const void *rhs) {
+   return nullptr != lhs and lhs == rhs;
   };
 
-  if (std::ranges::any_of(addresses, is_repeated)) {
+  if (std::ranges::adjacent_find(addresses, same_target) != addresses.end()) {
    throw std::invalid_argument("cannot stage one target more than once");
   }
  }
 }
 
-inline void prepare_bound_argument(auto&)
+inline void prepare_bound_argument(auto&) noexcept
 {}
 
-template <concepts::stageable T>
-void prepare_bound_argument(staged_proxy<T>& proxy) noexcept
+template <staged_argument ProxyT>
+void prepare_bound_argument(ProxyT& proxy)
+noexcept(noexcept(staged_access::prepare_attempt(proxy)))
 {
  staged_access::prepare_attempt(proxy);
 }
@@ -241,8 +297,8 @@ void prepare_bound_argument(staged_proxy<T>& proxy) noexcept
 inline void publish_bound_argument(auto&) noexcept
 {}
 
-template <concepts::stageable T>
-void publish_bound_argument(staged_proxy<T>& proxy) noexcept
+template <staged_argument ProxyT>
+void publish_bound_argument(ProxyT& proxy) noexcept
 {
  staged_access::publish(proxy);
 }
@@ -253,7 +309,8 @@ struct bound_invocation final
  FnT fn;
  std::tuple<ArgTs...> arguments;
 
- void prepare_attempt() noexcept
+ void prepare_attempt()
+ noexcept((noexcept(prepare_bound_argument(std::declval<ArgTs&>())) and ...))
  {
   std::apply([](auto& ...argument) {
     (prepare_bound_argument(argument), ...);
@@ -280,7 +337,8 @@ void prepare_invocation(FnT&) noexcept
 {}
 
 template <typename FnT, typename ...ArgTs>
-void prepare_invocation(bound_invocation<FnT, ArgTs...>& invocation) noexcept
+void prepare_invocation(bound_invocation<FnT, ArgTs...>& invocation)
+noexcept(noexcept(invocation.prepare_attempt()))
 {
  invocation.prepare_attempt();
 }
@@ -314,6 +372,14 @@ template <concepts::stageable T>
  return staged_proxy<T> {target};
 }
 
+// Construct fresh attempt-local state instead of copying the target:
+template <concepts::in_place_stageable T>
+[[nodiscard]] auto staged(T& target, std::in_place_t)
+ -> staged_proxy<T, detail::staged_initialization::in_place>
+{
+ return staged_proxy<T, detail::staged_initialization::in_place> {target};
+}
+
 // Overload tag for transactors that should report replay/commit metadata:
 struct with_result_t final {};
 inline constexpr with_result_t with_result;
@@ -339,19 +405,11 @@ struct commit_result final
 
 inline transaction_handle make_transaction(database_handle dbh)
 {
- if (not dbh) {
-  throw std::invalid_argument("make_transaction() requires database handle");
- }
-
  return std::make_shared<transaction>(std::move(dbh));
 }
 
 inline transaction_handle make_transaction(database_handle dbh, const transaction_options& opts)
 {
- if (not dbh) {
-  throw std::invalid_argument("make_transaction() requires database handle");
- }
-
  return std::make_shared<transaction>(std::move(dbh), opts);
 }
 
@@ -383,12 +441,10 @@ inline void prepare_replay(transaction_handle& txn, fdb_error_t error);
 
 [[nodiscard]] inline watch_handle make_watch(transaction_handle txn, std::string_view key)
 {
- return txn->make_watch(detail::as_fdb_span(key));
+ return txn->make_watch(detail::as_byte_view(key));
 }
 
-} // namespace ceph::libfdb
-
-namespace ceph::libfdb::detail {
+namespace detail {
 
 template <typename FnT, typename ...ArgTs>
 using transaction_invocation_result_t =
@@ -439,9 +495,7 @@ auto commit_noreplay(transaction_handle txn,
 template <transaction_op FnT>
 auto in_transaction(database_handle dbh, FnT&& fn) -> operation_result_t<FnT>;
 
-} // namespace ceph::libfdb::detail
-
-namespace ceph::libfdb {
+} // namespace detail
 
 /* A "transactor" is a function-like wrapper for running replayable transactions.
  * It defers transaction creation until called, commits after the user function
@@ -455,13 +509,13 @@ class transactor final
  std::optional<transaction_options> opts;
 
  private:
- explicit transactor(database_handle dbh_)
-  : dbh(std::move(dbh_))
+ explicit transactor(database_handle database)
+  : dbh(std::move(database))
  {}
 
- transactor(database_handle dbh_, const transaction_options& opts_)
-  : dbh(std::move(dbh_)),
-    opts(opts_)
+ transactor(database_handle database, const transaction_options& options)
+  : dbh(std::move(database)),
+    opts(options)
  {}
 
  // Bind the callable and arguments once so replays see stable state:
@@ -537,16 +591,14 @@ inline transactor make_transactor(database_handle dbh, const transaction_options
  return transactor(std::move(dbh), opts);
 }
 
-} // namespace ceph::libfdb
+namespace detail {
 
-namespace ceph::libfdb::detail {
-
-inline bool commit_or_throw(transaction_handle& txn)
+inline commit_result commit_or_throw(transaction_handle& txn)
 {
  const auto result = ceph::libfdb::commit(with_result, txn);
 
  if (result.committed) {
-  return true;
+  return result;
  }
 
  if (0 == result.replay_error) {
@@ -577,9 +629,7 @@ inline bool retry_after_error(transaction_handle& txn, const fdb_error_t error)
  return true;
 }
 
-} // namespace ceph::libfdb::detail
-
-namespace ceph::libfdb {
+} // namespace detail
 
 inline void prepare_replay(transaction_handle& txn, const fdb_error_t error)
 {
@@ -588,9 +638,7 @@ inline void prepare_replay(transaction_handle& txn, const fdb_error_t error)
  }
 }
 
-} // namespace ceph::libfdb
-
-namespace ceph::libfdb::detail {
+namespace detail {
 
 enum struct invocation_failure_policy { no_retry, retry };
 
@@ -598,17 +646,6 @@ struct no_invocation_result final {};
 
 // Keep the existing transactor retry behavior in one place:
 inline constexpr std::size_t transaction_retry_attempts = 10;
-
-inline void record_transaction_replay(transaction_result& result,
-                                      const fdb_error_t r,
-                                      const bool can_replay)
-{
- result.last_error = r;
-
- if (can_replay) {
-  ++result.replay_count;
- }
-}
 
 template <typename ResultT>
 struct invocation_result_traits final
@@ -648,6 +685,22 @@ template <typename ResultT>
 using stored_invocation_result_t =
  typename invocation_result_traits<ResultT>::stored_t;
 
+template <typename ResultT>
+struct invocation_attempt final
+{
+ std::optional<stored_invocation_result_t<ResultT>> value;
+ fdb_error_t replay_error = 0;
+};
+
+template <typename ResultT>
+struct invocation_outcome final
+{
+ std::optional<stored_invocation_result_t<ResultT>> value;
+ std::size_t attempts = 0;
+ std::size_t replay_count = 0;
+ fdb_error_t last_error = 0;
+};
+
 template <invocation_failure_policy FailurePolicy,
           typename FnT,
           typename CommitFnT,
@@ -655,7 +708,7 @@ template <invocation_failure_policy FailurePolicy,
 auto attempt_invocation(transaction_handle& txn,
                         FnT&& fn,
                         CommitFnT&& commit_fn)
- -> std::optional<stored_invocation_result_t<ResultT>>
+ -> invocation_attempt<ResultT>
 {
  using stored_result_t = stored_invocation_result_t<ResultT>;
 
@@ -673,90 +726,115 @@ auto attempt_invocation(transaction_handle& txn,
   }
 
   prepare_replay(txn, e.fdb_error_value);
-  return std::nullopt;
+  return invocation_attempt<ResultT> {
+   .value = std::nullopt,
+   .replay_error = e.fdb_error_value
+  };
  }
 
- if (not std::invoke(commit_fn, txn)) {
-  return std::nullopt;
+ const auto commit_state = std::invoke(commit_fn, txn);
+
+ if (not commit_state.committed) {
+  if (0 == commit_state.replay_error) {
+   throw libfdb_exception("transactor commit did not start");
+  }
+
+  return invocation_attempt<ResultT> {
+   .value = std::nullopt,
+   .replay_error = commit_state.replay_error
+  };
  }
 
- return result;
+ return {.value = std::move(result)};
 }
 
 template <invocation_failure_policy FailurePolicy,
           typename FnT,
           typename CommitFnT,
           typename ResultT = std::invoke_result_t<FnT&, transaction_handle&>>
-decltype(auto) invoke_with_retry(transaction_handle& txn,
-                                 FnT&& fn,
-                                 CommitFnT&& commit_fn)
+auto invoke_with_retry(transaction_handle& txn,
+                       FnT&& fn,
+                       CommitFnT&& commit_fn) -> invocation_outcome<ResultT>
 {
+ invocation_outcome<ResultT> outcome;
+
  for (auto tries = transaction_retry_attempts; tries; --tries) {
+  ++outcome.attempts;
   prepare_invocation(fn);
 
-  if (auto result = attempt_invocation<FailurePolicy>(txn, fn, commit_fn)) {
-   publish_invocation(fn);
+  auto attempt = attempt_invocation<FailurePolicy>(txn, fn, commit_fn);
 
-   return invocation_result_traits<ResultT>::take(std::move(result));
+  if (attempt.value) {
+   publish_invocation(fn);
+   outcome.value = std::move(attempt.value);
+
+   return outcome;
+  }
+
+  outcome.last_error = attempt.replay_error;
+
+  if (1 < tries) {
+   ++outcome.replay_count;
   }
  }
 
- throw libfdb_exception("transaction retry limit exceeded");
+ return outcome;
+}
+
+template <typename ResultT>
+decltype(auto) take_invocation_outcome(invocation_outcome<ResultT>&& outcome)
+{
+ if (not outcome.value) {
+  throw libfdb_exception("transaction retry limit exceeded");
+ }
+
+ return invocation_result_traits<ResultT>::take(std::move(outcome.value));
 }
 
 template <transaction_op FnT>
 auto maybe_retry(transaction_handle txn, FnT&& fn) -> operation_result_t<FnT>
 {
- return invoke_with_retry<invocation_failure_policy::retry>(
+ using result_t = transaction_invocation_result_t<FnT>;
+
+ auto outcome = invoke_with_retry<invocation_failure_policy::retry>(
    txn, std::forward<FnT>(fn),
    [](transaction_handle& active_txn) {
-     return ceph::libfdb::commit(active_txn);
+     return ceph::libfdb::commit(with_result, active_txn);
    });
+
+ return take_invocation_outcome<result_t>(std::move(outcome));
+}
+
+template <transaction_op FnT>
+auto retry_without_commit(transaction_handle txn,
+                          FnT&& fn) -> operation_result_t<FnT>
+{
+ using result_t = transaction_invocation_result_t<FnT>;
+
+ auto outcome = invoke_with_retry<invocation_failure_policy::retry>(
+   txn, std::forward<FnT>(fn),
+   [](transaction_handle&) {
+     return commit_result {.committed = true};
+   });
+
+ return take_invocation_outcome<result_t>(std::move(outcome));
 }
 
 template <result_reporting_transaction_op FnT>
 transaction_result maybe_retry_with_result(transaction_handle txn, FnT&& fn)
 {
- transaction_result result;
+ auto outcome = invoke_with_retry<invocation_failure_policy::retry>(
+   txn, std::forward<FnT>(fn),
+   [](transaction_handle& active_txn) {
+     return ceph::libfdb::commit(with_result, active_txn);
+   });
 
- for (auto attempts_left = transaction_retry_attempts;
-      attempts_left;
-      --attempts_left) {
-  ++result.attempts;
-  prepare_invocation(fn);
-
-  try {
-   std::invoke(fn, txn);
-  } catch (const libfdb_exception& e) {
-   if (not e.retryable()) {
-    throw;
-   }
-
-   prepare_replay(txn, e.fdb_error_value);
-   record_transaction_replay(result, e.fdb_error_value,
-                             1 < attempts_left);
-   continue;
-  }
-
-  const auto commit_state = commit(with_result, txn);
-
-  if (not commit_state.committed && 0 == commit_state.replay_error) {
-   throw libfdb_exception("transactor commit did not start");
-  }
-
-  if (not commit_state.committed) {
-   record_transaction_replay(result, commit_state.replay_error,
-                             1 < attempts_left);
-   continue;
-  }
-
-  result.committed = true;
-  publish_invocation(fn);
-
-  return result;
- }
-
- return result;
+ return {
+  .committed = outcome.value.has_value(),
+  .attempts = outcome.attempts,
+  .replay_count = outcome.replay_count,
+  .last_error = outcome.last_error
+ };
 }
 
 template <transaction_op FnT>
@@ -776,10 +854,16 @@ auto commit_noreplay(transaction_handle txn,
   return std::invoke(fn, txn);
  }
 
- return invoke_with_retry<invocation_failure_policy::no_retry>(
+ using result_t = transaction_invocation_result_t<FnT>;
+
+ auto outcome = invoke_with_retry<invocation_failure_policy::no_retry>(
    txn, std::forward<FnT>(fn), commit_or_throw);
+
+ return take_invocation_outcome<result_t>(std::move(outcome));
 }
 
-} // namespace ceph::libfdb::detail
+} // namespace detail
+
+} // namespace ceph::libfdb
 
 #endif

--- a/src/rgw/fdb/transaction.h
+++ b/src/rgw/fdb/transaction.h
@@ -1,0 +1,785 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025-2026 International Business Machines Corp. (IBM)
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_FDB_TRANSACTION_H
+#define CEPH_FDB_TRANSACTION_H
+
+#include "base.h"
+
+#include <array>
+#include <tuple>
+#include <optional>
+#include <string_view>
+
+#include <algorithm>
+
+#include <memory>
+#include <cstddef>
+#include <utility>
+#include <concepts>
+#include <stdexcept>
+#include <functional>
+#include <type_traits>
+
+namespace ceph::libfdb {
+
+namespace detail {
+
+template <typename T>
+inline constexpr bool is_staged_proxy = false;
+
+struct staged_access;
+
+} // namespace detail
+
+namespace concepts {
+
+// Staged values use attempt-local storage and move into place only after a
+// confirmed commit. Publication must not fail after the database commits:
+template <typename T>
+concept stageable =
+ std::copy_constructible<T> and std::is_nothrow_move_assignable_v<T>;
+
+} // namespace concepts
+
+template <concepts::stageable T>
+class staged_proxy;
+
+template <concepts::stageable T>
+[[nodiscard]] staged_proxy<T> staged(T& target);
+
+// A transaction-attempt-local view of a value supplied through staged(). It is
+// also the compile-time binding stored by a transactor invocation.
+template <concepts::stageable T>
+class staged_proxy final
+{
+ std::reference_wrapper<T> target;
+ std::optional<T> attempt_value;
+
+ T& materialize()
+ {
+  if (not attempt_value) {
+   attempt_value.emplace(target.get());
+  }
+
+  return *attempt_value;
+ }
+
+ explicit staged_proxy(T& target_)
+  : target(target_)
+ {}
+
+ public:
+ staged_proxy(const staged_proxy&) = delete;
+ staged_proxy(staged_proxy&&) noexcept = default;
+
+ staged_proxy& operator=(const staged_proxy&) = delete;
+ staged_proxy& operator=(staged_proxy&&) = delete;
+
+ staged_proxy& operator=(T replacement)
+ {
+  attempt_value.emplace(std::move(replacement));
+
+  return *this;
+ }
+
+ template <typename U>
+ requires requires(T& active_target, U&& value) {
+  active_target += std::forward<U>(value);
+ }
+ staged_proxy& operator+=(U&& value)
+ {
+  materialize() += std::forward<U>(value);
+
+  return *this;
+ }
+
+ void clear()
+ requires requires(T& active_target) { active_target.clear(); }
+ {
+  materialize().clear();
+ }
+
+ template <typename U>
+ requires requires(T& active_target, U&& value) {
+  active_target.push_back(std::forward<U>(value));
+ }
+ decltype(auto) push_back(U&& value)
+ {
+  return materialize().push_back(std::forward<U>(value));
+ }
+
+ template <typename ...ArgTs>
+ requires requires(T& active_target, ArgTs&& ...args) {
+  active_target.emplace_back(std::forward<ArgTs>(args)...);
+ }
+ decltype(auto) emplace_back(ArgTs&& ...args)
+ {
+  return materialize().emplace_back(std::forward<ArgTs>(args)...);
+ }
+
+ template <typename KeyT, typename ValueT>
+ requires requires(T& active_target, KeyT&& key, ValueT&& value) {
+  active_target.insert_or_assign(std::forward<KeyT>(key),
+                                 std::forward<ValueT>(value));
+ }
+ decltype(auto) insert_or_assign(KeyT&& key, ValueT&& value)
+ {
+  return materialize().insert_or_assign(std::forward<KeyT>(key),
+                                        std::forward<ValueT>(value));
+ }
+
+ // Escape hatch for an operation outside the intentionally small proxy API;
+ // this returns attempt-local state, not the original target:
+ [[nodiscard]] T& get_target() &
+ {
+  return materialize();
+ }
+
+ T& get_target() && = delete;
+
+ private:
+ friend struct detail::staged_access;
+ friend staged_proxy<T> staged<T>(T& target);
+};
+
+namespace detail {
+
+template <concepts::stageable T>
+inline constexpr bool is_staged_proxy<staged_proxy<T>> = true;
+
+struct staged_access final
+{
+ template <concepts::stageable T>
+ static void prepare_attempt(staged_proxy<T>& proxy) noexcept
+ {
+  proxy.attempt_value.reset();
+ }
+
+ template <concepts::stageable T>
+ static void publish(staged_proxy<T>& proxy) noexcept
+ {
+  if (not proxy.attempt_value) {
+   return;
+  }
+
+  proxy.target.get() = std::move(*proxy.attempt_value);
+  proxy.attempt_value.reset();
+ }
+
+ template <concepts::stageable T>
+ [[nodiscard]] static const void *target_address(
+   const staged_proxy<T>& proxy) noexcept
+ {
+  return std::addressof(proxy.target.get());
+ }
+};
+
+} // namespace detail
+
+namespace concepts {
+
+template <typename T>
+concept supported_invocation_result =
+ std::is_void_v<T> or
+ (not detail::is_staged_proxy<std::remove_cvref_t<T>> and
+  not std::is_reference_v<T> and
+  std::constructible_from<std::remove_cvref_t<T>, T> and
+  std::move_constructible<std::remove_cvref_t<T>>);
+
+} // namespace concepts
+
+namespace detail {
+
+inline const void *staged_target_address(const auto&) noexcept
+{
+ return nullptr;
+}
+
+template <concepts::stageable T>
+const void *staged_target_address(const staged_proxy<T>& proxy) noexcept
+{
+ return staged_access::target_address(proxy);
+}
+
+template <typename ...ArgTs>
+void validate_staged_arguments(const ArgTs& ...arguments)
+{
+ if constexpr ((is_staged_proxy<std::remove_cvref_t<ArgTs>> or ...)) {
+  const std::array addresses {staged_target_address(arguments)...};
+  const auto is_repeated = [&addresses](const void *address) {
+   return nullptr != address && 1 < std::ranges::count(addresses, address);
+  };
+
+  if (std::ranges::any_of(addresses, is_repeated)) {
+   throw std::invalid_argument("cannot stage one target more than once");
+  }
+ }
+}
+
+inline void prepare_bound_argument(auto&)
+{}
+
+template <concepts::stageable T>
+void prepare_bound_argument(staged_proxy<T>& proxy) noexcept
+{
+ staged_access::prepare_attempt(proxy);
+}
+
+inline void publish_bound_argument(auto&) noexcept
+{}
+
+template <concepts::stageable T>
+void publish_bound_argument(staged_proxy<T>& proxy) noexcept
+{
+ staged_access::publish(proxy);
+}
+
+template <typename FnT, typename ...ArgTs>
+struct bound_invocation final
+{
+ FnT fn;
+ std::tuple<ArgTs...> arguments;
+
+ void prepare_attempt() noexcept
+ {
+  std::apply([](auto& ...argument) {
+    (prepare_bound_argument(argument), ...);
+  }, arguments);
+ }
+
+ void publish() noexcept
+ {
+  std::apply([](auto& ...argument) noexcept {
+    (publish_bound_argument(argument), ...);
+  }, arguments);
+ }
+
+ decltype(auto) operator()(transaction_handle& txn)
+ {
+  return std::apply([this, &txn](auto& ...argument) -> decltype(auto) {
+    return std::invoke(fn, txn, argument...);
+  }, arguments);
+ }
+};
+
+template <typename FnT>
+void prepare_invocation(FnT&) noexcept
+{}
+
+template <typename FnT, typename ...ArgTs>
+void prepare_invocation(bound_invocation<FnT, ArgTs...>& invocation) noexcept
+{
+ invocation.prepare_attempt();
+}
+
+template <typename FnT>
+void publish_invocation(FnT&) noexcept
+{}
+
+template <typename FnT, typename ...ArgTs>
+void publish_invocation(bound_invocation<FnT, ArgTs...>& invocation) noexcept
+{
+ invocation.publish();
+}
+
+template <typename T>
+using bound_argument_t = std::decay_t<T>&;
+
+template <typename FnT, typename ...ArgTs>
+using bound_transaction_result_t =
+ std::invoke_result_t<std::decay_t<FnT>&,
+                      transaction_handle&,
+                      bound_argument_t<ArgTs>...>;
+
+} // namespace detail
+
+// Mark a bound transactor argument as local output. Each attempt gets isolated
+// state; the target is updated only after a confirmed commit:
+template <concepts::stageable T>
+[[nodiscard]] staged_proxy<T> staged(T& target)
+{
+ return staged_proxy<T> {target};
+}
+
+// Overload tag for transactors that should report replay/commit metadata:
+struct with_result_t final {};
+inline constexpr with_result_t with_result;
+
+// Describes replay/commit work performed by result-reporting transactors.
+struct transaction_result final
+{
+ bool committed = false;
+ std::size_t attempts = 0;
+
+ // Failures followed by another attempt; excludes the final exhausted attempt:
+ std::size_t replay_count = 0;
+
+ fdb_error_t last_error = 0;
+};
+
+// Describes a commit attempt when the caller owns transaction replay.
+struct commit_result final
+{
+ bool committed = false;
+ fdb_error_t replay_error = 0;
+};
+
+inline transaction_handle make_transaction(database_handle dbh)
+{
+ if (not dbh) {
+  throw std::invalid_argument("make_transaction() requires database handle");
+ }
+
+ return std::make_shared<transaction>(std::move(dbh));
+}
+
+inline transaction_handle make_transaction(database_handle dbh, const transaction_options& opts)
+{
+ if (not dbh) {
+  throw std::invalid_argument("make_transaction() requires database handle");
+ }
+
+ return std::make_shared<transaction>(std::move(dbh), opts);
+}
+
+// Note: only rarely is a direct call to this needed. You can use transactors or
+// pass database handles to operations for automatic transaction management.
+// After a transaction is committed, it cannot be used again. A false result
+// means that the client should replay the transaction:
+[[nodiscard]] inline bool commit(transaction_handle& txn)
+{
+ return txn->commit();
+}
+
+[[nodiscard]] inline commit_result commit(with_result_t, transaction_handle& txn)
+{
+ commit_result result;
+ result.committed = txn->commit(&result.replay_error);
+
+ return result;
+}
+
+[[nodiscard]] inline bool commit(transaction_handle& txn, const versionstamp& stamp)
+{
+ txn->mark_version(stamp);
+ return commit(txn);
+}
+
+// Prepare a transaction to replay after a retryable operation-body error:
+inline void prepare_replay(transaction_handle& txn, fdb_error_t error);
+
+[[nodiscard]] inline watch_handle make_watch(transaction_handle txn, std::string_view key)
+{
+ return txn->make_watch(detail::as_fdb_span(key));
+}
+
+} // namespace ceph::libfdb
+
+namespace ceph::libfdb::detail {
+
+template <typename FnT, typename ...ArgTs>
+using transaction_invocation_result_t =
+ std::invoke_result_t<FnT&, transaction_handle&, ArgTs&...>;
+
+template <typename FnT, typename ...ArgTs>
+concept transaction_op =
+ std::invocable<FnT&, transaction_handle&, ArgTs&...> &&
+ concepts::supported_invocation_result<
+   transaction_invocation_result_t<FnT, ArgTs...>>;
+
+template <typename FnT, typename ...ArgTs>
+concept result_reporting_transaction_op =
+ transaction_op<FnT, ArgTs...> &&
+ std::is_void_v<transaction_invocation_result_t<FnT, ArgTs...>>;
+
+template <typename FnT, typename ...ArgTs>
+concept bound_transaction_op =
+ std::constructible_from<std::decay_t<FnT>, FnT> &&
+ (std::constructible_from<std::decay_t<ArgTs>, ArgTs> && ...) &&
+ std::invocable<std::decay_t<FnT>&,
+                transaction_handle&,
+                bound_argument_t<ArgTs>...> &&
+ concepts::supported_invocation_result<bound_transaction_result_t<FnT, ArgTs...>>;
+
+template <typename FnT, typename ...ArgTs>
+concept bound_result_reporting_transaction_op =
+ bound_transaction_op<FnT, ArgTs...> &&
+ std::is_void_v<bound_transaction_result_t<FnT, ArgTs...>>;
+
+template <typename FnT>
+using operation_result_t =
+ std::conditional_t<std::is_void_v<transaction_invocation_result_t<FnT>>,
+                    void,
+                    std::remove_cvref_t<transaction_invocation_result_t<FnT>>>;
+
+template <transaction_op FnT>
+auto maybe_retry(transaction_handle txn, FnT&& fn) -> operation_result_t<FnT>;
+
+template <result_reporting_transaction_op FnT>
+transaction_result maybe_retry_with_result(transaction_handle txn, FnT&& fn);
+
+template <transaction_op FnT>
+auto commit_noreplay(transaction_handle txn,
+                     commit_after_op commit_after,
+                     FnT&& fn) -> operation_result_t<FnT>;
+
+template <transaction_op FnT>
+auto in_transaction(database_handle dbh, FnT&& fn) -> operation_result_t<FnT>;
+
+} // namespace ceph::libfdb::detail
+
+namespace ceph::libfdb {
+
+/* A "transactor" is a function-like wrapper for running replayable transactions.
+ * It defers transaction creation until called, commits after the user function
+ * returns, and replays when FoundationDB requests replay. Ordinary calls throw
+ * when recovery fails or retries are exhausted; with_result calls report retry
+ * exhaustion. Arguments wrapped with staged() publish only after a confirmed
+ * commit. Plus, the name is pretty cool. */
+class transactor final
+{
+ database_handle dbh;
+ std::optional<transaction_options> opts;
+
+ private:
+ explicit transactor(database_handle dbh_)
+  : dbh(std::move(dbh_))
+ {}
+
+ transactor(database_handle dbh_, const transaction_options& opts_)
+  : dbh(std::move(dbh_)),
+    opts(opts_)
+ {}
+
+ // Bind the callable and arguments once so replays see stable state:
+ template <typename FnT, typename ...ArgTs>
+ static auto bind_invocation(FnT&& fn, ArgTs&& ...args)
+ {
+  detail::validate_staged_arguments(args...);
+
+  return detail::bound_invocation<std::decay_t<FnT>,
+                                  std::decay_t<ArgTs>...> {
+   .fn = std::forward<FnT>(fn),
+   .arguments = {
+    std::forward<ArgTs>(args)...
+   }
+  };
+ }
+
+ transaction_handle make_transaction_for_call() const
+ {
+  return opts ? make_transaction(dbh, *opts) : make_transaction(dbh);
+ }
+
+ public:
+ template <typename FnT>
+ requires detail::transaction_op<FnT>
+ decltype(auto) operator()(FnT&& fn) const
+ {
+  return detail::maybe_retry(make_transaction_for_call(),
+                             std::forward<FnT>(fn));
+ }
+
+ template <typename FnT, typename ...ArgTs>
+ requires (0 < sizeof...(ArgTs) && detail::bound_transaction_op<FnT, ArgTs...>)
+ decltype(auto) operator()(FnT&& fn, ArgTs&& ...args) const
+ {
+  auto bound = bind_invocation(std::forward<FnT>(fn),
+                               std::forward<ArgTs>(args)...);
+
+  return (*this)(bound);
+ }
+
+ template <typename FnT>
+ requires detail::result_reporting_transaction_op<FnT>
+ transaction_result operator()(with_result_t, FnT&& fn) const
+ {
+  return detail::maybe_retry_with_result(make_transaction_for_call(),
+                                         std::forward<FnT>(fn));
+ }
+
+ template <typename FnT, typename ...ArgTs>
+ requires (0 < sizeof...(ArgTs) &&
+           detail::bound_result_reporting_transaction_op<FnT, ArgTs...>)
+ transaction_result operator()(with_result_t, FnT&& fn, ArgTs&& ...args) const
+ {
+  auto bound = bind_invocation(std::forward<FnT>(fn),
+                               std::forward<ArgTs>(args)...);
+
+  return (*this)(with_result, bound);
+ }
+
+ private:
+ friend inline transactor make_transactor(database_handle dbh);
+ friend inline transactor make_transactor(database_handle dbh, const transaction_options& opts);
+};
+
+inline transactor make_transactor(database_handle dbh)
+{
+ return transactor(std::move(dbh));
+}
+
+inline transactor make_transactor(database_handle dbh, const transaction_options& opts)
+{
+ return transactor(std::move(dbh), opts);
+}
+
+} // namespace ceph::libfdb
+
+namespace ceph::libfdb::detail {
+
+inline bool commit_or_throw(transaction_handle& txn)
+{
+ const auto result = ceph::libfdb::commit(with_result, txn);
+
+ if (result.committed) {
+  return true;
+ }
+
+ if (0 == result.replay_error) {
+  throw libfdb_exception("transactor commit did not start");
+ }
+
+ throw libfdb_exception(result.replay_error);
+}
+
+inline bool retry_after_error(transaction_handle& txn, const fdb_error_t error)
+{
+ if (0 == error) {
+  return false;
+ }
+
+ if (not fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, error)) {
+  // Non-retryable errors cannot be repaired by on_error():
+  throw libfdb_exception(error);
+ }
+
+ const auto on_error_result =
+  get_future_error(wait_for_on_error(txn->raw_handle(), error));
+
+ if (0 != on_error_result) {
+  throw libfdb_exception(error);
+ }
+
+ return true;
+}
+
+} // namespace ceph::libfdb::detail
+
+namespace ceph::libfdb {
+
+inline void prepare_replay(transaction_handle& txn, const fdb_error_t error)
+{
+ if (not detail::retry_after_error(txn, error)) {
+  throw libfdb_exception(error);
+ }
+}
+
+} // namespace ceph::libfdb
+
+namespace ceph::libfdb::detail {
+
+enum struct invocation_failure_policy { no_retry, retry };
+
+struct no_invocation_result final {};
+
+// Keep the existing transactor retry behavior in one place:
+inline constexpr std::size_t transaction_retry_attempts = 10;
+
+inline void record_transaction_replay(transaction_result& result,
+                                      const fdb_error_t r,
+                                      const bool can_replay)
+{
+ result.last_error = r;
+
+ if (can_replay) {
+  ++result.replay_count;
+ }
+}
+
+template <typename ResultT>
+struct invocation_result_traits final
+{
+ using stored_t = std::remove_cvref_t<ResultT>;
+
+ template <typename FnT>
+ static stored_t store(transaction_handle& txn, FnT&& fn)
+ {
+  return std::invoke(std::forward<FnT>(fn), txn);
+ }
+
+ static stored_t take(std::optional<stored_t>&& result)
+ {
+  return *std::move(result);
+ }
+};
+
+template <>
+struct invocation_result_traits<void> final
+{
+ using stored_t = no_invocation_result;
+
+ template <typename FnT>
+ static stored_t store(transaction_handle& txn, FnT&& fn)
+ {
+  std::invoke(std::forward<FnT>(fn), txn);
+
+  return {};
+ }
+
+ static void take(std::optional<stored_t>&&)
+ {}
+};
+
+template <typename ResultT>
+using stored_invocation_result_t =
+ typename invocation_result_traits<ResultT>::stored_t;
+
+template <invocation_failure_policy FailurePolicy,
+          typename FnT,
+          typename CommitFnT,
+          typename ResultT = std::invoke_result_t<FnT&, transaction_handle&>>
+auto attempt_invocation(transaction_handle& txn,
+                        FnT&& fn,
+                        CommitFnT&& commit_fn)
+ -> std::optional<stored_invocation_result_t<ResultT>>
+{
+ using stored_result_t = stored_invocation_result_t<ResultT>;
+
+ std::optional<stored_result_t> result;
+
+ try {
+  result.emplace(invocation_result_traits<ResultT>::store(txn, fn));
+ } catch (const libfdb_exception& e) {
+  if constexpr (invocation_failure_policy::no_retry == FailurePolicy) {
+   throw;
+  }
+
+  if (not e.retryable()) {
+   throw;
+  }
+
+  prepare_replay(txn, e.fdb_error_value);
+  return std::nullopt;
+ }
+
+ if (not std::invoke(commit_fn, txn)) {
+  return std::nullopt;
+ }
+
+ return result;
+}
+
+template <invocation_failure_policy FailurePolicy,
+          typename FnT,
+          typename CommitFnT,
+          typename ResultT = std::invoke_result_t<FnT&, transaction_handle&>>
+decltype(auto) invoke_with_retry(transaction_handle& txn,
+                                 FnT&& fn,
+                                 CommitFnT&& commit_fn)
+{
+ for (auto tries = transaction_retry_attempts; tries; --tries) {
+  prepare_invocation(fn);
+
+  if (auto result = attempt_invocation<FailurePolicy>(txn, fn, commit_fn)) {
+   publish_invocation(fn);
+
+   return invocation_result_traits<ResultT>::take(std::move(result));
+  }
+ }
+
+ throw libfdb_exception("transaction retry limit exceeded");
+}
+
+template <transaction_op FnT>
+auto maybe_retry(transaction_handle txn, FnT&& fn) -> operation_result_t<FnT>
+{
+ return invoke_with_retry<invocation_failure_policy::retry>(
+   txn, std::forward<FnT>(fn),
+   [](transaction_handle& active_txn) {
+     return ceph::libfdb::commit(active_txn);
+   });
+}
+
+template <result_reporting_transaction_op FnT>
+transaction_result maybe_retry_with_result(transaction_handle txn, FnT&& fn)
+{
+ transaction_result result;
+
+ for (auto attempts_left = transaction_retry_attempts;
+      attempts_left;
+      --attempts_left) {
+  ++result.attempts;
+  prepare_invocation(fn);
+
+  try {
+   std::invoke(fn, txn);
+  } catch (const libfdb_exception& e) {
+   if (not e.retryable()) {
+    throw;
+   }
+
+   prepare_replay(txn, e.fdb_error_value);
+   record_transaction_replay(result, e.fdb_error_value,
+                             1 < attempts_left);
+   continue;
+  }
+
+  const auto commit_state = commit(with_result, txn);
+
+  if (not commit_state.committed && 0 == commit_state.replay_error) {
+   throw libfdb_exception("transactor commit did not start");
+  }
+
+  if (not commit_state.committed) {
+   record_transaction_replay(result, commit_state.replay_error,
+                             1 < attempts_left);
+   continue;
+  }
+
+  result.committed = true;
+  publish_invocation(fn);
+
+  return result;
+ }
+
+ return result;
+}
+
+template <transaction_op FnT>
+auto in_transaction(database_handle dbh, FnT&& fn) -> operation_result_t<FnT>
+{
+ return maybe_retry(make_transaction(std::move(dbh)),
+                    std::forward<FnT>(fn));
+}
+
+// Commit only once; the caller is responsible for transaction replay:
+template <transaction_op FnT>
+auto commit_noreplay(transaction_handle txn,
+                     const commit_after_op commit_after,
+                     FnT&& fn) -> operation_result_t<FnT>
+{
+ if (commit_after_op::commit != commit_after) {
+  return std::invoke(fn, txn);
+ }
+
+ return invoke_with_retry<invocation_failure_policy::no_retry>(
+   txn, std::forward<FnT>(fn), commit_or_throw);
+}
+
+} // namespace ceph::libfdb::detail
+
+#endif

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -13,6 +13,8 @@
 
 #include <catch2/catch_config.hpp>
 
+#include <catch2/benchmark/catch_benchmark.hpp>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 
@@ -45,6 +47,8 @@
 #include <chrono>
 #include <thread>
 
+#include <limits>
+#include <memory>
 #include <cstdint>
 #include <utility>
 #include <compare>
@@ -254,12 +258,12 @@ inline void write_raw_fdb_value(lfdb::database_handle dbh,
                                 std::span<const std::uint8_t> value)
 {
  auto txn = lfdb::make_transaction(dbh);
+ const auto key_bytes = lfdb::detail::as_fdb_bytes(key);
+ const auto value_bytes = lfdb::detail::as_fdb_bytes(value);
 
  fdb_transaction_set(txn->raw_handle(),
-                     reinterpret_cast<const std::uint8_t *>(key.data()),
-                     static_cast<int>(std::size(key)),
-                     value.data(),
-                     static_cast<int>(std::size(value)));
+                     key_bytes.data, key_bytes.length,
+                     value_bytes.data, value_bytes.length);
 
  REQUIRE(lfdb::commit(txn));
 }
@@ -1363,7 +1367,7 @@ TEST_CASE("fdb conversions (built-in)", "[fdb][rgw]") {
 
  SECTION("spanlike") {
   // span<uint8_t> -> vector<uint8_t> -> vector<uint8_t>
-  const std::span<const std::uint8_t> n((const std::uint8_t *)msg, sizeof(msg));
+  const auto n = lfdb::detail::as_byte_view(std::string_view(msg, sizeof(msg)));
 
   std::vector<std::uint8_t> x;
   x = ceph::libfdb::to::convert(n);
@@ -1376,7 +1380,8 @@ TEST_CASE("fdb conversions (built-in)", "[fdb][rgw]") {
 
  SECTION("NULL-as-data") {
   // with NULL data-- const char* -> vector<uint8_t> -> vector<uint8_t>
-  const std::span<const std::uint8_t> n((const std::uint8_t *)msg_with_null, sizeof(msg_with_null));
+  const auto n = lfdb::detail::as_byte_view(
+    std::string_view(msg_with_null, sizeof(msg_with_null)));
 
   std::vector<std::uint8_t> x;
   x = ceph::libfdb::to::convert(n);
@@ -1386,6 +1391,80 @@ TEST_CASE("fdb conversions (built-in)", "[fdb][rgw]") {
 
   REQUIRE_THAT(n, Catch::Matchers::RangeEquals(o));
   REQUIRE_THAT(msg_with_null, Catch::Matchers::RangeEquals(o));
+ }
+
+ SECTION("fixed-size C array") {
+  const std::uint8_t input[] { 1, 2, 3, 4 };
+  std::uint8_t output[std::size(input)] {};
+
+  const auto encoded = lfdb::to::convert(input);
+  lfdb::from::convert(encoded, output);
+
+  CHECK(sizeof input == encoded.size());
+  CHECK_THAT(output, Catch::Matchers::RangeEquals(input));
+ }
+}
+
+TEST_CASE("FoundationDB C API argument conversion", "[fdb][rgw]")
+{
+ SECTION("integer options are little-endian") {
+  constexpr std::int64_t value = 0x0102030405060708;
+  constexpr auto versionstamp_offset =
+    lfdb::detail::little_endian_bytes(std::uint32_t {0x01020304});
+  const lfdb::transaction_options options {
+   { FDB_TR_OPTION_TIMEOUT, value }
+  };
+
+  FDBTransactionOption option = FDB_TR_OPTION_ACCESS_SYSTEM_KEYS;
+  std::vector<std::uint8_t> encoded;
+
+  lfdb::detail::apply_options(
+    options,
+    [&option, &encoded](const auto received_option,
+                        const std::uint8_t *data,
+                        const int size) {
+      option = received_option;
+      encoded.assign(data, data + size);
+
+      return fdb_error_t { 0 };
+    });
+
+  CHECK(FDB_TR_OPTION_TIMEOUT == option);
+  STATIC_REQUIRE(versionstamp_offset ==
+                 std::array<std::uint8_t, 4> { 4, 3, 2, 1 });
+  CHECK_THAT(encoded, Catch::Matchers::RangeEquals(
+    std::array<std::uint8_t, 8> { 8, 7, 6, 5, 4, 3, 2, 1 }));
+ }
+
+ SECTION("sizes outside the C API range are rejected") {
+  constexpr auto too_large = 1ZU + std::numeric_limits<int>::max();
+
+  CHECK_THROWS_WITH(lfdb::detail::checked_fdb_size(too_large),
+                    "value is too large for the FoundationDB C API");
+  CHECK_THROWS_WITH(lfdb::detail::checked_result_size(-1),
+                    "FoundationDB returned a negative result size");
+ }
+
+ SECTION("keys and values use the same checked byte representation") {
+  const std::string key("a\0b", 3);
+  const std::array<std::uint8_t, 3> value { 1, 0, 2 };
+
+  const auto key_bytes = lfdb::detail::as_fdb_bytes(key);
+  const auto value_bytes = lfdb::detail::as_fdb_bytes(lfdb::detail::byte_view(value));
+  const auto key_result = lfdb::detail::result_bytes(key_bytes.data, key_bytes.length);
+  const auto value_result = lfdb::detail::result_bytes(value_bytes.data, value_bytes.length);
+
+  CHECK(3 == key_bytes.length);
+  CHECK(3 == value_bytes.length);
+  CHECK(key == lfdb::detail::as_string_view(key_result));
+  CHECK_THAT(value_result, Catch::Matchers::RangeEquals(value));
+ }
+
+ SECTION("empty result buffers are accepted") {
+  const auto empty = lfdb::detail::result_bytes(nullptr, 0);
+
+  CHECK(empty.empty());
+  CHECK(lfdb::detail::as_string_view(empty).empty());
  }
 }
 
@@ -1430,7 +1509,7 @@ TEST_CASE("fdb conversions (functions)", "[fdb][rgw]")
     // Because we did /conversion/ on the inbound data, we're still obliged to
     // reverse this (otherwise we'll see whatever artefacts the conversion produced)--
     // the complication is a consequence of dealing with the underlying buffer directly:
-    std::span<const std::uint8_t> in_span((const std::uint8_t *)data, sz);
+    const auto in_span = lfdb::detail::as_byte_view(std::string_view(data, sz));
  
     ceph::libfdb::from::convert(in_span, o);
   };
@@ -1858,11 +1937,16 @@ TEST_CASE("transactors reject invalid database handles", "[fdb]")
 {
  lfdb::database_handle dbh;
 
+ SECTION("direct transaction") {
+  CHECK_THROWS_WITH(lfdb::transaction {dbh},
+                    "transaction requires a database handle");
+ }
+
  SECTION("default options") {
   auto txr = lfdb::make_transactor(dbh);
 
   CHECK_THROWS_WITH(txr(lfdb::with_result, [](auto) {}),
-                    "make_transaction() requires database handle");
+                    "transaction requires a database handle");
  }
 
  SECTION("explicit options") {
@@ -1870,7 +1954,7 @@ TEST_CASE("transactors reject invalid database handles", "[fdb]")
   auto txr = lfdb::make_transactor(dbh, opts);
 
   CHECK_THROWS_WITH(txr([](auto) {}),
-                    "make_transaction() requires database handle");
+                    "transaction requires a database handle");
  }
 
  SECTION("duplicate staged target") {
@@ -1880,6 +1964,10 @@ TEST_CASE("transactors reject invalid database handles", "[fdb]")
   CHECK_THROWS_WITH(txr([](auto, auto&, auto&) {},
                         lfdb::staged(output), lfdb::staged(output)),
                     "cannot stage one target more than once");
+  CHECK_THROWS_WITH(txr([](auto, auto&, auto&) {},
+                        lfdb::staged(output),
+                        lfdb::staged(output, std::in_place)),
+                    "cannot stage one target more than once");
  }
 }
 
@@ -1888,8 +1976,17 @@ SCENARIO("transactor", "[fdb]")
  janitor j;
 
  static_assert(lfdb::concepts::stageable<std::vector<int>>);
+ static_assert(lfdb::concepts::in_place_stageable<std::unique_ptr<int>>);
+ static_assert(not lfdb::concepts::stageable<std::unique_ptr<int>>);
  static_assert(not lfdb::concepts::supported_invocation_result<
    lfdb::staged_proxy<int>>);
+ static_assert(std::same_as<void, decltype(
+   std::declval<lfdb::staged_proxy<std::vector<int>>&>().push_back(1))>);
+ static_assert(std::same_as<void, decltype(
+   std::declval<lfdb::staged_proxy<std::vector<int>>&>().emplace_back(1))>);
+ static_assert(std::same_as<void, decltype(
+   std::declval<lfdb::staged_proxy<std::map<int, int>>&>().insert_or_assign(
+     1, 2))>);
  static_assert(lfdb::detail::result_reporting_transaction_op<decltype([](auto) {})>);
  static_assert(!lfdb::detail::result_reporting_transaction_op<decltype([](auto) {
   return 7;
@@ -2074,6 +2171,68 @@ SCENARIO("transactor", "[fdb]")
   CHECK((std::vector<std::string> {"before", "conflict"} == values));
  }
 
+ SECTION("in-place staged arguments start fresh on every attempt") {
+  auto txr = lfdb::make_transactor(j);
+  const auto key = test_key("in-place-staged-conflict-key");
+
+  lfdb::set(j, key, "initial");
+
+  std::vector<std::string> values {"before"};
+  const auto result = txr(lfdb::with_result,
+    [&j, &key](auto txn, auto& staged_values) {
+      std::string value;
+      if (not lfdb::get(txn, key, value)) {
+       throw std::runtime_error("expected key does not exist");
+      }
+
+      staged_values.push_back(value);
+
+      // Force the first attempt to conflict:
+      if ("initial" == value) {
+       lfdb::set(j, key, "conflict");
+      }
+
+      lfdb::set(txn, key, "final");
+    }, lfdb::staged(values, std::in_place));
+
+  CHECK(result.committed);
+  CHECK(2 == result.attempts);
+  CHECK((std::vector<std::string> {"conflict"} == values));
+ }
+
+ SECTION("an empty in-place result replaces the target") {
+  auto txr = lfdb::make_transactor(j);
+  std::vector<int> values {1, 2, 3};
+
+  txr([](auto, auto&) {}, lfdb::staged(values, std::in_place));
+
+  CHECK(values.empty());
+ }
+
+ SECTION("in-place staging does not require a copyable target") {
+  auto txr = lfdb::make_transactor(j);
+  auto value = std::make_unique<int>(5);
+
+  txr([](auto, auto& staged_value) {
+    staged_value = std::make_unique<int>(7);
+  }, lfdb::staged(value, std::in_place));
+
+  REQUIRE(value);
+  CHECK(7 == *value);
+ }
+
+ SECTION("in-place staged arguments remain unchanged after a body exception") {
+  auto txr = lfdb::make_transactor(j);
+  std::vector<int> values {1, 2, 3};
+
+  CHECK_THROWS_WITH(txr([](auto, auto& staged_values) {
+    staged_values.push_back(4);
+    throw std::runtime_error("transaction body failed");
+  }, lfdb::staged(values, std::in_place)), "transaction body failed");
+
+  CHECK((std::vector {1, 2, 3} == values));
+ }
+
  SECTION("staged arguments remain unchanged after retry exhaustion") {
   auto txr = lfdb::make_transactor(j);
   const auto key = test_key("staged-exhaustion-key");
@@ -2213,6 +2372,110 @@ SCENARIO("transactor", "[fdb]")
  }
 }
 
+TEST_CASE("staged proxy benchmarks", "[.benchmark][benchmark][fdb][staged]")
+{
+ const std::vector<int> initial_values(64, 7);
+ const std::string large_value(256, 'x');
+ const std::vector<std::string> large_initial_values(256, large_value);
+
+ auto append_values = [](auto& values) {
+  for (const auto value : std::views::iota(0, 64)) {
+   values.push_back(value);
+  }
+ };
+
+ BENCHMARK("direct mutation without replay isolation")
+ {
+  auto values = initial_values;
+  append_values(values);
+
+  return values;
+ };
+
+ BENCHMARK("manual replay-isolated mutation")
+ {
+  auto values = initial_values;
+  auto attempt_values = values;
+
+  append_values(attempt_values);
+  values = std::move(attempt_values);
+
+  return values;
+ };
+
+ BENCHMARK("manual replay-isolated replacement")
+ {
+  auto values = initial_values;
+  std::vector<int> attempt_values;
+
+  append_values(attempt_values);
+  values = std::move(attempt_values);
+
+  return values;
+ };
+
+ BENCHMARK("staged proxy replay-isolated mutation")
+ {
+  auto values = initial_values;
+  auto proxy = lfdb::staged(values);
+
+  lfdb::detail::validate_staged_arguments(proxy);
+  lfdb::detail::staged_access::prepare_attempt(proxy);
+  append_values(proxy);
+  lfdb::detail::staged_access::publish(proxy);
+
+  return values;
+ };
+
+ BENCHMARK("in-place staged proxy replacement")
+ {
+  auto values = initial_values;
+  auto proxy = lfdb::staged(values, std::in_place);
+
+  lfdb::detail::validate_staged_arguments(proxy);
+  lfdb::detail::staged_access::prepare_attempt(proxy);
+  append_values(proxy);
+  lfdb::detail::staged_access::publish(proxy);
+
+  return values;
+ };
+
+ auto rebuild_large_output = [&](auto& values) {
+  values.clear();
+  values.get_target().reserve(large_initial_values.size());
+
+  for (auto remaining = large_initial_values.size(); remaining; --remaining) {
+   values.push_back(large_value);
+  }
+ };
+
+ BENCHMARK("copying staged proxy large replacement")
+ {
+  auto values = large_initial_values;
+  auto proxy = lfdb::staged(values);
+
+  lfdb::detail::validate_staged_arguments(proxy);
+  lfdb::detail::staged_access::prepare_attempt(proxy);
+  rebuild_large_output(proxy);
+  lfdb::detail::staged_access::publish(proxy);
+
+  return values;
+ };
+
+ BENCHMARK("in-place staged proxy large replacement")
+ {
+  auto values = large_initial_values;
+  auto proxy = lfdb::staged(values, std::in_place);
+
+  lfdb::detail::validate_staged_arguments(proxy);
+  lfdb::detail::staged_access::prepare_attempt(proxy);
+  rebuild_large_output(proxy);
+  lfdb::detail::staged_access::publish(proxy);
+
+  return values;
+ };
+}
+
 SCENARIO("options", "[fdb]")
 {
  // For information about options, consult the FoundationDB's source tree's
@@ -2225,9 +2488,7 @@ SCENARIO("options", "[fdb]")
   ov = lfdb::option_flag;                 // flag
   ov = 42;                                // integer
   ov = std::string("hi");                 // string
-  ov = std::vector<std::uint8_t>(         // data
-        (const std::uint8_t *)pearl_msg, 
-        (const std::uint8_t *)(pearl_msg + sizeof(pearl_msg)));
+  ov = std::vector<std::uint8_t> { 1, 2, 3 }; // data
  }
 
   auto dbh0 = lfdb::create_database(

--- a/src/test/rgw/test_fdb.cc
+++ b/src/test/rgw/test_fdb.cc
@@ -31,23 +31,26 @@
 
 #include <boost/container/flat_map.hpp>
 
-#include <algorithm>
+#include <map>
+#include <list>
 #include <array>
+#include <vector>
+#include <unordered_map>
+
+#include <ranges>
+#include <iterator>
+#include <algorithm>
+
 #include <atomic>
 #include <chrono>
+#include <thread>
+
+#include <cstdint>
+#include <utility>
 #include <compare>
 #include <concepts>
-#include <cstdint>
 #include <exception>
-#include <iterator>
-#include <list>
-#include <map>
-#include <ranges>
 #include <stdexcept>
-#include <thread>
-#include <unordered_map>
-#include <utility>
-#include <vector>
 
 using Catch::Matchers::AllMatch;
 
@@ -1851,10 +1854,42 @@ SCENARIO("implicit transactions", "[fdb][rgw]")
  }
 }
 
+TEST_CASE("transactors reject invalid database handles", "[fdb]")
+{
+ lfdb::database_handle dbh;
+
+ SECTION("default options") {
+  auto txr = lfdb::make_transactor(dbh);
+
+  CHECK_THROWS_WITH(txr(lfdb::with_result, [](auto) {}),
+                    "make_transaction() requires database handle");
+ }
+
+ SECTION("explicit options") {
+  lfdb::transaction_options opts;
+  auto txr = lfdb::make_transactor(dbh, opts);
+
+  CHECK_THROWS_WITH(txr([](auto) {}),
+                    "make_transaction() requires database handle");
+ }
+
+ SECTION("duplicate staged target") {
+  auto txr = lfdb::make_transactor(dbh);
+  int output = 0;
+
+  CHECK_THROWS_WITH(txr([](auto, auto&, auto&) {},
+                        lfdb::staged(output), lfdb::staged(output)),
+                    "cannot stage one target more than once");
+ }
+}
+
 SCENARIO("transactor", "[fdb]")
 {
  janitor j;
 
+ static_assert(lfdb::concepts::stageable<std::vector<int>>);
+ static_assert(not lfdb::concepts::supported_invocation_result<
+   lfdb::staged_proxy<int>>);
  static_assert(lfdb::detail::result_reporting_transaction_op<decltype([](auto) {})>);
  static_assert(!lfdb::detail::result_reporting_transaction_op<decltype([](auto) {
   return 7;
@@ -2010,6 +2045,100 @@ SCENARIO("transactor", "[fdb]")
   CHECK(value == out);
  }
 
+ SECTION("staged arguments publish one successful attempt") {
+  auto txr = lfdb::make_transactor(j);
+  const auto key = test_key("staged-conflict-key");
+
+  lfdb::set(j, key, "initial");
+
+  std::vector<std::string> values {"before"};
+  const auto result = txr(lfdb::with_result,
+    [&j, &key](auto txn, auto& staged_values) {
+      std::string value;
+      if (not lfdb::get(txn, key, value)) {
+       throw std::runtime_error("expected key does not exist");
+      }
+
+      staged_values.push_back(value);
+
+      // Force the first attempt to conflict:
+      if ("initial" == value) {
+       lfdb::set(j, key, "conflict");
+      }
+
+      lfdb::set(txn, key, "final");
+    }, lfdb::staged(values));
+
+  CHECK(result.committed);
+  CHECK(2 == result.attempts);
+  CHECK((std::vector<std::string> {"before", "conflict"} == values));
+ }
+
+ SECTION("staged arguments remain unchanged after retry exhaustion") {
+  auto txr = lfdb::make_transactor(j);
+  const auto key = test_key("staged-exhaustion-key");
+
+  lfdb::set(j, key, "initial");
+
+  std::vector<std::string> values {"before"};
+  const auto result = txr(lfdb::with_result,
+    [&j, &key](auto txn, auto& staged_values) {
+      std::string value;
+      if (not lfdb::get(txn, key, value)) {
+       throw std::runtime_error("expected key does not exist");
+      }
+
+      staged_values.push_back(value);
+
+      // Force every attempt to conflict:
+      lfdb::set(j, key, "conflict");
+      lfdb::set(txn, key, "final");
+    }, lfdb::staged(values));
+
+  CHECK_FALSE(result.committed);
+  CHECK(std::vector<std::string> {"before"} == values);
+ }
+
+ SECTION("ordinary transactors publish staged arguments") {
+  auto txr = lfdb::make_transactor(j);
+  std::uint64_t total = 5;
+  std::vector<int> values {0};
+  std::map<std::string, int> index;
+
+  const auto answer = txr([](auto,
+                             auto& staged_total,
+                             auto& staged_values,
+                             auto& staged_index) {
+    staged_total = 7;
+    staged_total += 5;
+
+    staged_values.clear();
+    staged_values.emplace_back(1);
+    staged_values.push_back(2);
+
+    staged_index.insert_or_assign("answer", 42);
+
+    return 42;
+  }, lfdb::staged(total), lfdb::staged(values), lfdb::staged(index));
+
+  CHECK(42 == answer);
+  CHECK(12 == total);
+  CHECK((std::vector {1, 2} == values));
+  CHECK(42 == index.at("answer"));
+ }
+
+ SECTION("staged arguments remain unchanged after a body exception") {
+  auto txr = lfdb::make_transactor(j);
+  int value = 5;
+
+  CHECK_THROWS_WITH(txr([](auto, auto& staged_value) {
+    staged_value += 7;
+    throw std::runtime_error("transaction body failed");
+  }, lfdb::staged(value)), "transaction body failed");
+
+  CHECK(5 == value);
+ }
+
  SECTION("result-reporting transactor replays after conflict") {
   auto txr = lfdb::make_transactor(j);
   const auto key = test_key("result-conflict-key");
@@ -2065,14 +2194,6 @@ SCENARIO("transactor", "[fdb]")
   CHECK(result.attempts == 10);
   CHECK(result.replay_count == 9);
   CHECK(0 != result.last_error);
- }
-
- SECTION("result-reporting transactor rejects invalid database handles") {
-  lfdb::database_handle dbh;
-  auto txr = lfdb::make_transactor(dbh);
-
-  CHECK_THROWS_WITH(txr(lfdb::with_result, [](auto) {}),
-                    "make_transaction() requires database handle");
  }
 
  SECTION("transactor propagates transaction body exceptions") {

--- a/src/test/rgw/test_fdb_ceph.cc
+++ b/src/test/rgw/test_fdb_ceph.cc
@@ -190,41 +190,6 @@ TEST_CASE("fdb conversions (ceph)", "[fdb][rgw]") {
    CHECK(direct == via_serialize);
  }
 
- SECTION("buffer::list key span preserves logical key bytes")
- {
-   ceph::buffer::list key;
-   key.append("buffer-list-key");
-
-   auto key_span = ceph::libfdb::detail::as_fdb_span(key);
-
-   CHECK(key.length() == key_span.size());
-   CHECK(std::ranges::equal(std::span((const char *)key_span.data(), key_span.size()),
-                            std::string_view("buffer-list-key")));
- }
-
- SECTION("empty buffer::list key span is empty")
- {
-   ceph::buffer::list key;
-
-   auto key_span = ceph::libfdb::detail::as_fdb_span(key);
-
-   CHECK(0 == key_span.size());
- }
-
- SECTION("buffer::list key span preserves embedded nulls")
- {
-   constexpr char data[] = { '\0', 'k', 'e', 'y', '\0' };
-
-   ceph::buffer::list key;
-   key.append(data, sizeof(data));
-
-   auto key_span = ceph::libfdb::detail::as_fdb_span(key);
-
-   CHECK(key.length() == key_span.size());
-   CHECK(std::ranges::equal(std::span((const char *)key_span.data(), key_span.size()),
-                            std::string_view(data, sizeof(data))));
- }
-
  SECTION("empty buffer::list round trip through public set/get")
  {
    ceph::buffer::list in;
@@ -293,7 +258,8 @@ TEST_CASE("fdb conversions (ceph)", "[fdb][rgw]") {
  SECTION("buffer::ptr")
  {
     string_view in("Hello, World!");
-    ceph::buffer::ptr p(ceph::buffer::claim_char(in.length(), const_cast<char *>(in.data())));
+    ceph::buffer::ptr p(ceph::buffer::copy(in.data(), in.size()));
+
     CHECK(in == string_view(p.c_str(), p.length()));
 
     const auto key = test_key("key");

--- a/src/test/rgw/test_fdb_query.cc
+++ b/src/test/rgw/test_fdb_query.cc
@@ -274,7 +274,14 @@ using configured_difference =
  decltype(lq::with_options(lq::difference(lq::empty(), lq::universal()),
                            lq::query_options {}));
 
+template <typename T>
+concept exposes_rvalue_boundaries = requires(T value) {
+ std::move(value).lower();
+ std::move(value).upper();
+};
+
 static_assert(lq::expression<lq::interval>);
+static_assert(not exposes_rvalue_boundaries<lq::interval>);
 static_assert(lq::expression<decltype(lq::difference(lq::empty(), lq::universal()))>);
 static_assert(lq::expression<decltype(lq::set_union(lq::empty(), lq::universal()))>);
 static_assert(lq::expression<decltype(lq::after("m"))>);


### PR DESCRIPTION
Add supports for Staging Proxies

Reorganizes headers and adds significant core improvements and long-overdue cleanups, making
the implementation a more orthogonal.

Note: depends on PR #71067.

See EXAMPLES.md for new examples; test coverage significantly updated.

Assisted-by: Codex:GPT-5

Signed-off-by: Jesse F. Williamson <jfw@ibm.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>


