### PR TITLE
umbrella: mgr/cephadm: batch MDS upgrades when fail_fs is set

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -789,6 +789,45 @@ def test_enough_mds_for_ok_to_stop(get, get_daemons_by_service, cephadm_module: 
         DaemonDescription(daemon_type='mds', daemon_id='myfs.test.host1.gfknd', service_name='mds.myfs.test'))
 
 
+def _mds_need_upgrade_entries() -> List[Tuple[DaemonDescription, bool]]:
+    return [
+        (DaemonDescription(
+            daemon_type='mds',
+            daemon_id=f'cephfs.host{i}.abcdef',
+            hostname=f'host{i}',
+            container_image_id='old_digest',
+            service_name='mds.cephfs',
+        ), False)
+        for i in range(1, 4)
+    ]
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+@mock.patch.object(CephadmUpgrade, '_enough_mds_for_ok_to_stop', return_value=True)
+@mock.patch.object(CephadmUpgrade, '_wait_for_ok_to_stop', return_value=True)
+def test_to_upgrade_batches_mds_when_fail_fs(
+        _wait_for_ok_to_stop: mock.MagicMock,
+        _enough_mds_for_ok_to_stop: mock.MagicMock,
+        cephadm_module: CephadmOrchestrator):
+    # https://tracker.ceph.com/issues/78304
+    need_upgrade = _mds_need_upgrade_entries()
+
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image', 'pid', fail_fs=True)
+    cont, to_upgrade = cephadm_module.upgrade._to_upgrade(need_upgrade, 'target_image')
+    assert cont
+    assert len(to_upgrade) == 3
+    assert [d[0].name() for d in to_upgrade] == [d[0].name() for d in need_upgrade]
+    _wait_for_ok_to_stop.assert_not_called()
+
+    cephadm_module.upgrade.upgrade_state = UpgradeState(
+        'target_image', 'pid', fail_fs=False)
+    cont, to_upgrade = cephadm_module.upgrade._to_upgrade(need_upgrade, 'target_image')
+    assert cont
+    assert len(to_upgrade) == 1
+    assert to_upgrade[0][0].name() == need_upgrade[0][0].name()
+
+
 @pytest.mark.parametrize("current_version, use_tags, show_all_versions, tags, result",
                          [
                              # several candidate versions (from different major versions)

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1531,12 +1531,11 @@ class CephadmUpgrade:
                     return False, to_upgrade
 
             if d.daemon_type == 'mds' and self._enough_mds_for_ok_to_stop(d):
-                # when fail_fs is set to true, all MDS daemons will be moved to
-                # up:standby state, so Cephadm won't be able to upgrade due to
-                # this check and and will warn with "It is NOT safe to stop
-                # mds.<daemon_name> at this time: one or more filesystems is
-                # currently degraded", therefore we bypass this check for that
-                # case.
+                # When fail_fs is set to true, all MDS daemons will be moved to
+                # up:standby state. ok-to-stop would then warn with "It is NOT
+                # safe to stop mds.<daemon_name> at this time: one or more
+                # filesystems is currently degraded", so we bypass this check
+                # when fail_fs is set (via `not self.upgrade_state.fail_fs`).
                 assert self.upgrade_state is not None
                 if not self.upgrade_state.fail_fs \
                         and not self._wait_for_ok_to_stop(d, known_ok_to_stop):
@@ -1561,6 +1560,12 @@ class CephadmUpgrade:
                 # osd ok-to-upgrade batch is not empty, so keep looping to
                 # add more OSDs to the batch
                 if d.daemon_type == 'osd' and self._upgrade_uses_ok_to_upgrade_for_osds() and (len(known_ok_to_upgrade) > 0):
+                    continue  # do not break
+                # fail_fs already took the filesystem down; upgrade all MDS
+                # in one pass rather than one daemon per upgrade cycle.
+                if (d.daemon_type == 'mds'
+                        and self.upgrade_state is not None
+                        and self.upgrade_state.fail_fs):
                     continue  # do not break
                 break
 


### PR DESCRIPTION
parent tracker: https://tracker.ceph.com/issues/78304

backport of https://github.com/ceph/ceph/pull/70873

**Summary**

When `fail_fs` is enabled the filesystem is already failed, so MDS daemons are safe to upgrade together. Stop breaking after the first MDS in `_to_upgrade` so they are queued in one pass instead of one per upgrade cycle.

`fail_fs` is already on umbrella, but without this change MDS are still redeployed one daemon per upgrade cycle, so the "rapid multi-rank mds upgrade" path is incomplete.

Cherry-pick of `5afde9114d4f` applied cleanly. Tentacle is intentionally omitted (two supported versions).

## Test plan
- [ ] `tox -e py3 -- cephadm/tests/test_upgrade.py::test_to_upgrade_batches_mds_when_fail_fs`

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard
  - [x] Affects Orchestrator
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [ ] No tests