### PR TITLE
mgr/cephadm: don't gate explicit OSD paths on inventory availability

### DIFF
--- a/doc/cephadm/services/osd.rst
+++ b/doc/cephadm/services/osd.rst
@@ -186,6 +186,23 @@ There are multiple ways to create new OSDs:
 
     ceph orch daemon add osd host1:/dev/sdb
 
+* Create an OSD from a disk partition (NVMe, SCSI, virtio). Partitions are not
+  listed by ``ceph orch device ls`` and cannot be consumed by ``lvm batch``.
+  Pass ``raw`` as the method:
+
+  .. prompt:: bash #
+
+    ceph orch daemon add osd <host>:<partition-path> raw
+
+  For example:
+
+  .. prompt:: bash #
+
+    ceph orch daemon add osd host1:/dev/nvme0n1p1 raw
+
+  The same layout can be applied with a spec file that sets ``method: raw``
+  and lists the partition under ``data_devices.paths``.
+
 * Advanced OSD creation from specific devices on a specific host:
 
   .. prompt:: bash #

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3793,7 +3793,7 @@ Then run the following:
                             return f"Error: Device {device.path} is not found on host {host_name}"
                         continue
 
-                    if not matching_device.available:
+                    if not matching_device.available and not explicit_paths_only:
                         return (
                             f"Error: Device {device.path} is present but unavailable for OSD creation. "
                             f"Reason: {', '.join(matching_device.rejected_reasons) if matching_device.rejected_reasons else 'Unknown'}")

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1374,7 +1374,7 @@ class TestCephadm(object):
             assert cephadm_module.validate_device('test', dg) == ""
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    def test_validate_device_rejects_path_in_cache_but_unavailable(self, cephadm_module):
+    def test_validate_device_path_only_allows_unavailable_in_cache(self, cephadm_module):
         with with_host(cephadm_module, 'test'):
             cephadm_module.cache.update_host_devices('test', [
                 Device('/dev/sdb', available=False, rejected_reasons=['Has a File System']),
@@ -1383,8 +1383,20 @@ class TestCephadm(object):
                 placement=PlacementSpec(host_pattern='test'),
                 data_devices=DeviceSelection(paths=['/dev/sdb']),
             )
-            out = cephadm_module.validate_device('test', dg)
-            assert 'unavailable' in out
+            assert cephadm_module.validate_device('test', dg) == ""
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_validate_device_nvme_partition_missing_from_cache(self, cephadm_module):
+        with with_host(cephadm_module, 'test'):
+            cephadm_module.cache.update_host_devices('test', [
+                Device('/dev/sda', available=True),
+            ])
+            dg = DriveGroupSpec(
+                placement=PlacementSpec(host_pattern='test'),
+                method='raw',
+                data_devices=DeviceSelection(paths=['/dev/nvme0n1p1']),
+            )
+            assert cephadm_module.validate_device('test', dg) == ""
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_validate_device_rejects_empty_path(self, cephadm_module):
@@ -1434,6 +1446,21 @@ class TestCephadm(object):
                     saved = cephadm_module.spec_store.all_specs['osd.default']
                     assert saved.data_devices.paths[0].path == '/dev/sdb'
                     assert saved.data_devices.paths[0].crush_device_class == 'ssd'
+                    mock_apply.assert_called_once()
+
+    def test_create_osd_default_spec_preserves_method(self, cephadm_module):
+        with mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}')):
+            with mock.patch("cephadm.module.CephadmOrchestrator.apply") as mock_apply:
+                with with_host(cephadm_module, 'test'):
+                    dg = DriveGroupSpec(
+                        placement=PlacementSpec(host_pattern='test'),
+                        data_devices=DeviceSelection(paths=['/dev/nvme0n1p1']),
+                        method='raw',
+                        service_id='default',
+                    )
+                    cephadm_module.create_osd_default_spec(dg)
+                    saved = cephadm_module.spec_store.all_specs['osd.default']
+                    assert saved.method == 'raw'
                     mock_apply.assert_called_once()
 
     def test_create_osds_skips_default_spec_when_osd_default_exists(self, cephadm_module):
@@ -1611,6 +1638,16 @@ class TestCephadm(object):
             out = cephadm_module.osd_service.driveselection_to_ceph_volume(ds, [], preview)
             assert all(any(cmd in exp_cmd for exp_cmd in exp_commands)
                        for cmd in out), f'Expected cmds from f{out} in {exp_commands}'
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_raw_driveselection_nvme_partition(self, cephadm_module):
+        with with_host(cephadm_module, 'test'):
+            devices = ['/dev/nvme0n1p1']
+            dg = DriveGroupSpec(service_id='test.spec', method='raw', placement=PlacementSpec(
+                host_pattern='test'), data_devices=DeviceSelection(paths=devices))
+            ds = DriveSelection(dg, Devices([Device(path) for path in devices]))
+            out = cephadm_module.osd_service.driveselection_to_ceph_volume(ds, [], preview=False)
+            assert out == ['raw prepare --bluestore --data /dev/nvme0n1p1']
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm(
         json.dumps([

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1576,6 +1576,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         usage = """
 Usage:
   ceph orch daemon add osd host:device1,device2,...
+  ceph orch daemon add osd host:device raw
   ceph orch daemon add osd host:data_devices=device1,device2,db_devices=device3,osds_per_device=2[,encrypted=false]
   ceph orch daemon add osd host:data_devices=device1[,encrypted=true,tpm2=true]
 """


### PR DESCRIPTION
'daemon add osd' looks devices up in the host cache. Partitions usually aren't listed there, and a disk that already has partitions is often marked unavailable. apply -i with data_devices.paths doesn't care: it just uses the path.

This fixe skips the availability check when the spec is 'explicit paths only', so:

`ceph orch daemon add osd <host>:/dev/nvme0n1p1 raw`

matches the spec file behavior.

Fixes: https://tracker.ceph.com/issues/80310


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
