### PR TITLE
umbrella: mgr/PyFormatter: prevent segfault on non-printable characters

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -759,7 +759,15 @@ PyObject *ActivePyModules::get_store_prefix(const std::string &module_name,
   PyFormatter f;
   for (auto p = store_cache.lower_bound(global_prefix);
        p != store_cache.end() && p->first.find(global_prefix) == 0; ++p) {
-    f.dump_string(p->first.c_str() + base_prefix.size(), p->second);
+    PyObject *value = PyUnicode_FromStringAndSize(
+      p->second.c_str(), p->second.size());
+    if (!value) {
+      dout(1) << __func__ << " skipping key " << p->first
+              << " due to PyUnicode_FromStringAndSize failure" << dendl;
+      PyErr_Clear();
+      continue;
+    }
+    f.dump_pyobject(p->first.substr(base_prefix.size()).c_str(), value);
   }
   return f.get();
 }

--- a/src/mgr/PyFormatter.cc
+++ b/src/mgr/PyFormatter.cc
@@ -71,7 +71,12 @@ void PyFormatter::dump_float(std::string_view name, double d)
 
 void PyFormatter::dump_string(std::string_view name, std::string_view s)
 {
-  dump_pyobject(name, PyUnicode_FromString(s.data()));
+  PyObject *p = PyUnicode_FromStringAndSize(s.data(), s.size());
+  if (!p) {
+    PyErr_Clear();
+    return;
+  }
+  dump_pyobject(name, p);
 }
 
 void PyFormatter::dump_bool(std::string_view name, bool b)
@@ -112,6 +117,9 @@ void PyFormatter::dump_format_va(std::string_view name, const char *ns, bool quo
  */
 void PyFormatter::dump_pyobject(std::string_view name, PyObject *p)
 {
+  if (!p) {
+    ceph_abort_msg("PyFormatter::dump_pyobject received null PyObject");
+  }
   if (PyList_Check(cursor)) {
     PyList_Append(cursor, p);
     Py_DECREF(p);

--- a/src/mgr/PyFormatter.h
+++ b/src/mgr/PyFormatter.h
@@ -125,11 +125,12 @@ public:
 
   void finish_pending_streams();
 
+  void dump_pyobject(std::string_view name, PyObject *p);
+
 protected:
   PyObject *root;
   PyObject *cursor;
   std::stack<PyObject *> stack;
-  void dump_pyobject(std::string_view name, PyObject *p);
 private:
   class PendingStream {
     public:

--- a/src/test/mgr/test_pyformatter.cc
+++ b/src/test/mgr/test_pyformatter.cc
@@ -373,6 +373,76 @@ TEST(PyFormatter, EmptySectionName)
 
 /* End Negative Tests */
 
+TEST(PyFormatter, DumpPyObject_StoresPrebuiltObject)
+{
+  // Verify that dump_pyobject inserts a caller-owned PyObject into the dict
+  // without re-encoding, which is the pattern used in get_store_prefix.
+  PyFormatter py_f;
+  PyObject *value = PyUnicode_FromString("hello");
+  ASSERT_NE(value, nullptr);
+  py_f.dump_pyobject("key", value);
+
+  PyObject *result = py_f.get();
+  ASSERT_NE(result, nullptr);
+  ASSERT_TRUE(PyDict_Check(result));
+
+  PyObject *item = PyDict_GetItemString(result, "key");
+  ASSERT_NE(item, nullptr);
+  ASSERT_TRUE(PyUnicode_Check(item));
+  ASSERT_STREQ(PyUnicode_AsUTF8(item), "hello");
+
+  Py_DECREF(result);
+}
+
+TEST(PyFormatter, DumpString_SkipsNonUtf8Value)
+{
+  // dump_string uses PyUnicode_FromStringAndSize which fails on invalid UTF-8.
+  // The method must not crash and must simply skip the key.
+  PyFormatter py_f;
+  // "\x80\xff" is invalid UTF-8
+  std::string bad_utf8("\x80\xff", 2);
+  py_f.dump_string("bad_key", bad_utf8);
+
+  PyObject *result = py_f.get();
+  ASSERT_NE(result, nullptr);
+  ASSERT_TRUE(PyDict_Check(result));
+
+  // Key must be absent — dump_string skips on encoding failure
+  PyObject *item = PyDict_GetItemString(result, "bad_key");
+  ASSERT_EQ(item, nullptr);
+
+  Py_DECREF(result);
+}
+
+TEST(PyFormatter, DumpPyObject_NonUtf8ViLatin1Fallback)
+{
+  // This is the pattern used in get_store_prefix to handle crash metadata
+  // containing non-printable / non-UTF-8 bytes: try UTF-8, fall back to
+  // Latin-1, then call dump_pyobject directly with the validated PyObject*.
+  PyFormatter py_f;
+  std::string bad_utf8("\x80\xff", 2);
+
+  PyObject *value = PyUnicode_FromStringAndSize(bad_utf8.c_str(), bad_utf8.size());
+  if (!value) {
+    PyErr_Clear();
+    value = PyUnicode_DecodeLatin1(bad_utf8.c_str(), bad_utf8.size(), nullptr);
+  }
+  ASSERT_NE(value, nullptr);  // Latin-1 must always succeed
+  py_f.dump_pyobject("latin1_key", value);
+
+  PyObject *result = py_f.get();
+  ASSERT_NE(result, nullptr);
+  ASSERT_TRUE(PyDict_Check(result));
+
+  // Key must be present — Latin-1 fallback succeeded
+  PyObject *item = PyDict_GetItemString(result, "latin1_key");
+  ASSERT_NE(item, nullptr);
+  ASSERT_TRUE(PyUnicode_Check(item));
+
+  Py_DECREF(result);
+}
+
+
 /*
  * Tests for PyFormatterRO (read-only-on-the-fly builder):
  *  - lists -> tuples, sets -> frozensets


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80037

---

backport of https://github.com/ceph/ceph/pull/67022
parent tracker: https://tracker.ceph.com/issues/74379

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh