### PR TITLE
rgw/rgw_quota: avoids duplicated stats fetching/refreshing for the same bucket

### DIFF
--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -66,14 +66,27 @@ protected:
     }
   };
 
-  virtual int fetch_stats_from_storage(const rgw_owner& owner, const rgw_bucket& bucket, RGWStorageStats& stats, optional_yield y, const DoutPrefixProvider *dpp) = 0;
-
-  virtual bool map_find(const rgw_owner& owner, const rgw_bucket& bucket, RGWQuotaCacheStats& qs) = 0;
-
-  virtual bool map_find_and_update(const rgw_owner& owner, const rgw_bucket& bucket, typename lru_map<T, RGWQuotaCacheStats>::UpdateContext *ctx) = 0;
-  virtual void map_add(const rgw_owner& owner, const rgw_bucket& bucket, RGWQuotaCacheStats& qs) = 0;
-
-  virtual void data_modified(const rgw_owner& owner, const rgw_bucket& bucket) {}
+  virtual int fetch_stats_from_storage(
+    const T& key,
+    RGWStorageStats& stats,
+    optional_yield y,
+    const DoutPrefixProvider *dpp) = 0;
+  bool map_find(
+    const T& key,
+    RGWQuotaCacheStats& qs) {
+    return stats_map.find(key, qs);
+  }
+  bool map_find_and_update(
+    const T& key,
+    typename lru_map<T, RGWQuotaCacheStats>::UpdateContext *ctx) {
+    return stats_map.find_and_update(key, NULL, ctx);
+  }
+  void map_add(
+    const T& key,
+    RGWQuotaCacheStats& qs) {
+    stats_map.add(key, qs);
+  }
+  virtual void data_modified(const rgw_owner& owner, const rgw_bucket &bucket) {}
 public:
   RGWQuotaCache(rgw::sal::Driver* _driver, int size) : driver(_driver), stats_map(size) {
     async_refcount = new RefCountedWaitObject;
@@ -82,54 +95,70 @@ public:
     async_refcount->put_wait(); /* wait for all pending async requests to complete */
   }
 
-  int get_stats(const rgw_owner& owner, const rgw_bucket& bucket, RGWStorageStats& stats, optional_yield y,
-                const DoutPrefixProvider* dpp);
-  void adjust_stats(const rgw_owner& owner, rgw_bucket& bucket, int objs_delta, uint64_t added_bytes, uint64_t removed_bytes);
-
-  void set_stats(const rgw_owner& owner, const rgw_bucket& bucket, RGWQuotaCacheStats& qs, const RGWStorageStats& stats);
-  int async_refresh(const rgw_owner& owner, const rgw_bucket& bucket, RGWQuotaCacheStats& qs);
-  void async_refresh_response(const rgw_owner& owner, rgw_bucket& bucket, const RGWStorageStats& stats);
-  void async_refresh_fail(const rgw_owner& owner, rgw_bucket& bucket);
+  int get_stats(
+    const T& key,
+    RGWStorageStats& stats,
+    optional_yield y,
+    const DoutPrefixProvider* dpp);
+  void adjust_stats(
+    const rgw_owner &owner,
+    const rgw_bucket &bucket,
+    int objs_delta,
+    uint64_t added_bytes,
+    uint64_t removed_bytes);
+  void set_stats(
+    const T& key,
+    RGWQuotaCacheStats& qs,
+    const RGWStorageStats& stats);
+  int async_refresh(const T& key, RGWQuotaCacheStats& qs);
+  void async_refresh_response(const T& key, const RGWStorageStats& stats);
+  void async_refresh_fail(const T& key);
 
   /// start an async refresh that will eventually call async_refresh_response or
   /// async_refresh_fail. hold a reference to the waiter until completion
-  virtual int init_refresh(const rgw_owner& owner, const rgw_bucket& bucket,
-                           boost::intrusive_ptr<RefCountedWaitObject> waiter) = 0;
+  virtual int init_refresh(
+    const T& key, boost::intrusive_ptr<RefCountedWaitObject> waiter) = 0;
 };
 
 template<class T>
