### PR TITLE
build: support GITHUB_TOKEN for container builds

### DIFF
--- a/ContainerBuild.md
+++ b/ContainerBuild.md
@@ -177,3 +177,62 @@ The overlay can also be temporary, with no files persisted after the container
 has exited. Pass `--overlay-dir=-` to enable this option. Note that invoking
 `build-with-container.py` default targets may use multiple container instances
 and passing this option will break those targets.
+
+
+### Authenticating GitHub dependency fetches
+
+Ceph builds may fetch dependencies from GitHub during CMake configuration or
+other build steps (for example, via CMake's `FetchContent` or
+`ExternalProject_Add`). When many builds share the same public IP, these
+unauthenticated Git-over-HTTPS requests can be rate limited by GitHub.
+
+To avoid this, provide a GitHub Personal Access Token (PAT) through the
+`GITHUB_TOKEN` environment variable:
+
+```
+GITHUB_TOKEN="$MY_GITHUB_PAT" ./src/script/build-with-container.py -e build
+```
+
+The token can also be supplied via the `--env-file` option instead of the
+process environment:
+
+```
+# in the env file
+GITHUB_TOKEN=ghp_...
+```
+
+```
+./src/script/build-with-container.py --env-file=my.env -e build
+```
+
+There is intentionally no command line option that accepts the token value
+directly (e.g. `--github-token=...`). Putting a secret on the command line
+exposes it through shell history, process listings, and command logging, so
+always use one of the two mechanisms above.
+
+When a token is available, `build-with-container.py` configures Git *inside
+the runtime build container* to authenticate HTTPS requests to
+`github.com`, using `x-access-token` as the username, per GitHub's documented
+convention for token-based HTTPS authentication. This is applied to every
+runtime container the script starts (build, tests, packages, custom commands,
+and interactive mode).
+
+This feature only authenticates Git-over-HTTPS fetches to `github.com` (the
+operations CMake dependency fetches rely on). It does **not**:
+* authenticate arbitrary `curl` requests,
+* authenticate calls to the GitHub API,
+* authenticate pulls from a container image registry (including GitHub
+  Container Registry).
+
+The token is never used when building the build *image* itself (the
+`Dockerfile.build`-based image build only ever uses `--build-arg`, and the
+token is deliberately never passed there, since build arguments can leak
+into image metadata and build history).
+
+Only `GITHUB_TOKEN` is recognized (not `GH_TOKEN`), consistent with the
+variable name already used throughout this repository's own GitHub Actions
+workflows.
+
+We recommend using a minimally scoped, read-only PAT (for example, a
+fine-grained token with only public repository read access) for this
+purpose, and treating it like any other credential.

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -284,6 +284,36 @@ def _container_cmd(
         )
         cmd.append(f"-eCCACHE_DIR={ccdir}")
         cmd.append(f"-eCCACHE_BASEDIR={ctx.cli.homedir}")
+    token_handling = ctx.github_token_handling()
+    if token_handling is not GitHubTokenHandling.DISABLED:
+        if token_handling is GitHubTokenHandling.ENABLED_IN_ENVIRON:
+            # Forward GITHUB_TOKEN from this script's own environment
+            # into the container. A bare `-e NAME` (no `=value`) is
+            # resolved by the container engine from its own calling
+            # environment, so the secret value never appears as a
+            # command line argument, in _cmdstr() output, or in logs.
+            # If the token instead only came from --env-file, the
+            # engine's existing --env-file handling above already
+            # supplies it and nothing further is needed here.
+            cmd.append("-eGITHUB_TOKEN")
+        # Configure Git (inside the container) to authenticate
+        # HTTPS requests to github.com using GITHUB_TOKEN, via a
+        # credential helper that reads the token from the container's
+        # own environment only when Git asks for credentials. This
+        # only affects Git-over-HTTPS to github.com (e.g. CMake
+        # FetchContent/ExternalProject_Add dependency fetches); it
+        # does not authenticate curl, the GitHub API, or container
+        # registries. None of the values below contain the token
+        # itself, only a reference to the GITHUB_TOKEN variable name.
+        cmd.append("-eGIT_CONFIG_COUNT=1")
+        cmd.append(
+            "-eGIT_CONFIG_KEY_0=credential.https://github.com.helper"
+        )
+        cmd.append(
+            "-eGIT_CONFIG_VALUE_0="
+            '!f() { echo "username=x-access-token"; '
+            'echo "password=$GITHUB_TOKEN"; }; f'
+        )
     cmd.extend(extra_args or [])
     cmd.extend(ctx.cli.extra or [])
     if ctx.npm_cache_dir:
@@ -394,6 +424,22 @@ class ImageSource(StrEnum):
         return ", ".join(s.value for s in cls)
 
 
+class GitHubTokenHandling(enum.Enum):
+    # No GITHUB_TOKEN is available (from either the environment or an
+    # --env-file); nothing should be forwarded into the container.
+    DISABLED = enum.auto()
+    # A GITHUB_TOKEN is available, but only via --env-file. The
+    # container engine's own --env-file handling already supplies it;
+    # no extra `-e` argument is needed.
+    ENABLED = enum.auto()
+    # A GITHUB_TOKEN is available in this process's own environment
+    # (regardless of whether it's also in the --env-file). It must be
+    # forwarded explicitly with a bare `-e GITHUB_TOKEN` so the
+    # container engine copies the value from its own calling
+    # environment rather than the command line.
+    ENABLED_IN_ENVIRON = enum.auto()
+
+
 class ImageVariant(StrEnum):
     DEFAULT = 'default'  # build everything + make check
     # test dependencies will not be instaled, other parameters
@@ -468,6 +514,35 @@ class Context:
         if len(values) != 1:
             raise ValueError(f"unexpected value in env file: {found!r}")
         return values[0]
+
+    @ftcache
+    def github_token_handling(self):
+        """Return a GitHubTokenHandling value describing whether and how
+        a GITHUB_TOKEN should be forwarded into the container. The
+        secret value itself is only held transiently (for this presence
+        check and, if sourced from the environment, for the container
+        engine's own env-passthrough) and is never written into any
+        generated command, exception, or log message.
+        """
+        from_env = os.environ.get('GITHUB_TOKEN')
+        from_file = self.lookup_env_file('GITHUB_TOKEN')
+        log.debug("Environment GITHUB_TOKEN present=%r", from_env is not None)
+        log.debug(
+            "Env file GITHUB_TOKEN present=%r", from_file is not None
+        )
+        if (
+            from_env != from_file
+            and from_env is not None
+            and from_file is not None
+        ):
+            raise ValueError(
+                'conflicting GITHUB_TOKEN values in env and env file'
+            )
+        if from_env is not None:
+            return GitHubTokenHandling.ENABLED_IN_ENVIRON
+        if from_file is not None:
+            return GitHubTokenHandling.ENABLED
+        return GitHubTokenHandling.DISABLED
 
     def packages_build(self):
         """Return true if only packages will be build (not make check)."""


### PR DESCRIPTION
Add docs and runtime support for supplying a GitHub personal access token (GITHUB_TOKEN) to build-with-container.py. If provided (via the environment or --env-file) the token is forwarded into runtime containers without appearing on the command line, and Git inside the container is configured with a credential helper to authenticate HTTPS fetches from github.com. The token is not used when building the build image, does not affect curl/GitHub API/container registries, and the script errors on conflicting env vs env-file values.

Signed-off-by: Christopher Smith <chsmith@akamai.com>


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
