### PR TITLE
rgw/radosgw-admin: remove unused CLI locals and macros

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -1033,14 +1033,6 @@ Bucket Notifications/PubSub Options
 
    The bucket notifications/pubsub topic name.
 
-.. option:: --subscription
-
-   The pubsub subscription name.
-
-.. option:: --event-id
-
-   The event id in a pubsub subscription.
-
 
 Examples
 ========

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -132,15 +132,6 @@ static const DoutPrefixProvider* dpp() {
     } \
   } while (0)
 
-#define CHECK_SUCCESS(x, msg) \
-  do { \
-    int _x_val = (x); \
-    if (_x_val < 0) { \
-      cerr << msg << ": " << cpp_strerror(-_x_val) << std::endl; \
-      return _x_val; \
-    } \
-  } while (0)
-
 using namespace std;
 using rgw::run_coro;
 
@@ -3811,11 +3802,11 @@ int main(int argc, const char **argv)
   std::optional<string> opt_region;
   std::string master_zone;
   std::string realm_name, realm_id, realm_new_name;
-  std::optional<string> opt_realm_name, opt_realm_id;
+  std::optional<string> opt_realm_id;
   std::string zone_name, zone_id, zone_new_name;
-  std::optional<string> opt_zone_name, opt_zone_id;
+  std::optional<string> opt_zone_id;
   std::string zonegroup_name, zonegroup_id, zonegroup_new_name;
-  std::optional<string> opt_zonegroup_name, opt_zonegroup_id;
+  std::optional<string> opt_zonegroup_id;
   std::string api_name;
   std::string role_name, path, assume_role_doc, policy_name, perm_policy_doc, path_prefix, max_session_duration;
   std::string provider_url, client_ids_str, thumbprints_str;
@@ -3899,8 +3890,6 @@ int main(int argc, const char **argv)
   int shard_id = -1;
   bool specified_shard_id = false;
   std::optional<std::uint64_t> count;
-  string client_id;
-  string op_id;
   string op_mask_str;
   string quota_scope;
   string ratelimit_scope;
@@ -3982,7 +3971,6 @@ int main(int argc, const char **argv)
   int detail = false;
 
   std::string val;
-  std::ostringstream errs;
   string err;
 
   string source_zone_name;
@@ -4016,8 +4004,6 @@ int main(int argc, const char **argv)
 
   string topic_name;
   string notification_id;
-  string sub_name;
-  string event_id;
 
   std::optional<uint64_t> gen;
   std::optional<std::string> str_script_ctx;
@@ -4078,12 +4064,6 @@ int main(int argc, const char **argv)
   std::optional<std::string> rgw_obj_fs; // radoslist field separator
   std::optional<std::string> restore_status_filter;
   int show_restore_stats = false;
-
-  // global CORS settings
-  std::optional<std::string> gcors_allow_origins;
-  std::optional<std::string> gcors_allow_methods;
-  std::optional<std::string> gcors_allow_headers;
-  std::optional<std::string> gcors_expose_headers;
 
   init_realm_param(cct.get(), realm_id, opt_realm_id, "rgw_realm_id");
   init_realm_param(cct.get(), zonegroup_id, opt_zonegroup_id, "rgw_zonegroup_id");
