### PR TITLE
rgw/radosgw-admin: extract account commands into a module

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -819,7 +819,8 @@ if(WITH_RADOSGW_STANDALONE)
 endif()
 
 set(radosgw_admin_srcs
-  radosgw-admin/radosgw-admin.cc)
+  radosgw-admin/radosgw-admin.cc
+  radosgw-admin/account.cc)
 
 # this is unsatisfying and hopefully temporary; ARROW should not be
 # part of radosgw_admin

--- a/src/rgw/radosgw-admin/account.cc
+++ b/src/rgw/radosgw-admin/account.cc
@@ -1,0 +1,186 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include "radosgw-admin/account.h"
+
+#include <list>
+#include <string>
+
+#include "common/ceph_json.h"
+#include "common/errno.h"
+#include "include/scope_guard.h"
+#include "rgw_account.h"
+#include "rgw_sal.h"
+#include "radosgw-admin/util.h"
+
+using ceph::Formatter;
+
+namespace {
+
+constexpr int DEFAULT_MAX_KEYS = 1000;
+
+rgw::account::AdminOpState make_op_state(const rgw_admin_account_options& o)
+{
+  return rgw::account::AdminOpState{
+    .account_id = o.account_id,
+    .tenant = o.tenant,
+    .account_name = o.account_name,
+    .email = o.user_email,
+    .max_users = o.max_users,
+    .max_roles = o.max_roles,
+    .max_groups = o.max_groups,
+    .max_access_keys = o.max_access_keys,
+    .max_buckets = o.max_buckets,
+    .purge_data = o.purge_data,
+  };
+}
+
+int handle_account_op(const DoutPrefixProvider* dpp,
+                      rgw::sal::Driver* driver,
+                      RGWStreamFlusher& stream_flusher,
+                      const rgw_admin_account_options& o)
+{
+  auto op_state = make_op_state(o);
+  std::string err_msg;
+  int ret = 0;
+
+  switch (o.command) {
+  case account_command::create:
+    ret = rgw::account::create(dpp, driver, op_state, err_msg,
+                               stream_flusher, null_yield);
+    if (ret < 0) {
+      return rgw_admin::report_error("failed to create account", ret, err_msg);
+    }
+    break;
+
+  case account_command::modify:
+    ret = rgw::account::modify(dpp, driver, op_state, err_msg,
+                               stream_flusher, null_yield);
+    if (ret < 0) {
+      return rgw_admin::report_error("failed to modify account", ret, err_msg);
+    }
+    break;
+
+  case account_command::get:
+    ret = rgw::account::info(dpp, driver, op_state, err_msg,
+                             stream_flusher, null_yield);
+    if (ret < 0) {
+      return rgw_admin::report_error("failed to read account", ret, err_msg);
+    }
+    break;
+
+  case account_command::stats:
+    ret = rgw::account::stats(dpp, driver, op_state,
+                              o.sync_stats, o.reset_stats, err_msg,
+                              stream_flusher, null_yield);
+    if (ret < 0) {
+      return rgw_admin::report_error("failed to read account stats", ret, err_msg);
+    }
+    break;
+
+  case account_command::rm:
+    ret = rgw::account::remove(dpp, driver, op_state, err_msg,
+                               stream_flusher, null_yield);
+    if (ret < 0) {
+      return rgw_admin::report_error("failed to remove account", ret, err_msg);
+    }
+    break;
+
+  default:
+    return EINVAL;
+  }
+
+  return 0;
+}
+
+int handle_account_list(const DoutPrefixProvider* dpp,
+                        rgw::sal::Driver* driver,
+                        RGWStreamFlusher& stream_flusher,
+                        const rgw_admin_account_options& o)
+{
+  if (o.max_entries && *o.max_entries < 0) {
+    return rgw_admin::report_error("invalid max entries", -EINVAL);
+  }
+
+  void* handle = nullptr;
+  int ret = driver->meta_list_keys_init(dpp, "account", o.marker, &handle);
+  if (ret < 0) {
+    return rgw_admin::report_error("can't get key", ret);
+  }
+
+  auto handle_guard = make_scope_guard([&] {
+    driver->meta_list_keys_complete(handle);
+  });
+
+  bool truncated = false;
+  uint64_t count = 0;
+  Formatter* formatter = stream_flusher.get_formatter();
+  const bool limit_specified = o.max_entries.has_value();
+
+  if (limit_specified) {
+    formatter->open_object_section("result");
+  }
+  formatter->open_array_section("keys");
+
+  do {
+    std::list<std::string> keys;
+    const uint64_t left = limit_specified
+        ? static_cast<uint64_t>(*o.max_entries) - count
+        : static_cast<uint64_t>(DEFAULT_MAX_KEYS);
+
+    if (left == 0) {
+      break;
+    }
+
+    ret = driver->meta_list_keys_next(dpp, handle, left, keys, &truncated);
+    if (ret < 0 && ret != -ENOENT) {
+      return rgw_admin::report_error("failed to list account keys", ret);
+    }
+    if (ret != -ENOENT) {
+      for (const auto& key : keys) {
+        formatter->dump_string("key", key);
+        ++count;
+      }
+      formatter->flush(std::cout);
+    }
+  } while (truncated &&
+           (!limit_specified ||
+            count < static_cast<uint64_t>(*o.max_entries)));
+
+  formatter->close_section(); // keys
+
+  if (limit_specified) {
+    encode_json("truncated", truncated, formatter);
+    encode_json("count", count, formatter);
+    if (truncated) {
+      encode_json("marker", driver->meta_get_marker(handle), formatter);
+    }
+    formatter->close_section();
+  }
+  formatter->flush(std::cout);
+
+  return 0;
+}
+
+} // anonymous namespace
+
+int rgw_admin_account(const DoutPrefixProvider* dpp,
+                      rgw::sal::Driver* driver,
+                      RGWStreamFlusher& stream_flusher,
+                      const rgw_admin_account_options& o)
+{
+  switch (o.command) {
+  case account_command::create:
+  case account_command::modify:
+  case account_command::get:
+  case account_command::stats:
+  case account_command::rm:
+    return handle_account_op(dpp, driver, stream_flusher, o);
+
+  case account_command::list:
+    return handle_account_list(dpp, driver, stream_flusher, o);
+
+  default:
+    return EINVAL;
+  }
+}

--- a/src/rgw/radosgw-admin/account.cc
+++ b/src/rgw/radosgw-admin/account.cc
@@ -8,8 +8,13 @@
 
 #include "common/ceph_json.h"
 #include "common/errno.h"
+#include "include/ceph_assert.h"
 #include "include/scope_guard.h"
+#ifdef WITH_RADOSGW_RADOS
+#include "cls/rgw/cls_rgw_types.h"
+#endif
 #include "rgw_account.h"
+#include "rgw_formats.h"
 #include "rgw_sal.h"
 #include "radosgw-admin/util.h"
 
@@ -37,7 +42,7 @@ rgw::account::AdminOpState make_op_state(const rgw_admin_account_options& o)
 
 int handle_account_op(const DoutPrefixProvider* dpp,
                       rgw::sal::Driver* driver,
-                      RGWStreamFlusher& stream_flusher,
+                      RGWFormatterFlusher& stream_flusher,
                       const rgw_admin_account_options& o)
 {
   auto op_state = make_op_state(o);
@@ -93,9 +98,19 @@ int handle_account_op(const DoutPrefixProvider* dpp,
   return 0;
 }
 
+// NOTE: this pagination loop is intentionally near-identical to
+// rgw_admin_meta_list_keys() being added in the sibling "user module"
+// slice (#71578, admin_meta.cc): same guard/loop/section structure,
+// differing only in the hardcoded "account" metadata key and the error
+// message text. This PR is based directly on main and lands
+// independently, so it can't call into admin_meta.cc yet. Once both
+// slices have landed, this function should be replaced with a call to
+// rgw_admin_meta_list_keys(dpp, driver, stream_flusher,
+// {.metadata_key = "account", .marker = o.marker, .max_entries =
+// o.max_entries}) to avoid maintaining two copies of the same loop.
 int handle_account_list(const DoutPrefixProvider* dpp,
                         rgw::sal::Driver* driver,
-                        RGWStreamFlusher& stream_flusher,
+                        RGWFormatterFlusher& stream_flusher,
                         const rgw_admin_account_options& o)
 {
   if (o.max_entries && *o.max_entries < 0) {
@@ -166,7 +181,7 @@ int handle_account_list(const DoutPrefixProvider* dpp,
 
 int rgw_admin_account(const DoutPrefixProvider* dpp,
                       rgw::sal::Driver* driver,
-                      RGWStreamFlusher& stream_flusher,
+                      RGWFormatterFlusher& stream_flusher,
                       const rgw_admin_account_options& o)
 {
   switch (o.command) {
@@ -181,6 +196,8 @@ int rgw_admin_account(const DoutPrefixProvider* dpp,
     return handle_account_list(dpp, driver, stream_flusher, o);
 
   default:
-    return EINVAL;
+    // every account_command enumerator is handled above; reaching here
+    // means a new enumerator was added without updating this switch.
+    ceph_abort();
   }
 }

--- a/src/rgw/radosgw-admin/account.h
+++ b/src/rgw/radosgw-admin/account.h
@@ -1,0 +1,43 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+class DoutPrefixProvider;
+class RGWStreamFlusher;
+namespace rgw::sal { class Driver; }
+
+enum class account_command {
+  create,
+  modify,
+  get,
+  stats,
+  rm,
+  list,
+};
+
+struct rgw_admin_account_options {
+  account_command command = account_command::create;
+  std::string tenant;
+  std::string account_id;
+  std::string account_name;
+  std::string user_email;
+  std::string marker;
+  std::optional<int> max_users;
+  std::optional<int> max_roles;
+  std::optional<int> max_groups;
+  std::optional<int> max_access_keys;
+  std::optional<int> max_buckets;
+  std::optional<int> max_entries;
+  bool purge_data = false;
+  bool sync_stats = false;
+  bool reset_stats = false;
+};
+
+int rgw_admin_account(const DoutPrefixProvider* dpp,
+                      rgw::sal::Driver* driver,
+                      RGWStreamFlusher& stream_flusher,
+                      const rgw_admin_account_options& opts);

--- a/src/rgw/radosgw-admin/account.h
+++ b/src/rgw/radosgw-admin/account.h
@@ -7,7 +7,7 @@
 #include <string>
 
 class DoutPrefixProvider;
-class RGWStreamFlusher;
+class RGWFormatterFlusher;
 namespace rgw::sal { class Driver; }
 
 enum class account_command {
@@ -39,5 +39,5 @@ struct rgw_admin_account_options {
 
 int rgw_admin_account(const DoutPrefixProvider* dpp,
                       rgw::sal::Driver* driver,
-                      RGWStreamFlusher& stream_flusher,
+                      RGWFormatterFlusher& stream_flusher,
                       const rgw_admin_account_options& opts);

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -55,6 +55,7 @@ extern "C" {
 #include "radosgw-admin/orphan.h"
 #include "radosgw-admin/sync_checkpoint.h"
 #endif
+#include "radosgw-admin/account.h"
 
 #include "rgw/async_utils.h"
 
@@ -10515,8 +10516,7 @@ next:
 #ifdef WITH_RADOSGW_RADOS
       opt_cmd == OPT::METADATA_LIST ||
 #endif
-      opt_cmd == OPT::USER_LIST ||
-      opt_cmd == OPT::ACCOUNT_LIST) {
+      opt_cmd == OPT::USER_LIST) {
     if (opt_cmd == OPT::USER_LIST) {
       metadata_key = "user";
 
@@ -10538,8 +10538,6 @@ next:
         }
         return 0;
       }
-    } else if (opt_cmd == OPT::ACCOUNT_LIST) {
-      metadata_key = "account";
     }
     void *handle;
     int max = 1000;
@@ -13000,71 +12998,50 @@ next:
       opt_cmd == OPT::ACCOUNT_MODIFY ||
       opt_cmd == OPT::ACCOUNT_GET ||
       opt_cmd == OPT::ACCOUNT_STATS ||
-      opt_cmd == OPT::ACCOUNT_RM)
-  {
-    auto op_state = rgw::account::AdminOpState{
-      .account_id = account_id,
-      .tenant = tenant,
-      .account_name = account_name,
-      .email = user_email,
-      .max_users = max_users,
-      .max_roles = max_roles,
-      .max_groups = max_groups,
-      .max_access_keys = max_access_keys,
-      .max_buckets = max_buckets,
-      .purge_data = static_cast<bool>(purge_data),
-    };
-
-    std::string err_msg;
-    if (opt_cmd == OPT::ACCOUNT_CREATE) {
-      ret = rgw::account::create(dpp(), driver, op_state, err_msg,
-                                 stream_flusher, null_yield);
-      if (ret < 0) {
-        cerr << "ERROR: failed to create account with " << cpp_strerror(-ret)
-            << ": " << err_msg << std::endl;
-        return -ret;
-      }
+      opt_cmd == OPT::ACCOUNT_RM ||
+      opt_cmd == OPT::ACCOUNT_LIST) {
+    rgw_admin_account_options account_opts;
+    switch (opt_cmd) {
+    case OPT::ACCOUNT_CREATE:
+      account_opts.command = account_command::create;
+      break;
+    case OPT::ACCOUNT_MODIFY:
+      account_opts.command = account_command::modify;
+      break;
+    case OPT::ACCOUNT_GET:
+      account_opts.command = account_command::get;
+      break;
+    case OPT::ACCOUNT_STATS:
+      account_opts.command = account_command::stats;
+      break;
+    case OPT::ACCOUNT_RM:
+      account_opts.command = account_command::rm;
+      break;
+    case OPT::ACCOUNT_LIST:
+      account_opts.command = account_command::list;
+      break;
+    default:
+      ceph_abort();
     }
-
-    if (opt_cmd == OPT::ACCOUNT_MODIFY) {
-      ret = rgw::account::modify(dpp(), driver, op_state, err_msg,
-                                 stream_flusher, null_yield);
-      if (ret < 0) {
-        cerr << "ERROR: failed to modify account with " << cpp_strerror(-ret)
-            << ": " << err_msg << std::endl;
-        return -ret;
-      }
+    account_opts.tenant = tenant;
+    account_opts.account_id = account_id;
+    account_opts.account_name = account_name;
+    account_opts.user_email = user_email;
+    account_opts.marker = marker;
+    account_opts.max_users = max_users;
+    account_opts.max_roles = max_roles;
+    account_opts.max_groups = max_groups;
+    account_opts.max_access_keys = max_access_keys;
+    account_opts.max_buckets = max_buckets;
+    account_opts.purge_data = static_cast<bool>(purge_data);
+    account_opts.sync_stats = sync_stats;
+    account_opts.reset_stats = reset_stats;
+    if (max_entries_specified) {
+      account_opts.max_entries = max_entries;
     }
-
-    if (opt_cmd == OPT::ACCOUNT_GET) {
-      ret = rgw::account::info(dpp(), driver, op_state, err_msg,
-                               stream_flusher, null_yield);
-      if (ret < 0) {
-        cerr << "ERROR: failed to read account with " << cpp_strerror(-ret)
-            << ": " << err_msg << std::endl;
-        return -ret;
-      }
-    }
-
-    if (opt_cmd == OPT::ACCOUNT_STATS) {
-      ret = rgw::account::stats(dpp(), driver, op_state,
-                                sync_stats, reset_stats, err_msg,
-                                stream_flusher, null_yield);
-      if (ret < 0) {
-        cerr << "ERROR: failed to read account stats with " << cpp_strerror(-ret)
-            << ": " << err_msg << std::endl;
-        return -ret;
-      }
-    }
-
-    if (opt_cmd == OPT::ACCOUNT_RM) {
-      ret = rgw::account::remove(dpp(), driver, op_state, err_msg,
-                                 stream_flusher, null_yield);
-      if (ret < 0) {
-        cerr << "ERROR: failed to remove account with " << cpp_strerror(-ret)
-            << ": " << err_msg << std::endl;
-        return -ret;
-      }
+    ret = rgw_admin_account(dpp(), driver, stream_flusher, account_opts);
+    if (ret != 0) {
+      return ret;
     }
   }
   if (opt_cmd == OPT::RESTORE_STATUS ||

--- a/src/rgw/radosgw-admin/util.h
+++ b/src/rgw/radosgw-admin/util.h
@@ -1,0 +1,23 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "common/errno.h"
+
+namespace rgw_admin {
+inline int report_error(std::string_view what, int ret,
+                        std::string_view err_msg = {})
+{
+  std::cerr << "ERROR: " << what << " with " << cpp_strerror(-ret);
+  if (!err_msg.empty()) {
+    std::cerr << ": " << err_msg;
+  }
+  std::cerr << std::endl;
+  return -ret;
+}
+} // namespace rgw_admin

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -427,6 +427,11 @@ target_link_libraries(unittest_rgw_object_ctx ${rgw_libs})
 add_ceph_test(test-ceph-diff-sorted.sh
   ${CMAKE_CURRENT_SOURCE_DIR}/test-ceph-diff-sorted.sh)
 
+if(WITH_RADOSGW)
+add_ceph_test(test-account-exit-codes.sh
+  ${CMAKE_CURRENT_SOURCE_DIR}/radosgw-admin/test-account-exit-codes.sh)
+endif()
+
 if(WITH_RADOSGW_RADOS)
 # unittest_log_backing
 add_executable(unittest_log_backing test_log_backing.cc)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -427,7 +427,7 @@ target_link_libraries(unittest_rgw_object_ctx ${rgw_libs})
 add_ceph_test(test-ceph-diff-sorted.sh
   ${CMAKE_CURRENT_SOURCE_DIR}/test-ceph-diff-sorted.sh)
 
-if(WITH_RADOSGW)
+if(WITH_RADOSGW_RADOS)
 add_ceph_test(test-account-exit-codes.sh
   ${CMAKE_CURRENT_SOURCE_DIR}/radosgw-admin/test-account-exit-codes.sh)
 endif()

--- a/src/test/rgw/radosgw-admin/test-account-exit-codes.sh
+++ b/src/test/rgw/radosgw-admin/test-account-exit-codes.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# Exit-code tests for radosgw-admin account commands (account.cc module).
+#
+# Usage:
+#   ./test-account-exit-codes.sh
+#   RGW_ADMIN=/path/to/radosgw-admin ./test-account-exit-codes.sh
+#   CEPH_CONF=/path/to/ceph.conf ./test-account-exit-codes.sh
+#
+# Test types:
+#   check()        - no cluster needed; runs with --no-mon-config
+#   check_cluster()- needs a running cluster, SKIPs when there is none
+#
+# Both verify the exit code.
+#
+# Run from the build directory:
+#   cd /path/to/ceph/build && bash /path/to/test-account-exit-codes.sh
+
+. "`dirname $0`/test-radosgw-admin-exit-codes-common.sh"
+
+# ============================================================
+echo "=== account (bare) ==="
+# ============================================================
+
+# no arguments at all: the usage text, before any command is resolved
+check "bare account" 1 account
+check "unknown subcommand" 1 account banana
+check "stray before account" 1 foo account list
+check "stray after account" 1 account list foo
+
+# ============================================================
+echo ""
+echo "=== account create ==="
+# ============================================================
+
+check "create: unrecognized flag" 22 account create --fakeflag
+check "create: stray after flags" 1 account create --email x@y.com strayarg
+check "create: stray before account" 1 foo account create
+
+# missing option value
+# Leaving the value out is the way to check that an option is defined as
+# taking a value: a value-taking option should reject the command when its
+# value is missing.
+check "create: --account-name missing value" 1 account create --account-name
+check "create: --account-id missing value" 1 account create --account-id
+check "create: --email missing value" 1 account create --email
+check "create: --max-users missing value" 1 account create --max-users
+check "create: --max-roles missing value" 1 account create --max-roles
+check "create: --max-groups missing value" 1 account create --max-groups
+check "create: --max-access-keys missing value" 1 account create --max-access-keys
+check "create: --max-buckets missing value" 1 account create --max-buckets
+check "create: --format missing value" 1 account create --format
+
+check "create: --max-users invalid int" 22 account create --max-users banana
+
+# account id must be 20 bytes, start with RGW, and end with digits
+check_cluster "create: --account-id wrong length" 22 -- \
+  account create --account-id badid
+check_cluster "create: --account-id too short" 22 -- \
+  account create --account-id RGW123
+check_cluster "create: --account-name contains $" 22 -- \
+  account create --account-name 'bad$name'
+check_cluster "create: --account-name contains :" 22 -- \
+  account create --account-name 'bad:name'
+
+# name and id are optional; the command auto-generates an id when omitted
+check_cluster "create: no identity flags" 0 -- account create
+check_cluster "create: --email only" 0 -- \
+  account create --email "exit-code-test-$RANDOM@example.com"
+
+# ============================================================
+echo ""
+echo "=== account get ==="
+# ============================================================
+
+check "get: unrecognized flag" 22 account get --fakeflag
+check "get: stray after flags" 1 account get strayarg
+check "get: stray before account" 1 foo account get
+check "get: stray between account and get" 1 account extra get
+
+check "get: --account-name missing value" 1 account get --account-name
+check "get: --account-id missing value" 1 account get --account-id
+check "get: --email missing value" 1 account get --email
+check "get: --format missing value" 1 account get --format
+
+check_cluster "get: no identity flags" 22 -- account get
+check_cluster "get: nonexistent account" 2 -- \
+  account get --account-name no-such-account-$RANDOM
+
+# ============================================================
+echo ""
+echo "=== account modify ==="
+# ============================================================
+
+check "modify: unrecognized flag" 22 account modify --fakeflag
+check "modify: stray after flags" 1 account modify strayarg
+
+check "modify: --account-name missing value" 1 account modify --account-name
+check "modify: --account-id missing value" 1 account modify --account-id
+check "modify: --email missing value" 1 account modify --email
+check "modify: --max-users missing value" 1 account modify --max-users
+check "modify: --max-roles missing value" 1 account modify --max-roles
+
+check "modify: --max-roles invalid int" 22 \
+  account modify --max-roles banana
+
+check_cluster "modify: no identity flags" 22 -- account modify
+check_cluster "modify: nonexistent account" 2 -- \
+  account modify --account-name no-such-account-$RANDOM
+
+# ============================================================
+echo ""
+echo "=== account rm ==="
+# ============================================================
+
+check "rm: unrecognized flag" 22 account rm --fakeflag
+check "rm: stray after flags" 1 account rm strayarg
+
+check "rm: --account-name missing value" 1 account rm --account-name
+check "rm: --account-id missing value" 1 account rm --account-id
+check "rm: --email missing value" 1 account rm --email
+
+check_cluster "rm: no identity flags" 22 -- account rm
+check_cluster "rm: nonexistent account" 2 -- \
+  account rm --account-name no-such-account-$RANDOM
+
+# ============================================================
+echo ""
+echo "=== account stats ==="
+# ============================================================
+
+check "stats: unrecognized flag" 22 account stats --fakeflag
+check "stats: stray after flags" 1 account stats strayarg
+
+check "stats: --account-name missing value" 1 account stats --account-name
+check "stats: --account-id missing value" 1 account stats --account-id
+check "stats: --format missing value" 1 account stats --format
+
+# stats requires an account identity, even when only asking for sync flags
+check_cluster "stats: no identity flags" 22 -- account stats
+check_cluster "stats: --sync-stats without identity" 22 -- account stats --sync-stats
+check_cluster "stats: --reset-stats without identity" 22 -- account stats --reset-stats
+check_cluster "stats: nonexistent account" 2 -- \
+  account stats --account-name no-such-account-$RANDOM
+
+# ============================================================
+echo ""
+echo "=== account list ==="
+# ============================================================
+
+check "list: unrecognized flag" 22 account list --fakeflag
+check "list: stray after flags" 1 account list strayarg
+check "list: stray before account" 1 foo account list
+check "list: stray between account and list" 1 account extra list
+
+check "list: --max-entries missing value" 1 account list --max-entries
+check "list: --marker missing value" 1 account list --marker
+check "list: --format missing value" 1 account list --format
+
+check "list: --max-entries invalid int" 22 account list --max-entries banana
+check "list: --max-entries out of int range" 22 \
+  account list --max-entries 5000000000
+
+check_cluster "list: --max-entries negative" 22 -- account list --max-entries -1
+check_cluster "list: default" 0 -- account list
+check_cluster "list: --max-entries 10" 0 -- account list --max-entries 10
+check_cluster "list: --format json" 0 -- --format json account list
+
+# ============================================================
+echo ""
+echo "=== flags: underscore vs dash spelling ==="
+# ============================================================
+# Long option names accept '_' as well as '-'. Each pair below proves the
+# underscore spelling behaves identically to the dash spelling.
+
+check "list: --max-entries space form (dash)" 22 account list --max-entries banana
+check "list: --max_entries space form (underscore)" 22 account list --max_entries banana
+check "list: --max-entries= form (dash)" 22 account list --max-entries=banana
+check "list: --max_entries= form (underscore)" 22 account list --max_entries=banana
+
+check_cluster "rm: --purge-data (dash)" 2 -- \
+  account rm --account-name no-such-account --purge-data
+check_cluster "rm: --purge_data (underscore)" 2 -- \
+  account rm --account-name no-such-account --purge_data
+
+check_cluster "list: underscore spelling on success path" 0 -- \
+  account list --max_entries 100
+
+# ============================================================
+echo ""
+echo "=== integration: account lifecycle ==="
+# ============================================================
+# Create, read, modify, stats, list, and remove a real account on a live cluster.
+
+if cluster_running; then
+  _test_acct="exit-code-acct-$$"
+
+  check_cluster "integration: create" 0 -- \
+    account create --account-name "$_test_acct"
+  check_cluster "integration: get" 0 -- \
+    account get --account-name "$_test_acct"
+  check_cluster "integration: modify" 0 -- \
+    account modify --account-name "$_test_acct" --email "${_test_acct}@example.com"
+  check_cluster "integration: stats" 0 -- \
+    account stats --account-name "$_test_acct"
+  check_cluster "integration: list" 0 -- account list
+  check_cluster "integration: rm --purge-data" 0 -- \
+    account rm --account-name "$_test_acct" --purge-data
+  check_cluster "integration: get after rm" 2 -- \
+    account get --account-name "$_test_acct"
+else
+  echo "SKIP [integration: account lifecycle]: no cluster running"
+  SKIP=$((SKIP+1))
+fi
+
+report_results

--- a/src/test/rgw/radosgw-admin/test-radosgw-admin-exit-codes-common.sh
+++ b/src/test/rgw/radosgw-admin/test-radosgw-admin-exit-codes-common.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Shared helpers for radosgw-admin exit-code tests.
+#
+# Sourced by test-*-exit-codes.sh under this directory. See also PR #71155
+# (test-bucket-exit-codes.sh, test-script-exit-codes.sh, test-globals.sh).
+
+RGW_ADMIN="${RGW_ADMIN:-${CEPH_BIN:-./bin}/radosgw-admin}"
+export CEPH_CONF="${CEPH_CONF:-${CEPH_BUILD_DIR:-.}/ceph.conf}"
+# Keep ceph log lines off stderr so they cannot interleave with the output printed
+# when a test fails. rgw_global_init consumes --log-to-stderr before the flags
+# are read.
+export CEPH_ARGS="--log-to-stderr=false${CEPH_ARGS:+ ${CEPH_ARGS}}"
+PASS=0
+FAIL=0
+SKIP=0
+
+# Filter out noisy ceph log lines (timestamped) and config-not-found lines
+filter() {
+  grep -v "^[0-9]\{4\}-" | \
+  grep -v "^did not load config" | \
+  grep -v "^unable to get monitor" | \
+  grep -v "^failed to fetch mon config"
+}
+
+# --no-mon-config skips monitor connection so check() runs without a cluster.
+_run() { "$RGW_ADMIN" --no-mon-config "$@"; }
+
+cluster_running() { pgrep -x radosgw > /dev/null 2>&1; }
+
+# check "desc" expected_exit args
+check() {
+  local desc="$1" expected_exit="$2"
+  shift 2
+  local tmpfile; tmpfile=$(mktemp)
+  _run "$@" >"$tmpfile" 2>&1
+  local exit_code=$?
+
+  if [ "$exit_code" = "$expected_exit" ]; then
+    echo "PASS [$desc]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$desc]: expected exit $expected_exit, got $exit_code"
+    echo "     output: $(filter <"$tmpfile")"
+    FAIL=$((FAIL+1))
+  fi
+  rm -f "$tmpfile"
+}
+
+# check_cluster "desc" expected_exit -- args
+# Runs against a real cluster. Skips if no cluster is running.
+check_cluster() {
+  local desc="$1" expected_exit="$2"
+  shift 2
+  shift  # skip --
+
+  if ! cluster_running; then
+    echo "SKIP [$desc]: no cluster running"
+    SKIP=$((SKIP+1))
+    return
+  fi
+
+  local tmpfile; tmpfile=$(mktemp)
+  "$RGW_ADMIN" "$@" >"$tmpfile" 2>&1
+  local exit_code=$?
+
+  if [ "$exit_code" = "$expected_exit" ]; then
+    echo "PASS [$desc]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$desc]: expected exit $expected_exit, got $exit_code"
+    echo "     output: $(filter <"$tmpfile")"
+    FAIL=$((FAIL+1))
+  fi
+  rm -f "$tmpfile"
+}
+
+report_results() {
+  echo ""
+  echo "========================================"
+  echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+  [ "$SKIP" -gt 0 ] && echo "(some tests require a running cluster)"
+  echo "========================================"
+  [ "$FAIL" -eq 0 ] && exit 0 || exit 1
+}


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Context (incremental split from #71462)

This is **slice 3** in the incremental landing plan for the radosgw-admin modularization work in [#71462](https://github.com/ceph/ceph/pull/71462).

This PR contains **only** the account module extraction and its exit-code tests. It is based directly on `main` and does **not** include the dead-code cleanup (#71569) or command-types header split (#71570). The account module uses a module-local `account_command` enum so it does not depend on a shared `radosgw-admin.h`.

## Summary

- Add `account.h` / `account.cc` with `rgw_admin_account()` for account create/modify/get/stats/rm/list
- Add `util.h` with shared `rgw_admin::report_error()` for consistent CLI error output
- Wire dispatch from `radosgw-admin.cc` through `rgw_admin_account_options`
- Move `account list` metadata iteration out of the shared user/metadata list block into the account module
- Add `account.cc` to the `radosgw-admin` CMake target
- Add shell exit-code tests: `test-account-exit-codes.sh` and shared helpers

Supported account commands and flags are unchanged.

## Testing

Local build and tests (Release, `WITH_RADOSGW_RADOS=ON`, vstart cluster):

- `ninja radosgw-admin`
- `cram src/test/cli/radosgw-admin/help.t` — passed
- `bash src/test/rgw/radosgw-admin/test-account-exit-codes.sh` — passed
- `ninja ceph_test_cls_rgw_admin_account_quota_set` — built and run (exit 0)
- Manual smoke: `account list`, `account list --max-entries=2`, `account get`, `account stats`, create/get/rm cycle

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-submodules.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>