### PR TITLE
Ubuntu 26.04 (resolute) build and test enablement

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2020,6 +2020,7 @@ rm -rf %{_vpath_builddir}
 %{_sbindir}/ceph-create-keys
 %dir %{_libexecdir}/ceph
 %{_libexecdir}/ceph/ceph_common.sh
+%{_libexecdir}/ceph/block-device-health
 %dir %{_libdir}/rados-classes
 %{_libdir}/rados-classes/*
 %dir %{_libdir}/ceph

--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -8,6 +8,7 @@ usr/bin/monmaptool
 usr/bin/osdmaptool
 usr/bin/ceph-kvstore-tool
 usr/libexec/ceph/ceph_common.sh
+usr/libexec/ceph/block-device-health
 usr/lib/ceph/erasure-code/*
 usr/lib/ceph/extblkdev/*
 usr/lib/rados-classes/*

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,14 @@ export DESTDIR=$(CURDIR)/debian/tmp
 
 include /usr/share/dpkg/default.mk
 
+# gcc 15's fat LTO objects leave std::_Sp_counted_base::_M_release_last_use_cold
+# unresolved when linking our static convenience libraries (first seen on
+# Ubuntu 26.04, whose dpkg enables -flto=auto -ffat-lto-objects by default),
+# so opt deb builds out of LTO on gcc >= 15.
+ifeq ($(shell expr $(shell gcc -dumpversion | cut -d. -f1) \>= 15),1)
+  export DEB_BUILD_MAINT_OPTIONS += optimize=-lto
+endif
+
 ifneq (,$(findstring WITH_STATIC_LIBSTDCXX,$(CEPH_EXTRA_CMAKE_ARGS)))
   # dh_auto_build sets LDFLAGS with `dpkg-buildflags --get LDFLAGS` on ubuntu,
   # which makes the application aborts when the shared library throws

--- a/qa/distros/all/ubuntu_26.04.yaml
+++ b/qa/distros/all/ubuntu_26.04.yaml
@@ -1,0 +1,3 @@
+os_type: ubuntu
+os_version: "26.04"
+ktype: distro

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -938,6 +938,7 @@ install(FILES
 install(PROGRAMS
   ceph_common.sh
   ceph-osd-prestart.sh
+  block-device-health
   DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/ceph)
 
 install(PROGRAMS

--- a/src/block-device-health
+++ b/src/block-device-health
@@ -1,0 +1,65 @@
+#!/bin/sh
+#
+# Privileged helper for collecting device health metrics on behalf of the
+# ceph daemons (which run as user ceph).  Installed as
+# /usr/libexec/ceph/block-device-health and the only command sudoers.d/
+# ceph-smartctl lets the ceph user run.  The fixed command lines used to
+# live in sudoers as argument patterns; sudo-rs (Ubuntu >= 25.10) does not
+# support wildcards there, so the confinement moved here instead.
+#
+# Usage:
+#   block-device-health smartctl /dev/<dev>
+#   block-device-health nvme <vendor> /dev/<dev>
+
+set -eu
+
+# The old sudoers rules pinned /usr/sbin/smartctl and /usr/sbin/nvme; don't
+# let the invoking user's PATH pick the binaries here either.
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+
+usage() {
+    echo "usage: $0 smartctl /dev/<dev> | nvme <vendor> /dev/<dev>" >&2
+    exit 64
+}
+
+check_dev() {
+    case "$1" in
+        /dev/*) ;;
+        *) echo "$0: refusing device path '$1'" >&2; exit 65 ;;
+    esac
+    case "$1" in
+        *..*|*/./*|*' '*|*'	'*) echo "$0: refusing device path '$1'" >&2; exit 65 ;;
+    esac
+    if [ ! -b "$1" ] && [ ! -c "$1" ]; then
+        echo "$0: '$1' is not a device node" >&2
+        exit 66
+    fi
+}
+
+check_word() {
+    case "$1" in
+        ''|*[!A-Za-z0-9_-]*) echo "$0: refusing argument '$1'" >&2; exit 65 ;;
+    esac
+}
+
+[ $# -ge 2 ] || usage
+mode=$1
+shift
+
+case "$mode" in
+    smartctl)
+        [ $# -eq 1 ] || usage
+        check_dev "$1"
+        exec smartctl -x --json=o "$1"
+        ;;
+    nvme)
+        [ $# -eq 2 ] || usage
+        check_word "$1"
+        check_dev "$2"
+        exec nvme "$1" smart-log-add --json "$2"
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -545,20 +545,26 @@ static std::string get_device_vendor(const std::string& devname)
   return {};
 }
 
+// Privileged helper that runs the smartctl/nvme health queries for us; it
+// is the only command sudoers.d/ceph-smartctl grants the ceph user, so the
+// path here and there must match.
+#define BLOCK_DEVICE_HEALTH_HELPER "/usr/libexec/ceph/block-device-health"
+
 static int block_device_run_vendor_nvme(
   const string& devname, const string& vendor, int timeout,
   std::string *result)
 {
   string device = "/dev/" + devname;
 
+  // sudoers.d/ceph-smartctl only lets the ceph user run the helper, which
+  // validates its arguments and execs the fixed nvme command line
   SubProcessTimed nvmecli(
     "sudo", SubProcess::CLOSE, SubProcess::PIPE, SubProcess::CLOSE,
     timeout);
   nvmecli.add_cmd_args(
+    BLOCK_DEVICE_HEALTH_HELPER,
     "nvme",
     vendor.c_str(),
-    "smart-log-add",
-    "--json",
     device.c_str(),
     NULL);
   int ret = nvmecli.spawn();
@@ -620,14 +626,14 @@ static int block_device_run_smartctl(const string& devname, int timeout,
   string device = "/dev/" + devname;
 
   // when using --json, smartctl will report its errors in JSON format to stdout 
+  // sudoers.d/ceph-smartctl only lets the ceph user run the helper, which
+  // validates the device path and execs `smartctl -x --json=o <dev>`
   SubProcessTimed smartctl(
     "sudo", SubProcess::CLOSE, SubProcess::PIPE, SubProcess::CLOSE,
     timeout);
   smartctl.add_cmd_args(
+    BLOCK_DEVICE_HEALTH_HELPER,
     "smartctl",
-    //"-a",    // all SMART info
-    "-x",    // all SMART and non-SMART info
-    "--json=o",
     device.c_str(),
     NULL);
 

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -84,8 +84,10 @@ function prepare() {
     if command -v apt-get > /dev/null 2>&1 ; then
         which_pkg="debianutils"
 
-        get_llvm
-        sts=$?
+        # get_llvm's nonzero "use distro clang" return (10) must not trip
+        # errexit before we can inspect it
+        sts=0
+        get_llvm || sts=$?
         if [ $sts -eq 10 ]; then
             distro_llvm=clang
         elif [ $sts -ne 0 ]; then

--- a/sudoers.d/ceph-smartctl
+++ b/sudoers.d/ceph-smartctl
@@ -1,4 +1,7 @@
-## allow ceph daemons (which run as user ceph) to collect device health metrics
+## allow ceph daemons (which run as user ceph) to collect device health
+## metrics through the block-device-health helper, which validates its
+## arguments and runs the fixed smartctl / nvme command lines.  (The
+## command lines used to be argument patterns here; sudo-rs, the default
+## sudo on Ubuntu >= 25.10, does not allow wildcards in arguments.)
 
-ceph ALL=NOPASSWD: /usr/sbin/smartctl -x --json=o /dev/*
-ceph ALL=NOPASSWD: /usr/sbin/nvme * smart-log-add --json /dev/*
+ceph ALL=NOPASSWD: /usr/libexec/ceph/block-device-health


### PR DESCRIPTION
Everything ceph.git needs to build for and schedule on Ubuntu 26.04 (Resolute Raccoon), the first Ceph release to target it being vampire:

- **qa/distros: add ubuntu_26.04** — distro fragment so suites can schedule on it. `ubuntu_latest.yaml`/`supported*` flips come later, once packages and testnode images exist and vampire declares support.
- **script/run-make: don't let get_llvm's status-10 trip errexit** — `run-make.sh` runs under `set -e`, so `get_llvm`'s deliberate "distro too new, use distro clang" `return 10` aborted `prepare()` before the caller could inspect `$?`. 26.04 is the first distro to take that path in CI (first hit: ceph-dev-pipeline build 8825's builder-container stage).
- **debian: opt out of LTO on gcc >= 15** — gcc 15's fat LTO objects (Ubuntu's default `-flto=auto -ffat-lto-objects`) leave `std::_Sp_counted_base::_M_release_last_use_cold` unresolved when linking the static convenience libs into test binaries (gcc PR113208 style; e.g. `libextblkdev.a` into `ceph_erasure_code_benchmark`). noble/jammy (gcc 13/14) keep building exactly as before.

- **common/blkdev: run smartctl/nvme through a privileged helper** — sudo-rs (Ubuntu ≥ 25.10's default sudo) rejects the argument wildcards in `sudoers.d/ceph-smartctl` and refuses the whole file, which every OSD device-health probe then logs (`wildcards are not allowed in command arguments`); the first 26.04 smoke runs failed the cluster-log scan on it. The confinement moves into `/usr/libexec/ceph/block-device-health`, which validates its arguments (device node under `/dev`, vendor limited to `[A-Za-z0-9_-]`) and execs the fixed `smartctl -x --json=o <dev>` / `nvme <vendor> smart-log-add --json <dev>` command line; sudoers grants only the helper, with no argument patterns, and `blkdev.cc` calls it.

With these four (verified incrementally via ceph-ci `wip-resolute` throwaway builds), main compiles and packages for ubuntu 26.04 in ceph-dev-pipeline. `build-with-container.py` already knew the distro (c9cca3ad821); CI-side enablement (shaman/chacra deployed, ceph-build #2706, ceph-cm-ansible #881, teuthology #2253) is in flight in the respective repos.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] New feature (ticket optional)
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
