### PR TITLE
debian: opt out of LTO on gcc >= 15

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,14 @@ export DESTDIR=$(CURDIR)/debian/tmp
 
 include /usr/share/dpkg/default.mk
 
+# gcc 15's fat LTO objects leave std::_Sp_counted_base::_M_release_last_use_cold
+# unresolved when linking our static convenience libraries (first seen on
+# Ubuntu 26.04, whose dpkg enables -flto=auto -ffat-lto-objects by default),
+# so opt deb builds out of LTO on gcc >= 15.
+ifeq ($(shell expr $(shell gcc -dumpversion | cut -d. -f1) \>= 15),1)
+  export DEB_BUILD_MAINT_OPTIONS += optimize=-lto
+endif
+
 ifneq (,$(findstring WITH_STATIC_LIBSTDCXX,$(CEPH_EXTRA_CMAKE_ARGS)))
   # dh_auto_build sets LDFLAGS with `dpkg-buildflags --get LDFLAGS` on ubuntu,
   # which makes the application aborts when the shared library throws


### PR DESCRIPTION
gcc 15's fat LTO objects (Ubuntu's default `-flto=auto -ffat-lto-objects` dpkg flags) leave `std::_Sp_counted_base::_M_release_last_use_cold` unresolved when linking our static convenience libraries into test binaries — first seen building main for Ubuntu 26.04 (resolute) in ceph-dev-pipeline build 8825 (`libextblkdev.a` into `ceph_erasure_code_benchmark` / `ceph_test_admin_socket_output`), in the style of gcc PR113208. Opt deb builds out of LTO when gcc >= 15; noble/jammy (gcc 13/14) keep building exactly as before.

Part of Ubuntu 26.04 CI enablement, alongside #71559 and #71560.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
