### PR TITLE
squid: objecter_requests does not dump all the inflight op's from rgw admin socket

### DIFF
--- a/src/include/neorados/RADOS.hpp
+++ b/src/include/neorados/RADOS.hpp
@@ -1302,6 +1302,7 @@ public:
     std::optional<std::string> conf_files;
     std::optional<std::string> cluster;
     std::optional<std::string> name;
+    std::optional<std::string> objecter_admin_socket_name;
     std::vector<std::pair<std::string, std::string>> configs;
     bool no_default_conf = false;
     bool no_mon_conf = false;
@@ -1315,6 +1316,13 @@ public:
     }
     Builder& set_name(std::string_view n) {
       name = std::string(n);
+      return *this;
+    }
+
+    Builder&
+    set_objecter_admin_socket_name(std::string_view n)
+    {
+      objecter_admin_socket_name = std::string(n);
       return *this;
     }
     Builder& set_no_default_conf() {
@@ -1349,15 +1357,20 @@ public:
   /// We take an `intrusive_ptr<CephContext>` to make it clear that we
   /// will take ownership of the reference.
   template<boost::asio::completion_token_for<BuildSig> CompletionToken>
-  static auto make_with_cct(boost::intrusive_ptr<CephContext> cct,
-			    boost::asio::io_context& ioctx,
-			    CompletionToken&& token) {
+  static auto make_with_cct(
+      boost::intrusive_ptr<CephContext> cct,
+      boost::asio::io_context& ioctx,
+      CompletionToken&& token,
+      std::optional<std::string> objecter_admin_socket_name = std::nullopt) {
     auto consigned = boost::asio::consign(
       std::forward<CompletionToken>(token), boost::asio::make_work_guard(
 	boost::asio::get_associated_executor(token, ioctx.get_executor())));
     return boost::asio::async_initiate<decltype(consigned), BuildSig>(
-      [cct = std::move(cct), &ioctx](auto&& handler) mutable {
-	make_with_cct_(std::move(cct), ioctx, std::move(handler));
+      [cct = std::move(cct), &ioctx,
+       objecter_admin_socket_name =
+	 std::move(objecter_admin_socket_name)](auto&& handler) mutable {
+	make_with_cct_(std::move(cct), ioctx, std::move(handler),
+		       objecter_admin_socket_name);
       }, consigned);
   }
 
@@ -1767,9 +1780,11 @@ private:
   friend Builder;
 
   RADOS(std::shared_ptr<detail::Client> impl);
-  static void make_with_cct_(boost::intrusive_ptr<CephContext> cct,
-			     boost::asio::io_context& ioctx,
-			     BuildComp c);
+  static void make_with_cct_(
+      boost::intrusive_ptr<CephContext> cct,
+      boost::asio::io_context& ioctx,
+      BuildComp c,
+      const std::optional<std::string>& objecter_admin_socket_name = std::nullopt);
 
   void execute_(Object o, IOContext ioc, ReadOp op,
 		ceph::buffer::list* bl, Op::Completion c,

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1411,6 +1411,12 @@ inline namespace v14_2_0 {
     config_t cct();
     int connect();
     void shutdown();
+
+    /// Set the name suffix for the objecter admin socket command.
+    /// Call before connect(). If non-empty, the command will be
+    /// registered as "objecter_requests.<name>" instead of "objecter_requests".
+    void set_objecter_admin_socket_name(std::string name);
+
     int watch_flush();
     int aio_watch_flush(AioCompletion*);
     int conf_read_file(const char * const path) const;

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -257,7 +257,8 @@ int librados::RadosClient::connect()
 
   ldout(cct, 1) << "starting objecter" << dendl;
 
-  objecter = new (std::nothrow) Objecter(cct, messenger, &monclient, poolctx);
+  objecter = new (std::nothrow) Objecter(cct, messenger, &monclient, poolctx,
+					 objecter_admin_socket_name);
   if (!objecter)
     goto out;
   objecter->set_balanced_budget();

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -68,6 +68,11 @@ private:
 
   uint64_t instance_id{0};
 
+  // Optional name suffix for objecter admin socket command.
+  // If empty, registers as "objecter_requests".
+  // If non-empty, registers as "objecter_requests.<name>".
+  std::string objecter_admin_socket_name;
+
   bool _dispatch(Message *m);
   bool ms_dispatch(Message *m) override;
 
@@ -104,6 +109,13 @@ public:
   int ping_monitor(std::string mon_id, std::string *result);
   int connect();
   void shutdown();
+
+  /// Set the name suffix for the objecter admin socket command.
+  /// Call before connect(). If non-empty, the command will be
+  /// registered as "objecter_requests.<name>" instead of "objecter_requests".
+  void set_objecter_admin_socket_name(std::string name) {
+    objecter_admin_socket_name = std::move(name);
+  }
 
   int watch_flush();
   int async_watch_flush(AioCompletionImpl *c);

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -2397,6 +2397,11 @@ int librados::Rados::connect()
   return client->connect();
 }
 
+void librados::Rados::set_objecter_admin_socket_name(std::string name)
+{
+  client->set_objecter_admin_socket_name(std::move(name));
+}
+
 librados::config_t librados::Rados::cct()
 {
   return (config_t)client->cct;

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -865,15 +865,20 @@ void RADOS::Builder::build_(asio::io_context& ioctx,
   }
   common_init_finish(cct.get());
 
-  RADOS::make_with_cct(std::move(cct), ioctx, std::move(c));
+  RADOS::make_with_cct_(
+      std::move(cct), ioctx, std::move(c), objecter_admin_socket_name);
 }
 
-void RADOS::make_with_cct_(boost::intrusive_ptr<CephContext> cct,
-			   asio::io_context& ioctx,
-			   BuildComp c) {
+void
+RADOS::make_with_cct_(
+    boost::intrusive_ptr<CephContext> cct,
+    asio::io_context& ioctx,
+    BuildComp c,
+    const std::optional<std::string>& objecter_admin_socket_name)
+{
   try {
-    auto r = std::make_shared<detail::NeoClient>(
-      std::make_unique<detail::RADOS>(ioctx, std::move(cct)));
+    auto r = std::make_shared<detail::NeoClient>(std::make_unique<detail::RADOS>(
+        ioctx, std::move(cct), objecter_admin_socket_name));
     r->objecter->wait_for_osd_map([c = std::move(c),
                                    r = std::move(r)]() mutable {
       asio::dispatch(

--- a/src/neorados/RADOSImpl.cc
+++ b/src/neorados/RADOSImpl.cc
@@ -23,7 +23,8 @@ namespace neorados {
 namespace detail {
 
 RADOS::RADOS(boost::asio::io_context& ioctx,
-	     boost::intrusive_ptr<CephContext> cct)
+             boost::intrusive_ptr<CephContext> cct,
+             const std::optional<std::string>& objecter_admin_socket_name)
   : Dispatcher(cct.get()),
     ioctx(ioctx),
     cct(cct),
@@ -43,7 +44,9 @@ RADOS::RADOS(boost::asio::io_context& ioctx,
   messenger->set_default_policy(
     Messenger::Policy::lossy_client(CEPH_FEATURE_OSDREPLYMUX));
 
-  objecter = std::make_unique<Objecter>(cct.get(), messenger.get(), &monclient, ioctx);
+  objecter = std::make_unique<Objecter>(cct.get(), messenger.get(), &monclient,
+					ioctx,
+					objecter_admin_socket_name.value_or(""));
 
   objecter->set_balanced_budget();
   monclient.set_messenger(messenger.get());

--- a/src/neorados/RADOSImpl.h
+++ b/src/neorados/RADOSImpl.h
@@ -17,6 +17,8 @@
 #include <functional>
 #include <atomic>
 #include <memory>
+#include <optional>
+#include <string>
 
 #include <boost/asio/io_context.hpp>
 #include <boost/intrusive_ptr.hpp>
@@ -61,8 +63,10 @@ class RADOS : public Dispatcher {
   std::atomic<bool> finished = false;
 
 public:
-
-  RADOS(boost::asio::io_context& ioctx, boost::intrusive_ptr<CephContext> cct);
+  RADOS(
+      boost::asio::io_context& ioctx,
+      boost::intrusive_ptr<CephContext> cct,
+      const std::optional<std::string>& objecter_admin_socket_name);
   ~RADOS();
   bool ms_dispatch(Message *m) override;
   void ms_handle_connect(Connection *con) override;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -384,13 +384,16 @@ void Objecter::init()
 
   m_request_state_hook = new RequestStateHook(this);
   auto admin_socket = cct->get_admin_socket();
-  int ret = admin_socket->register_command("objecter_requests",
-					   m_request_state_hook,
-					   "show in-progress osd requests");
 
-  /* Don't warn on EEXIST, happens if multiple ceph clients
-   * are instantiated from one process */
-  if (ret < 0 && ret != -EEXIST) {
+  std::string cmd_name = "objecter_requests";
+  if (!m_admin_socket_name.empty()) {
+    cmd_name += ".";
+    cmd_name += m_admin_socket_name;
+  }
+  int ret = admin_socket->register_command(
+      cmd_name, m_request_state_hook, "show in-progress osd requests");
+
+  if (ret < 0) {
     lderr(cct) << "error registering admin socket command: "
 	       << cpp_strerror(ret) << dendl;
   }
@@ -5091,8 +5094,10 @@ Objecter::OSDSession::~OSDSession()
 
 Objecter::Objecter(CephContext *cct,
 		   Messenger *m, MonClient *mc,
-		   asio::io_context& service) :
-  Dispatcher(cct), messenger(m), monc(mc), service(service)
+		   asio::io_context& service,
+		   std::string_view admin_socket_name) :
+  Dispatcher(cct), messenger(m), monc(mc), service(service),
+  m_admin_socket_name(admin_socket_name)
 {
   mon_timeout = cct->_conf.get_val<std::chrono::seconds>("rados_mon_op_timeout");
   osd_timeout = cct->_conf.get_val<std::chrono::seconds>("rados_osd_op_timeout");

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -393,7 +393,17 @@ void Objecter::init()
   int ret = admin_socket->register_command(
       cmd_name, m_request_state_hook, "show in-progress osd requests");
 
-  if (ret < 0) {
+  if (ret == -EEXIST && m_admin_socket_name.empty()) {
+    /* Don't warn on EEXIST for unnamed clients, happens if multiple ceph
+     * clients are instantiated from one process.  Only the first
+     * registration wins */
+    ldout(cct, 1)
+        << "admin socket command " << cmd_name
+        << " is already registered by another objecter in this process; "
+           "requests issued by this objecter will not be shown. Call "
+           "set_objecter_admin_socket_name() to register under a distinct name"
+        << dendl;
+  } else if (ret < 0) {
     lderr(cct) << "error registering admin socket command: "
 	       << cpp_strerror(ret) << dendl;
   }

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1818,6 +1818,7 @@ private:
   class RequestStateHook;
 
   RequestStateHook *m_request_state_hook = nullptr;
+  std::string m_admin_socket_name;
 
 public:
   /*** track pending operations ***/
@@ -2699,8 +2700,12 @@ private:
 			   static_cast<int64_t>(
 			     cct->_conf->objecter_inflight_ops)};
  public:
+  /// @param admin_socket_name Optional name for the admin socket command.
+  ///        If empty (default), registers as "objecter_requests".
+  ///        If non-empty, registers as "objecter_requests.<name>".
   Objecter(CephContext *cct, Messenger *m, MonClient *mc,
-	   boost::asio::io_context& service);
+	   boost::asio::io_context& service,
+	   std::string_view admin_socket_name = {});
   ~Objecter() override;
 
   void init();

--- a/src/rgw/driver/rados/config/store.cc
+++ b/src/rgw/driver/rados/config/store.cc
@@ -39,6 +39,10 @@ auto create_config_store(const DoutPrefixProvider* dpp)
         << cpp_strerror(-r) << dendl;
     return nullptr;
   }
+  // Use a distinct admin socket command name for the config store client,
+  // so it doesn't conflict with the main RGWRados objecter_requests command.
+  impl->rados.set_objecter_admin_socket_name("ConfigStore");
+
   r = impl->rados.connect();
   if (r < 0) {
     ldpp_dout(dpp, -1) << "Rados client connection failed with "

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1895,4 +1895,12 @@ public:
 
 };
 
+#ifdef WITH_RADOSGW_RADOS
+std::optional<neorados::RADOS>
+make_neorados(
+    CephContext* cct,
+    boost::asio::io_context& io_context,
+    std::optional<std::string> objecter_admin_socket_name = std::nullopt);
+#endif
+
 /** @} */


### PR DESCRIPTION
This is a combined backport that pulls commits from **two** main-branch PRs:

- #67471 — osdc/objecter: Allow Objecter to store custom name for admin socket
  (tracker: https://tracker.ceph.com/issues/74983)
  - 8f6e7a0c osdc/objecter: Allow Objecter to store custom name for admin socket
  - dd3df28c rgw/objecter: Set distinct socket names for Neorados and ConfigStore
- #71064 — osdc/objecter: only log admin socket EEXIST for named clients
  (no upstream Redmine tracker filed for this PR)
  - e961c12d osdc/objecter: only log admin socket EEXIST for named clients

Note: squid predates the neorados-based RGW driver, so the `make_neorados()` hunks from #67471 (RGW passing a distinct admin socket name to its neorados client) do not apply here — squid's RGW driver only creates two librados clients (the config-store client and the main RGWRados backend client), not three. The Objecter/RADOS admin-socket-naming mechanism and the config-store socket rename are backported as-is.

backport tracker: https://tracker.ceph.com/issues/79482