@@ -4155,10 +4135,6 @@ int main(int argc, const char **argv)
       objects_file = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--object-version", (char*)NULL)) {
       object_version = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "--client-id", (char*)NULL)) {
-      client_id = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "--op-id", (char*)NULL)) {
-      op_id = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--op-mask", (char*)NULL)) {
       op_mask_str = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--key-type", (char*)NULL)) {
@@ -4624,10 +4600,6 @@ int main(int argc, const char **argv)
       topic_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--notification-id", (char*)NULL)) {
       notification_id = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "--subscription", (char*)NULL)) {
-      sub_name = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "--event-id", (char*)NULL)) {
-      event_id = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--group-id", (char*)NULL)) {
       opt_group_id = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--status", (char*)NULL)) {
@@ -4719,14 +4691,6 @@ int main(int argc, const char **argv)
       restore_status_filter = val;
     } else if (ceph_argparse_binary_flag(args, i, &show_restore_stats, NULL, "--show-restore-stats", (char*)NULL)){
       // do nothing
-    } else if (ceph_argparse_witharg(args, i, &val, "--allow-origin", (char*)NULL)) {
-      gcors_allow_origins = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "--allow-methods", (char*)NULL)) {
-      gcors_allow_methods = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "--allow-headers", (char*)NULL)) {
-      gcors_allow_headers = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "--expose-headers", (char*)NULL)) {
-      gcors_expose_headers = val;
     } else if (strncmp(*i, "-", 1) == 0) {
       cerr << "ERROR: invalid flag " << *i << std::endl;
       return EINVAL;
@@ -5114,18 +5078,6 @@ int main(int argc, const char **argv)
   realm_name = g_conf()->rgw_realm;
   zone_name = g_conf()->rgw_zone;
   zonegroup_name = g_conf()->rgw_zonegroup;
-
-  if (!realm_name.empty()) {
-    opt_realm_name = realm_name;
-  }
-
-  if (!zone_name.empty()) {
-    opt_zone_name = zone_name;
-  }
-
-  if (!zonegroup_name.empty()) {
-    opt_zonegroup_name = zonegroup_name;
-  }
 
   RGWStreamFlusher stream_flusher(formatter.get(), cout);
 


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Context (split from #71462)

This PR is the **first in a planned series** spun out of the larger
radosgw-admin modularization work in [#71462](https://github.com/ceph/ceph/pull/71462).

Reviewing that WIP as one change set is difficult and time-consuming. To
reduce merge risk and keep review rounds focused, I am landing **small,
behavior-neutral slices on `main` first**—each PR is easy to verify
independently—before stacking the structural modularization on top.

The end goal is that the combined series covers everything in #71462 (and
follow-up improvements from review), after which #71462 itself can be closed.

cc @chardan — you reviewed much of the modularization options/wiring feedback
on #71462; this slice removes only dead locals/macros that predate that work
and do not change supported CLI behavior. Happy to adjust the split order if
you prefer a different sequencing.

## Summary

Remove dead locals, argparse branches, and the unused `CHECK_SUCCESS` macro in
`radosgw-admin` that parsed CLI flags (or were defined) but never read the
values. This is behavior-neutral cleanup: supported commands and flags
(`global-cors get`, `--client-ids`, `--topic`, `--notification-id`, etc.) are
unchanged.

Removed unused locals / flags / macros:

- `CHECK_SUCCESS` (defined, never used)
- `errs`
- `gcors_allow_*` and `--allow-origin`, `--allow-methods`, `--allow-headers`, `--expose-headers` (only `global-cors get` exists; it reads `g_conf()`)
- `client_id`, `op_id` and `--client-id`, `--op-id` (`--client-ids` remains for OIDC)
- `opt_realm_name`, `opt_zone_name`, `opt_zonegroup_name` (config name copies; `init_realm_param` uses the `*_id` optionals)
- `sub_name`, `event_id` and `--subscription`, `--event-id` (pubsub uses `--topic` / `--notification-id`)

Also drop the matching `--subscription` / `--event-id` entries from
`doc/man/8/radosgw-admin.rst` so the man page matches supported flags.

## Testing

Local build and tests (Release, `WITH_RADOSGW_RADOS=ON`, vstart cluster):

- `ninja radosgw-admin`
- `cram src/test/cli/radosgw-admin/help.t` — passed
- `ninja ceph_test_cls_rgw_log ceph_test_cls_rgw_meta ceph_test_cls_rgw_admin_account_quota_set` — built and run against local `ceph.conf`
- Manual smoke: `radosgw-admin user list`, `bucket list`, `realm list`, `global-cors get`
- Verified removed flags now report `invalid flag`; `--client-ids` and `--notification-id` still parse

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
