### PR TITLE
script/run-make: don't let get_llvm's status-10 trip errexit

### DIFF
--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -84,8 +84,10 @@ function prepare() {
     if command -v apt-get > /dev/null 2>&1 ; then
         which_pkg="debianutils"
 
-        get_llvm
-        sts=$?
+        # get_llvm's nonzero "use distro clang" return (10) must not trip
+        # errexit before we can inspect it
+        sts=0
+        get_llvm || sts=$?
         if [ $sts -eq 10 ]; then
             distro_llvm=clang
         elif [ $sts -ne 0 ]; then


### PR DESCRIPTION
`run-make.sh` runs under `set -e`, so `get_llvm`'s deliberate "distro too new, use distro clang" `return 10` aborts `prepare()` before the caller can inspect `$?` — the EXIT trap fires and the builder-container image build dies with exit status 10. Ubuntu 26.04 is the first distro to take that path in CI (first hit: ceph-dev-pipeline build 8821, `DIST=resolute`); jammy/noble return 0 there, which is why this never fired before.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
