### PR TITLE
crimson/os/seastore: introduce BlockIODriver and NVMeIODriver transport abstractions

### DIFF
--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -5,6 +5,7 @@ set(crimson_seastore_srcs
   segment_manager.cc
   segment_manager/ephemeral.cc
   segment_manager/block.cc
+  block_io_driver.cc
   transaction_interruptor.cc
   transaction_manager.cc
   cache.cc

--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -46,6 +46,7 @@ set(crimson_seastore_srcs
   random_block_manager.cc
   random_block_manager/block_rb_manager.cc
   random_block_manager/rbm_device.cc
+  random_block_manager/nvme_io_driver.cc
   random_block_manager/nvme_block_device.cc
   random_block_manager/hdd_device.cc
   random_block_manager/avlallocator.cc

--- a/src/crimson/os/seastore/block_io_driver.cc
+++ b/src/crimson/os/seastore/block_io_driver.cc
@@ -1,0 +1,281 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+
+#include <seastar/core/reactor.hh>
+
+#include "include/buffer.h"
+
+#include "crimson/common/errorator-utils.h"
+
+#include "crimson/os/seastore/logging.h"
+#include "crimson/os/seastore/block_io_driver.h"
+
+SET_SUBSYS(seastore_device);
+
+namespace crimson::os::seastore {
+
+ceph::unique_leakable_ptr<ceph::buffer::raw>
+BlockIODriver::alloc_io_buffer(size_t len)
+{
+  return ceph::buffer::create_page_aligned(len);
+}
+
+// ---------------------------------------------------------------------------
+// Kernel/io_uring raw block I/O helpers.
+//
+// These are the long-standing BlockSegmentManager do_* helpers, moved here
+// unchanged so both backends share a single implementation. They are kept as
+// namespace-scope free functions (rather than member functions of the
+// anonymous-namespace driver below) so the parallel_for_each lambdas retain
+// linkage.
+// ---------------------------------------------------------------------------
+
+using write_ertr = BlockIODriver::write_ertr;
+using read_ertr = BlockIODriver::read_ertr;
+
+static write_ertr::future<> do_write(
+  device_id_t device_id,
+  seastar::file &device,
+  uint64_t offset,
+  bufferptr &bptr)
+{
+  LOG_PREFIX(block_io_driver_do_write);
+  auto len = bptr.length();
+  TRACE("{} poffset=0x{:x}~0x{:x} ...",
+        device_id_printer_t{device_id}, offset, len);
+  return device.dma_write(
+    offset,
+    bptr.c_str(),
+    len
+  ).handle_exception(
+    [FNAME, device_id, offset, len](auto e) -> write_ertr::future<size_t> {
+    ERROR("{} poffset=0x{:x}~0x{:x} got error -- {}",
+          device_id_printer_t{device_id}, offset, len, e);
+    return crimson::ct_error::input_output_error::make();
+  }).then([FNAME, device_id, offset, len](auto result) -> write_ertr::future<> {
+    if (result != len) {
+      ERROR("{} poffset=0x{:x}~0x{:x} write len=0x{:x} inconsistent",
+            device_id_printer_t{device_id}, offset, len, result);
+      return crimson::ct_error::input_output_error::make();
+    }
+    TRACE("{} poffset=0x{:x}~0x{:x} done", device_id_printer_t{device_id}, offset, len);
+    return write_ertr::now();
+  });
+}
+
+static write_ertr::future<> do_writev(
+  device_id_t device_id,
+  seastar::file &device,
+  uint64_t offset,
+  bufferlist&& bl,
+  size_t block_size)
+{
+  LOG_PREFIX(block_io_driver_do_writev);
+  TRACE("{} poffset=0x{:x}~0x{:x}, {} buffers",
+        device_id_printer_t{device_id}, offset, bl.length(), bl.get_num_buffers());
+
+  // writev requires each buffer to be aligned to the disks' block
+  // size, we need to rebuild here
+  bl.rebuild_aligned(block_size);
+
+  return seastar::do_with(
+    bl.prepare_iovs(),
+    std::move(bl),
+    [&device, device_id, offset, FNAME](auto& iovs, auto& bl)
+  {
+    return write_ertr::parallel_for_each(
+      iovs,
+      [&device, device_id, offset, FNAME](auto& p) mutable
+    {
+      auto off = offset + p.offset;
+      auto len = p.length;
+      auto& iov = p.iov;
+      TRACE("{} poffset=0x{:x}~0x{:x} dma_write ...",
+            device_id_printer_t{device_id}, off, len);
+      return device.dma_write(off, std::move(iov)
+      ).handle_exception(
+        [FNAME, device_id, off, len](auto e) -> write_ertr::future<size_t>
+      {
+        ERROR("{} poffset=0x{:x}~0x{:x} dma_write got error -- {}",
+              device_id_printer_t{device_id}, off, len, e);
+	return crimson::ct_error::input_output_error::make();
+      }).then([FNAME, device_id, off, len](size_t written) -> write_ertr::future<> {
+	if (written != len) {
+          ERROR("{} poffset=0x{:x}~0x{:x} dma_write len=0x{:x} inconsistent",
+                device_id_printer_t{device_id}, off, len, written);
+	  return crimson::ct_error::input_output_error::make();
+	}
+        TRACE("{} poffset=0x{:x}~0x{:x} dma_write done",
+              device_id_printer_t{device_id}, off, len);
+	return write_ertr::now();
+      });
+    });
+  });
+}
+
+static read_ertr::future<> do_read(
+  device_id_t device_id,
+  seastar::file &device,
+  uint64_t offset,
+  size_t len,
+  bufferptr &bptr)
+{
+  LOG_PREFIX(block_io_driver_do_read);
+  TRACE("{} poffset=0x{:x}~0x{:x} ...", device_id_printer_t{device_id}, offset, len);
+  assert(len <= bptr.length());
+  return device.dma_read(
+    offset,
+    bptr.c_str(),
+    len
+  ).handle_exception(
+    //FIXME: this is a little bit tricky, since seastar::future<T>::handle_exception
+    //	returns seastar::future<T>, to return an crimson::ct_error, we have to create
+    //	a seastar::future<T> holding that crimson::ct_error. This is not necessary
+    //	once seastar::future<T>::handle_exception() returns seastar::futurize_t<T>
+    [FNAME, device_id, offset, len](auto e) -> read_ertr::future<size_t>
+  {
+    ERROR("{} poffset=0x{:x}~0x{:x} got error -- {}",
+          device_id_printer_t{device_id}, offset, len, e);
+    return crimson::ct_error::input_output_error::make();
+  }).then([FNAME, device_id, offset, len](auto result) -> read_ertr::future<> {
+    if (result != len) {
+      ERROR("{} poffset=0x{:x}~0x{:x} read len=0x{:x} inconsistent",
+            device_id_printer_t{device_id}, offset, len, result);
+      return crimson::ct_error::input_output_error::make();
+    }
+    TRACE("{} poffset=0x{:x}~0x{:x} done", device_id_printer_t{device_id}, offset, len);
+    return read_ertr::now();
+  });
+}
+
+static read_ertr::future<> do_readv(
+  device_id_t device_id,
+  seastar::file &device,
+  uint64_t offset,
+  std::vector<bufferptr> ptrs)
+{
+  LOG_PREFIX(block_io_driver_do_readv);
+  std::vector<iovec> iov;
+  size_t len = 0;
+  for (auto &ptr : ptrs) {
+    iov.emplace_back(ptr.c_str(), ptr.length());
+    len += ptr.length();
+  }
+  TRACE("{} poffset=0x{:x}~0x{:x} {} buffers",
+    device_id_printer_t{device_id}, offset, len, ptrs.size());
+  return device.dma_read(offset, std::move(iov)
+  ).handle_exception(
+    [FNAME, device_id, offset, len](auto e) -> read_ertr::future<size_t>
+  {
+    ERROR("{} poffset=0x{:x}~0x{:x} got error -- {}",
+          device_id_printer_t{device_id}, offset, len, e);
+    return crimson::ct_error::input_output_error::make();
+  }).then([FNAME, device_id, offset, len](auto result) -> read_ertr::future<> {
+    if (result != len) {
+      ERROR("{} poffset=0x{:x}~0x{:x} read len=0x{:x} inconsistent",
+            device_id_printer_t{device_id}, offset, len, result);
+      return crimson::ct_error::input_output_error::make();
+    }
+    TRACE("{} poffset=0x{:x}~0x{:x} done", device_id_printer_t{device_id}, offset, len);
+    return read_ertr::now();
+  });
+}
+
+namespace {
+
+/**
+ * KernelBlockIODriver
+ *
+ * Default transport: byte-addressed DMA against a seastar::file, backed by
+ * io_uring (or the configured Seastar reactor backend) and the kernel NVMe
+ * driver.
+ */
+class KernelBlockIODriver final : public BlockIODriver {
+  seastar::file device;
+
+public:
+  KernelBlockIODriver() = default;
+
+  open_ertr::future<seastar::stat_data> open(
+    const std::string &path,
+    seastar::open_flags flags) final
+  {
+    LOG_PREFIX(KernelBlockIODriver::open);
+    return seastar::file_stat(path, seastar::follow_symlink::yes
+    ).then([this, path, flags, FNAME](auto stat) mutable {
+      return seastar::open_file_dma(path, flags
+      ).then([this, stat, path, FNAME](auto file) mutable {
+        device = file;
+        return device.size().then(
+            [this, stat, path, FNAME](auto size) mutable {
+          stat.size = size;
+          // Use Seastar's DMA alignment for optimal I/O alignment; clamp to
+          // laddr_t::UNIT_SIZE since SeaStore operates at 4 KiB granularity
+          // and rejects smaller device-reported block sizes.
+          stat.block_size = std::max<uint64_t>(device.disk_write_dma_alignment(),
+                                               laddr_t::UNIT_SIZE);
+          INFO("path={} successful, size=0x{:x}, block_size=0x{:x}",
+               path, stat.size, stat.block_size);
+          return stat;
+        });
+      });
+    }).handle_exception([FNAME, path](auto e)
+        -> open_ertr::future<seastar::stat_data> {
+      ERROR("path={} got error -- {}", path, e);
+      return crimson::ct_error::input_output_error::make();
+    });
+  }
+
+  close_ertr::future<> close() final
+  {
+    return device.close().then([] {
+      return close_ertr::now();
+    });
+  }
+
+  write_ertr::future<> write(
+    device_id_t device_id,
+    uint64_t offset,
+    bufferptr &bptr) final
+  {
+    return do_write(device_id, device, offset, bptr);
+  }
+
+  write_ertr::future<> writev(
+    device_id_t device_id,
+    uint64_t offset,
+    bufferlist &&bl,
+    size_t block_size) final
+  {
+    return do_writev(device_id, device, offset, std::move(bl), block_size);
+  }
+
+  read_ertr::future<> read(
+    device_id_t device_id,
+    uint64_t offset,
+    size_t len,
+    bufferptr &out) final
+  {
+    return do_read(device_id, device, offset, len, out);
+  }
+
+  read_ertr::future<> readv(
+    device_id_t device_id,
+    uint64_t offset,
+    std::vector<bufferptr> ptrs) final
+  {
+    return do_readv(device_id, device, offset, std::move(ptrs));
+  }
+};
+
+} // anonymous namespace
+
+BlockIODriverRef make_block_io_driver(
+  const std::string &path,
+  device_type_t dtype)
+{
+  return std::make_unique<KernelBlockIODriver>();
+}
+
+}

--- a/src/crimson/os/seastore/block_io_driver.h
+++ b/src/crimson/os/seastore/block_io_driver.h
@@ -1,0 +1,105 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <seastar/core/file.hh>
+#include <seastar/core/future.hh>
+
+#include "include/buffer_fwd.h"
+
+#include "crimson/common/errorator.h"
+#include "crimson/os/seastore/seastore_types.h"
+
+namespace crimson::os::seastore {
+
+/**
+ * BlockIODriver
+ *
+ * Shared low-level raw block I/O primitive used by both SeaStore backends:
+ * the segmented backend (BlockSegmentManager) and the random-block backend
+ * (NVMeBlockDevice). It abstracts byte-addressed DMA reads and writes against
+ * an underlying device so the transport (kernel io_uring vs. SPDK polled NVMe)
+ * can be swapped without touching the backends above it.
+ *
+ * A driver instance is owned by, and used on, a single Seastar shard. All
+ * offsets are absolute byte offsets into the device.
+ */
+class BlockIODriver {
+public:
+  using write_ertr = crimson::errorator<
+    crimson::ct_error::input_output_error>;
+  using read_ertr = crimson::errorator<
+    crimson::ct_error::input_output_error>;
+  using open_ertr = crimson::errorator<
+    crimson::ct_error::input_output_error,
+    crimson::ct_error::permission_denied,
+    crimson::ct_error::enoent>;
+  using close_ertr = crimson::errorator<
+    crimson::ct_error::input_output_error>;
+
+  virtual ~BlockIODriver() = default;
+
+  /// Open the underlying device and return its detected {size, block_size}.
+  virtual open_ertr::future<seastar::stat_data> open(
+    const std::string &path,
+    seastar::open_flags flags) = 0;
+
+  /// Close the underlying device.
+  virtual close_ertr::future<> close() = 0;
+
+  /// Write a single buffer at the given absolute device offset.
+  virtual write_ertr::future<> write(
+    device_id_t device_id,
+    uint64_t offset,
+    bufferptr &bptr) = 0;
+
+  /// Scatter-write a bufferlist at the given absolute device offset.
+  /// Buffers are re-aligned to block_size as required by the transport.
+  virtual write_ertr::future<> writev(
+    device_id_t device_id,
+    uint64_t offset,
+    bufferlist &&bl,
+    size_t block_size) = 0;
+
+  /// Read len bytes at the given absolute device offset into out.
+  virtual read_ertr::future<> read(
+    device_id_t device_id,
+    uint64_t offset,
+    size_t len,
+    bufferptr &out) = 0;
+
+  /// Gather-read at the given absolute device offset into ptrs.
+  virtual read_ertr::future<> readv(
+    device_id_t device_id,
+    uint64_t offset,
+    std::vector<bufferptr> ptrs) = 0;
+
+  /// Allocate a buffer suitable for DMA on this transport. The default is a
+  /// plain page-aligned buffer; the SPDK driver overrides this to allocate
+  /// from its registered hugepage pool, enabling the zero-copy paths.
+  virtual ceph::unique_leakable_ptr<ceph::buffer::raw> alloc_io_buffer(
+    size_t len);
+};
+using BlockIODriverRef = std::unique_ptr<BlockIODriver>;
+
+/**
+ * make_block_io_driver
+ *
+ * The single point that selects the I/O transport. Returns the SPDK driver
+ * when seastore_spdk_transport_id is configured (and supported for dtype),
+ * otherwise the kernel/io_uring driver. dtype lets the factory reject
+ * transports that a device type cannot use (e.g. SPDK for ZBD/ZNS).
+ *
+ * Construction is synchronous and non-blocking for both transports (the SPDK
+ * driver defers env init / device probe to open()), so the result is the
+ * driver directly rather than a future.
+ */
+BlockIODriverRef make_block_io_driver(
+  const std::string &path,
+  device_type_t dtype);
+
+}

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
@@ -52,23 +52,25 @@ open_ertr::future<> NVMeBlockDevice::open(
   const std::string &in_path,
   seastar::open_flags mode) {
   LOG_PREFIX(NVMeBlockDevice::open);
-  auto file = co_await seastar::open_file_dma(in_path, mode);
-  device = std::move(file);
-  // Get SSD's features from identify_controller and namespace command.
-  // Do identify_controller first, and then identify_namespace.
-  auto id_ctr_data = co_await identify_controller(device);
-  if (id_ctr_data) {
-    // TODO: enable multi-stream if the nvme device supports
-    auto id_controller_data = *id_ctr_data;
-    awupf = id_controller_data.awupf + 1;
-    auto id_ns_data = co_await identify_namespace(device);
-    if (id_ns_data) {
-      auto id_namespace_data = *id_ns_data;
+  driver = make_nvme_io_driver(in_path);
+  co_await driver->open(in_path, mode
+  ).handle_error(
+    open_ertr::pass_further{},
+    crimson::ct_error::assert_all("Invalid error in NVMeBlockDevice::open"));
+  // Combine the raw identify-derived capabilities with this device's superblock
+  // block size (the on-disk logical block size) to compute the write
+  // granularity / alignment / atomic-write-unit, exactly as before. The math
+  // stays here because it depends on super.block_size, which the driver does
+  // not own.
+  const auto &caps = driver->get_caps();
+  if (caps.ctrl_identified) {
+    awupf = caps.awupf;
+    if (caps.ns_identified) {
       atomic_write_unit = awupf * super.block_size;
-      if (id_namespace_data.nsfeat.opterf == 1){
+      if (caps.opterf) {
 	// NPWG and NPWA is 0'based value
-	write_granularity = super.block_size * (id_namespace_data.npwg + 1);
-	write_alignment = super.block_size * (id_namespace_data.npwa + 1);
+	write_granularity = super.block_size * (caps.npwg + 1);
+	write_alignment = super.block_size * (caps.npwa + 1);
       }
     } else {
       DEBUG("identify_namespace failed.\
@@ -78,18 +80,10 @@ open_ertr::future<> NVMeBlockDevice::open(
     DEBUG("identify_controller failed.\
       Proceeding to open the device normally without adding device-specific information.");
   }
-  co_return co_await open_for_io(in_path, mode);
-}
-
-open_ertr::future<> NVMeBlockDevice::open_for_io(
-  const std::string& in_path,
-  seastar::open_flags mode) {
-  io_device.resize(stream_id_count);
-  for (auto &target_device : io_device) {
-    auto file = co_await seastar::open_file_dma(in_path, mode);
-    assert(io_device.size() > stream_index_to_open);
-    target_device = std::move(file);
-  }
+  // PI is activated on the driver once the superblock that records it is
+  // available: in try_enable_end_to_end_protection() during mkfs, and in
+  // mount() after read_rbm_superblock. super is not yet loaded here on the
+  // mount path, so there is nothing to push at open() time.
 }
 
 NVMeBlockDevice::mount_ret NVMeBlockDevice::mount()
@@ -106,8 +100,30 @@ NVMeBlockDevice::mount_ret NVMeBlockDevice::mount()
     });
   });
 
+  // Superblocks are loaded now: activate PI on each shard's driver if the
+  // device was formatted with end-to-end data protection, so subsequent I/O
+  // uses the PI command path.
+  co_await shard_devices.invoke_on_all([](auto &local_device) {
+    for (auto& mshard_device : local_device.mshard_devices) {
+      if (mshard_device->is_end_to_end_data_protection()) {
+        mshard_device->driver->set_protection_info(
+          true, mshard_device->super.nvme_block_size);
+      }
+    }
+    return seastar::now();
+  });
+
   if (is_end_to_end_data_protection()) {
-    auto id_ns_data = co_await identify_namespace(device);
+    // Validate the attached device actually supports the PI the superblock
+    // expects. A throwaway driver performs the identify.
+    auto io_driver = make_nvme_io_driver(device_path);
+    co_await io_driver->open(device_path,
+      seastar::open_flags::rw | seastar::open_flags::dsync
+    ).handle_error(crimson::ct_error::assert_all(
+      "Invalid error open in NVMeBlockDevice::mount PI-validate"));
+    auto id_ns_data = co_await io_driver->identify_namespace();
+    co_await io_driver->close().handle_error(crimson::ct_error::assert_all(
+      "Invalid error close in NVMeBlockDevice::mount PI-validate"));
     assert(id_ns_data);
     auto id_namespace_data = *id_ns_data;
     if (id_namespace_data.dps.protection_type !=
@@ -117,7 +133,7 @@ NVMeBlockDevice::mount_ret NVMeBlockDevice::mount()
 	the functionality. Please check the device.");
       ceph_abort();
     }
-    if (id_namespace_data.lbaf[id_namespace_data.flbas.lba_index].ms != 
+    if (id_namespace_data.lbaf[id_namespace_data.flbas.lba_index].ms !=
 	nvme_identify_namespace_data_t::METASIZE_FOR_CHECKSUM_OFFLOAD) {
       ERROR("seastore was formated with end-to-end-data-protection \
 	but the formatted device meta size is wrong. Please check the device.");
@@ -131,94 +147,23 @@ write_ertr::future<> NVMeBlockDevice::write(
   bufferptr bptr,
   uint16_t stream) {
   LOG_PREFIX(NVMeBlockDevice::write);
-  DEBUG("block: write offset {} len {}",
-      offset,
-      bptr.length());
-  auto length = bptr.length();
-
-  assert((length % super.block_size) == 0);
-  uint16_t supported_stream = stream;
-  if (stream >= stream_id_count) {
-    supported_stream = WRITE_LIFE_NOT_SET;
-  }
-  if (is_end_to_end_data_protection()) {
-    co_await nvme_write(offset, bptr.length(), bptr.c_str());
-    co_return;
-  }
-  auto ret = co_await io_device[supported_stream].dma_write(
-    offset, bptr.c_str(), length).handle_exception(
-    [FNAME](auto e) -> write_ertr::future<size_t> {
-    ERROR("write: dma_write got error{}", e);
-    return crimson::ct_error::input_output_error::make();
-  });
-  if (ret != length) {
-    ERROR("write: dma_write got error with not proper length");
-    co_await write_ertr::future<>(
-      crimson::ct_error::input_output_error::make());
-  }
+  DEBUG("block: write offset {} len {}", offset, bptr.length());
+  assert((bptr.length() % super.block_size) == 0);
+  // bptr is a by-value parameter: co_await (rather than returning the future)
+  // keeps it alive in this coroutine frame for the duration of the driver call.
+  co_await driver->write(get_device_id(), offset, bptr, stream);
 }
 
 read_ertr::future<> NVMeBlockDevice::read(
   uint64_t offset,
   bufferptr &bptr) {
-  LOG_PREFIX(NVMeBlockDevice::read);
-  DEBUG("block: read offset {} len {}",
-      offset,
-      bptr.length());
-  auto length = bptr.length();
-  if (length == 0) {
-    co_return;
-  }
-  assert((length % super.block_size) == 0);
-
-  if (is_end_to_end_data_protection()) {
-    co_await nvme_read(offset, length, bptr.c_str());
-    co_return;
-  }
-  auto ret = co_await device.dma_read(offset, bptr.c_str(), length
-  ).handle_exception(
-    [FNAME](auto e) -> read_ertr::future<size_t> {
-    ERROR("read: dma_read got error{}", e);
-    return crimson::ct_error::input_output_error::make();
-  });
-  if (ret != length) {
-    ERROR("read: dma_read got error with not proper length");
-    co_await read_ertr::future<>(
-      crimson::ct_error::input_output_error::make());
-  }
+  return driver->read(get_device_id(), offset, bptr.length(), bptr);
 }
 
 read_ertr::future<> NVMeBlockDevice::_readv(
   uint64_t offset,
   std::vector<bufferptr> ptrs) {
-  LOG_PREFIX(NVMeBlockDevice::_readv);
-  DEBUG("block: read offset {}, {} buffers", offset, ptrs.size());
-  if (ptrs.size() == 0) {
-    return read_ertr::now();
-  }
-
-  if (is_end_to_end_data_protection()) {
-    return nvme_readv(offset, std::move(ptrs));
-  }
-  std::vector<iovec> iov;
-  size_t length = 0;
-  for (auto &ptr : ptrs) {
-    length += ptr.length();
-    assert((ptr.length() % super.block_size) == 0);
-    iov.emplace_back(ptr.c_str(), ptr.length());
-  }
-  return device.dma_read(offset, std::move(iov)
-  ).handle_exception(
-    [FNAME](auto e) -> read_ertr::future<size_t> {
-      ERROR("read: dma_read got error{}", e);
-      return crimson::ct_error::input_output_error::make();
-    }).then([length, FNAME](auto result) -> read_ertr::future<> {
-      if (result != length) {
-        ERROR("read: dma_read got error with not proper length");
-        return crimson::ct_error::input_output_error::make();
-      }
-      return read_ertr::now();
-    });
+  return driver->readv(get_device_id(), offset, std::move(ptrs));
 }
 
 write_ertr::future<> NVMeBlockDevice::writev(
@@ -226,151 +171,29 @@ write_ertr::future<> NVMeBlockDevice::writev(
   ceph::bufferlist bl,
   uint16_t stream) {
   LOG_PREFIX(NVMeBlockDevice::writev);
-  DEBUG("block: write offset {} len {}",
-    offset,
-    bl.length());
-
-  uint16_t supported_stream = stream;
-  if (stream >= stream_id_count) {
-    supported_stream = WRITE_LIFE_NOT_SET;
-  }
-  if (is_end_to_end_data_protection()) {
-    co_await nvme_write(offset, bl.length(), bl.c_str());
-    co_return;
-  }
-  bl.rebuild_aligned(super.block_size);
-  auto iovs = bl.prepare_iovs();
-  auto has_error = seastar::make_lw_shared<bool>(false);
-  co_await seastar::coroutine::parallel_for_each(
-    iovs,
-    [this, supported_stream, offset, has_error, FNAME](auto& p)
-  {
-    auto off = offset + p.offset;
-    auto len = p.length;
-    auto& iov = p.iov;
-    return io_device[supported_stream].dma_write(off, std::move(iov)
-    ).handle_exception(
-      [this, off, len, has_error, FNAME](auto e) -> seastar::future<size_t>
-    {
-      ERROR("{} poffset={}~{} dma_write got error -- {}",
-	device_id_printer_t{get_device_id()}, off, len, e);
-      *has_error = true;
-      return seastar::make_ready_future<size_t>(0);
-    }).then([this, off, len, has_error, FNAME](size_t written) {
-      if (written != len) {
-	ERROR("{} poffset={}~{} dma_write len={} inconsistent",
-	  device_id_printer_t{get_device_id()}, off, len, written);
-	*has_error = true;
-      }
-      return seastar::now();
-    });
-  });
-  if (*has_error) {
-    co_await write_ertr::future<>(
-      crimson::ct_error::input_output_error::make());
-  }
+  DEBUG("block: write offset {} len {}", offset, bl.length());
+  // bl is a by-value parameter: co_await keeps it (and the iovecs the driver
+  // builds from it) alive for the duration of the driver call.
+  co_await driver->writev(
+    get_device_id(), offset, std::move(bl), super.block_size, stream);
 }
 
 Device::close_ertr::future<> NVMeBlockDevice::close() {
   LOG_PREFIX(NVMeBlockDevice::close);
   DEBUG("close");
-  stream_index_to_open = WRITE_LIFE_NOT_SET;
-  co_await device.close();
-  for (auto& target_device : io_device) {
-    co_await target_device.close();
+  if (!driver) {
+    return close_ertr::now();
   }
-}
-
-seastar::future<std::optional<nvme_identify_controller_data_t>>
-NVMeBlockDevice::identify_controller(seastar::file f) {
-
-  nvme_admin_command_t admin_command;
-  nvme_identify_controller_data_t data;
-  admin_command.common.opcode = nvme_admin_command_t::OPCODE_IDENTIFY;
-  admin_command.common.addr = (uint64_t)&data;
-  admin_command.common.data_len = sizeof(data);
-  admin_command.identify.cns = nvme_identify_command_t::CNS_CONTROLLER;
-  auto ret = co_await pass_admin(admin_command, f
-  ).handle_error(crimson::ct_error::input_output_error::handle([] {
-    return seastar::make_ready_future<int>(-1);
-  }));
-  if (ret < 0) {
-    co_return std::nullopt;
-  }
-  co_return std::move(data);
+  return driver->close();
 }
 
 discard_ertr::future<> NVMeBlockDevice::discard(uint64_t offset, uint64_t len) {
-  co_return co_await device.discard(offset, len);
-}
-
-seastar::future<std::optional<nvme_identify_namespace_data_t>>
-NVMeBlockDevice::identify_namespace(seastar::file f) {
-
-  auto nsid = co_await get_nsid(f
-  ).handle_error(crimson::ct_error::input_output_error::handle([] {
-    return seastar::make_ready_future<int>(-1);
-  }));
-  if (nsid < 0) {
-    co_return std::nullopt;
-  }
-  namespace_id = nsid;
-  nvme_admin_command_t admin_command;
-  nvme_identify_namespace_data_t data;
-  admin_command.common.opcode = nvme_admin_command_t::OPCODE_IDENTIFY;
-  admin_command.common.addr = (uint64_t)&data;
-  admin_command.common.data_len = sizeof(data);
-  admin_command.common.nsid = nsid;
-  admin_command.identify.cns = nvme_identify_command_t::CNS_NAMESPACE;
-
-  auto ret = co_await pass_admin(admin_command, f
-  ).handle_error(crimson::ct_error::input_output_error::handle([] {
-    return seastar::make_ready_future<int>(-1);
-  }));
-  if (ret < 0) {
-    co_return std::nullopt;
-  }
-  co_return std::move(data);
-}
-
-nvme_command_ertr::future<int> NVMeBlockDevice::get_nsid(seastar::file f) {
-  auto ret = co_await f.ioctl(NVME_IOCTL_ID, nullptr
-  ).handle_exception(
-    [](auto e)->nvme_command_ertr::future<int> {
-    LOG_PREFIX(NVMeBlockDevice::get_nsid);
-    ERROR("pass_admin: ioctl failed {}", e);
-    return crimson::ct_error::input_output_error::make();
-  });
-  co_return ret;
-}
-
-nvme_command_ertr::future<int> NVMeBlockDevice::pass_admin(
-  nvme_admin_command_t& admin_cmd, seastar::file f) {
-  auto ret = co_await f.ioctl(NVME_IOCTL_ADMIN_CMD, &admin_cmd
-  ).handle_exception(
-    [](auto e)->nvme_command_ertr::future<int> {
-    LOG_PREFIX(NVMeBlockDevice::pass_admin);
-    ERROR("pass_admin: ioctl failed {}", e);
-    return crimson::ct_error::input_output_error::make();
-  });
-  co_return ret;
-}
-
-nvme_command_ertr::future<int> NVMeBlockDevice::pass_through_io(
-  nvme_io_command_t& io_cmd) {
-  auto ret = co_await device.ioctl(NVME_IOCTL_IO_CMD, &io_cmd
-  ).handle_exception(
-    [](auto e)->nvme_command_ertr::future<int> {
-    LOG_PREFIX(NVMeBlockDevice::pass_through_io);
-    ERROR("pass_through_io: ioctl failed {}", e);
-    return crimson::ct_error::input_output_error::make();
-  });
-  co_return ret;
+  return driver->discard(offset, len);
 }
 
 nvme_command_ertr::future<> NVMeBlockDevice::try_enable_end_to_end_protection() {
   LOG_PREFIX(NVMeBlockDevice::try_enable_end_to_end_protection);
-  auto id_ns_data = co_await identify_namespace(device);
+  auto id_ns_data = co_await driver->identify_namespace();
   if (!id_ns_data) {
     INFO("the device does not support end to end data protection,\
       mkfs() will be done without this functionality.");
@@ -384,7 +207,7 @@ nvme_command_ertr::future<> NVMeBlockDevice::try_enable_end_to_end_protection() 
   }
   int lba_format_index = -1;
   for (int i = 0; i < id_namespace_data.nlbaf; i++) {
-    // TODO: enable other types of end to end data protection 
+    // TODO: enable other types of end to end data protection
     // Note that the nvme device will generate crc if the namespace
     // is formatted with meta size 8
     // The nvme device can provide other types of data protections.
@@ -402,101 +225,35 @@ nvme_command_ertr::future<> NVMeBlockDevice::try_enable_end_to_end_protection() 
     co_return;
   }
 
-  auto nsid = co_await get_nsid(device);
+  auto nsid = driver->get_namespace_id();
   nvme_admin_command_t cmd;
   cmd.common.opcode = nvme_admin_command_t::OPCODE_FORMAT_NVM;
   cmd.common.nsid = nsid;
   // TODO: configure other protect information types (2 or 3) see above
   cmd.format.pi = nvme_format_nvm_command_t::PROTECT_INFORMATION_TYPE_2;
   cmd.format.lbaf = lba_format_index;
-  auto ret = co_await pass_admin(cmd, device);
+  auto ret = co_await driver->pass_admin(cmd);
   if (ret != 0) {
     ERROR(
       "formt nvm command to use end-to-end-protection fails : {}", ret);
     ceph_abort();
   }
 
-  id_ns_data = co_await identify_namespace(device);
+  id_ns_data = co_await driver->identify_namespace();
   assert(id_ns_data);
   id_namespace_data = *id_ns_data;
   ceph_assert(id_namespace_data.dps.protection_type ==
      nvme_format_nvm_command_t::PROTECT_INFORMATION_TYPE_2);
   super.set_end_to_end_data_protection();
+  // Activate PI on the driver so the superblock write that follows in
+  // do_primary_mkfs() uses the PI command path.
+  driver->set_protection_info(true, super.nvme_block_size);
 }
 
 nvme_command_ertr::future<> NVMeBlockDevice::initialize_nvme_features() {
   if (!crimson::common::get_conf<bool>("seastore_disable_end_to_end_data_protection")) {
     co_await try_enable_end_to_end_protection();
   }
-}
-
-write_ertr::future<> NVMeBlockDevice::nvme_write(
-  uint64_t offset, size_t len, void *buffer_ptr) {
-  nvme_io_command_t cmd;
-  cmd.common.opcode = nvme_io_command_t::OPCODE_WRITE;
-  cmd.common.nsid = namespace_id;
-  cmd.common.data_len = len;
-  // To perform checksum offload, we need to set PRACT to 1 and PRCHK to 4
-  // according to NVMe spec.
-  cmd.rw.prinfo_pract = nvme_rw_command_t::PROTECT_INFORMATION_ACTION_ENABLE;
-  cmd.rw.prinfo_prchk = nvme_rw_command_t::PROTECT_INFORMATION_CHECK_GUARD;
-  cmd.common.addr = (__u64)(uintptr_t)buffer_ptr;
-  ceph_assert(super.nvme_block_size > 0);
-  auto lba_shift = ffsll(super.nvme_block_size) - 1;
-  cmd.rw.s_lba = offset >> lba_shift;
-  cmd.rw.nlb = (len >> lba_shift) - 1;
-  auto ret = co_await pass_through_io(cmd);
-  if (ret != 0) {
-    LOG_PREFIX(NVMeBlockDevice::nvme_write);
-    ERROR("write nvm command with checksum offload fails : {}", ret);
-    ceph_abort();
-  }
-}
-
-read_ertr::future<> NVMeBlockDevice::nvme_read(
-  uint64_t offset, size_t len, void *buffer_ptr) {
-
-  nvme_io_command_t cmd;
-  cmd.common.opcode = nvme_io_command_t::OPCODE_READ;
-  cmd.common.nsid = namespace_id;
-  cmd.common.data_len = len;
-  cmd.rw.prinfo_pract = nvme_rw_command_t::PROTECT_INFORMATION_ACTION_ENABLE;
-  cmd.rw.prinfo_prchk = nvme_rw_command_t::PROTECT_INFORMATION_CHECK_GUARD;
-  cmd.common.addr = (__u64)(uintptr_t)buffer_ptr;
-  ceph_assert(super.nvme_block_size > 0);
-  auto lba_shift = ffsll(super.nvme_block_size) - 1;
-  cmd.rw.s_lba = offset >> lba_shift;
-  cmd.rw.nlb = (len >> lba_shift) - 1;
-  auto ret = co_await pass_through_io(cmd);
-  if (ret != 0) {
-    LOG_PREFIX(NVMeBlockDevice::nvme_read);
-    ERROR("read nvm command with checksum offload fails : {}", ret);
-    ceph_abort();
-  }
-}
-
-read_ertr::future<> NVMeBlockDevice::nvme_readv(
-  uint64_t offset, std::vector<bufferptr> ptrs) {
-  struct io_t {
-    uint64_t offset = 0;
-    bufferptr ptr;
-  };
-  std::vector<io_t> iov;
-  size_t off = 0;
-  for (auto &ptr : ptrs) {
-    auto len = ptr.length();
-    iov.emplace_back(offset + off, std::move(ptr));
-    off += len;
-  }
-  return seastar::do_with(
-    std::move(iov),
-    [this](auto &iov) {
-    return read_ertr::parallel_for_each(
-      iov,
-      [this](auto &io) {
-      return nvme_read(io.offset, io.ptr.length(), io.ptr.c_str());
-    });
-  });
 }
 
 }

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
@@ -7,11 +7,12 @@
 #include <vector>
 
 #include <seastar/core/file.hh>
-#include <linux/nvme_ioctl.h>
 
 #include "crimson/osd/exceptions.h"
 #include "crimson/common/layout.h"
 #include "rbm_device.h"
+#include "nvme_command.h"
+#include "nvme_io_driver.h"
 
 namespace ceph {
   namespace buffer {
@@ -20,171 +21,6 @@ namespace ceph {
 }
 
 namespace crimson::os::seastore::random_block_device::nvme {
-/*
- * NVMe protocol structures (nvme_XX, identify_XX)
- *
- * All structures relative to NVMe protocol are following NVMe protocol v1.4
- * (latest). NVMe is protocol for fast interfacing between user and SSD device.
- * We selectively adopted features among various NVMe features to ease
- * implementation. And also, NVMeBlockDevice provides generic command submission
- * APIs for IO and Admin commands. Please use pass_through_io() and pass_admin()
- * to do it.
- *
- * For more information about NVMe protocol, refer https://nvmexpress.org/
- */
-struct nvme_identify_command_t {
-  uint32_t common_dw[10];
-
-  uint32_t cns : 8;
-  uint32_t reserved : 8;
-  uint32_t cnt_id : 16;
-
-  static const uint8_t CNS_NAMESPACE = 0x00;
-  static const uint8_t CNS_CONTROLLER = 0x01;
-};
-
-struct nvme_format_nvm_command_t {
-  uint32_t common_dw[10];
-
-  uint8_t lbaf : 4;
-  uint8_t mset : 1;
-  uint8_t pi : 3;
-  uint8_t pil : 1;
-  
-  static const uint8_t PROTECT_INFORMATION_TYPE_2 = 2;
-};
-
-struct nvme_admin_command_t {
-  union {
-    nvme_passthru_cmd common;
-    nvme_identify_command_t identify;
-    nvme_format_nvm_command_t format;
-  };
-
-  static const uint8_t OPCODE_IDENTIFY = 0x06;
-  static const uint8_t OPCODE_FORMAT_NVM = 0x80;
-};
-
-// Optional Admin Command Support (OACS)
-// Indicates optional commands are supported by SSD or not 
-struct oacs_t {
-  uint16_t unused : 5;
-  uint16_t support_directives : 1; // Support multi-stream
-  uint16_t unused2 : 10;
-};
-
-struct nvme_identify_controller_data_t {
-  union {
-    struct {
-      uint8_t unused[256];  // [255:0]
-      oacs_t oacs;          // [257:256]
-      uint8_t unused2[270]; // [527:258]
-      uint16_t awupf;       // [529:528]
-    };
-    uint8_t raw[4096];
-  };
-};
-
-// End-to-end Data Protection Capabilities (DPC)
-// Indicates type of E2E data protection supported by SSD
-struct dpc_t {
-  uint8_t support_type1 : 1;
-  uint8_t support_type2 : 1;
-  uint8_t support_type3 : 1;
-  uint8_t support_first_meta : 1;
-  uint8_t support_last_meta : 1;
-  uint8_t reserved : 3;
-};
-
-// End-to-end Data Protection Type Settings (DPS)
-// Indicates enabled type of E2E data protection
-struct dps_t {
-  uint8_t protection_type : 3;
-  uint8_t protection_info : 1;
-  uint8_t reserved : 4;
-};
-
-// Namespace Features (NSFEAT)
-// Indicates features of namespace
-struct nsfeat_t {
-  uint8_t thinp : 1;
-  uint8_t nsabp : 1;
-  uint8_t dae : 1;
-  uint8_t uid_reuse : 1;
-  uint8_t opterf : 1; // Support NPWG, NPWA
-  uint8_t reserved : 3;
-};
-
-// LBA Format (LBAF)
-// Indicates LBA format (metadata size, data size, performance)
-struct lbaf_t {
-  uint32_t ms : 16;
-  uint32_t lbads : 8;
-  uint32_t rp : 2;
-  uint32_t reserved : 6;
-};
-
-struct flbas_t {
-  uint8_t lba_index : 4;
-  uint8_t ms_transferred :1;
-  uint8_t reserved : 3;
-};
-
-struct nvme_identify_namespace_data_t {
-  union {
-    struct {
-      uint8_t unused[24];   // [23:0]
-      nsfeat_t nsfeat;      // [24]
-      uint8_t nlbaf;      // [25]
-      flbas_t flbas;      // [26]
-      uint8_t unused2;   // [27]
-      dpc_t dpc;            // [28]
-      dps_t dps;            // [29]
-      uint8_t unused3[34];  // [63:30]
-      uint16_t npwg;        // [65:64]
-      uint16_t npwa;        // [67:66]
-      uint8_t unused4[60];  // [127:68]
-      lbaf_t lbaf[64];         // [383:128]
-    };
-    uint8_t raw[4096];
-  };
-  // meta size value to use device-level checksum
-  static const uint8_t METASIZE_FOR_CHECKSUM_OFFLOAD = 8; 
-};
-
-struct nvme_rw_command_t {
-  uint32_t common_dw[10];
-
-  uint64_t s_lba;
-
-  uint32_t nlb : 16; // 0's based value
-  uint32_t reserved : 4;
-  uint32_t d_type : 4;
-  uint32_t reserved2 : 2;
-  uint32_t prinfo_prchk : 3;
-  uint32_t prinfo_pract : 1;
-  uint32_t fua : 1;
-  uint32_t lr : 1;
-
-  uint32_t reserved3 : 16;
-  uint32_t dspec : 16;
-
-  static const uint32_t DTYPE_STREAM = 1;
-
-  static const uint8_t PROTECT_INFORMATION_ACTION_ENABLE = 1;
-  static const uint8_t PROTECT_INFORMATION_CHECK_GUARD = 4;
-  static const uint8_t PROTECT_INFORMATION_CHECK_APPLICATION_TAG = 2;
-  static const uint8_t PROTECT_INFORMATION_CHECK_LOGICAL_REFERENCE_TAG = 1;
-};
-
-struct nvme_io_command_t {
-  union {
-    nvme_passthru_cmd common;
-    nvme_rw_command_t rw;
-  };
-  static const uint8_t OPCODE_WRITE = 0x01;
-  static const uint8_t OPCODE_READ = 0x02;
-};
 
 /*
  * Implementation of NVMeBlockDevice with POSIX APIs
@@ -234,11 +70,6 @@ public:
     uint64_t offset,
     std::vector<bufferptr> ptrs) final;
 
-  read_ertr::future<> nvme_read(
-    uint64_t offset, size_t len, void *buffer_ptr);
-  read_ertr::future<> nvme_readv(
-    uint64_t offset, std::vector<bufferptr> ptrs);
-
   close_ertr::future<> close() override;
 
   discard_ertr::future<> discard(
@@ -256,32 +87,19 @@ public:
     ceph::bufferlist bl,
     uint16_t stream = 0) final;
 
-  write_ertr::future<> nvme_write(
-    uint64_t offset, size_t len, void *buffer_ptr);
-
   stat_device_ret stat_device() final {
-    auto stat = co_await seastar::file_stat(
-      device_path, seastar::follow_symlink::yes
-    ).handle_exception([](auto e) -> stat_device_ret {
+    // sizing only: a throwaway driver does the open + identify and reports
+    // {size, block_size}, then is dropped.
+    auto io_driver = make_nvme_io_driver(device_path);
+    auto stat = co_await io_driver->open(
+      device_path, seastar::open_flags::rw | seastar::open_flags::dsync
+    ).handle_error(crimson::ct_error::all_same_way([]() -> stat_device_ret {
       return crimson::ct_error::input_output_error::make();
-    });
-
-    auto file = co_await seastar::open_file_dma(device_path,
-	seastar::open_flags::rw | seastar::open_flags::dsync);
-
-    auto size = co_await file.size();
-    stat.size = size;
-    auto id_ns_data = co_await identify_namespace(file);
-    if (id_ns_data) {
-      // LBA format provides LBA size which is power of 2. LBA is the
-      // minimum size of read and write.
-      stat.block_size = (1 << (*id_ns_data).lbaf[0].lbads);
-    } 
-    if (stat.block_size < RBM_SUPERBLOCK_SIZE) {
-      stat.block_size = RBM_SUPERBLOCK_SIZE;
-    } 
-
-    co_await file.close();
+    }));
+    co_await io_driver->close().handle_error(
+      crimson::ct_error::assert_all("Invalid error in stat_device close"));
+    // driver->open() already derives block_size from the LBA format and clamps
+    // it to RBM_SUPERBLOCK_SIZE.
     co_return std::move(stat);
   }
 
@@ -331,14 +149,6 @@ public:
    */
    virtual nvme_command_ertr::future<> set_data_recovery_level(
      uint32_t level) { return nvme_command_ertr::now(); }
-  /*
-   * For passsing through nvme IO or Admin command to SSD
-   * Caller can construct and execute its own nvme command
-   */
-  nvme_command_ertr::future<int> pass_admin(
-    nvme_admin_command_t& admin_cmd, seastar::file f);
-  nvme_command_ertr::future<int> pass_through_io(
-    nvme_io_command_t& io_cmd);
 
   bool support_multistream = false;
 
@@ -350,28 +160,16 @@ public:
    */
 
 private:
-  // identify_controller/namespace are used to get SSD internal information such
-  // as supported features, NPWG and NPWA
-  seastar::future<std::optional<nvme_identify_controller_data_t>>
-    identify_controller(seastar::file f);
-  seastar::future<std::optional<nvme_identify_namespace_data_t>>
-    identify_namespace(seastar::file f);
-  nvme_command_ertr::future<int> get_nsid(seastar::file f);
-  open_ertr::future<> open_for_io(
-    const std::string& in_path,
-    seastar::open_flags mode);
+  // The NVMe transport (kernel today, SPDK later). Owns the device handles and
+  // the NVMe control plane (identify, PI-aware I/O, streams, passthrough).
+  NVMeIODriverRef driver;
 
-  seastar::file device;
-  std::vector<seastar::file> io_device;
-  uint32_t stream_index_to_open = WRITE_LIFE_NOT_SET;
-  uint32_t stream_id_count = 1; // stream is disabled, defaultly.
   uint32_t awupf = 0;
 
   uint64_t write_granularity = 4096;
   uint64_t write_alignment = 4096;
   uint32_t atomic_write_unit = 4096;
 
-  int namespace_id; // TODO: multi namespaces
   std::string device_path;
 
   seastar::sharded<MultiShardDevices<NVMeBlockDevice>> shard_devices;

--- a/src/crimson/os/seastore/random_block_manager/nvme_command.h
+++ b/src/crimson/os/seastore/random_block_manager/nvme_command.h
@@ -1,0 +1,177 @@
+//-*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#pragma once
+
+#include <cstdint>
+
+#include <linux/nvme_ioctl.h>
+
+namespace crimson::os::seastore::random_block_device::nvme {
+/*
+ * NVMe protocol structures (nvme_XX, identify_XX)
+ *
+ * All structures relative to NVMe protocol are following NVMe protocol v1.4
+ * (latest). NVMe is protocol for fast interfacing between user and SSD device.
+ * We selectively adopted features among various NVMe features to ease
+ * implementation. And also, NVMeBlockDevice provides generic command submission
+ * APIs for IO and Admin commands. Please use pass_through_io() and pass_admin()
+ * to do it.
+ *
+ * For more information about NVMe protocol, refer https://nvmexpress.org/
+ */
+struct nvme_identify_command_t {
+  uint32_t common_dw[10];
+
+  uint32_t cns : 8;
+  uint32_t reserved : 8;
+  uint32_t cnt_id : 16;
+
+  static const uint8_t CNS_NAMESPACE = 0x00;
+  static const uint8_t CNS_CONTROLLER = 0x01;
+};
+
+struct nvme_format_nvm_command_t {
+  uint32_t common_dw[10];
+
+  uint8_t lbaf : 4;
+  uint8_t mset : 1;
+  uint8_t pi : 3;
+  uint8_t pil : 1;
+
+  static const uint8_t PROTECT_INFORMATION_TYPE_2 = 2;
+};
+
+struct nvme_admin_command_t {
+  union {
+    nvme_passthru_cmd common;
+    nvme_identify_command_t identify;
+    nvme_format_nvm_command_t format;
+  };
+
+  static const uint8_t OPCODE_IDENTIFY = 0x06;
+  static const uint8_t OPCODE_FORMAT_NVM = 0x80;
+};
+
+// Optional Admin Command Support (OACS)
+// Indicates optional commands are supported by SSD or not
+struct oacs_t {
+  uint16_t unused : 5;
+  uint16_t support_directives : 1; // Support multi-stream
+  uint16_t unused2 : 10;
+};
+
+struct nvme_identify_controller_data_t {
+  union {
+    struct {
+      uint8_t unused[256];  // [255:0]
+      oacs_t oacs;          // [257:256]
+      uint8_t unused2[270]; // [527:258]
+      uint16_t awupf;       // [529:528]
+    };
+    uint8_t raw[4096];
+  };
+};
+
+// End-to-end Data Protection Capabilities (DPC)
+// Indicates type of E2E data protection supported by SSD
+struct dpc_t {
+  uint8_t support_type1 : 1;
+  uint8_t support_type2 : 1;
+  uint8_t support_type3 : 1;
+  uint8_t support_first_meta : 1;
+  uint8_t support_last_meta : 1;
+  uint8_t reserved : 3;
+};
+
+// End-to-end Data Protection Type Settings (DPS)
+// Indicates enabled type of E2E data protection
+struct dps_t {
+  uint8_t protection_type : 3;
+  uint8_t protection_info : 1;
+  uint8_t reserved : 4;
+};
+
+// Namespace Features (NSFEAT)
+// Indicates features of namespace
+struct nsfeat_t {
+  uint8_t thinp : 1;
+  uint8_t nsabp : 1;
+  uint8_t dae : 1;
+  uint8_t uid_reuse : 1;
+  uint8_t opterf : 1; // Support NPWG, NPWA
+  uint8_t reserved : 3;
+};
+
+// LBA Format (LBAF)
+// Indicates LBA format (metadata size, data size, performance)
+struct lbaf_t {
+  uint32_t ms : 16;
+  uint32_t lbads : 8;
+  uint32_t rp : 2;
+  uint32_t reserved : 6;
+};
+
+struct flbas_t {
+  uint8_t lba_index : 4;
+  uint8_t ms_transferred :1;
+  uint8_t reserved : 3;
+};
+
+struct nvme_identify_namespace_data_t {
+  union {
+    struct {
+      uint8_t unused[24];   // [23:0]
+      nsfeat_t nsfeat;      // [24]
+      uint8_t nlbaf;      // [25]
+      flbas_t flbas;      // [26]
+      uint8_t unused2;   // [27]
+      dpc_t dpc;            // [28]
+      dps_t dps;            // [29]
+      uint8_t unused3[34];  // [63:30]
+      uint16_t npwg;        // [65:64]
+      uint16_t npwa;        // [67:66]
+      uint8_t unused4[60];  // [127:68]
+      lbaf_t lbaf[64];         // [383:128]
+    };
+    uint8_t raw[4096];
+  };
+  // meta size value to use device-level checksum
+  static const uint8_t METASIZE_FOR_CHECKSUM_OFFLOAD = 8;
+};
+
+struct nvme_rw_command_t {
+  uint32_t common_dw[10];
+
+  uint64_t s_lba;
+
+  uint32_t nlb : 16; // 0's based value
+  uint32_t reserved : 4;
+  uint32_t d_type : 4;
+  uint32_t reserved2 : 2;
+  uint32_t prinfo_prchk : 3;
+  uint32_t prinfo_pract : 1;
+  uint32_t fua : 1;
+  uint32_t lr : 1;
+
+  uint32_t reserved3 : 16;
+  uint32_t dspec : 16;
+
+  static const uint32_t DTYPE_STREAM = 1;
+
+  static const uint8_t PROTECT_INFORMATION_ACTION_ENABLE = 1;
+  static const uint8_t PROTECT_INFORMATION_CHECK_GUARD = 4;
+  static const uint8_t PROTECT_INFORMATION_CHECK_APPLICATION_TAG = 2;
+  static const uint8_t PROTECT_INFORMATION_CHECK_LOGICAL_REFERENCE_TAG = 1;
+};
+
+struct nvme_io_command_t {
+  union {
+    nvme_passthru_cmd common;
+    nvme_rw_command_t rw;
+  };
+  static const uint8_t OPCODE_WRITE = 0x01;
+  static const uint8_t OPCODE_READ = 0x02;
+};
+
+}

--- a/src/crimson/os/seastore/random_block_manager/nvme_io_driver.cc
+++ b/src/crimson/os/seastore/random_block_manager/nvme_io_driver.cc
@@ -1,0 +1,429 @@
+//-*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include <strings.h>
+
+#include <fcntl.h>
+#include <seastar/coroutine/parallel_for_each.hh>
+
+#include "crimson/common/log.h"
+#include "crimson/common/errorator-utils.h"
+
+#include "include/buffer.h"
+#include "nvme_io_driver.h"
+#include "crimson/os/seastore/logging.h"
+
+SET_SUBSYS(seastore_device);
+
+namespace crimson::os::seastore::random_block_device::nvme {
+
+/**
+ * KernelNVMeIODriver
+ *
+ * Kernel/io_uring NVMe transport. The data path is plain dma_read/dma_write
+ * against seastar::file handles (device for reads, io_device[stream] for
+ * writes); the control plane uses NVME_IOCTL_* on those handles. The PI path
+ * (nvme_read/nvme_write) submits passthrough commands carrying protection
+ * information. This is the code that previously lived in NVMeBlockDevice,
+ * decoupled from the RBM superblock: PI state and the formatted NVMe block size
+ * are pushed in via set_protection_info().
+ */
+class KernelNVMeIODriver final : public NVMeIODriver {
+  seastar::file device;
+  std::vector<seastar::file> io_device;
+  caps_t caps;
+
+  bool pi_enabled = false;
+  uint32_t nvme_block_size = 0;
+  int namespace_id = 0;
+
+  uint32_t stream_index_to_open = WRITE_LIFE_NOT_SET;
+  uint32_t stream_id_count = 1; // stream is disabled, defaultly.
+
+  open_ertr::future<> open_for_io(
+    const std::string &in_path, seastar::open_flags mode)
+  {
+    io_device.resize(stream_id_count);
+    for (auto &target_device : io_device) {
+      auto file = co_await seastar::open_file_dma(in_path, mode);
+      assert(io_device.size() > stream_index_to_open);
+      target_device = std::move(file);
+    }
+  }
+
+  nvme_command_ertr::future<int> get_nsid() {
+    auto ret = co_await device.ioctl(NVME_IOCTL_ID, nullptr
+    ).handle_exception(
+      [](auto e)->nvme_command_ertr::future<int> {
+      LOG_PREFIX(KernelNVMeIODriver::get_nsid);
+      ERROR("get_nsid: ioctl failed {}", e);
+      return crimson::ct_error::input_output_error::make();
+    });
+    co_return ret;
+  }
+
+public:
+  KernelNVMeIODriver() = default;
+
+  const caps_t &get_caps() const final {
+    return caps;
+  }
+
+  int get_namespace_id() const final {
+    return namespace_id;
+  }
+
+  void set_protection_info(bool enabled, uint32_t block_size) final {
+    pi_enabled = enabled;
+    nvme_block_size = block_size;
+  }
+
+  open_ertr::future<seastar::stat_data> open(
+    const std::string &in_path,
+    seastar::open_flags mode) final
+  {
+    LOG_PREFIX(KernelNVMeIODriver::open);
+    auto file = co_await seastar::open_file_dma(in_path, mode);
+    device = std::move(file);
+    // Get SSD's features from identify_controller and namespace command.
+    // Do identify_controller first, and then identify_namespace.
+    auto id_ctr_data = co_await identify_controller();
+    std::optional<nvme_identify_namespace_data_t> id_ns_data;
+    if (id_ctr_data) {
+      // TODO: enable multi-stream if the nvme device supports
+      caps.ctrl_identified = true;
+      caps.awupf = id_ctr_data->awupf + 1;
+      id_ns_data = co_await identify_namespace();
+      if (id_ns_data) {
+        caps.ns_identified = true;
+        if (id_ns_data->nsfeat.opterf == 1) {
+          // NPWG and NPWA is 0'based value
+          caps.opterf = true;
+          caps.npwg = id_ns_data->npwg;
+          caps.npwa = id_ns_data->npwa;
+        }
+      } else {
+        DEBUG("identify_namespace failed.");
+      }
+    } else {
+      DEBUG("identify_controller failed.");
+    }
+
+    seastar::stat_data stat = co_await seastar::file_stat(
+      in_path, seastar::follow_symlink::yes);
+    stat.size = co_await device.size();
+    // LBA format provides the LBA size (power of 2); fall back to the RBM
+    // superblock size when identify is unavailable.
+    if (id_ns_data) {
+      stat.block_size = (1 << (*id_ns_data).lbaf[0].lbads);
+    }
+    if (stat.block_size < RBM_SUPERBLOCK_SIZE) {
+      stat.block_size = RBM_SUPERBLOCK_SIZE;
+    }
+
+    co_await open_for_io(in_path, mode);
+    co_return stat;
+  }
+
+  close_ertr::future<> close() final {
+    LOG_PREFIX(KernelNVMeIODriver::close);
+    DEBUG("close");
+    stream_index_to_open = WRITE_LIFE_NOT_SET;
+    co_await device.close();
+    for (auto &target_device : io_device) {
+      co_await target_device.close();
+    }
+  }
+
+  seastar::future<std::optional<nvme_identify_controller_data_t>>
+  identify_controller() final {
+    nvme_admin_command_t admin_command;
+    nvme_identify_controller_data_t data;
+    admin_command.common.opcode = nvme_admin_command_t::OPCODE_IDENTIFY;
+    admin_command.common.addr = (uint64_t)&data;
+    admin_command.common.data_len = sizeof(data);
+    admin_command.identify.cns = nvme_identify_command_t::CNS_CONTROLLER;
+    auto ret = co_await pass_admin(admin_command
+    ).handle_error(crimson::ct_error::input_output_error::handle([] {
+      return seastar::make_ready_future<int>(-1);
+    }));
+    if (ret < 0) {
+      co_return std::nullopt;
+    }
+    co_return std::move(data);
+  }
+
+  seastar::future<std::optional<nvme_identify_namespace_data_t>>
+  identify_namespace() final {
+    auto nsid = co_await get_nsid(
+    ).handle_error(crimson::ct_error::input_output_error::handle([] {
+      return seastar::make_ready_future<int>(-1);
+    }));
+    if (nsid < 0) {
+      co_return std::nullopt;
+    }
+    namespace_id = nsid;
+    nvme_admin_command_t admin_command;
+    nvme_identify_namespace_data_t data;
+    admin_command.common.opcode = nvme_admin_command_t::OPCODE_IDENTIFY;
+    admin_command.common.addr = (uint64_t)&data;
+    admin_command.common.data_len = sizeof(data);
+    admin_command.common.nsid = nsid;
+    admin_command.identify.cns = nvme_identify_command_t::CNS_NAMESPACE;
+
+    auto ret = co_await pass_admin(admin_command
+    ).handle_error(crimson::ct_error::input_output_error::handle([] {
+      return seastar::make_ready_future<int>(-1);
+    }));
+    if (ret < 0) {
+      co_return std::nullopt;
+    }
+    co_return std::move(data);
+  }
+
+  nvme_command_ertr::future<int> pass_admin(
+    nvme_admin_command_t &admin_cmd) final {
+    auto ret = co_await device.ioctl(NVME_IOCTL_ADMIN_CMD, &admin_cmd
+    ).handle_exception(
+      [](auto e)->nvme_command_ertr::future<int> {
+      LOG_PREFIX(KernelNVMeIODriver::pass_admin);
+      ERROR("pass_admin: ioctl failed {}", e);
+      return crimson::ct_error::input_output_error::make();
+    });
+    co_return ret;
+  }
+
+  nvme_command_ertr::future<int> pass_through_io(
+    nvme_io_command_t &io_cmd) final {
+    auto ret = co_await device.ioctl(NVME_IOCTL_IO_CMD, &io_cmd
+    ).handle_exception(
+      [](auto e)->nvme_command_ertr::future<int> {
+      LOG_PREFIX(KernelNVMeIODriver::pass_through_io);
+      ERROR("pass_through_io: ioctl failed {}", e);
+      return crimson::ct_error::input_output_error::make();
+    });
+    co_return ret;
+  }
+
+  discard_ertr::future<> discard(uint64_t offset, uint64_t len) final {
+    co_return co_await device.discard(offset, len);
+  }
+
+  // ---- data path -------------------------------------------------------
+
+  write_ertr::future<> nvme_write(
+    uint64_t offset, size_t len, void *buffer_ptr) {
+    nvme_io_command_t cmd;
+    cmd.common.opcode = nvme_io_command_t::OPCODE_WRITE;
+    cmd.common.nsid = namespace_id;
+    cmd.common.data_len = len;
+    // To perform checksum offload, we need to set PRACT to 1 and PRCHK to 4
+    // according to NVMe spec.
+    cmd.rw.prinfo_pract = nvme_rw_command_t::PROTECT_INFORMATION_ACTION_ENABLE;
+    cmd.rw.prinfo_prchk = nvme_rw_command_t::PROTECT_INFORMATION_CHECK_GUARD;
+    cmd.common.addr = (__u64)(uintptr_t)buffer_ptr;
+    ceph_assert(nvme_block_size > 0);
+    auto lba_shift = ffsll(nvme_block_size) - 1;
+    cmd.rw.s_lba = offset >> lba_shift;
+    cmd.rw.nlb = (len >> lba_shift) - 1;
+    auto ret = co_await pass_through_io(cmd);
+    if (ret != 0) {
+      LOG_PREFIX(KernelNVMeIODriver::nvme_write);
+      ERROR("write nvm command with checksum offload fails : {}", ret);
+      ceph_abort();
+    }
+  }
+
+  read_ertr::future<> nvme_read(
+    uint64_t offset, size_t len, void *buffer_ptr) {
+    nvme_io_command_t cmd;
+    cmd.common.opcode = nvme_io_command_t::OPCODE_READ;
+    cmd.common.nsid = namespace_id;
+    cmd.common.data_len = len;
+    cmd.rw.prinfo_pract = nvme_rw_command_t::PROTECT_INFORMATION_ACTION_ENABLE;
+    cmd.rw.prinfo_prchk = nvme_rw_command_t::PROTECT_INFORMATION_CHECK_GUARD;
+    cmd.common.addr = (__u64)(uintptr_t)buffer_ptr;
+    ceph_assert(nvme_block_size > 0);
+    auto lba_shift = ffsll(nvme_block_size) - 1;
+    cmd.rw.s_lba = offset >> lba_shift;
+    cmd.rw.nlb = (len >> lba_shift) - 1;
+    auto ret = co_await pass_through_io(cmd);
+    if (ret != 0) {
+      LOG_PREFIX(KernelNVMeIODriver::nvme_read);
+      ERROR("read nvm command with checksum offload fails : {}", ret);
+      ceph_abort();
+    }
+  }
+
+  read_ertr::future<> nvme_readv(
+    uint64_t offset, std::vector<bufferptr> ptrs) {
+    struct io_t {
+      uint64_t offset = 0;
+      bufferptr ptr;
+    };
+    std::vector<io_t> iov;
+    size_t off = 0;
+    for (auto &ptr : ptrs) {
+      auto len = ptr.length();
+      iov.emplace_back(offset + off, std::move(ptr));
+      off += len;
+    }
+    return seastar::do_with(
+      std::move(iov),
+      [this](auto &iov) {
+      return read_ertr::parallel_for_each(
+        iov,
+        [this](auto &io) {
+        return nvme_read(io.offset, io.ptr.length(), io.ptr.c_str());
+      });
+    });
+  }
+
+  read_ertr::future<> read(
+    device_id_t device_id,
+    uint64_t offset,
+    size_t len,
+    bufferptr &bptr) final {
+    LOG_PREFIX(KernelNVMeIODriver::read);
+    DEBUG("block: read offset {} len {}", offset, len);
+    if (len == 0) {
+      co_return;
+    }
+    if (pi_enabled) {
+      co_await nvme_read(offset, len, bptr.c_str());
+      co_return;
+    }
+    auto ret = co_await device.dma_read(offset, bptr.c_str(), len
+    ).handle_exception(
+      [FNAME](auto e) -> read_ertr::future<size_t> {
+      ERROR("read: dma_read got error{}", e);
+      return crimson::ct_error::input_output_error::make();
+    });
+    if (ret != len) {
+      ERROR("read: dma_read got error with not proper length");
+      co_await read_ertr::future<>(
+        crimson::ct_error::input_output_error::make());
+    }
+  }
+
+  read_ertr::future<> readv(
+    device_id_t device_id,
+    uint64_t offset,
+    std::vector<bufferptr> ptrs) final {
+    LOG_PREFIX(KernelNVMeIODriver::readv);
+    DEBUG("block: read offset {}, {} buffers", offset, ptrs.size());
+    if (ptrs.size() == 0) {
+      return read_ertr::now();
+    }
+    if (pi_enabled) {
+      return nvme_readv(offset, std::move(ptrs));
+    }
+    std::vector<iovec> iov;
+    size_t length = 0;
+    for (auto &ptr : ptrs) {
+      length += ptr.length();
+      iov.emplace_back(ptr.c_str(), ptr.length());
+    }
+    return device.dma_read(offset, std::move(iov)
+    ).handle_exception(
+      [FNAME](auto e) -> read_ertr::future<size_t> {
+        ERROR("read: dma_read got error{}", e);
+        return crimson::ct_error::input_output_error::make();
+      }).then([length, FNAME](auto result) -> read_ertr::future<> {
+        if (result != length) {
+          ERROR("read: dma_read got error with not proper length");
+          return crimson::ct_error::input_output_error::make();
+        }
+        return read_ertr::now();
+      });
+  }
+
+  using NVMeIODriver::write;
+  using NVMeIODriver::writev;
+
+  write_ertr::future<> write(
+    device_id_t device_id,
+    uint64_t offset,
+    bufferptr &bptr,
+    uint16_t stream) final {
+    LOG_PREFIX(KernelNVMeIODriver::write);
+    auto length = bptr.length();
+    DEBUG("block: write offset {} len {}", offset, length);
+    uint16_t supported_stream = stream;
+    if (stream >= stream_id_count) {
+      supported_stream = WRITE_LIFE_NOT_SET;
+    }
+    if (pi_enabled) {
+      co_await nvme_write(offset, length, bptr.c_str());
+      co_return;
+    }
+    auto ret = co_await io_device[supported_stream].dma_write(
+      offset, bptr.c_str(), length).handle_exception(
+      [FNAME](auto e) -> write_ertr::future<size_t> {
+      ERROR("write: dma_write got error{}", e);
+      return crimson::ct_error::input_output_error::make();
+    });
+    if (ret != length) {
+      ERROR("write: dma_write got error with not proper length");
+      co_await write_ertr::future<>(
+        crimson::ct_error::input_output_error::make());
+    }
+  }
+
+  write_ertr::future<> writev(
+    device_id_t device_id,
+    uint64_t offset,
+    bufferlist &&bl,
+    size_t block_size,
+    uint16_t stream) final {
+    LOG_PREFIX(KernelNVMeIODriver::writev);
+    DEBUG("block: write offset {} len {}", offset, bl.length());
+    uint16_t supported_stream = stream;
+    if (stream >= stream_id_count) {
+      supported_stream = WRITE_LIFE_NOT_SET;
+    }
+    if (pi_enabled) {
+      co_await nvme_write(offset, bl.length(), bl.c_str());
+      co_return;
+    }
+    bl.rebuild_aligned(block_size);
+    auto iovs = bl.prepare_iovs();
+    auto has_error = seastar::make_lw_shared<bool>(false);
+    co_await seastar::coroutine::parallel_for_each(
+      iovs,
+      [this, supported_stream, offset, has_error, device_id, FNAME](auto &p)
+    {
+      auto off = offset + p.offset;
+      auto len = p.length;
+      auto &iov = p.iov;
+      return io_device[supported_stream].dma_write(off, std::move(iov)
+      ).handle_exception(
+        [this, off, len, has_error, device_id, FNAME](auto e) -> seastar::future<size_t>
+      {
+        ERROR("{} poffset={}~{} dma_write got error -- {}",
+          device_id_printer_t{device_id}, off, len, e);
+        *has_error = true;
+        return seastar::make_ready_future<size_t>(0);
+      }).then([this, off, len, has_error, device_id, FNAME](size_t written) {
+        if (written != len) {
+          ERROR("{} poffset={}~{} dma_write len={} inconsistent",
+            device_id_printer_t{device_id}, off, len, written);
+          *has_error = true;
+        }
+        return seastar::now();
+      });
+    });
+    if (*has_error) {
+      co_await write_ertr::future<>(
+        crimson::ct_error::input_output_error::make());
+    }
+  }
+};
+
+NVMeIODriverRef make_nvme_io_driver(const std::string &path)
+{
+  // Phase 6 adds the SPDK branch keyed on seastore_spdk_transport_id.
+  return std::make_unique<KernelNVMeIODriver>();
+}
+
+}

--- a/src/crimson/os/seastore/random_block_manager/nvme_io_driver.h
+++ b/src/crimson/os/seastore/random_block_manager/nvme_io_driver.h
@@ -1,0 +1,130 @@
+//-*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#pragma once
+
+#include <list>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <seastar/core/file.hh>
+
+#include "crimson/os/seastore/block_io_driver.h"
+#include "rbm_device.h"        // RBM ertr aliases (nvme_command_ertr, ...)
+#include "nvme_command.h"
+
+namespace crimson::os::seastore::random_block_device::nvme {
+
+/**
+ * NVMeIODriver
+ *
+ * Tier-2 transport for the random-block (RBM) backend. It is a BlockIODriver
+ * (so the bulk read/write/writev/readv data path is shared with the segmented
+ * backend) plus the NVMe control plane that an NVMe SSD exposes:
+ *
+ *   - identify-derived capabilities (caps_t),
+ *   - end-to-end data protection (PI) aware I/O,
+ *   - write streams,
+ *   - admin / IO command passthrough.
+ *
+ * Ownership boundary: the *driver* owns all device interaction (data and admin)
+ * and the transient PI state used to choose plain DMA vs. PI passthrough. The
+ * *device* (NVMeBlockDevice/RBMDevice) still owns the on-disk superblock, which
+ * persists whether PI is enabled and the formatted NVMe block size; it pushes
+ * that state into the driver via set_protection_info(). Nothing in the driver
+ * reaches into RBMDevice::super, which is what lets a kernel and an SPDK
+ * implementation share this interface.
+ */
+class NVMeIODriver : public crimson::os::seastore::BlockIODriver {
+public:
+  /// Raw identify-derived controller/namespace capabilities, valid after open().
+  /// The device combines these with its own superblock block_size to compute
+  /// write_granularity / write_alignment / atomic_write_unit (kept on the device
+  /// so that math stays tied to the on-disk block size, unchanged from today).
+  struct caps_t {
+    bool ctrl_identified = false;        ///< identify_controller succeeded
+    bool ns_identified = false;          ///< identify_namespace succeeded
+    uint32_t awupf = 0;                  ///< AWUPF + 1 (i.e. already 1's based)
+    bool opterf = false;                 ///< namespace supports NPWG/NPWA
+    uint16_t npwg = 0;                   ///< preferred write granularity (0's based)
+    uint16_t npwa = 0;                   ///< preferred write alignment (0's based)
+    bool supports_multistream = false;
+    uint32_t stream_id_count = 1;        ///< 1 == multistream disabled
+  };
+  virtual const caps_t &get_caps() const = 0;
+
+  /// NVMe namespace id, cached by identify_namespace()/open().
+  virtual int get_namespace_id() const = 0;
+
+  /**
+   * Configure PI for subsequent I/O. PI is a device-wide mode: the device reads
+   * it from the superblock (set at mkfs, validated at mount) and pushes it here.
+   * When enabled, read()/write() submit PI-carrying NVMe commands using
+   * nvme_block_size as the LBA unit; otherwise they use plain DMA.
+   */
+  virtual void set_protection_info(bool enabled, uint32_t nvme_block_size) = 0;
+
+  /// Stream-aware write. stream is ignored when stream_id_count == 1. PI is
+  /// applied internally per set_protection_info().
+  virtual write_ertr::future<> write(
+    device_id_t device_id,
+    uint64_t offset,
+    bufferptr &bptr,
+    uint16_t stream) = 0;
+  virtual write_ertr::future<> writev(
+    device_id_t device_id,
+    uint64_t offset,
+    bufferlist &&bl,
+    size_t block_size,
+    uint16_t stream) = 0;
+
+  // The BlockIODriver base write/writev (no stream) forward to the stream-aware
+  // overloads with the default stream.
+  write_ertr::future<> write(
+    device_id_t device_id, uint64_t offset, bufferptr &bptr) final {
+    return write(device_id, offset, bptr, /*stream=*/0);
+  }
+  write_ertr::future<> writev(
+    device_id_t device_id, uint64_t offset,
+    bufferlist &&bl, size_t block_size) final {
+    return writev(device_id, offset, std::move(bl), block_size, /*stream=*/0);
+  }
+
+  /// NVMe identify, exposed so device-level logic (mkfs PI formatting, mount
+  /// validation) can run without owning the transport.
+  virtual seastar::future<std::optional<nvme_identify_controller_data_t>>
+    identify_controller() = 0;
+  virtual seastar::future<std::optional<nvme_identify_namespace_data_t>>
+    identify_namespace() = 0;
+
+  /// Raw NVMe passthrough for advanced features and PI formatting.
+  virtual nvme_command_ertr::future<int> pass_admin(
+    nvme_admin_command_t &admin_cmd) = 0;
+  virtual nvme_command_ertr::future<int> pass_through_io(
+    nvme_io_command_t &io_cmd) = 0;
+
+  /// Data-health / recovery-level hooks (default no-ops on devices that lack
+  /// the corresponding NVMe features).
+  virtual nvme_command_ertr::future<std::list<uint64_t>> get_data_health() {
+    return nvme_command_ertr::make_ready_future<std::list<uint64_t>>();
+  }
+  virtual nvme_command_ertr::future<> set_data_recovery_level(uint32_t level) {
+    return nvme_command_ertr::now();
+  }
+
+  /// discard/trim the given device range.
+  virtual discard_ertr::future<> discard(uint64_t offset, uint64_t len) = 0;
+};
+using NVMeIODriverRef = std::unique_ptr<NVMeIODriver>;
+
+/**
+ * make_nvme_io_driver
+ *
+ * RBM transport factory. Returns the kernel NVMe driver today; Phase 6 adds the
+ * SPDK branch keyed on seastore_spdk_transport_id. Synchronous, non-blocking
+ * construction (env init / probe is deferred to open()).
+ */
+NVMeIODriverRef make_nvme_io_driver(const std::string &path);
+
+}

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -56,182 +56,29 @@ template <> struct fmt::formatter<segment_state_t>: fmt::formatter<std::string_v
 
 namespace crimson::os::seastore::segment_manager::block {
 
-static write_ertr::future<> do_write(
-  device_id_t device_id,
-  seastar::file &device,
-  uint64_t offset,
-  bufferptr &bptr)
-{
-  LOG_PREFIX(block_do_write);
-  auto len = bptr.length();
-  TRACE("{} poffset=0x{:x}~0x{:x} ...",
-        device_id_printer_t{device_id}, offset, len);
-  return device.dma_write(
-    offset,
-    bptr.c_str(),
-    len
-  ).handle_exception(
-    [FNAME, device_id, offset, len](auto e) -> write_ertr::future<size_t> {
-    ERROR("{} poffset=0x{:x}~0x{:x} got error -- {}",
-          device_id_printer_t{device_id}, offset, len, e);
-    return crimson::ct_error::input_output_error::make();
-  }).then([FNAME, device_id, offset, len](auto result) -> write_ertr::future<> {
-    if (result != len) {
-      ERROR("{} poffset=0x{:x}~0x{:x} write len=0x{:x} inconsistent",
-            device_id_printer_t{device_id}, offset, len, result);
-      return crimson::ct_error::input_output_error::make();
-    }
-    TRACE("{} poffset=0x{:x}~0x{:x} done", device_id_printer_t{device_id}, offset, len);
-    return write_ertr::now();
-  });
-}
-
-static write_ertr::future<> do_writev(
-  device_id_t device_id,
-  seastar::file &device,
-  uint64_t offset,
-  bufferlist&& bl,
-  size_t block_size)
-{
-  LOG_PREFIX(block_do_writev);
-  TRACE("{} poffset=0x{:x}~0x{:x}, {} buffers",
-        device_id_printer_t{device_id}, offset, bl.length(), bl.get_num_buffers());
-
-  // writev requires each buffer to be aligned to the disks' block
-  // size, we need to rebuild here
-  bl.rebuild_aligned(block_size);
-
-  return seastar::do_with(
-    bl.prepare_iovs(),
-    std::move(bl),
-    [&device, device_id, offset, FNAME](auto& iovs, auto& bl)
-  {
-    return write_ertr::parallel_for_each(
-      iovs,
-      [&device, device_id, offset, FNAME](auto& p) mutable
-    {
-      auto off = offset + p.offset;
-      auto len = p.length;
-      auto& iov = p.iov;
-      TRACE("{} poffset=0x{:x}~0x{:x} dma_write ...",
-            device_id_printer_t{device_id}, off, len);
-      return device.dma_write(off, std::move(iov)
-      ).handle_exception(
-        [FNAME, device_id, off, len](auto e) -> write_ertr::future<size_t>
-      {
-        ERROR("{} poffset=0x{:x}~0x{:x} dma_write got error -- {}",
-              device_id_printer_t{device_id}, off, len, e);
-	return crimson::ct_error::input_output_error::make();
-      }).then([FNAME, device_id, off, len](size_t written) -> write_ertr::future<> {
-	if (written != len) {
-          ERROR("{} poffset=0x{:x}~0x{:x} dma_write len=0x{:x} inconsistent",
-                device_id_printer_t{device_id}, off, len, written);
-	  return crimson::ct_error::input_output_error::make();
-	}
-        TRACE("{} poffset=0x{:x}~0x{:x} dma_write done",
-              device_id_printer_t{device_id}, off, len);
-	return write_ertr::now();
-      });
-    });
-  });
-}
-
-static read_ertr::future<> do_read(
-  device_id_t device_id,
-  seastar::file &device,
-  uint64_t offset,
-  size_t len,
-  bufferptr &bptr)
-{
-  LOG_PREFIX(block_do_read);
-  TRACE("{} poffset=0x{:x}~0x{:x} ...", device_id_printer_t{device_id}, offset, len);
-  assert(len <= bptr.length());
-  return device.dma_read(
-    offset,
-    bptr.c_str(),
-    len
-  ).handle_exception(
-    //FIXME: this is a little bit tricky, since seastar::future<T>::handle_exception
-    //	returns seastar::future<T>, to return an crimson::ct_error, we have to create
-    //	a seastar::future<T> holding that crimson::ct_error. This is not necessary
-    //	once seastar::future<T>::handle_exception() returns seastar::futurize_t<T>
-    [FNAME, device_id, offset, len](auto e) -> read_ertr::future<size_t>
-  {
-    ERROR("{} poffset=0x{:x}~0x{:x} got error -- {}",
-          device_id_printer_t{device_id}, offset, len, e);
-    return crimson::ct_error::input_output_error::make();
-  }).then([FNAME, device_id, offset, len](auto result) -> read_ertr::future<> {
-    if (result != len) {
-      ERROR("{} poffset=0x{:x}~0x{:x} read len=0x{:x} inconsistent",
-            device_id_printer_t{device_id}, offset, len, result);
-      return crimson::ct_error::input_output_error::make();
-    }
-    TRACE("{} poffset=0x{:x}~0x{:x} done", device_id_printer_t{device_id}, offset, len);
-    return read_ertr::now();
-  });
-}
-
-static read_ertr::future<> do_readv(
-  device_id_t device_id,
-  seastar::file &device,
-  uint64_t offset,
-  std::vector<bufferptr> ptrs)
-{
-  LOG_PREFIX(block_do_readv);
-  std::vector<iovec> iov;
-  size_t len = 0;
-  for (auto &ptr : ptrs) {
-    iov.emplace_back(ptr.c_str(), ptr.length());
-    len += ptr.length();
-  }
-  TRACE("{} poffset=0x{:x}~0x{:x} {} buffers",
-    device_id_printer_t{device_id}, offset, len, ptrs.size());
-  return device.dma_read(offset, std::move(iov)
-  ).handle_exception(
-    //FIXME: this is a little bit tricky, since seastar::future<T>::handle_exception
-    //	returns seastar::future<T>, to return an crimson::ct_error, we have to create
-    //	a seastar::future<T> holding that crimson::ct_error. This is not necessary
-    //	once seastar::future<T>::handle_exception() returns seastar::futurize_t<T>
-    [FNAME, device_id, offset, len](auto e) -> read_ertr::future<size_t>
-  {
-    ERROR("{} poffset=0x{:x}~0x{:x} got error -- {}",
-          device_id_printer_t{device_id}, offset, len, e);
-    return crimson::ct_error::input_output_error::make();
-  }).then([FNAME, device_id, offset, len](auto result) -> read_ertr::future<> {
-    if (result != len) {
-      ERROR("{} poffset=0x{:x}~0x{:x} read len=0x{:x} inconsistent",
-            device_id_printer_t{device_id}, offset, len, result);
-      return crimson::ct_error::input_output_error::make();
-    }
-    TRACE("{} poffset=0x{:x}~0x{:x} done", device_id_printer_t{device_id}, offset, len);
-    return read_ertr::now();
-  });
-}
-
 write_ertr::future<>
 SegmentStateTracker::write_out(
   device_id_t device_id,
-  seastar::file &device,
+  BlockIODriver &driver,
   uint64_t offset)
 {
   LOG_PREFIX(SegmentStateTracker::write_out);
   DEBUG("{} poffset=0x{:x}~0x{:x}",
         device_id_printer_t{device_id}, offset, bptr.length());
-  return do_write(device_id, device, offset, bptr);
+  return driver.write(device_id, offset, bptr);
 }
 
 write_ertr::future<>
 SegmentStateTracker::read_in(
   device_id_t device_id,
-  seastar::file &device,
+  BlockIODriver &driver,
   uint64_t offset)
 {
   LOG_PREFIX(SegmentStateTracker::read_in);
   DEBUG("{} poffset=0x{:x}~0x{:x}",
         device_id_printer_t{device_id}, offset, bptr.length());
-  return do_read(
+  return driver.read(
     device_id,
-    device,
     offset,
     bptr.length(),
     bptr);
@@ -288,45 +135,11 @@ device_superblock_t make_superblock(
     std::move(shard_infos));
 }
 
-using open_device_ret = 
-  BlockSegmentManager::access_ertr::future<
-  std::pair<seastar::file, seastar::stat_data>
-  >;
-static
-open_device_ret open_device(
-  const std::string &path)
-{
-  LOG_PREFIX(block_open_device);
-  return seastar::file_stat(path, seastar::follow_symlink::yes
-  ).then([&path, FNAME](auto stat) mutable {
-    return seastar::open_file_dma(
-      path,
-      seastar::open_flags::rw | seastar::open_flags::dsync
-    ).then([stat, &path, FNAME](auto file) mutable {
-      return file.size().then([stat, file, &path, FNAME](auto size) mutable {
-        stat.size = size;
-        // Use Seastar's DMA alignment for optimal I/O alignment; clamp to
-        // laddr_t::UNIT_SIZE since SeaStore operates at 4 KiB granularity
-        // and rejects smaller device-reported block sizes.
-        stat.block_size = std::max<uint64_t>(file.disk_write_dma_alignment(),
-                                             laddr_t::UNIT_SIZE);
-        INFO("path={} successful, size=0x{:x}, block_size=0x{:x}",
-             path, stat.size, stat.block_size);
-        return std::make_pair(file, stat);
-      });
-    });
-  }).handle_exception([FNAME, &path](auto e) -> open_device_ret {
-    ERROR("path={} got error -- {}", path, e);
-    return crimson::ct_error::input_output_error::make();
-  });
-}
-
-
 static
 BlockSegmentManager::access_ertr::future<>
 write_superblock(
     device_id_t device_id,
-    seastar::file &device,
+    BlockIODriver &driver,
     device_superblock_t sb)
 {
   LOG_PREFIX(block_write_superblock);
@@ -336,7 +149,7 @@ write_superblock(
 	 ceph::encoded_sizeof<device_superblock_t>(sb) < sb.block_size);
   return seastar::do_with(
     bufferptr(ceph::buffer::create_page_aligned(sb.block_size)),
-    [=, &device](auto &bp)
+    [=, &driver](auto &bp)
   {
     bp.zero();
     // magic at offset 0, followed by 37 bytes of null padding (already zero)
@@ -348,23 +161,22 @@ write_superblock(
     auto iter = bl.begin();
     assert(SUPERBLOCK_HEADER_PREFIX + bl.length() < sb.block_size);
     iter.copy(bl.length(), bp.c_str() + SUPERBLOCK_HEADER_PREFIX);
-    return do_write(device_id, device, 0, bp);
+    return driver.write(device_id, 0, bp);
   });
 }
 
 static
 BlockSegmentManager::access_ertr::future<device_superblock_t>
-read_superblock(seastar::file &device, seastar::stat_data sd)
+read_superblock(BlockIODriver &driver, seastar::stat_data sd)
 {
   LOG_PREFIX(block_read_superblock);
   DEBUG("reading superblock ...");
   return seastar::do_with(
     bufferptr(ceph::buffer::create_page_aligned(sd.block_size)),
-    [=, &device](auto &bp)
+    [=, &driver](auto &bp)
   {
-    return do_read(
+    return driver.read(
       DEVICE_ID_NULL, // unknown
-      device,
       0,
       bp.length(),
       bp
@@ -464,7 +276,7 @@ Segment::close_ertr::future<> BlockSegmentManager::segment_close(
   stats.closed_segments_unused_bytes += unused_bytes;
   stats.metadata_write.increment(tracker->get_size());
   return tracker->write_out(
-      get_device_id(), device,
+      get_device_id(), *driver,
       shard_info.tracker_offset);
 }
 
@@ -476,9 +288,8 @@ Segment::write_ertr::future<> BlockSegmentManager::segment_write(
   assert(addr.get_device_id() == get_device_id());
   assert((bl.length() % superblock.block_size) == 0);
   stats.data_write.increment(bl.length());
-  return do_writev(
+  return driver->writev(
       get_device_id(),
-      device,
       get_offset(addr),
       std::move(bl),
       superblock.block_size);
@@ -509,14 +320,20 @@ Device& BlockSegmentManager::get_sharded_device(store_index_t store_index)
   return *shard_devices.local().mshard_devices[store_index];
 }
 
+BlockSegmentManager::access_ertr::future<seastar::stat_data>
+BlockSegmentManager::open_driver()
+{
+  driver = make_block_io_driver(device_path, superblock.config.spec.dtype);
+  return driver->open(
+    device_path,
+    seastar::open_flags::rw | seastar::open_flags::dsync);
+}
+
 SegmentManager::read_ertr::future<uint32_t> BlockSegmentManager::get_shard_nums()
 {
-  return open_device(
-    device_path
-  ).safe_then([this](auto p) {
-    device = std::move(p.first);
-    auto sd = p.second;
-    return read_superblock(device, sd);
+  return open_driver(
+  ).safe_then([this](auto sd) {
+    return read_superblock(*driver, sd);
   }).safe_then([](auto sb) {
     return read_ertr::make_ready_future<uint32_t>(sb.shard_num);
   }).handle_error(
@@ -542,12 +359,9 @@ BlockSegmentManager::mount_ret BlockSegmentManager::mount()
 BlockSegmentManager::mount_ret BlockSegmentManager::shard_mount()
 {
   LOG_PREFIX(BlockSegmentManager::shard_mount);
-  return open_device(
-    device_path
-  ).safe_then([=, this](auto p) {
-    device = std::move(p.first);
-    auto sd = p.second;
-    return read_superblock(device, sd);
+  return open_driver(
+  ).safe_then([=, this](auto sd) {
+    return read_superblock(*driver, sd);
   }).safe_then([=, this](auto sb) ->mount_ertr::future<> {
     set_device_id(sb.config.spec.id);
     if(seastar::this_shard_id() + seastar::this_smp_shard_count() * store_index >= sb.shard_num) {
@@ -570,7 +384,7 @@ BlockSegmentManager::mount_ret BlockSegmentManager::shard_mount()
     stats.data_read.increment(tracker->get_size());
     return tracker->read_in(
       get_device_id(),
-      device,
+      *driver,
       shard_info.tracker_offset
     ).safe_then([this] {
       for (device_segment_id_t i = 0; i < tracker->get_capacity(); ++i) {
@@ -580,7 +394,7 @@ BlockSegmentManager::mount_ret BlockSegmentManager::shard_mount()
       }
       stats.metadata_write.increment(tracker->get_size());
       return tracker->write_out(
-          get_device_id(), device,
+          get_device_id(), *driver,
           shard_info.tracker_offset);
     });
   }).safe_then([this, FNAME] {
@@ -615,37 +429,34 @@ BlockSegmentManager::mkfs_ret BlockSegmentManager::primary_mkfs(
   INFO("{} path={}, {}",
        device_id_printer_t{get_device_id()}, device_path, sm_config);
 
-  seastar::file device;
   seastar::stat_data stat;
   device_superblock_t sb;
-  std::unique_ptr<SegmentStateTracker> tracker;
 
   using crimson::common::get_conf;
   if (get_conf<bool>("seastore_block_create")) {
     auto size = get_conf<Option::size_t>("seastore_device_size");
      co_await check_create_device(device_path, size);
   }
-  auto p = co_await open_device(device_path);
-  device = p.first;
-  stat = p.second;
-  auto closer = seastar::defer([&device] {
-    std::ignore = device.close();
+  auto local_driver = make_block_io_driver(
+    device_path, superblock.config.spec.dtype);
+  stat = co_await local_driver->open(
+    device_path,
+    seastar::open_flags::rw | seastar::open_flags::dsync);
+  auto closer = seastar::defer([&local_driver] {
+    std::ignore = local_driver->close();
   });
   sb = make_superblock(get_device_id(), sm_config, stat);
   stats.metadata_write.increment(ceph::encoded_sizeof<device_superblock_t>(sb));
-  co_await write_superblock(get_device_id(), device, sb);
+  co_await write_superblock(get_device_id(), *local_driver, sb);
   INFO("{} complete", device_id_printer_t{get_device_id()});
 }
 
 BlockSegmentManager::mkfs_ret BlockSegmentManager::shard_mkfs()
 {
   LOG_PREFIX(BlockSegmentManager::shard_mkfs);
-  return open_device(
-    device_path
-  ).safe_then([this](auto p) {
-    device = std::move(p.first);
-    auto sd = p.second;
-    return read_superblock(device, sd);
+  return open_driver(
+  ).safe_then([this](auto sd) {
+    return read_superblock(*driver, sd);
   }).safe_then([this, FNAME](auto sb) {
     set_device_id(sb.config.spec.id);
     shard_info = sb.shard_infos[seastar::this_shard_id()];
@@ -655,10 +466,10 @@ BlockSegmentManager::mkfs_ret BlockSegmentManager::shard_mkfs()
       shard_info.segments, sb.block_size));
     stats.metadata_write.increment(tracker->get_size());
     return tracker->write_out(
-      get_device_id(), device,
+      get_device_id(), *driver,
       shard_info.tracker_offset);
   }).finally([this] {
-    return device.close();
+    return driver->close();
   }).safe_then([FNAME, this] {
     INFO("{} complete", device_id_printer_t{get_device_id()});
     return mkfs_ertr::now();
@@ -670,7 +481,7 @@ BlockSegmentManager::close_ertr::future<> BlockSegmentManager::close()
   LOG_PREFIX(BlockSegmentManager::close);
   INFO("{}", device_id_printer_t{get_device_id()});
   metrics.clear();
-  return device.close();
+  return driver->close();
 }
 
 SegmentManager::open_ertr::future<SegmentRef> BlockSegmentManager::open(
@@ -695,7 +506,7 @@ SegmentManager::open_ertr::future<SegmentRef> BlockSegmentManager::open(
   tracker->set(s_id, segment_state_t::OPEN);
   stats.metadata_write.increment(tracker->get_size());
   return tracker->write_out(
-      get_device_id(), device,
+      get_device_id(), *driver,
       shard_info.tracker_offset
   ).safe_then([this, id, FNAME] {
     ++stats.opened_segments;
@@ -729,7 +540,7 @@ SegmentManager::release_ertr::future<> BlockSegmentManager::release(
   ++stats.released_segments;
   stats.metadata_write.increment(tracker->get_size());
   return tracker->write_out(
-      get_device_id(), device,
+      get_device_id(), *driver,
       shard_info.tracker_offset);
 }
 
@@ -778,9 +589,8 @@ SegmentManager::read_ertr::future<> BlockSegmentManager::readv(
   }
 
   stats.data_read.increment(len);
-  return do_readv(
+  return driver->readv(
     get_device_id(),
-    device,
     p_off,
     std::move(ptrs));
 }
@@ -827,9 +637,8 @@ SegmentManager::read_ertr::future<> BlockSegmentManager::read(
   }
 
   stats.data_read.increment(len);
-  return do_read(
+  return driver->read(
     get_device_id(),
-    device,
     p_off,
     len,
     out);

--- a/src/crimson/os/seastore/segment_manager/block.h
+++ b/src/crimson/os/seastore/segment_manager/block.h
@@ -12,6 +12,7 @@
 
 #include "crimson/common/layout.h"
 
+#include "crimson/os/seastore/block_io_driver.h"
 #include "crimson/os/seastore/segment_manager.h"
 
 namespace crimson::os::seastore::segment_manager::block {
@@ -74,12 +75,12 @@ public:
 
   write_ertr::future<> write_out(
     device_id_t device_id,
-    seastar::file &device,
+    BlockIODriver &driver,
     uint64_t offset);
 
   read_ertr::future<> read_in(
     device_id_t device_id,
-    seastar::file &device,
+    BlockIODriver &driver,
     uint64_t offset);
 };
 
@@ -222,7 +223,7 @@ private:
   std::unique_ptr<SegmentStateTracker> tracker;
   device_shard_info_t shard_info;
   device_superblock_t superblock;
-  seastar::file device;
+  BlockIODriverRef driver;
 
   void set_device_id(device_id_t id) {
     assert(id <= DEVICE_ID_MAX_VALID);
@@ -251,6 +252,10 @@ private:
       segment_id_t id, segment_off_t write_pointer);
 
 private:
+  // create the I/O driver for this shard and open the underlying device,
+  // returning its detected {size, block_size}. Stores the driver in `driver`.
+  access_ertr::future<seastar::stat_data> open_driver();
+
   // shard 0 mkfs
   mkfs_ret primary_mkfs(device_config_t);
   // all shards mkfs


### PR DESCRIPTION
Preparation for the SPDK I/O path (#69516), split out per review so the shared-path change can be reviewed and merged on its own.

Two refactors, no behaviour change, no new dependencies:

- `BlockIODriver`: the raw block I/O that `BlockSegmentManager` did through `seastar::file` moves into `KernelBlockIODriver` behind a small transport interface (open/close/read/write/writev). The segment manager keeps its logic and calls the driver.
- `NVMeIODriver`: same for `NVMeBlockDevice`; the kernel NVMe passthrough path becomes `KernelNVMeIODriver`, and the raw NVMe command structs move to `nvme_command.h`, which drops the `linux/nvme_ioctl.h` dependency from the RBM device header.

Both factories return the kernel implementation unconditionally in this PR; the SPDK implementations arrive in #69516 and select themselves only when `seastore_spdk_transport_id` is set.

Tested with the seastore unit tests (transaction manager, journal, RBM, segment manager) against both backends.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