-int RGWQuotaCache<T>::async_refresh(const rgw_owner& owner, const rgw_bucket& bucket, RGWQuotaCacheStats& qs)
+int RGWQuotaCache<T>::async_refresh(const T &key, RGWQuotaCacheStats& qs)
 {
   /* protect against multiple updates */
   StatsAsyncTestSet test_update;
-  if (!map_find_and_update(owner, bucket, &test_update)) {
+  if (!map_find_and_update(key, &test_update)) {
     /* most likely we just raced with another update */
     return 0;
   }
 
-  return init_refresh(owner, bucket, async_refcount);
+  return init_refresh(key, async_refcount);
 }
 
 template<class T>
-void RGWQuotaCache<T>::async_refresh_fail(const rgw_owner& owner, rgw_bucket& bucket)
+void RGWQuotaCache<T>::async_refresh_fail(const T& key)
 {
-  ldout(driver->ctx(), 20) << "async stats refresh response for bucket=" << bucket << dendl;
+  ldout(driver->ctx(), 20) << "async stats refresh response for bucket=" << key << dendl;
 }
 
 template<class T>
-void RGWQuotaCache<T>::async_refresh_response(const rgw_owner& owner, rgw_bucket& bucket, const RGWStorageStats& stats)
+void RGWQuotaCache<T>::async_refresh_response(
+  const T& key,
+  const RGWStorageStats& stats)
 {
-  ldout(driver->ctx(), 20) << "async stats refresh response for bucket=" << bucket << dendl;
+  ldout(driver->ctx(), 20) << "async stats refresh response for bucket="
+    << key << dendl;
 
   RGWQuotaCacheStats qs;
 
-  map_find(owner, bucket, qs);
+  map_find(key, qs);
 
-  set_stats(owner, bucket, qs, stats);
+  set_stats(key, qs, stats);
 }
 
 template<class T>
-void RGWQuotaCache<T>::set_stats(const rgw_owner& owner, const rgw_bucket& bucket, RGWQuotaCacheStats& qs, const RGWStorageStats& stats)
+void RGWQuotaCache<T>::set_stats(
+  const T& key,
+  RGWQuotaCacheStats& qs,
+  const RGWStorageStats& stats)
 {
   qs.stats = stats;
   qs.expiration = ceph_clock_now();
@@ -137,16 +166,21 @@ void RGWQuotaCache<T>::set_stats(const rgw_owner& owner, const rgw_bucket& bucke
   qs.expiration += driver->ctx()->_conf->rgw_bucket_quota_ttl;
   qs.async_refresh_time += driver->ctx()->_conf->rgw_bucket_quota_ttl / 2;
 
-  map_add(owner, bucket, qs);
+  map_add(key, qs);
 }
 
 template<class T>
-int RGWQuotaCache<T>::get_stats(const rgw_owner& owner, const rgw_bucket& bucket, RGWStorageStats& stats, optional_yield y, const DoutPrefixProvider* dpp) {
+int RGWQuotaCache<T>::get_stats(
+  const T& key,
+  RGWStorageStats& stats,
+  optional_yield y,
+  const DoutPrefixProvider* dpp)
+{
   RGWQuotaCacheStats qs;
   utime_t now = ceph_clock_now();
-  if (map_find(owner, bucket, qs)) {
+  if (map_find(key, qs)) {
     if (qs.async_refresh_time.sec() > 0 && now >= qs.async_refresh_time) {
-      int r = async_refresh(owner, bucket, qs);
+      int r = async_refresh(key, qs);
       if (r < 0) {
         ldpp_dout(dpp, 0) << "ERROR: quota async refresh returned ret=" << r << dendl;
 
@@ -160,11 +194,11 @@ int RGWQuotaCache<T>::get_stats(const rgw_owner& owner, const rgw_bucket& bucket
     }
   }
 
-  int ret = fetch_stats_from_storage(owner, bucket, stats, y, dpp);
+  int ret = fetch_stats_from_storage(key, stats, y, dpp);
   if (ret < 0 && ret != -ENOENT)
     return ret;
 
-  set_stats(owner, bucket, qs, stats);
+  set_stats(key, qs, stats);
 
   return 0;
 }
@@ -212,40 +246,48 @@ public:
 
 
 template<class T>
-void RGWQuotaCache<T>::adjust_stats(const rgw_owner& owner, rgw_bucket& bucket, int objs_delta,
-                                 uint64_t added_bytes, uint64_t removed_bytes)
+void RGWQuotaCache<T>::adjust_stats(
+  const rgw_owner &owner,
+  const rgw_bucket &bucket,
+  int objs_delta,
+  uint64_t added_bytes,
+  uint64_t removed_bytes)
 {
   RGWQuotaStatsUpdate<T> update(objs_delta, added_bytes, removed_bytes);
-  map_find_and_update(owner, bucket, &update);
+  if constexpr (std::is_same_v<T, rgw_bucket>) {
+    map_find_and_update(bucket, &update);
+  } else {
+    static_assert(std::is_same_v<T, rgw_owner>);
+    map_find_and_update(owner, &update);
+  }
 
   data_modified(owner, bucket);
 }
 
 class RGWBucketStatsCache : public RGWQuotaCache<rgw_bucket> {
 protected:
-  bool map_find(const rgw_owner& owner, const rgw_bucket& bucket, RGWQuotaCacheStats& qs) override {
-    return stats_map.find(bucket, qs);
-  }
-
-  bool map_find_and_update(const rgw_owner& owner, const rgw_bucket& bucket, lru_map<rgw_bucket, RGWQuotaCacheStats>::UpdateContext *ctx) override {
-    return stats_map.find_and_update(bucket, NULL, ctx);
-  }
-
-  void map_add(const rgw_owner& owner, const rgw_bucket& bucket, RGWQuotaCacheStats& qs) override {
-    stats_map.add(bucket, qs);
-  }
-
-  int fetch_stats_from_storage(const rgw_owner& owner, const rgw_bucket& bucket, RGWStorageStats& stats, optional_yield y, const DoutPrefixProvider *dpp) override;
+  int fetch_stats_from_storage(
+    const rgw_bucket& bucket,
+    RGWStorageStats& stats,
+    optional_yield y,
+    const DoutPrefixProvider *dpp) override;
 
 public:
-  explicit RGWBucketStatsCache(rgw::sal::Driver* _driver) : RGWQuotaCache<rgw_bucket>(_driver, _driver->ctx()->_conf->rgw_bucket_quota_cache_size) {
-  }
+  explicit RGWBucketStatsCache(rgw::sal::Driver* _driver)
+    : RGWQuotaCache<rgw_bucket>(
+        _driver,
+        _driver->ctx()->_conf->rgw_bucket_quota_cache_size) {}
 
-  int init_refresh(const rgw_owner& owner, const rgw_bucket& bucket,
-                   boost::intrusive_ptr<RefCountedWaitObject> waiter) override;
+  int init_refresh(
+    const rgw_bucket& bucket,
+    boost::intrusive_ptr<RefCountedWaitObject> waiter) override;
 };
 
-int RGWBucketStatsCache::fetch_stats_from_storage(const rgw_owner& owner, const rgw_bucket& _b, RGWStorageStats& stats, optional_yield y, const DoutPrefixProvider *dpp)
+int RGWBucketStatsCache::fetch_stats_from_storage(
+  const rgw_bucket& _b,
+  RGWStorageStats& stats,
+  optional_yield y,
+  const DoutPrefixProvider *dpp)
 {
   std::unique_ptr<rgw::sal::Bucket> bucket;
 
@@ -288,27 +330,26 @@ int RGWBucketStatsCache::fetch_stats_from_storage(const rgw_owner& owner, const 
 class BucketAsyncRefreshHandler : public rgw::sal::ReadStatsCB {
   RGWBucketStatsCache* cache;
   boost::intrusive_ptr<RefCountedWaitObject> waiter;
-  rgw_owner owner;
   rgw_bucket bucket;
 public:
   BucketAsyncRefreshHandler(RGWBucketStatsCache* cache,
                             boost::intrusive_ptr<RefCountedWaitObject> waiter,
-                            const rgw_owner& owner, const rgw_bucket& bucket)
-    : cache(cache), waiter(std::move(waiter)), owner(owner), bucket(bucket) {}
+                            const rgw_bucket& bucket)
+    : cache(cache), waiter(std::move(waiter)), bucket(bucket) {}
 
   void handle_response(int r, const RGWStorageStats& stats) override {
     if (r < 0) {
-      cache->async_refresh_fail(owner, bucket);
+      cache->async_refresh_fail(bucket);
       return;
     }
 
-    cache->async_refresh_response(owner, bucket, stats);
+    cache->async_refresh_response(bucket, stats);
   }
 };
 
 
-int RGWBucketStatsCache::init_refresh(const rgw_owner& owner, const rgw_bucket& bucket,
-                                     boost::intrusive_ptr<RefCountedWaitObject> waiter)
+int RGWBucketStatsCache::init_refresh(
+  const rgw_bucket& bucket, boost::intrusive_ptr<RefCountedWaitObject> waiter)
 {
   std::unique_ptr<rgw::sal::Bucket> rbucket;
 
@@ -327,7 +368,7 @@ int RGWBucketStatsCache::init_refresh(const rgw_owner& owner, const rgw_bucket& 
   }
 
   boost::intrusive_ptr handler = new BucketAsyncRefreshHandler(
-      this, std::move(waiter), owner, bucket);
+      this, std::move(waiter), bucket);
 
   r = rbucket->read_stats_async(&dp, index, RGW_NO_SHARD, std::move(handler));
   if (r < 0) {
@@ -464,25 +505,24 @@ class RGWOwnerStatsCache : public RGWQuotaCache<rgw_owner> {
   OwnerSyncThread* user_sync_thread = nullptr;
   OwnerSyncThread* account_sync_thread = nullptr;
 protected:
-  bool map_find(const rgw_owner& owner,const rgw_bucket& bucket, RGWQuotaCacheStats& qs) override {
-    return stats_map.find(owner, qs);
-  }
-
-  bool map_find_and_update(const rgw_owner& owner, const rgw_bucket& bucket, lru_map<rgw_owner, RGWQuotaCacheStats>::UpdateContext *ctx) override {
-    return stats_map.find_and_update(owner, NULL, ctx);
-  }
-
-  void map_add(const rgw_owner& owner, const rgw_bucket& bucket, RGWQuotaCacheStats& qs) override {
-    stats_map.add(owner, qs);
-  }
-
-  int fetch_stats_from_storage(const rgw_owner& owner, const rgw_bucket& bucket, RGWStorageStats& stats, optional_yield y, const DoutPrefixProvider *dpp) override;
-  int sync_bucket(const rgw_owner& owner, const rgw_bucket& bucket, optional_yield y, const DoutPrefixProvider *dpp);
-  int sync_owner(const DoutPrefixProvider *dpp, const rgw_owner& owner, optional_yield y);
+  int fetch_stats_from_storage(
+    const rgw_owner& owner,
+    RGWStorageStats& stats,
+    optional_yield y,
+    const DoutPrefixProvider *dpp) override;
+  int sync_bucket(
+    const rgw_owner& owner,
+    const rgw_bucket& bucket,
+    optional_yield y,
+    const DoutPrefixProvider *dpp);
+  int sync_owner(
+    const DoutPrefixProvider *dpp,
+    const rgw_owner& owner,
+    optional_yield y);
   int sync_all_owners(const DoutPrefixProvider *dpp,
                       const std::string& metadata_section);
 
-  void data_modified(const rgw_owner& owner, const rgw_bucket& bucket) override;
+  void data_modified(const rgw_owner& owner, const rgw_bucket &bucket) override;
 
   void swap_modified_buckets(map<rgw_bucket, rgw_owner>& out) {
     std::unique_lock lock{mutex};
@@ -518,8 +558,9 @@ public:
     stop();
   }
 
-  int init_refresh(const rgw_owner& owner, const rgw_bucket& bucket,
-                   boost::intrusive_ptr<RefCountedWaitObject> waiter) override;
+  int init_refresh(
+    const rgw_owner& owner,
+    boost::intrusive_ptr<RefCountedWaitObject> waiter) override;
 
   bool going_down() {
     return down_flag;
@@ -539,23 +580,23 @@ public:
 class OwnerAsyncRefreshHandler : public rgw::sal::ReadStatsCB {
   RGWOwnerStatsCache* cache;
   boost::intrusive_ptr<RefCountedWaitObject> waiter;
-  rgw_bucket bucket;
   rgw_owner owner;
  public:
   OwnerAsyncRefreshHandler(RGWOwnerStatsCache* cache,
                            boost::intrusive_ptr<RefCountedWaitObject> waiter,
-                           const rgw_owner& owner, const rgw_bucket& bucket)
-      : cache(cache), waiter(std::move(waiter)), bucket(bucket), owner(owner)
+                           const rgw_owner& owner)
+      : cache(cache), waiter(std::move(waiter)), owner(owner)
   {}
 
   void handle_response(int r, const RGWStorageStats& stats) override;
 };
 
-int RGWOwnerStatsCache::init_refresh(const rgw_owner& owner, const rgw_bucket& bucket,
-                                     boost::intrusive_ptr<RefCountedWaitObject> waiter)
+int RGWOwnerStatsCache::init_refresh(
+  const rgw_owner& owner,
+  boost::intrusive_ptr<RefCountedWaitObject> waiter)
 {
   boost::intrusive_ptr cb = new OwnerAsyncRefreshHandler(
-      this, std::move(waiter), owner, bucket);
+      this, std::move(waiter), owner);
 
   ldpp_dout(dpp, 20) << "initiating async quota refresh for owner=" << owner << dendl;
 
@@ -571,18 +612,18 @@ int RGWOwnerStatsCache::init_refresh(const rgw_owner& owner, const rgw_bucket& b
 void OwnerAsyncRefreshHandler::handle_response(int r, const RGWStorageStats& stats)
 {
   if (r < 0) {
-    cache->async_refresh_fail(owner, bucket);
+    cache->async_refresh_fail(owner);
     return;
   }
 
-  cache->async_refresh_response(owner, bucket, stats);
+  cache->async_refresh_response(owner, stats);
 }
 
-int RGWOwnerStatsCache::fetch_stats_from_storage(const rgw_owner& owner,
-                                                 const rgw_bucket& bucket,
-                                                 RGWStorageStats& stats,
-                                                 optional_yield y,
-                                                 const DoutPrefixProvider *dpp)
+int RGWOwnerStatsCache::fetch_stats_from_storage(
+  const rgw_owner& owner,
+  RGWStorageStats& stats,
+  optional_yield y,
+  const DoutPrefixProvider *dpp)
 {
   ceph::real_time synced; // ignored
   ceph::real_time updated; // ignored
@@ -950,7 +991,7 @@ public:
     const DoutPrefix dp(driver->ctx(), dout_subsys, "rgw quota handler: ");
     if (quota.bucket_quota.enabled) {
       RGWStorageStats bucket_stats;
-      int ret = bucket_stats_cache.get_stats(owner, bucket, bucket_stats, y, &dp);
+      int ret = bucket_stats_cache.get_stats(bucket, bucket_stats, y, &dp);
       if (ret < 0) {
         return ret;
       }
@@ -962,7 +1003,7 @@ public:
 
     if (quota.user_quota.enabled) {
       RGWStorageStats owner_stats;
-      int ret = owner_stats_cache.get_stats(owner, bucket, owner_stats, y, &dp);
+      int ret = owner_stats_cache.get_stats(owner, owner_stats, y, &dp);
       if (ret < 0) {
         return ret;
       }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -17,7 +17,7 @@
 #include "include/function2.hpp"
 #include "include/utime.h"
 #include "common/Clock.h" // for ceph_clock_now()
-#include "common/lru_map.h"
+#include "common/intrusive_lru.h"
 #include "common/RefCountedObj.h"
 #include "common/Thread.h"
 #include "common/ceph_mutex.h"
@@ -37,58 +37,69 @@
 
 using namespace std;
 
-struct RGWQuotaCacheStats {
+// RQCS: abbreviation of RGWQuotaCacheStats
+template <typename RQCS, typename Key>
+struct rqcs_to_key {
+  using type = Key;
+  const Key &operator()(const RQCS &rqcs) {
+    return rqcs.key;
+  }
+};
+
+template <typename Key>
+struct RGWQuotaCacheStats
+  : public ceph::common::intrusive_lru_base<
+      ceph::common::intrusive_lru_config<
+        Key,
+        RGWQuotaCacheStats<Key>,
+        rqcs_to_key<RGWQuotaCacheStats<Key>, Key>>> {
+  Key key;
   RGWStorageStats stats;
   utime_t expiration;
   utime_t async_refresh_time;
+  explicit RGWQuotaCacheStats(const Key &key) : key(key) {}
 };
+template <typename Key>
+using RGWQuotaCacheStatsRef = RGWQuotaCacheStats<Key>::Ref;
+
+template <typename Key>
+using RGWQuotaCacheStatsConfig =
+  ceph::common::intrusive_lru_config<
+    Key,
+    RGWQuotaCacheStats<Key>,
+    rqcs_to_key<RGWQuotaCacheStats<Key>, Key>>;
 
 template<class T>
 class RGWQuotaCache {
 protected:
   rgw::sal::Driver* driver;
-  lru_map<T, RGWQuotaCacheStats> stats_map;
+  ceph::mutex stats_lock;
+  ceph::common::intrusive_lru<RGWQuotaCacheStatsConfig<T>> stats_set;
   RefCountedWaitObject *async_refcount;
 
-  class StatsAsyncTestSet : public lru_map<T, RGWQuotaCacheStats>::UpdateContext {
-    int objs_delta;
-    uint64_t added_bytes;
-    uint64_t removed_bytes;
-  public:
-    StatsAsyncTestSet() : objs_delta(0), added_bytes(0), removed_bytes(0) {}
-    bool update(RGWQuotaCacheStats *entry) override {
-      if (entry->async_refresh_time.sec() == 0)
-        return false;
-
-      entry->async_refresh_time = utime_t(0, 0);
-
-      return true;
-    }
-  };
-
+  using stats_update_func_t = std::function<bool (RGWQuotaCacheStats<T>&)>;
   virtual int fetch_stats_from_storage(
     const T& key,
     RGWStorageStats& stats,
     optional_yield y,
     const DoutPrefixProvider *dpp) = 0;
-  bool map_find(
-    const T& key,
-    RGWQuotaCacheStats& qs) {
-    return stats_map.find(key, qs);
-  }
-  bool map_find_and_update(
-    const T& key,
-    typename lru_map<T, RGWQuotaCacheStats>::UpdateContext *ctx) {
-    return stats_map.find_and_update(key, NULL, ctx);
-  }
-  void map_add(
-    const T& key,
-    RGWQuotaCacheStats& qs) {
-    stats_map.add(key, qs);
+  std::pair<RGWQuotaCacheStatsRef<T>, bool>
+  get_or_create_stats(const T& key) {
+    std::lock_guard l(stats_lock);
   }
   virtual void data_modified(const rgw_owner& owner, const rgw_bucket &bucket) {}
+  bool update(
+    RGWQuotaCacheStats<T> &entry,
+    int objs_delta,
+    uint64_t added_bytes,
+    uint64_t removed_bytes);
+
 public:
-  RGWQuotaCache(rgw::sal::Driver* _driver, int size) : driver(_driver), stats_map(size) {
+  RGWQuotaCache(rgw::sal::Driver* _driver, int size)
+    : driver(_driver),
+      stats_lock(ceph::make_mutex("RGWQuotaCache::stats_lock"))
+  {
+    stats_set.set_target_size(size);
     async_refcount = new RefCountedWaitObject;
   }
   virtual ~RGWQuotaCache() {
@@ -108,30 +119,21 @@ public:
     uint64_t removed_bytes);
   void set_stats(
     const T& key,
-    RGWQuotaCacheStats& qs,
+    RGWQuotaCacheStats<T>& qs,
     const RGWStorageStats& stats);
-  int async_refresh(const T& key, RGWQuotaCacheStats& qs);
-  void async_refresh_response(const T& key, const RGWStorageStats& stats);
+  void async_refresh_response(
+    const T& key,
+    const RGWStorageStats& stats,
+    RGWQuotaCacheStats<T> &qs);
   void async_refresh_fail(const T& key);
 
   /// start an async refresh that will eventually call async_refresh_response or
   /// async_refresh_fail. hold a reference to the waiter until completion
   virtual int init_refresh(
-    const T& key, boost::intrusive_ptr<RefCountedWaitObject> waiter) = 0;
+    const T& key,
+    boost::intrusive_ptr<RefCountedWaitObject> waiter,
+    RGWQuotaCacheStats<T> &) = 0;
 };
-
-template<class T>
-int RGWQuotaCache<T>::async_refresh(const T &key, RGWQuotaCacheStats& qs)
-{
-  /* protect against multiple updates */
-  StatsAsyncTestSet test_update;
-  if (!map_find_and_update(key, &test_update)) {
-    /* most likely we just raced with another update */
-    return 0;
-  }
-
-  return init_refresh(key, async_refcount);
-}
 
 template<class T>
 void RGWQuotaCache<T>::async_refresh_fail(const T& key)
@@ -142,22 +144,21 @@ void RGWQuotaCache<T>::async_refresh_fail(const T& key)
 template<class T>
 void RGWQuotaCache<T>::async_refresh_response(
   const T& key,
-  const RGWStorageStats& stats)
+  const RGWStorageStats& stats,
+  RGWQuotaCacheStats<T> &qs)
 {
   ldout(driver->ctx(), 20) << "async stats refresh response for bucket="
     << key << dendl;
-
-  RGWQuotaCacheStats qs;
-
-  map_find(key, qs);
-
-  set_stats(key, qs, stats);
+  {
+    std::lock_guard l(stats_lock);
+    set_stats(key, qs, stats);
+  }
 }
 
 template<class T>
 void RGWQuotaCache<T>::set_stats(
   const T& key,
-  RGWQuotaCacheStats& qs,
+  RGWQuotaCacheStats<T>& qs,
   const RGWStorageStats& stats)
 {
   qs.stats = stats;
@@ -165,8 +166,6 @@ void RGWQuotaCache<T>::set_stats(
   qs.async_refresh_time = qs.expiration;
   qs.expiration += driver->ctx()->_conf->rgw_bucket_quota_ttl;
   qs.async_refresh_time += driver->ctx()->_conf->rgw_bucket_quota_ttl / 2;
-
-  map_add(key, qs);
 }
 
 template<class T>
@@ -176,74 +175,93 @@ int RGWQuotaCache<T>::get_stats(
   optional_yield y,
   const DoutPrefixProvider* dpp)
 {
-  RGWQuotaCacheStats qs;
-  utime_t now = ceph_clock_now();
-  if (map_find(key, qs)) {
-    if (qs.async_refresh_time.sec() > 0 && now >= qs.async_refresh_time) {
-      int r = async_refresh(key, qs);
-      if (r < 0) {
-        ldpp_dout(dpp, 0) << "ERROR: quota async refresh returned ret=" << r << dendl;
-
-        /* continue processing, might be a transient error, async refresh is just optimization */
-      }
-    }
-
-    if (qs.expiration > ceph_clock_now()) {
-      stats = qs.stats;
-      return 0;
+  bool do_async_refresh = false;
+  bool do_fetch_stats = false;
+  RGWQuotaCacheStatsRef<T> rqcs_ref;
+  {
+    std::lock_guard l(stats_lock);
+    auto [qs_ref, found] = stats_set.get_or_create(key);
+    auto now = ceph_clock_now();
+    rqcs_ref = qs_ref;
+    auto &qs = *qs_ref;
+    do_fetch_stats = (!found) || (qs.expiration <= now);
+    do_async_refresh =
+      (found) &&
+      qs.async_refresh_time.sec() > 0 &&
+      now >= qs.async_refresh_time;
+    if (do_async_refresh) {
+      qs.async_refresh_time = utime_t{0, 0};
     }
   }
 
-  int ret = fetch_stats_from_storage(key, stats, y, dpp);
-  if (ret < 0 && ret != -ENOENT)
-    return ret;
+  if (do_async_refresh) {
+    ldout(driver->ctx(), 20) << "refreshing stats for "
+      << rqcs_ref->key << dendl;
+    int r = init_refresh(key, async_refcount, *rqcs_ref);
+    if (r < 0) {
+      ldpp_dout(dpp, 0)
+        << "ERROR: quota async refresh returned ret="
+        << r << dendl;
+      /* continue processing, might be a transient error,
+       * async refresh is just optimization */
+    }
+  }
 
-  set_stats(key, qs, stats);
+  if (do_fetch_stats) {
+    ldout(driver->ctx(), 20) << "fetching stats for " << rqcs_ref->key << dendl;
+    int ret = fetch_stats_from_storage(key, stats, y, dpp);
+    if (ret < 0 && ret != -ENOENT)
+      return ret;
 
+    {
+      std::lock_guard l(stats_lock);
+      set_stats(key, *rqcs_ref, stats);
+    }
+    ldout(driver->ctx(), 20) << "fetched stats for " << rqcs_ref->key << dendl;
+    return 0;
+  }
+
+  ldout(driver->ctx(), 20) << "cached stats for "
+    << rqcs_ref->key << " still valid" << dendl;
+  {
+    std::lock_guard l(stats_lock);
+    stats = rqcs_ref->stats;
+  }
   return 0;
 }
 
+template <typename T>
+bool RGWQuotaCache<T>::update(
+  RGWQuotaCacheStats<T> &entry,
+  int objs_delta,
+  uint64_t added_bytes,
+  uint64_t removed_bytes)
+{
+  const uint64_t rounded_added = rgw_rounded_objsize(added_bytes);
+  const uint64_t rounded_removed = rgw_rounded_objsize(removed_bytes);
 
-template<class T>
-class RGWQuotaStatsUpdate : public lru_map<T, RGWQuotaCacheStats>::UpdateContext {
-  const int objs_delta;
-  const uint64_t added_bytes;
-  const uint64_t removed_bytes;
-public:
-  RGWQuotaStatsUpdate(const int objs_delta,
-                      const uint64_t added_bytes,
-                      const uint64_t removed_bytes)
-    : objs_delta(objs_delta),
-      added_bytes(added_bytes),
-      removed_bytes(removed_bytes) {
+  if (auto s = ((int64_t)(entry.stats.size + added_bytes - removed_bytes));
+      s >= 0) {
+    entry.stats.size += added_bytes - removed_bytes;
+  } else {
+    entry.stats.size = 0;
   }
 
-  bool update(RGWQuotaCacheStats * const entry) override {
-    const uint64_t rounded_added = rgw_rounded_objsize(added_bytes);
-    const uint64_t rounded_removed = rgw_rounded_objsize(removed_bytes);
-
-    if (((int64_t)(entry->stats.size + added_bytes - removed_bytes)) >= 0) {
-      entry->stats.size += added_bytes - removed_bytes;
-    } else {
-      entry->stats.size = 0;
-    }
-
-    if (((int64_t)(entry->stats.size_rounded + rounded_added - rounded_removed)) >= 0) {
-      entry->stats.size_rounded += rounded_added - rounded_removed;
-    } else {
-      entry->stats.size_rounded = 0;
-    }
-
-    if (((int64_t)(entry->stats.num_objects + objs_delta)) >= 0) {
-      entry->stats.num_objects += objs_delta;
-    } else {
-      entry->stats.num_objects = 0;
-    }
-
-    return true;
+  if (auto s =((int64_t)(entry.stats.size_rounded + rounded_added - rounded_removed));
+      s >= 0) {
+    entry.stats.size_rounded += rounded_added - rounded_removed;
+  } else {
+    entry.stats.size_rounded = 0;
   }
-};
 
+  if (((int64_t)(entry.stats.num_objects + objs_delta)) >= 0) {
+    entry.stats.num_objects += objs_delta;
+  } else {
+    entry.stats.num_objects = 0;
+  }
+
+  return true;
+}
 
 template<class T>
 void RGWQuotaCache<T>::adjust_stats(
@@ -253,14 +271,20 @@ void RGWQuotaCache<T>::adjust_stats(
   uint64_t added_bytes,
   uint64_t removed_bytes)
 {
-  RGWQuotaStatsUpdate<T> update(objs_delta, added_bytes, removed_bytes);
-  if constexpr (std::is_same_v<T, rgw_bucket>) {
-    map_find_and_update(bucket, &update);
-  } else {
-    static_assert(std::is_same_v<T, rgw_owner>);
-    map_find_and_update(owner, &update);
-  }
+  {
+    std::lock_guard l(stats_lock);
+    RGWQuotaCacheStatsRef<T> rqcs_ref;
+    if constexpr (std::is_same_v<T, rgw_bucket>) {
+      rqcs_ref = stats_set.get(bucket);
+    } else {
+      static_assert(std::is_same_v<T, rgw_owner>);
+      rqcs_ref = stats_set.get(owner);
+    }
 
+    if (rqcs_ref) {
+      update(*rqcs_ref, objs_delta, added_bytes, removed_bytes);
+    }
+  }
   data_modified(owner, bucket);
 }
 
@@ -280,7 +304,8 @@ public:
 
   int init_refresh(
     const rgw_bucket& bucket,
-    boost::intrusive_ptr<RefCountedWaitObject> waiter) override;
+    boost::intrusive_ptr<RefCountedWaitObject> waiter,
+    RGWQuotaCacheStats<rgw_bucket> &qs) override;
 };
 
 int RGWBucketStatsCache::fetch_stats_from_storage(
@@ -331,11 +356,16 @@ class BucketAsyncRefreshHandler : public rgw::sal::ReadStatsCB {
   RGWBucketStatsCache* cache;
   boost::intrusive_ptr<RefCountedWaitObject> waiter;
   rgw_bucket bucket;
+  RGWQuotaCacheStats<rgw_bucket> &qs;
 public:
   BucketAsyncRefreshHandler(RGWBucketStatsCache* cache,
                             boost::intrusive_ptr<RefCountedWaitObject> waiter,
-                            const rgw_bucket& bucket)
-    : cache(cache), waiter(std::move(waiter)), bucket(bucket) {}
+                            const rgw_bucket& bucket,
+                            RGWQuotaCacheStats<rgw_bucket> &qs)
+    : cache(cache),
+      waiter(std::move(waiter)),
+      bucket(bucket),
+      qs(qs) {}
 
   void handle_response(int r, const RGWStorageStats& stats) override {
     if (r < 0) {
@@ -343,13 +373,15 @@ public:
       return;
     }
 
-    cache->async_refresh_response(bucket, stats);
+    cache->async_refresh_response(bucket, stats, qs);
   }
 };
 
 
 int RGWBucketStatsCache::init_refresh(
-  const rgw_bucket& bucket, boost::intrusive_ptr<RefCountedWaitObject> waiter)
+  const rgw_bucket& bucket,
+  boost::intrusive_ptr<RefCountedWaitObject> waiter,
+  RGWQuotaCacheStats<rgw_bucket> &qs)
 {
   std::unique_ptr<rgw::sal::Bucket> rbucket;
 
@@ -368,7 +400,7 @@ int RGWBucketStatsCache::init_refresh(
   }
 
   boost::intrusive_ptr handler = new BucketAsyncRefreshHandler(
-      this, std::move(waiter), bucket);
+      this, std::move(waiter), bucket, qs);
 
   r = rbucket->read_stats_async(&dp, index, RGW_NO_SHARD, std::move(handler));
   if (r < 0) {
@@ -560,7 +592,8 @@ public:
 
   int init_refresh(
     const rgw_owner& owner,
-    boost::intrusive_ptr<RefCountedWaitObject> waiter) override;
+    boost::intrusive_ptr<RefCountedWaitObject> waiter,
+    RGWQuotaCacheStats<rgw_owner> &qs) override;
 
   bool going_down() {
     return down_flag;
@@ -581,11 +614,13 @@ class OwnerAsyncRefreshHandler : public rgw::sal::ReadStatsCB {
   RGWOwnerStatsCache* cache;
   boost::intrusive_ptr<RefCountedWaitObject> waiter;
   rgw_owner owner;
+  RGWQuotaCacheStats<rgw_owner> &qs;
  public:
   OwnerAsyncRefreshHandler(RGWOwnerStatsCache* cache,
                            boost::intrusive_ptr<RefCountedWaitObject> waiter,
-                           const rgw_owner& owner)
-      : cache(cache), waiter(std::move(waiter)), owner(owner)
+                           const rgw_owner& owner,
+                          RGWQuotaCacheStats<rgw_owner> &qs)
+      : cache(cache), waiter(std::move(waiter)), owner(owner), qs(qs)
   {}
 
   void handle_response(int r, const RGWStorageStats& stats) override;
@@ -593,10 +628,11 @@ class OwnerAsyncRefreshHandler : public rgw::sal::ReadStatsCB {
 
 int RGWOwnerStatsCache::init_refresh(
   const rgw_owner& owner,
-  boost::intrusive_ptr<RefCountedWaitObject> waiter)
+  boost::intrusive_ptr<RefCountedWaitObject> waiter,
+  RGWQuotaCacheStats<rgw_owner> &qs)
 {
   boost::intrusive_ptr cb = new OwnerAsyncRefreshHandler(
-      this, std::move(waiter), owner);
+      this, std::move(waiter), owner, qs);
 
   ldpp_dout(dpp, 20) << "initiating async quota refresh for owner=" << owner << dendl;
 
@@ -616,7 +652,7 @@ void OwnerAsyncRefreshHandler::handle_response(int r, const RGWStorageStats& sta
     return;
   }
 
-  cache->async_refresh_response(owner, stats);
+  cache->async_refresh_response(owner, stats, qs);
 }
 
 int RGWOwnerStatsCache::fetch_stats_from_storage(


### PR DESCRIPTION
Before this PR, RGWQuotaCache::get_stats only avoids duplicated stats refreshing, but there can still be concurrent stats fetching, or concurrent stats fetching and refreshing, for the same bucket.

This commit refactors `RGWQuotaCache` related code and makes sure that there can be at most one ongoing stats fetching or refreshing at any time.

Fixes: https://tracker.ceph.com/issues/80598
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
