### PR TITLE
rgw/dedup: defer EC pool alignment check to dedup request time

### DIFF
--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -383,25 +383,19 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  int Background::init_rados_access_handles(bool init_pool)
+  // Detect whether the data pool supports truncate (needed for split-head).
+  // EC pools without allow_ec_overwrites reject TRUNCATE with -EOPNOTSUPP.
+  // We only check the default placement pool because the BI filter applies
+  // exclusively to RGW_STORAGE_CLASS_STANDARD objects, which always reside
+  // in the default placement's data pool. Non-default storage classes have
+  // an empty head and skip the filter entirely.
+  static int detect_pool_alignment(rgw::sal::RadosStore* store,
+                                   const DoutPrefixProvider* dpp,
+                                   bool* p_pool_supports_truncate /* OUT-PARAM */)
   {
-    store = dynamic_cast<rgw::sal::RadosStore*>(driver);
-    if (!store) {
-      ldpp_dout(dpp, 0) << "ERR: failed dynamic_cast to RadosStore" << dendl;
-      // this is the return code used in rgw_bucket.cc
-      return -ENOTSUP;
-    }
+    auto p_rados_handle = store->getRados()->get_rados_handle();
 
-    rados = store->getRados();
-    rados_handle = rados->get_rados_handle();
-
-    // Detect whether the data pool supports truncate (needed for split-head).
-    // EC pools without allow_ec_overwrites reject TRUNCATE with -EOPNOTSUPP.
-    // We only check the default placement pool because the BI filter applies
-    // exclusively to RGW_STORAGE_CLASS_STANDARD objects, which always reside
-    // in the default placement's data pool. Non-default storage classes have
-    // an empty head and skip the filter entirely.
-    d_pool_supports_truncate = true;
+    *p_pool_supports_truncate = true;
     const auto& zone_params = store->svc()->zone->get_zone_params();
     const auto& zonegroup = store->svc()->zone->get_zonegroup();
     const std::string& default_placement_name = zonegroup.default_placement.name;
@@ -410,7 +404,7 @@ namespace rgw::dedup {
       const rgw_pool& data_pool = it->second.get_standard_data_pool();
       if (!data_pool.name.empty()) {
         librados::IoCtx data_ioctx;
-        int ret = rgw_init_ioctx(dpp, rados_handle, data_pool, data_ioctx);
+        int ret = rgw_init_ioctx(dpp, p_rados_handle, data_pool, data_ioctx);
         if (ret < 0) {
           ldpp_dout(dpp, 5) << __func__ << "::failed to open default data pool "
                             << data_pool.name << ": " << cpp_strerror(-ret) << dendl;
@@ -426,7 +420,7 @@ namespace rgw::dedup {
         }
 
         if (requires_alignment) {
-          d_pool_supports_truncate = false;
+          *p_pool_supports_truncate = false;
           ldpp_dout(dpp, 5) << __func__ << "::default data pool " << data_pool.name
                             << " is EC without allow_ec_overwrites, "
                             << "disabling split-head" << dendl;
@@ -443,6 +437,22 @@ namespace rgw::dedup {
                         << default_placement_name << ") has no valid pool" << dendl;
       return -ENOENT;
     }
+
+    return 0;
+  }
+
+  //---------------------------------------------------------------------------
+  int Background::init_rados_access_handles(bool init_pool)
+  {
+    store = dynamic_cast<rgw::sal::RadosStore*>(driver);
+    if (!store) {
+      ldpp_dout(dpp, 0) << "ERR: failed dynamic_cast to RadosStore" << dendl;
+      // this is the return code used in rgw_bucket.cc
+      return -ENOTSUP;
+    }
+
+    rados = store->getRados();
+    rados_handle = rados->get_rados_handle();
 
     if (init_pool) {
       int ret = init_dedup_pool_ioctx(store, dpp, d_dedup_cluster_ioctx);
@@ -3566,6 +3576,7 @@ namespace rgw::dedup {
     // 256x8KB=2MB
     const uint64_t PER_SHARD_BUFFER_SIZE = DISK_BLOCK_COUNT *sizeof(disk_block_t);
     ldpp_dout(dpp, 20) <<__func__ << "::dedup::main loop" << dendl;
+    bool has_default_placement_pool = false;
 
     while (!d_ctl.shutdown_req) {
       if (unlikely(d_ctl.should_pause())) {
@@ -3588,37 +3599,55 @@ namespace rgw::dedup {
           ldpp_dout(dpp, 1) << __func__ << "::bad pool_id" << dendl;
           return;
         }
-        work_shard_t num_work_shards = epoch.num_work_shards;
-        md5_shard_t  num_md5_shards  = epoch.num_md5_shards;
-        const uint64_t RAW_MEM_SIZE = PER_SHARD_BUFFER_SIZE * num_md5_shards;
-        ldpp_dout(dpp, 5) <<__func__ << "::RAW_MEM_SIZE=" << RAW_MEM_SIZE
-                          << "::num_work_shards=" << num_work_shards
-                          << "::num_md5_shards=" << num_md5_shards << dendl;
-        // DEDUP_DYN_ALLOC
-        auto raw_mem = std::make_unique<uint8_t[]>(RAW_MEM_SIZE);
-        if (raw_mem == nullptr) {
-          ldpp_dout(dpp, 1) << "failed slab memory allocation - size=" << RAW_MEM_SIZE << dendl;
-          return;
-        }
 
-        process_all_shards(true, &Background::f_ingress_work_shard, raw_mem.get(),
-                           RAW_MEM_SIZE, num_work_shards, num_md5_shards);
-        if (!d_ctl.should_stop()) {
-          // Wait for all other workers to finish ingress step
-          work_shards_barrier(num_work_shards);
-          if (!d_ctl.should_stop()) {
-            process_all_shards(false, &Background::f_dedup_md5_shard, raw_mem.get(),
-                               RAW_MEM_SIZE, num_work_shards, num_md5_shards);
-            // Wait for all other md5 shards to finish
-            md5_shards_barrier(num_md5_shards);
-            safe_pool_delete(store, dpp, pool_id);
+        if (!has_default_placement_pool) {
+          int ret = detect_pool_alignment(store, dpp, &d_pool_supports_truncate);
+          if (ret == 0) {
+            has_default_placement_pool = true;
+          }
+          else if (ret != -ENOENT) {
+            ldpp_dout(dpp, 1) << __func__ << "::ERR: Failed detect_pool_alignment -> exit" << dendl;
+            return;
           }
           else {
-            ldpp_dout(dpp, 5) <<__func__ << "::stop req from barrier" << dendl;
+            ldpp_dout(dpp, 1) << __func__ << "::default placement pool does not exist"
+                              << " -> There is nothing to dedup yet" << dendl;
           }
         }
-        else {
-          ldpp_dout(dpp, 5) <<__func__ << "::stop req from ingress_work_shard" << dendl;
+
+        if (has_default_placement_pool) {
+          work_shard_t num_work_shards = epoch.num_work_shards;
+          md5_shard_t  num_md5_shards  = epoch.num_md5_shards;
+          const uint64_t RAW_MEM_SIZE = PER_SHARD_BUFFER_SIZE * num_md5_shards;
+          ldpp_dout(dpp, 5) <<__func__ << "::RAW_MEM_SIZE=" << RAW_MEM_SIZE
+                            << "::num_work_shards=" << num_work_shards
+                            << "::num_md5_shards=" << num_md5_shards << dendl;
+          // DEDUP_DYN_ALLOC
+          auto raw_mem = std::make_unique<uint8_t[]>(RAW_MEM_SIZE);
+          if (raw_mem == nullptr) {
+            ldpp_dout(dpp, 1) << "failed slab memory allocation - size=" << RAW_MEM_SIZE << dendl;
+            return;
+          }
+
+          process_all_shards(true, &Background::f_ingress_work_shard, raw_mem.get(),
+                             RAW_MEM_SIZE, num_work_shards, num_md5_shards);
+          if (!d_ctl.should_stop()) {
+            // Wait for all other workers to finish ingress step
+            work_shards_barrier(num_work_shards);
+            if (!d_ctl.should_stop()) {
+              process_all_shards(false, &Background::f_dedup_md5_shard, raw_mem.get(),
+                                 RAW_MEM_SIZE, num_work_shards, num_md5_shards);
+              // Wait for all other md5 shards to finish
+              md5_shards_barrier(num_md5_shards);
+              safe_pool_delete(store, dpp, pool_id);
+            }
+            else {
+              ldpp_dout(dpp, 5) <<__func__ << "::stop req from barrier" << dendl;
+            }
+          }
+          else {
+            ldpp_dout(dpp, 5) <<__func__ << "::stop req from ingress_work_shard" << dendl;
+          }
         }
       } // dedup_exec
 

--- a/src/rgw/driver/rados/rgw_dedup.h
+++ b/src/rgw/driver/rados/rgw_dedup.h
@@ -258,7 +258,7 @@ namespace rgw::dedup {
 
     uint32_t d_min_obj_size_for_dedup = (64ULL * 1024);
     bool     d_split_head             = true;
-    bool     d_pool_supports_truncate = true;
+    bool     d_pool_supports_truncate = false;
     uint32_t d_head_object_size       = (4ULL * 1024 * 1024);
     control_t d_ctl;
     dedup_filter_t d_filter;


### PR DESCRIPTION
Commit 6e720b1bf7a (rgw/dedup: skip split-head on EC pools) added EC pool detection inside init_rados_access_handles(), which runs at RGW startup. It tries to open default.rgw.buckets.data to check alignment, but on a fresh cluster that pool does not exist yet, so dedup init fails with -ENOENT.

Fix:
Defer the call to the point where dedup is initiated by caller (pool should exist at that point)

Fixes: https://tracker.ceph.com/issues/80304





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
