### PR TITLE
squid: mgr/PyFormatter: prevent segfault on non-printable characters

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -720,7 +720,15 @@ PyObject *ActivePyModules::get_store_prefix(const std::string &module_name,
   PyFormatter f;
   for (auto p = store_cache.lower_bound(global_prefix);
        p != store_cache.end() && p->first.find(global_prefix) == 0; ++p) {
-    f.dump_string(p->first.c_str() + base_prefix.size(), p->second);
+    PyObject *value = PyUnicode_FromStringAndSize(
+      p->second.c_str(), p->second.size());
+    if (!value) {
+      dout(1) << __func__ << " skipping key " << p->first
+              << " due to PyUnicode_FromStringAndSize failure" << dendl;
+      PyErr_Clear();
+      continue;
+    }
+    f.dump_pyobject(p->first.substr(base_prefix.size()).c_str(), value);
   }
   return f.get();
 }

--- a/src/mgr/PyFormatter.cc
+++ b/src/mgr/PyFormatter.cc
@@ -63,7 +63,12 @@ void PyFormatter::dump_float(std::string_view name, double d)
 
 void PyFormatter::dump_string(std::string_view name, std::string_view s)
 {
-  dump_pyobject(name, PyUnicode_FromString(s.data()));
+  PyObject *p = PyUnicode_FromStringAndSize(s.data(), s.size());
+  if (!p) {
+    PyErr_Clear();
+    return;
+  }
+  dump_pyobject(name, p);
 }
 
 void PyFormatter::dump_bool(std::string_view name, bool b)
@@ -104,6 +109,9 @@ void PyFormatter::dump_format_va(std::string_view name, const char *ns, bool quo
  */
 void PyFormatter::dump_pyobject(std::string_view name, PyObject *p)
 {
+  if (!p) {
+    ceph_abort_msg("PyFormatter::dump_pyobject received null PyObject");
+  }
   if (PyList_Check(cursor)) {
     PyList_Append(cursor, p);
     Py_DECREF(p);

--- a/src/mgr/PyFormatter.h
+++ b/src/mgr/PyFormatter.h
@@ -124,12 +124,12 @@ public:
 
   void finish_pending_streams();
 
+  void dump_pyobject(std::string_view name, PyObject *p);
+
 private:
   PyObject *root;
   PyObject *cursor;
   std::stack<PyObject *> stack;
-
-  void dump_pyobject(std::string_view name, PyObject *p);
 
   class PendingStream {
     public:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80036

---

backport of https://github.com/ceph/ceph/pull/67022
parent tracker: https://tracker.ceph.com/issues/74379

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh