### PR TITLE
Cephadm: allow nvmeof in --daemon-types for staggered upgrade

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -5048,9 +5048,9 @@ Then run the following:
             # `--daemon_types "mon, crash"` is treated the same as `--daemon_types "mon,crash"`.
             daemon_types = [dtype.strip() for dtype in daemon_types]
             for dtype in daemon_types:
-                if dtype not in utils.CEPH_IMAGE_TYPES:
+                if dtype not in utils.SUPPORTED_UPGRADE_DAEMON_TYPES:
                     raise OrchestratorError(f'Upgrade aborted - Got unexpected daemon type "{dtype}".\n'
-                                            f'Viable daemon types for this command are: {utils.CEPH_IMAGE_TYPES}')
+                                            f'Viable daemon types for this command are: {utils.SUPPORTED_UPGRADE_DAEMON_TYPES}')
         if services is not None:
             for service in services:
                 if service not in self.spec_store:

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -87,6 +87,37 @@ def test_upgrade_start_offline_hosts(cephadm_module: CephadmOrchestrator):
 
 
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_upgrade_start_nvmeof_daemon_type(cephadm_module: CephadmOrchestrator):
+    """Regression: --daemon-types nvmeof must not raise 'Got unexpected daemon type'."""
+    with with_host(cephadm_module, 'test'):
+        with with_host(cephadm_module, 'test2'):
+            with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                with mock.patch.object(
+                    cephadm_module.upgrade, '_validate_upgrade_filters'
+                ):
+                    result = wait(
+                        cephadm_module,
+                        cephadm_module.upgrade_start(
+                            'image_id', None,
+                            daemon_types=['nvmeof'],
+                        ),
+                    )
+                    assert result == 'Initiating upgrade to image_id'
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+def test_upgrade_start_invalid_daemon_type(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'test'):
+        with with_host(cephadm_module, 'test2'):
+            with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
+                with pytest.raises(OrchestratorError, match=r'Got unexpected daemon type "foo"'):
+                    cephadm_module.upgrade_start(
+                        'image_id', None,
+                        daemon_types=['foo'],
+                    )
+
+
+@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
 def test_upgrade_daemons_offline_hosts(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'test'):
         with with_host(cephadm_module, 'test2'):

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -52,6 +52,9 @@ CEPH_IMAGE_TYPES = CEPH_TYPES + ['iscsi', 'nfs', 'node-proxy']
 # that are part of the upgrade order here
 NON_CEPH_IMAGE_TYPES = MONITORING_STACK_TYPES + ['nvmeof', 'smb'] + MGMT_GATEWAY_STACK_TYPES
 
+# daemon types that can be passed to --daemon-types for targeted upgrades
+SUPPORTED_UPGRADE_DAEMON_TYPES = CEPH_IMAGE_TYPES + ['nvmeof']
+
 # Used for _run_cephadm used for check-host etc that don't require an --image parameter
 cephadmNoImage = CephadmNoImage.token
 


### PR DESCRIPTION
**Summary**

ceph orch upgrade start --daemon-types nvmeof fails with:

```
Upgrade aborted - Got unexpected daemon type "nvmeof".
Viable daemon types for this command are: ['mgr', 'mon', 'crash', 'osd', 'mds', 'rgw',
'rbd-mirror', 'cephfs-mirror', 'ceph-exporter', 'iscsi', 'nfs', 'node-proxy']
```

**Root Cause**

The --daemon-types validation in upgrade_start() only accepted CEPH_IMAGE_TYPES (daemons using the shared ceph container image). nvmeof was excluded because it uses its own container image and is classified as NON_CEPH_IMAGE_TYPES. However, nvmeof is already in CEPH_UPGRADE_ORDER and the upgrade loop (_do_upgrade) already handles it correctly — redeploying nvmeof daemons only after all ceph-image daemons are upgraded.

**Fix**

`Introduce SUPPORTED_UPGRADE_DAEMON_TYPES = CEPH_IMAGE_TYPES + ['nvmeof'] and use it for the --daemon-types validation instead of CEPH_IMAGE_TYPES.
`

Fixes: https://tracker.ceph.com/issues/80313
Signed-off-by: Shubha Jain [SHUBHA.JAIN1@ibm.com]

Logs:

Before fix:

```
[ceph: root@ceph-node-00 /]# ceph orch upgrade start \
  --image cp.stg.icr.io/cp/ibm-ceph/ceph-9-rhel10:v9.9.2-24930 \
  --daemon-types nvmeof
Error EINVAL: Upgrade aborted - Got unexpected daemon type "nvmeof".
Viable daemon types for this command are: ['mgr', 'mon', 'crash', 'osd', 'mds', 'rgw', 'rbd-mirror', 'cephfs-mirror', 'ceph-exporter', 'iscsi', 'nfs', 'node-proxy']
```

After fix:

```
[ceph: root@ceph-node-00 /]# ceph orch upgrade start \
  --image quay.io/shubhjai/ceph1:nvmeof-daemons-fix-final-update
Initiating upgrade to quay.io/shubhjai/ceph1:nvmeof-daemons-fix-final-update
[ceph: root@ceph-node-00 /]# ceph orch upgrade status
There are no upgrades in progress currently.
```

```
[ceph: root@ceph-node-00 /]# ceph orch upgrade start \
  --image quay.io/shubhjai/ceph1:nvmeof-daemons-fix-final-update \
  --daemon-types nvmeof
Initiating upgrade to quay.io/shubhjai/ceph1:nvmeof-daemons-fix-final-update

[ceph: root@ceph-node-00 /]# ceph orch upgrade status
{
    "in_progress": true,
    "target_image": "quay.io/shubhjai/ceph1@sha256:438b3f6ee16565c2060d5193481818dd570d0aae53576a3b032ee37e05f456b1",
    "services_complete": [],
    "which": "Upgrading daemons of type(s) nvmeof",
    "progress": "0/3 daemons upgraded",
    "message": "",
    "is_paused": false
}
[ceph: root@ceph-node-00 /]# ceph orch upgrade status
There are no upgrades in progress currently.

[ceph: root@ceph-node-00 /]# ceph orch ps --daemon-type nvmeof
NAME                                                 HOST          PORTS                   STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION  IMAGE ID      CONTAINER ID  
nvmeof.nvmeof_pool.nvmeof_group.ceph-node-00.nmdnbl  ceph-node-00  *:5500,4420,8009,10008  running (38s)    24s ago   2d    88.9M        -  1.9.6    77e84a2eaaa6  cadc891abbbd  
nvmeof.nvmeof_pool.nvmeof_group.ceph-node-01.qryrjx  ceph-node-01  *:5500,4420,8009,10008  running (33s)    28s ago   2d    48.0M        -  1.9.6    77e84a2eaaa6  7dc684ccdb16  
nvmeof.nvmeof_pool.nvmeof_group.ceph-node-02.eelthz  ceph-node-02  *:5500,4420,8009,10008  running (31s)    26s ago   2d    54.8M        -  1.9.6    77e84a2eaaa6  431a1341abff  
```



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [X] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
