### PR TITLE
rgw/radosgw-admin: extract user commands into a module

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -819,7 +819,9 @@ if(WITH_RADOSGW_STANDALONE)
 endif()
 
 set(radosgw_admin_srcs
-  radosgw-admin/radosgw-admin.cc)
+  radosgw-admin/radosgw-admin.cc
+  radosgw-admin/admin_meta.cc
+  radosgw-admin/user.cc)
 
 # this is unsatisfying and hopefully temporary; ARROW should not be
 # part of radosgw_admin

--- a/src/rgw/radosgw-admin/admin_meta.cc
+++ b/src/rgw/radosgw-admin/admin_meta.cc
@@ -59,6 +59,12 @@ int rgw_admin_meta_list_keys(const DoutPrefixProvider* dpp,
         ? static_cast<uint64_t>(*opts.max_entries) - count
         : static_cast<uint64_t>(DEFAULT_MAX_KEYS);
 
+    // NOTE: intentional behavior change vs. the original inline code in
+    // radosgw-admin.cc, which looped on `while (truncated && left > 0)`
+    // using the pre-fetch `left`. That could issue one extra
+    // meta_list_keys_next() call with left == 0 once count reached
+    // max_entries exactly. We break here instead, and the loop condition
+    // below re-checks `count` (post-fetch) rather than the stale `left`.
     if (left == 0) {
       break;
     }

--- a/src/rgw/radosgw-admin/admin_meta.cc
+++ b/src/rgw/radosgw-admin/admin_meta.cc
@@ -1,0 +1,94 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include "radosgw-admin/admin_meta.h"
+
+#include <list>
+#include <string>
+
+#include "common/ceph_json.h"
+#ifdef WITH_RADOSGW_RADOS
+#include "cls/rgw/cls_rgw_types.h"
+#endif
+#include "include/scope_guard.h"
+#include "rgw_formats.h"
+#include "rgw_sal.h"
+#include "radosgw-admin/util.h"
+
+using ceph::Formatter;
+
+namespace {
+
+constexpr int DEFAULT_MAX_KEYS = 1000;
+
+} // anonymous namespace
+
+int rgw_admin_meta_list_keys(const DoutPrefixProvider* dpp,
+                             rgw::sal::Driver* driver,
+                             RGWFormatterFlusher& stream_flusher,
+                             const rgw_admin_meta_list_options& opts)
+{
+  if (opts.max_entries && *opts.max_entries < 0) {
+    return rgw_admin::report_error("invalid max entries", -EINVAL);
+  }
+
+  void* handle = nullptr;
+  int ret = driver->meta_list_keys_init(dpp, opts.metadata_key, opts.marker,
+                                        &handle);
+  if (ret < 0) {
+    return rgw_admin::report_error("can't get key", ret);
+  }
+
+  auto handle_guard = make_scope_guard([&] {
+    driver->meta_list_keys_complete(handle);
+  });
+
+  bool truncated = false;
+  uint64_t count = 0;
+  Formatter* formatter = stream_flusher.get_formatter();
+  const bool limit_specified = opts.max_entries.has_value();
+
+  if (limit_specified) {
+    formatter->open_object_section("result");
+  }
+  formatter->open_array_section("keys");
+
+  do {
+    std::list<std::string> keys;
+    const uint64_t left = limit_specified
+        ? static_cast<uint64_t>(*opts.max_entries) - count
+        : static_cast<uint64_t>(DEFAULT_MAX_KEYS);
+
+    if (left == 0) {
+      break;
+    }
+
+    ret = driver->meta_list_keys_next(dpp, handle, left, keys, &truncated);
+    if (ret < 0 && ret != -ENOENT) {
+      return rgw_admin::report_error("failed to list metadata keys", ret);
+    }
+    if (ret != -ENOENT) {
+      for (const auto& key : keys) {
+        formatter->dump_string("key", key);
+        ++count;
+      }
+      formatter->flush(std::cout);
+    }
+  } while (truncated &&
+           (!limit_specified ||
+            count < static_cast<uint64_t>(*opts.max_entries)));
+
+  formatter->close_section(); // keys
+
+  if (limit_specified) {
+    encode_json("truncated", truncated, formatter);
+    encode_json("count", count, formatter);
+    if (truncated) {
+      encode_json("marker", driver->meta_get_marker(handle), formatter);
+    }
+    formatter->close_section();
+  }
+  formatter->flush(std::cout);
+
+  return 0;
+}

--- a/src/rgw/radosgw-admin/admin_meta.h
+++ b/src/rgw/radosgw-admin/admin_meta.h
@@ -1,0 +1,22 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+class DoutPrefixProvider;
+class RGWFormatterFlusher;
+namespace rgw::sal { class Driver; }
+
+struct rgw_admin_meta_list_options {
+  std::string metadata_key;
+  std::string marker;
+  std::optional<int> max_entries;
+};
+
+int rgw_admin_meta_list_keys(const DoutPrefixProvider* dpp,
+                             rgw::sal::Driver* driver,
+                             RGWFormatterFlusher& stream_flusher,
+                             const rgw_admin_meta_list_options& opts);

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -55,6 +55,7 @@ extern "C" {
 #include "radosgw-admin/orphan.h"
 #include "radosgw-admin/sync_checkpoint.h"
 #endif
+#include "radosgw-admin/user.h"
 
 #include "rgw/async_utils.h"
 
@@ -7286,119 +7287,78 @@ int main(int argc, const char **argv)
 
   switch (opt_cmd) {
   case OPT::USER_INFO:
-    if (rgw::sal::User::empty(user) && access_key.empty()) {
-      cerr << "ERROR: --uid or --access-key required" << std::endl;
-      return EINVAL;
-    }
-    break;
   case OPT::USER_CREATE:
-    if (!user_op.has_existing_user() && (generate_key != OPTION_SET_FALSE)) {
-      user_op.set_generate_key(); // generate a new key by default
-    }
-    ret = ruser.add(dpp(), user_op, null_yield, &err_msg);
-    if (ret < 0) {
-      cerr << "could not create user: " << err_msg << std::endl;
-      if (ret == -ERR_INVALID_TENANT_NAME)
-	ret = -EINVAL;
-
-      return -ret;
-    }
-    if (!subuser.empty()) {
-      ret = ruser.subusers.add(dpp(),user_op, null_yield, &err_msg);
-      if (ret < 0) {
-        cerr << "could not create subuser: " << err_msg << std::endl;
-        return -ret;
-      }
-    }
-    break;
   case OPT::USER_RM:
-    ret = ruser.remove(dpp(), user_op, null_yield, &err_msg);
-    if (ret < 0) {
-      cerr << "could not remove user: " << err_msg << std::endl;
-      return -ret;
-    }
-
-    output_user_info = false;
-    break;
   case OPT::USER_RENAME:
-    if (yes_i_really_mean_it) {
-      user_op.set_overwrite_new_user(true);
-    }
-    ret = ruser.rename(user_op, null_yield, dpp(), &err_msg);
-    if (ret < 0) {
-      if (ret == -EEXIST) {
-        err_msg += ". to overwrite this user, add --yes-i-really-mean-it";
-      }
-      cerr << "could not rename user: " << err_msg << std::endl;
-      return -ret;
-    }
-
-    break;
   case OPT::USER_ENABLE:
   case OPT::USER_SUSPEND:
   case OPT::USER_MODIFY:
-    ret = ruser.modify(dpp(), user_op, null_yield, &err_msg);
-    if (ret < 0) {
-      cerr << "could not modify user: " << err_msg << std::endl;
-      return -ret;
-    }
-
-    break;
   case OPT::SUBUSER_CREATE:
-    ret = ruser.subusers.add(dpp(), user_op, null_yield, &err_msg);
-    if (ret < 0) {
-      cerr << "could not create subuser: " << err_msg << std::endl;
-      return -ret;
-    }
-
-    break;
   case OPT::SUBUSER_MODIFY:
-    ret = ruser.subusers.modify(dpp(), user_op, null_yield, &err_msg);
-    if (ret < 0) {
-      cerr << "could not modify subuser: " << err_msg << std::endl;
-      return -ret;
-    }
-
-    break;
   case OPT::SUBUSER_RM:
-    ret = ruser.subusers.remove(dpp(), user_op, null_yield, &err_msg);
-    if (ret < 0) {
-      cerr << "could not remove subuser: " << err_msg << std::endl;
-      return -ret;
-    }
-
-    break;
   case OPT::CAPS_ADD:
-    ret = ruser.caps.add(dpp(), user_op, null_yield, &err_msg);
-    if (ret < 0) {
-      cerr << "could not add caps: " << err_msg << std::endl;
-      return -ret;
-    }
-
-    break;
   case OPT::CAPS_RM:
-    ret = ruser.caps.remove(dpp(), user_op, null_yield, &err_msg);
-    if (ret < 0) {
-      cerr << "could not remove caps: " << err_msg << std::endl;
-      return -ret;
-    }
-
-    break;
   case OPT::KEY_CREATE:
-    ret = ruser.keys.add(dpp(), user_op, null_yield, &err_msg);
-    if (ret < 0) {
-      cerr << "could not create key: " << err_msg << std::endl;
-      return -ret;
+  case OPT::KEY_RM: {
+    rgw_admin_user_mutate_options mutate_opts;
+    switch (opt_cmd) {
+    case OPT::USER_INFO:
+      mutate_opts.command = user_mutate_command::info;
+      break;
+    case OPT::USER_CREATE:
+      mutate_opts.command = user_mutate_command::create;
+      break;
+    case OPT::USER_RM:
+      mutate_opts.command = user_mutate_command::rm;
+      break;
+    case OPT::USER_RENAME:
+      mutate_opts.command = user_mutate_command::rename;
+      break;
+    case OPT::USER_ENABLE:
+      mutate_opts.command = user_mutate_command::enable;
+      break;
+    case OPT::USER_SUSPEND:
+      mutate_opts.command = user_mutate_command::suspend;
+      break;
+    case OPT::USER_MODIFY:
+      mutate_opts.command = user_mutate_command::modify;
+      break;
+    case OPT::SUBUSER_CREATE:
+      mutate_opts.command = user_mutate_command::subuser_create;
+      break;
+    case OPT::SUBUSER_MODIFY:
+      mutate_opts.command = user_mutate_command::subuser_modify;
+      break;
+    case OPT::SUBUSER_RM:
+      mutate_opts.command = user_mutate_command::subuser_rm;
+      break;
+    case OPT::CAPS_ADD:
+      mutate_opts.command = user_mutate_command::caps_add;
+      break;
+    case OPT::CAPS_RM:
+      mutate_opts.command = user_mutate_command::caps_rm;
+      break;
+    case OPT::KEY_CREATE:
+      mutate_opts.command = user_mutate_command::key_create;
+      break;
+    case OPT::KEY_RM:
+      mutate_opts.command = user_mutate_command::key_rm;
+      break;
+    default:
+      ceph_abort();
     }
-
-    break;
-  case OPT::KEY_RM:
-    ret = ruser.keys.remove(dpp(), user_op, null_yield, &err_msg);
-    if (ret < 0) {
-      cerr << "could not remove key: " << err_msg << std::endl;
-      return -ret;
+    mutate_opts.access_key = access_key;
+    mutate_opts.subuser = subuser;
+    mutate_opts.yes_i_really_mean_it = yes_i_really_mean_it;
+    mutate_opts.generate_key = static_cast<int>(generate_key);
+    ret = rgw_admin_user_mutate(dpp(), driver, formatter.get(), ruser,
+                                user_op, user, mutate_opts, err_msg);
+    if (ret != 0) {
+      return ret;
     }
+    output_user_info = false;
     break;
+  }
   case OPT::PERIOD_PUSH:
     {
       RGWEnv env;
@@ -10274,207 +10234,66 @@ next:
   }
 #endif
 
-  if (opt_cmd == OPT::USER_CHECK) {
-    check_bad_owner_bucket_mapping(driver, user->get_id(),
-                                   user->get_display_name(), user->get_tenant(),
-                                   fix, null_yield, dpp());
+  if (opt_cmd == OPT::USER_CHECK ||
+      opt_cmd == OPT::USER_STATS ||
+      opt_cmd == OPT::USER_LIST) {
+    rgw_admin_user_query_options query_opts;
+    switch (opt_cmd) {
+    case OPT::USER_CHECK:
+      query_opts.command = user_query_command::check;
+      break;
+    case OPT::USER_STATS:
+      query_opts.command = user_query_command::stats;
+      break;
+    case OPT::USER_LIST:
+      query_opts.command = user_query_command::list;
+      break;
+    default:
+      ceph_abort();
+    }
+    query_opts.tenant = tenant;
+    query_opts.bucket_name = bucket_name;
+    query_opts.bucket_id = bucket_id;
+    query_opts.account_id = account_id;
+    query_opts.account_name = account_name;
+    query_opts.path_prefix = path_prefix;
+    query_opts.marker = marker;
+    if (max_entries_specified) {
+      query_opts.max_entries = max_entries;
+    }
+    query_opts.account_root = account_root;
+    query_opts.sync_stats = sync_stats;
+    query_opts.reset_stats = reset_stats;
+    query_opts.fix = fix;
+    ret = rgw_admin_user_query(dpp(), driver, formatter.get(), stream_flusher,
+                               user, bucket, query_opts);
+    if (ret != 0) {
+      return ret;
+    }
   }
 
-  if (opt_cmd == OPT::USER_STATS) {
-    if (rgw::sal::User::empty(user)) {
-      cerr << "ERROR: uid not specified" << std::endl;
-      return EINVAL;
+  if (opt_cmd == OPT::USER_POLICY_ATTACH ||
+      opt_cmd == OPT::USER_POLICY_DETACH ||
+      opt_cmd == OPT::USER_POLICY_LIST_ATTACHED) {
+    rgw_admin_user_policy_options upopts;
+    switch (opt_cmd) {
+    case OPT::USER_POLICY_ATTACH:
+      upopts.command = user_policy_command::attach;
+      break;
+    case OPT::USER_POLICY_DETACH:
+      upopts.command = user_policy_command::detach;
+      break;
+    case OPT::USER_POLICY_LIST_ATTACHED:
+      upopts.command = user_policy_command::list_attached;
+      break;
+    default:
+      ceph_abort();
     }
-    if (reset_stats) {
-      if (!bucket_name.empty()) {
-	cerr << "ERROR: --reset-stats does not work on buckets and "
-	  "bucket specified" << std::endl;
-	return EINVAL;
-      }
-      if (sync_stats) {
-	cerr << "ERROR: sync-stats includes the reset-stats functionality, "
-	  "so at most one of the two should be specified" << std::endl;
-	return EINVAL;
-      }
-      ret = driver->reset_stats(dpp(), null_yield, user->get_id());
-      if (ret < 0) {
-	cerr << "ERROR: could not reset user stats: " << cpp_strerror(-ret) <<
-	  std::endl;
-	return -ret;
-      }
+    upopts.policy_arn = policy_arn;
+    ret = rgw_admin_user_policy(dpp(), driver, formatter.get(), user, upopts);
+    if (ret != 0) {
+      return ret;
     }
-
-    if (sync_stats) {
-      if (!bucket_name.empty()) {
-        int ret = init_bucket(tenant, bucket_name, bucket_id, &bucket);
-        if (ret < 0) {
-          cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
-          return -ret;
-        }
-        ret = bucket->sync_owner_stats(dpp(), null_yield, nullptr);
-        if (ret < 0) {
-          cerr << "ERROR: could not sync bucket stats: " <<
-	    cpp_strerror(-ret) << std::endl;
-          return -ret;
-        }
-      } else {
-        int ret = rgw_sync_all_stats(dpp(), null_yield, driver,
-                                     user->get_id(), user->get_tenant());
-        if (ret < 0) {
-          cerr << "ERROR: could not sync user stats: " <<
-	    cpp_strerror(-ret) << std::endl;
-          return -ret;
-        }
-      }
-    }
-
-    int ret = user->load_user(dpp(), null_yield);
-    if (ret < 0) {
-      cerr << "User has not been initialized or user does not exist" << std::endl;
-      return -ret;
-    }
-
-    const RGWUserInfo& info = user->get_info();
-    rgw_owner owner = info.user_id;
-    if (!info.account_id.empty()) {
-      cerr << "Reading stats for user account " << info.account_id << std::endl;
-      owner = info.account_id;
-    }
-
-    constexpr bool omit_utilized_stats = false;
-    RGWStorageStats stats(omit_utilized_stats);
-    ceph::real_time last_stats_sync;
-    ceph::real_time last_stats_update;
-    ret = driver->load_stats(dpp(), null_yield, owner, stats,
-                             last_stats_sync, last_stats_update);
-    if (ret < 0) {
-      if (ret == -ENOENT) { /* in case of ENOENT */
-        cerr << "User has not been initialized or user does not exist" << std::endl;
-      } else {
-        cerr << "ERROR: can't read user: " << cpp_strerror(ret) << std::endl;
-      }
-      return -ret;
-    }
-
-
-    {
-      Formatter::ObjectSection os(*formatter, "result");
-      encode_json("stats", stats, formatter.get());
-      utime_t last_sync_ut(last_stats_sync);
-      encode_json("last_stats_sync", last_sync_ut, formatter.get());
-      utime_t last_update_ut(last_stats_update);
-      encode_json("last_stats_update", last_update_ut, formatter.get());
-    }
-    formatter->flush(cout);
-  }
-
-  if (opt_cmd == OPT::USER_POLICY_ATTACH) {
-    if (rgw::sal::User::empty(user)) {
-      cerr << "ERROR: uid not specified" << std::endl;
-      return EINVAL;
-    }
-    if (policy_arn.empty()) {
-      cerr << "policy arn is empty" << std::endl;
-      return EINVAL;
-    }
-    ret = user->load_user(dpp(), null_yield);
-    if (ret < 0) {
-      return -ret;
-    }
-    if (user->get_info().account_id.empty()) {
-      std::cerr << "Managed policies are only supported for account users" << std::endl;
-      return EINVAL;
-    }
-
-    try {
-      if (!rgw::IAM::get_managed_policy(g_ceph_context, policy_arn)) {
-        cerr << "unrecognized policy arn " << policy_arn << std::endl;
-        return ENOENT;
-      }
-    } catch (rgw::IAM::PolicyParseException& e) {
-      cerr << "failed to parse managed policy: " << e.what() << std::endl;
-      return EINVAL;
-    }
-
-    rgw::IAM::ManagedPolicies policies;
-    auto& attrs = user->get_attrs();
-    if (auto it = attrs.find(RGW_ATTR_MANAGED_POLICY); it != attrs.end()) {
-      decode(policies, it->second);
-    }
-    const bool inserted = policies.arns.insert(policy_arn).second;
-    if (!inserted) {
-      cout << "That managed policy is already attached." << std::endl;
-      return EEXIST;
-    }
-
-    bufferlist in_bl;
-    encode(policies, in_bl);
-    attrs[RGW_ATTR_MANAGED_POLICY] = in_bl;
-
-    ret = user->store_user(dpp(), null_yield, false);
-    if (ret < 0) {
-      return -ret;
-    }
-    cout << "Managed policy attached successfully" << std::endl;
-    return 0;
-  }
-  if (opt_cmd == OPT::USER_POLICY_DETACH) {
-    if (rgw::sal::User::empty(user)) {
-      cerr << "ERROR: uid not specified" << std::endl;
-      return EINVAL;
-    }
-    if (policy_arn.empty()) {
-      cerr << "policy arn is empty" << std::endl;
-      return EINVAL;
-    }
-    ret = user->load_user(dpp(), null_yield);
-    if (ret < 0) {
-      return -ret;
-    }
-
-    rgw::IAM::ManagedPolicies policies;
-    auto& attrs = user->get_attrs();
-    if (auto it = attrs.find(RGW_ATTR_MANAGED_POLICY); it != attrs.end()) {
-      decode(policies, it->second);
-    }
-
-    auto i = policies.arns.find(policy_arn);
-    if (i == policies.arns.end()) {
-      cout << "That managed policy is not attached." << std::endl;
-      return ENOENT;
-    }
-    policies.arns.erase(i);
-
-    bufferlist in_bl;
-    encode(policies, in_bl);
-    attrs[RGW_ATTR_MANAGED_POLICY] = in_bl;
-
-    ret = user->store_user(dpp(), null_yield, false);
-    if (ret < 0) {
-      return -ret;
-    }
-    cout << "Managed policy detached successfully" << std::endl;
-    return 0;
-  }
-  if (opt_cmd == OPT::USER_POLICY_LIST_ATTACHED) {
-    if (rgw::sal::User::empty(user)) {
-      cerr << "ERROR: uid not specified" << std::endl;
-      return -EINVAL;
-    }
-    ret = user->load_user(dpp(), null_yield);
-    if (ret < 0) {
-      return -ret;
-    }
-
-    rgw::IAM::ManagedPolicies policies;
-    auto& attrs = user->get_attrs();
-    if (auto it = attrs.find(RGW_ATTR_MANAGED_POLICY); it != attrs.end()) {
-      decode(policies, it->second);
-    }
-
-    show_policy_arns(policies.arns, formatter.get());
-    formatter->flush(cout);
-    return 0;
   }
 
 #ifdef WITH_RADOSGW_RADOS
@@ -10515,30 +10334,8 @@ next:
 #ifdef WITH_RADOSGW_RADOS
       opt_cmd == OPT::METADATA_LIST ||
 #endif
-      opt_cmd == OPT::USER_LIST ||
       opt_cmd == OPT::ACCOUNT_LIST) {
-    if (opt_cmd == OPT::USER_LIST) {
-      metadata_key = "user";
-
-      if (!account_id.empty() || !account_name.empty()) {
-        // list users by account
-        rgw::account::AdminOpState op_state;
-        op_state.account_id = account_id;
-        op_state.tenant = tenant;
-        op_state.account_name = account_name;
-
-        std::string err_msg;
-        int ret = rgw::account::list_users(
-            dpp(), driver, op_state, path_prefix, marker,
-            max_entries_specified, max_entries, account_root,
-            err_msg, stream_flusher, null_yield);
-        if (ret < 0)  {
-          cerr << "ERROR: " << err_msg << std::endl;
-          return -ret;
-        }
-        return 0;
-      }
-    } else if (opt_cmd == OPT::ACCOUNT_LIST) {
+    if (opt_cmd == OPT::ACCOUNT_LIST) {
       metadata_key = "account";
     }
     void *handle;

--- a/src/rgw/radosgw-admin/user.cc
+++ b/src/rgw/radosgw-admin/user.cc
@@ -1,0 +1,467 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#include "radosgw-admin/user.h"
+
+#include <iostream>
+#include <list>
+#include <string>
+
+#include "common/ceph_json.h"
+#include "common/errno.h"
+#include "common/Formatter.h"
+#include "driver/rados/rgw_bucket.h"
+#include "driver/rados/rgw_user.h"
+#include "include/utime.h"
+#include "rgw_account.h"
+#include "rgw_formats.h"
+#include "rgw_iam_managed_policy.h"
+#include "rgw_iam_policy.h"
+#include "rgw_sal.h"
+#include "rgw_user.h"
+#include "radosgw-admin/admin_meta.h"
+
+using ceph::Formatter;
+
+namespace {
+
+void show_user_info(RGWUserInfo& info, Formatter* formatter)
+{
+  encode_json("user_info", info, formatter);
+  formatter->flush(std::cout);
+  std::cout << std::endl;
+}
+
+int init_bucket(const DoutPrefixProvider* dpp,
+                rgw::sal::Driver* driver,
+                const std::string& tenant_name,
+                const std::string& bucket_name,
+                const std::string& bucket_id,
+                std::unique_ptr<rgw::sal::Bucket>* out_bucket)
+{
+  rgw_bucket b{tenant_name, bucket_name, bucket_id};
+  return driver->load_bucket(dpp, b, out_bucket, null_yield);
+}
+
+void show_policy_arns(const boost::container::flat_set<std::string>& arns,
+                      Formatter* formatter)
+{
+  formatter->open_array_section("AttachedPolicies");
+  for (const auto& arn : arns) {
+    formatter->dump_string("PolicyArn", arn);
+  }
+  formatter->close_section();
+}
+
+} // anonymous namespace
+
+int rgw_admin_user_mutate(const DoutPrefixProvider* dpp,
+                          rgw::sal::Driver* driver,
+                          Formatter* formatter,
+                          RGWUser& ruser,
+                          RGWUserAdminOpState& user_op,
+                          std::unique_ptr<rgw::sal::User>& user,
+                          const rgw_admin_user_mutate_options& opts,
+                          std::string& err_msg)
+{
+  int ret = 0;
+  bool output_user_info = true;
+  RGWUserInfo info;
+
+  switch (opts.command) {
+  case user_mutate_command::info:
+    if (rgw::sal::User::empty(user) && opts.access_key.empty()) {
+      std::cerr << "ERROR: --uid or --access-key required" << std::endl;
+      return EINVAL;
+    }
+    break;
+  case user_mutate_command::create:
+    if (!user_op.has_existing_user() && (opts.generate_key != 0)) {
+      user_op.set_generate_key();
+    }
+    ret = ruser.add(dpp, user_op, null_yield, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not create user: " << err_msg << std::endl;
+      if (ret == -ERR_INVALID_TENANT_NAME) {
+        ret = -EINVAL;
+      }
+      return -ret;
+    }
+    if (!opts.subuser.empty()) {
+      ret = ruser.subusers.add(dpp, user_op, null_yield, &err_msg);
+      if (ret < 0) {
+        std::cerr << "could not create subuser: " << err_msg << std::endl;
+        return -ret;
+      }
+    }
+    break;
+  case user_mutate_command::rm:
+    ret = ruser.remove(dpp, user_op, null_yield, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not remove user: " << err_msg << std::endl;
+      return -ret;
+    }
+    output_user_info = false;
+    break;
+  case user_mutate_command::rename:
+    if (opts.yes_i_really_mean_it) {
+      user_op.set_overwrite_new_user(true);
+    }
+    ret = ruser.rename(user_op, null_yield, dpp, &err_msg);
+    if (ret < 0) {
+      if (ret == -EEXIST) {
+        err_msg += ". to overwrite this user, add --yes-i-really-mean-it";
+      }
+      std::cerr << "could not rename user: " << err_msg << std::endl;
+      return -ret;
+    }
+    break;
+  case user_mutate_command::enable:
+  case user_mutate_command::suspend:
+  case user_mutate_command::modify:
+    ret = ruser.modify(dpp, user_op, null_yield, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not modify user: " << err_msg << std::endl;
+      return -ret;
+    }
+    break;
+  case user_mutate_command::subuser_create:
+    ret = ruser.subusers.add(dpp, user_op, null_yield, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not create subuser: " << err_msg << std::endl;
+      return -ret;
+    }
+    break;
+  case user_mutate_command::subuser_modify:
+    ret = ruser.subusers.modify(dpp, user_op, null_yield, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not modify subuser: " << err_msg << std::endl;
+      return -ret;
+    }
+    break;
+  case user_mutate_command::subuser_rm:
+    ret = ruser.subusers.remove(dpp, user_op, null_yield, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not remove subuser: " << err_msg << std::endl;
+      return -ret;
+    }
+    break;
+  case user_mutate_command::key_create:
+    ret = ruser.keys.add(dpp, user_op, null_yield, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not create key: " << err_msg << std::endl;
+      return -ret;
+    }
+    break;
+  case user_mutate_command::key_rm:
+    ret = ruser.keys.remove(dpp, user_op, null_yield, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not remove key: " << err_msg << std::endl;
+      return -ret;
+    }
+    break;
+  case user_mutate_command::caps_add:
+    ret = ruser.caps.add(dpp, user_op, null_yield, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not add caps: " << err_msg << std::endl;
+      return -ret;
+    }
+    break;
+  case user_mutate_command::caps_rm:
+    ret = ruser.caps.remove(dpp, user_op, null_yield, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not remove caps: " << err_msg << std::endl;
+      return -ret;
+    }
+    break;
+  default:
+    return EINVAL;
+  }
+
+  if (output_user_info) {
+    ret = ruser.info(info, &err_msg);
+    if (ret < 0) {
+      std::cerr << "could not fetch user info: " << err_msg << std::endl;
+      return -ret;
+    }
+    show_user_info(info, formatter);
+  }
+
+  return 0;
+}
+
+int rgw_admin_user_query(const DoutPrefixProvider* dpp,
+                         rgw::sal::Driver* driver,
+                         Formatter* formatter,
+                         RGWFormatterFlusher& stream_flusher,
+                         std::unique_ptr<rgw::sal::User>& user,
+                         std::unique_ptr<rgw::sal::Bucket>& bucket,
+                         const rgw_admin_user_query_options& opts)
+{
+  const bool limit_specified = opts.max_entries.has_value();
+  const int max_entries = opts.max_entries.value_or(0);
+  int ret = 0;
+
+  switch (opts.command) {
+  case user_query_command::check:
+    check_bad_owner_bucket_mapping(driver, user->get_id(),
+                                   user->get_display_name(), user->get_tenant(),
+                                   opts.fix, null_yield, dpp);
+    break;
+  case user_query_command::stats: {
+    if (rgw::sal::User::empty(user)) {
+      std::cerr << "ERROR: uid not specified" << std::endl;
+      return EINVAL;
+    }
+    if (opts.reset_stats) {
+      if (!opts.bucket_name.empty()) {
+        std::cerr << "ERROR: --reset-stats does not work on buckets and "
+                     "bucket specified" << std::endl;
+        return EINVAL;
+      }
+      if (opts.sync_stats) {
+        std::cerr << "ERROR: sync-stats includes the reset-stats functionality, "
+                     "so at most one of the two should be specified"
+                  << std::endl;
+        return EINVAL;
+      }
+      ret = driver->reset_stats(dpp, null_yield, user->get_id());
+      if (ret < 0) {
+        std::cerr << "ERROR: could not reset user stats: " << cpp_strerror(-ret)
+                  << std::endl;
+        return -ret;
+      }
+    }
+
+    if (opts.sync_stats) {
+      if (!opts.bucket_name.empty()) {
+        ret = init_bucket(dpp, driver, opts.tenant, opts.bucket_name,
+                          opts.bucket_id, &bucket);
+        if (ret < 0) {
+          std::cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret)
+                    << std::endl;
+          return -ret;
+        }
+        ret = bucket->sync_owner_stats(dpp, null_yield, nullptr);
+        if (ret < 0) {
+          std::cerr << "ERROR: could not sync bucket stats: "
+                    << cpp_strerror(-ret) << std::endl;
+          return -ret;
+        }
+      } else {
+        ret = rgw_sync_all_stats(dpp, null_yield, driver,
+                                 user->get_id(), user->get_tenant());
+        if (ret < 0) {
+          std::cerr << "ERROR: could not sync user stats: "
+                    << cpp_strerror(-ret) << std::endl;
+          return -ret;
+        }
+      }
+    }
+
+    ret = user->load_user(dpp, null_yield);
+    if (ret < 0) {
+      std::cerr << "User has not been initialized or user does not exist"
+                << std::endl;
+      return -ret;
+    }
+
+    const RGWUserInfo& uinfo = user->get_info();
+    rgw_owner owner = uinfo.user_id;
+    if (!uinfo.account_id.empty()) {
+      std::cerr << "Reading stats for user account " << uinfo.account_id
+                << std::endl;
+      owner = uinfo.account_id;
+    }
+
+    constexpr bool omit_utilized_stats = false;
+    RGWStorageStats stats(omit_utilized_stats);
+    ceph::real_time last_stats_sync;
+    ceph::real_time last_stats_update;
+    ret = driver->load_stats(dpp, null_yield, owner, stats,
+                             last_stats_sync, last_stats_update);
+    if (ret < 0) {
+      if (ret == -ENOENT) {
+        std::cerr << "User has not been initialized or user does not exist"
+                  << std::endl;
+      } else {
+        std::cerr << "ERROR: can't read user: " << cpp_strerror(ret)
+                  << std::endl;
+      }
+      return -ret;
+    }
+
+    {
+      Formatter::ObjectSection os(*formatter, "result");
+      encode_json("stats", stats, formatter);
+      utime_t last_sync_ut(last_stats_sync);
+      encode_json("last_stats_sync", last_sync_ut, formatter);
+      utime_t last_update_ut(last_stats_update);
+      encode_json("last_stats_update", last_update_ut, formatter);
+    }
+    formatter->flush(std::cout);
+    break;
+  }
+  case user_query_command::list: {
+    if (!opts.account_id.empty() || !opts.account_name.empty()) {
+      rgw::account::AdminOpState op_state;
+      op_state.account_id = opts.account_id;
+      op_state.tenant = opts.tenant;
+      op_state.account_name = opts.account_name;
+
+      std::string err_msg;
+      ret = rgw::account::list_users(
+          dpp, driver, op_state, opts.path_prefix, opts.marker,
+          limit_specified, max_entries, opts.account_root,
+          err_msg, stream_flusher, null_yield);
+      if (ret < 0) {
+        std::cerr << "ERROR: " << err_msg << std::endl;
+        return -ret;
+      }
+      return 0;
+    }
+
+    rgw_admin_meta_list_options list_opts;
+    list_opts.metadata_key = "user";
+    list_opts.marker = opts.marker;
+    if (limit_specified) {
+      list_opts.max_entries = max_entries;
+    }
+    return rgw_admin_meta_list_keys(dpp, driver, stream_flusher, list_opts);
+  }
+  default:
+    return EINVAL;
+  }
+
+  return 0;
+}
+
+int rgw_admin_user_policy(const DoutPrefixProvider* dpp,
+                          rgw::sal::Driver* driver,
+                          Formatter* formatter,
+                          std::unique_ptr<rgw::sal::User>& user,
+                          const rgw_admin_user_policy_options& opts)
+{
+  const auto& policy_arn = opts.policy_arn;
+  int ret = 0;
+
+  switch (opts.command) {
+  case user_policy_command::attach:
+    if (rgw::sal::User::empty(user)) {
+      std::cerr << "ERROR: uid not specified" << std::endl;
+      return EINVAL;
+    }
+    if (policy_arn.empty()) {
+      std::cerr << "policy arn is empty" << std::endl;
+      return EINVAL;
+    }
+    ret = user->load_user(dpp, null_yield);
+    if (ret < 0) {
+      return -ret;
+    }
+    if (user->get_info().account_id.empty()) {
+      std::cerr << "Managed policies are only supported for account users"
+                << std::endl;
+      return EINVAL;
+    }
+
+    try {
+      if (!rgw::IAM::get_managed_policy(driver->ctx(), policy_arn)) {
+        std::cerr << "unrecognized policy arn " << policy_arn << std::endl;
+        return ENOENT;
+      }
+    } catch (rgw::IAM::PolicyParseException& e) {
+      std::cerr << "failed to parse managed policy: " << e.what() << std::endl;
+      return EINVAL;
+    }
+
+    {
+      rgw::IAM::ManagedPolicies policies;
+      auto& attrs = user->get_attrs();
+      if (auto it = attrs.find(RGW_ATTR_MANAGED_POLICY); it != attrs.end()) {
+        decode(policies, it->second);
+      }
+      const bool inserted = policies.arns.insert(policy_arn).second;
+      if (!inserted) {
+        std::cout << "That managed policy is already attached." << std::endl;
+        return EEXIST;
+      }
+
+      bufferlist in_bl;
+      encode(policies, in_bl);
+      attrs[RGW_ATTR_MANAGED_POLICY] = in_bl;
+
+      ret = user->store_user(dpp, null_yield, false);
+      if (ret < 0) {
+        return -ret;
+      }
+      std::cout << "Managed policy attached successfully" << std::endl;
+    }
+    return 0;
+
+  case user_policy_command::detach:
+    if (rgw::sal::User::empty(user)) {
+      std::cerr << "ERROR: uid not specified" << std::endl;
+      return EINVAL;
+    }
+    if (policy_arn.empty()) {
+      std::cerr << "policy arn is empty" << std::endl;
+      return EINVAL;
+    }
+    ret = user->load_user(dpp, null_yield);
+    if (ret < 0) {
+      return -ret;
+    }
+
+    {
+      rgw::IAM::ManagedPolicies policies;
+      auto& attrs = user->get_attrs();
+      if (auto it = attrs.find(RGW_ATTR_MANAGED_POLICY); it != attrs.end()) {
+        decode(policies, it->second);
+      }
+
+      auto i = policies.arns.find(policy_arn);
+      if (i == policies.arns.end()) {
+        std::cout << "That managed policy is not attached." << std::endl;
+        return ENOENT;
+      }
+      policies.arns.erase(i);
+
+      bufferlist in_bl;
+      encode(policies, in_bl);
+      attrs[RGW_ATTR_MANAGED_POLICY] = in_bl;
+
+      ret = user->store_user(dpp, null_yield, false);
+      if (ret < 0) {
+        return -ret;
+      }
+      std::cout << "Managed policy detached successfully" << std::endl;
+    }
+    return 0;
+
+  case user_policy_command::list_attached:
+    if (rgw::sal::User::empty(user)) {
+      std::cerr << "ERROR: uid not specified" << std::endl;
+      return EINVAL;
+    }
+    ret = user->load_user(dpp, null_yield);
+    if (ret < 0) {
+      return -ret;
+    }
+
+    {
+      rgw::IAM::ManagedPolicies policies;
+      auto& attrs = user->get_attrs();
+      if (auto it = attrs.find(RGW_ATTR_MANAGED_POLICY); it != attrs.end()) {
+        decode(policies, it->second);
+      }
+
+      show_policy_arns(policies.arns, formatter);
+      formatter->flush(std::cout);
+    }
+    return 0;
+
+  default:
+    return EINVAL;
+  }
+}

--- a/src/rgw/radosgw-admin/user.cc
+++ b/src/rgw/radosgw-admin/user.cc
@@ -10,6 +10,7 @@
 #include "common/ceph_json.h"
 #include "common/errno.h"
 #include "common/Formatter.h"
+#include "include/ceph_assert.h"
 #include "driver/rados/rgw_bucket.h"
 #include "driver/rados/rgw_user.h"
 #include "include/utime.h"
@@ -175,7 +176,9 @@ int rgw_admin_user_mutate(const DoutPrefixProvider* dpp,
     }
     break;
   default:
-    return EINVAL;
+    // every user_mutate_command enumerator is handled above; reaching
+    // here means a new enumerator was added without updating this switch.
+    ceph_abort();
   }
 
   if (output_user_info) {
@@ -330,7 +333,9 @@ int rgw_admin_user_query(const DoutPrefixProvider* dpp,
     return rgw_admin_meta_list_keys(dpp, driver, stream_flusher, list_opts);
   }
   default:
-    return EINVAL;
+    // every user_query_command enumerator is handled above; reaching
+    // here means a new enumerator was added without updating this switch.
+    ceph_abort();
   }
 
   return 0;
@@ -442,6 +447,13 @@ int rgw_admin_user_policy(const DoutPrefixProvider* dpp,
   case user_policy_command::list_attached:
     if (rgw::sal::User::empty(user)) {
       std::cerr << "ERROR: uid not specified" << std::endl;
+      // NOTE: behavior fix vs. the pre-extraction code, which returned
+      // -EINVAL here (the only one of the three policy subcommands that
+      // did). main()'s return value becomes the process exit code, so
+      // that was exit 234 (-22 & 0xff) instead of 22 like attach/detach.
+      // Returning EINVAL here makes exit codes consistent across
+      // attach/detach/list_attached; test-user-exit-codes.sh now asserts
+      // exit 22 for "policy list: no uid".
       return EINVAL;
     }
     ret = user->load_user(dpp, null_yield);
@@ -462,6 +474,8 @@ int rgw_admin_user_policy(const DoutPrefixProvider* dpp,
     return 0;
 
   default:
-    return EINVAL;
+    // every user_policy_command enumerator is handled above; reaching
+    // here means a new enumerator was added without updating this switch.
+    ceph_abort();
   }
 }

--- a/src/rgw/radosgw-admin/user.h
+++ b/src/rgw/radosgw-admin/user.h
@@ -1,0 +1,96 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+
+class DoutPrefixProvider;
+class RGWFormatterFlusher;
+class RGWUser;
+class RGWUserAdminOpState;
+namespace ceph { class Formatter; }
+namespace rgw::sal { class Driver; class User; class Bucket; }
+
+enum class user_mutate_command {
+  info,
+  create,
+  rm,
+  rename,
+  enable,
+  suspend,
+  modify,
+  subuser_create,
+  subuser_modify,
+  subuser_rm,
+  key_create,
+  key_rm,
+  caps_add,
+  caps_rm,
+};
+
+struct rgw_admin_user_mutate_options {
+  user_mutate_command command = user_mutate_command::info;
+  std::string access_key;
+  std::string subuser;
+  bool yes_i_really_mean_it = false;
+  int generate_key = 2; // 0=set-false, 1=set-true, 2=not-set
+};
+
+int rgw_admin_user_mutate(const DoutPrefixProvider* dpp,
+                          rgw::sal::Driver* driver,
+                          ceph::Formatter* formatter,
+                          RGWUser& ruser,
+                          RGWUserAdminOpState& user_op,
+                          std::unique_ptr<rgw::sal::User>& user,
+                          const rgw_admin_user_mutate_options& opts,
+                          std::string& err_msg);
+
+enum class user_policy_command {
+  attach,
+  detach,
+  list_attached,
+};
+
+struct rgw_admin_user_policy_options {
+  user_policy_command command = user_policy_command::attach;
+  std::string policy_arn;
+};
+
+int rgw_admin_user_policy(const DoutPrefixProvider* dpp,
+                          rgw::sal::Driver* driver,
+                          ceph::Formatter* formatter,
+                          std::unique_ptr<rgw::sal::User>& user,
+                          const rgw_admin_user_policy_options& opts);
+
+enum class user_query_command {
+  check,
+  stats,
+  list,
+};
+
+struct rgw_admin_user_query_options {
+  user_query_command command = user_query_command::check;
+  std::string tenant;
+  std::string bucket_name;
+  std::string bucket_id;
+  std::string account_id;
+  std::string account_name;
+  std::string path_prefix;
+  std::string marker;
+  std::optional<int> max_entries;
+  bool account_root = false;
+  bool sync_stats = false;
+  bool reset_stats = false;
+  bool fix = false;
+};
+
+int rgw_admin_user_query(const DoutPrefixProvider* dpp,
+                         rgw::sal::Driver* driver,
+                         ceph::Formatter* formatter,
+                         RGWFormatterFlusher& stream_flusher,
+                         std::unique_ptr<rgw::sal::User>& user,
+                         std::unique_ptr<rgw::sal::Bucket>& bucket,
+                         const rgw_admin_user_query_options& opts);

--- a/src/rgw/radosgw-admin/util.h
+++ b/src/rgw/radosgw-admin/util.h
@@ -1,0 +1,23 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab ft=cpp
+
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "common/errno.h"
+
+namespace rgw_admin {
+inline int report_error(std::string_view what, int ret,
+                        std::string_view err_msg = {})
+{
+  std::cerr << "ERROR: " << what << " with " << cpp_strerror(-ret);
+  if (!err_msg.empty()) {
+    std::cerr << ": " << err_msg;
+  }
+  std::cerr << std::endl;
+  return -ret;
+}
+} // namespace rgw_admin

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -427,6 +427,11 @@ target_link_libraries(unittest_rgw_object_ctx ${rgw_libs})
 add_ceph_test(test-ceph-diff-sorted.sh
   ${CMAKE_CURRENT_SOURCE_DIR}/test-ceph-diff-sorted.sh)
 
+if(WITH_RADOSGW)
+add_ceph_test(test-user-exit-codes.sh
+  ${CMAKE_CURRENT_SOURCE_DIR}/radosgw-admin/test-user-exit-codes.sh)
+endif()
+
 if(WITH_RADOSGW_RADOS)
 # unittest_log_backing
 add_executable(unittest_log_backing test_log_backing.cc)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -427,7 +427,7 @@ target_link_libraries(unittest_rgw_object_ctx ${rgw_libs})
 add_ceph_test(test-ceph-diff-sorted.sh
   ${CMAKE_CURRENT_SOURCE_DIR}/test-ceph-diff-sorted.sh)
 
-if(WITH_RADOSGW)
+if(WITH_RADOSGW_RADOS)
 add_ceph_test(test-user-exit-codes.sh
   ${CMAKE_CURRENT_SOURCE_DIR}/radosgw-admin/test-user-exit-codes.sh)
 endif()

--- a/src/test/rgw/radosgw-admin/test-radosgw-admin-exit-codes-common.sh
+++ b/src/test/rgw/radosgw-admin/test-radosgw-admin-exit-codes-common.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Shared helpers for radosgw-admin exit-code tests.
+#
+# Sourced by test-*-exit-codes.sh under this directory. See also PR #71155
+# (test-bucket-exit-codes.sh, test-script-exit-codes.sh, test-globals.sh).
+
+RGW_ADMIN="${RGW_ADMIN:-${CEPH_BIN:-./bin}/radosgw-admin}"
+export CEPH_CONF="${CEPH_CONF:-${CEPH_BUILD_DIR:-.}/ceph.conf}"
+# Keep ceph log lines off stderr so they cannot interleave with the output printed
+# when a test fails. rgw_global_init consumes --log-to-stderr before the flags
+# are read.
+export CEPH_ARGS="--log-to-stderr=false${CEPH_ARGS:+ ${CEPH_ARGS}}"
+PASS=0
+FAIL=0
+SKIP=0
+
+# Filter out noisy ceph log lines (timestamped) and config-not-found lines
+filter() {
+  grep -v "^[0-9]\{4\}-" | \
+  grep -v "^did not load config" | \
+  grep -v "^unable to get monitor" | \
+  grep -v "^failed to fetch mon config"
+}
+
+# --no-mon-config skips monitor connection so check() runs without a cluster.
+_run() { "$RGW_ADMIN" --no-mon-config "$@"; }
+
+cluster_running() { pgrep -x radosgw > /dev/null 2>&1; }
+
+# check "desc" expected_exit args
+check() {
+  local desc="$1" expected_exit="$2"
+  shift 2
+  local tmpfile; tmpfile=$(mktemp)
+  _run "$@" >"$tmpfile" 2>&1
+  local exit_code=$?
+
+  if [ "$exit_code" = "$expected_exit" ]; then
+    echo "PASS [$desc]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$desc]: expected exit $expected_exit, got $exit_code"
+    echo "     output: $(filter <"$tmpfile")"
+    FAIL=$((FAIL+1))
+  fi
+  rm -f "$tmpfile"
+}
+
+# check_cluster "desc" expected_exit -- args
+# Runs against a real cluster. Skips if no cluster is running.
+check_cluster() {
+  local desc="$1" expected_exit="$2"
+  shift 2
+  shift  # skip --
+
+  if ! cluster_running; then
+    echo "SKIP [$desc]: no cluster running"
+    SKIP=$((SKIP+1))
+    return
+  fi
+
+  local tmpfile; tmpfile=$(mktemp)
+  "$RGW_ADMIN" "$@" >"$tmpfile" 2>&1
+  local exit_code=$?
+
+  if [ "$exit_code" = "$expected_exit" ]; then
+    echo "PASS [$desc]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$desc]: expected exit $expected_exit, got $exit_code"
+    echo "     output: $(filter <"$tmpfile")"
+    FAIL=$((FAIL+1))
+  fi
+  rm -f "$tmpfile"
+}
+
+report_results() {
+  echo ""
+  echo "========================================"
+  echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+  [ "$SKIP" -gt 0 ] && echo "(some tests require a running cluster)"
+  echo "========================================"
+  [ "$FAIL" -eq 0 ] && exit 0 || exit 1
+}

--- a/src/test/rgw/radosgw-admin/test-user-exit-codes.sh
+++ b/src/test/rgw/radosgw-admin/test-user-exit-codes.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Exit-code tests for radosgw-admin user commands (user.cc module).
+#
+# Usage:
+#   ./test-user-exit-codes.sh
+#   RGW_ADMIN=/path/to/radosgw-admin ./test-user-exit-codes.sh
+#   CEPH_CONF=/path/to/ceph.conf ./test-user-exit-codes.sh
+#
+# Run from the build directory:
+#   cd /path/to/ceph/build && bash /path/to/test-user-exit-codes.sh
+
+. "`dirname $0`/test-radosgw-admin-exit-codes-common.sh"
+
+# ============================================================
+echo "=== user (bare) ==="
+# ============================================================
+
+check "bare user" 1 user
+check "unknown subcommand" 1 user banana
+check "stray before user" 1 foo user list
+check "stray after user" 1 user list foo
+
+# ============================================================
+echo ""
+echo "=== user info ==="
+# ============================================================
+
+check "info: unrecognized flag" 22 user info --fakeflag
+check "info: stray after flags" 1 user info --uid u strayarg
+check "info: --uid missing value" 1 user info --uid
+check "info: --access-key missing value" 1 user info --access-key
+check "info: no identity flags" 22 user info
+
+# ============================================================
+echo ""
+echo "=== user create ==="
+# ============================================================
+
+check "create: unrecognized flag" 22 user create --fakeflag
+check "create: --uid missing value" 1 user create --uid
+check "create: --display-name missing value" 1 user create --display-name
+check "create: --email missing value" 1 user create --email
+check "create: --max-buckets invalid int" 22 user create --uid u --max-buckets banana
+check "create: no display-name" 22 user create --uid u-no-display
+
+# ============================================================
+echo ""
+echo "=== user modify / enable / suspend ==="
+# ============================================================
+
+check "modify: unrecognized flag" 22 user modify --fakeflag
+check "modify: no uid" 22 user modify --email x@y.com
+check "enable: no uid" 22 user enable
+check "suspend: no uid" 22 user suspend
+
+# ============================================================
+echo ""
+echo "=== user rm / rename ==="
+# ============================================================
+
+check "rm: unrecognized flag" 22 user rm --fakeflag
+check "rm: no uid" 22 user rm
+check "rename: no uid" 22 user rename --new-uid newname
+check "rename: --new-uid missing value" 1 user rename --uid u --new-uid
+
+# ============================================================
+echo ""
+echo "=== user stats ==="
+# ============================================================
+
+check "stats: unrecognized flag" 22 user stats --fakeflag
+check "stats: no uid" 22 user stats
+check "stats: --sync-stats and --reset-stats" 22 user stats --uid u --sync-stats --reset-stats
+check "stats: --reset-stats with bucket" 22 user stats --uid u --reset-stats --bucket b
+
+check_cluster "stats: nonexistent user" 2 -- user stats --uid "no-such-user-$RANDOM"
+
+# ============================================================
+echo ""
+echo "=== user list ==="
+# ============================================================
+
+check "list: unrecognized flag" 22 user list --fakeflag
+check "list: --max-entries missing value" 1 user list --max-entries
+check "list: --max-entries invalid int" 22 user list --max-entries banana
+check "list: --max-entries out of int range" 22 user list --max-entries 5000000000
+
+check_cluster "list: default" 0 -- user list
+check_cluster "list: --max-entries 5" 0 -- user list --max-entries 5
+
+# ============================================================
+echo ""
+echo "=== user policy ==="
+# ============================================================
+
+check "policy attach: no uid" 22 user policy attach --policy-arn arn:x
+check "policy attach: empty arn" 22 user policy attach --uid u
+check "policy detach: no uid" 22 user policy detach --policy-arn arn:x
+check "policy list: no uid" 22 user policy list attached
+
+# ============================================================
+echo ""
+echo "=== subuser / key / caps ==="
+# ============================================================
+
+check "subuser create: no uid" 22 subuser create --subuser s:u
+check "key create: no uid" 22 key create
+check "caps add: no uid" 22 caps add --caps "buckets=*"
+
+# ============================================================
+echo ""
+echo "=== flags: underscore vs dash spelling ==="
+# ============================================================
+
+check "list: --max-entries space form (dash)" 22 user list --max-entries banana
+check "list: --max_entries space form (underscore)" 22 user list --max_entries banana
+
+check_cluster "list: underscore spelling on success path" 0 -- \
+  user list --max_entries 100
+
+# ============================================================
+echo ""
+echo "=== integration: user lifecycle ==="
+# ============================================================
+
+if cluster_running; then
+  _uid="exit-code-user-$$"
+
+  check_cluster "integration: create" 0 -- \
+    user create --uid "$_uid" --display-name "$_uid"
+  check_cluster "integration: info" 0 -- user info --uid "$_uid"
+  check_cluster "integration: modify" 0 -- \
+    user modify --uid "$_uid" --email "${_uid}@example.com"
+  check_cluster "integration: stats" 0 -- user stats --uid "$_uid"
+  check_cluster "integration: list" 0 -- user list
+  check_cluster "integration: rm" 0 -- user rm --uid "$_uid"
+  check_cluster "integration: info after rm" 22 -- user info --uid "$_uid"
+else
+  echo "SKIP [integration: user lifecycle]: no cluster running"
+  SKIP=$((SKIP+1))
+fi
+
+report_results

--- a/src/test/rgw/radosgw-admin/test-user-exit-codes.sh
+++ b/src/test/rgw/radosgw-admin/test-user-exit-codes.sh
@@ -6,6 +6,12 @@
 #   RGW_ADMIN=/path/to/radosgw-admin ./test-user-exit-codes.sh
 #   CEPH_CONF=/path/to/ceph.conf ./test-user-exit-codes.sh
 #
+# Test types:
+#   check()         - no cluster needed; runs with --no-mon-config
+#   check_cluster() - needs a running cluster, SKIPs when there is none
+#
+# Both verify the exit code.
+#
 # Run from the build directory:
 #   cd /path/to/ceph/build && bash /path/to/test-user-exit-codes.sh
 
@@ -29,7 +35,7 @@ check "info: unrecognized flag" 22 user info --fakeflag
 check "info: stray after flags" 1 user info --uid u strayarg
 check "info: --uid missing value" 1 user info --uid
 check "info: --access-key missing value" 1 user info --access-key
-check "info: no identity flags" 22 user info
+check_cluster "info: no identity flags" 22 -- user info
 
 # ============================================================
 echo ""
@@ -41,7 +47,7 @@ check "create: --uid missing value" 1 user create --uid
 check "create: --display-name missing value" 1 user create --display-name
 check "create: --email missing value" 1 user create --email
 check "create: --max-buckets invalid int" 22 user create --uid u --max-buckets banana
-check "create: no display-name" 22 user create --uid u-no-display
+check_cluster "create: no display-name" 22 -- user create --uid u-no-display
 
 # ============================================================
 echo ""
@@ -49,9 +55,9 @@ echo "=== user modify / enable / suspend ==="
 # ============================================================
 
 check "modify: unrecognized flag" 22 user modify --fakeflag
-check "modify: no uid" 22 user modify --email x@y.com
-check "enable: no uid" 22 user enable
-check "suspend: no uid" 22 user suspend
+check_cluster "modify: no uid" 22 -- user modify --email x@y.com
+check_cluster "enable: no uid" 22 -- user enable
+check_cluster "suspend: no uid" 22 -- user suspend
 
 # ============================================================
 echo ""
@@ -59,8 +65,8 @@ echo "=== user rm / rename ==="
 # ============================================================
 
 check "rm: unrecognized flag" 22 user rm --fakeflag
-check "rm: no uid" 22 user rm
-check "rename: no uid" 22 user rename --new-uid newname
+check_cluster "rm: no uid" 22 -- user rm
+check_cluster "rename: no uid" 22 -- user rename --new-uid newname
 check "rename: --new-uid missing value" 1 user rename --uid u --new-uid
 
 # ============================================================
@@ -69,9 +75,11 @@ echo "=== user stats ==="
 # ============================================================
 
 check "stats: unrecognized flag" 22 user stats --fakeflag
-check "stats: no uid" 22 user stats
-check "stats: --sync-stats and --reset-stats" 22 user stats --uid u --sync-stats --reset-stats
-check "stats: --reset-stats with bucket" 22 user stats --uid u --reset-stats --bucket b
+check_cluster "stats: no uid" 22 -- user stats
+check_cluster "stats: --sync-stats and --reset-stats" 22 -- \
+  user stats --uid u --sync-stats --reset-stats
+check_cluster "stats: --reset-stats with bucket" 22 -- \
+  user stats --uid u --reset-stats --bucket b
 
 check_cluster "stats: nonexistent user" 2 -- user stats --uid "no-such-user-$RANDOM"
 
@@ -93,19 +101,19 @@ echo ""
 echo "=== user policy ==="
 # ============================================================
 
-check "policy attach: no uid" 22 user policy attach --policy-arn arn:x
-check "policy attach: empty arn" 22 user policy attach --uid u
-check "policy detach: no uid" 22 user policy detach --policy-arn arn:x
-check "policy list: no uid" 22 user policy list attached
+check_cluster "policy attach: no uid" 22 -- user policy attach --policy-arn arn:x
+check_cluster "policy attach: empty arn" 22 -- user policy attach --uid u
+check_cluster "policy detach: no uid" 22 -- user policy detach --policy-arn arn:x
+check_cluster "policy list: no uid" 22 -- user policy list attached
 
 # ============================================================
 echo ""
 echo "=== subuser / key / caps ==="
 # ============================================================
 
-check "subuser create: no uid" 22 subuser create --subuser s:u
-check "key create: no uid" 22 key create
-check "caps add: no uid" 22 caps add --caps "buckets=*"
+check_cluster "subuser create: no uid" 22 -- subuser create --subuser s:u
+check_cluster "key create: no uid" 22 -- key create
+check_cluster "caps add: no uid" 22 -- caps add --caps "buckets=*"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Context (incremental split from #71462)

This is **slice 4** in the incremental landing plan for the radosgw-admin modularization work in [#71462](https://github.com/ceph/ceph/pull/71462).

This PR contains **only** the user module extraction and its exit-code tests. It is based directly on `main` and does **not** include the dead-code cleanup (#71569), command-types header split (#71570), or the account module (#71575). The user module uses module-local command enums so it does not depend on a shared `radosgw-admin.h`.

Note: `util.h` is identical to the helper added in #71575; after that PR merges I will rebase and drop the duplicate file from this branch.

## Summary

- Add `user.h` / `user.cc` with `rgw_admin_user_mutate()`, `rgw_admin_user_query()`, and `rgw_admin_user_policy()` for user/subuser/key/caps commands plus user check/stats/list and managed policy attach/detach/list
- Add `admin_meta.h` / `admin_meta.cc` with `rgw_admin_meta_list_keys()` for plain `user list`
- Add `util.h` with shared `rgw_admin::report_error()` for consistent CLI error output
- Wire dispatch from `radosgw-admin.cc` through module-local option structs and enums
- Move `user list` (including account-filtered list) out of the shared metadata list block into the user module
- Add `user.cc` and `admin_meta.cc` to the `radosgw-admin` CMake target
- Add shell exit-code tests: `test-user-exit-codes.sh` and shared helpers

Supported user commands and flags are unchanged.

## Testing

Local build and tests (Release, `WITH_RADOSGW_RADOS=ON`, vstart cluster):

- `ninja radosgw-admin`
- `bash src/test/rgw/radosgw-admin/test-user-exit-codes.sh` — 51 passed, 0 failed
- Manual smoke: `user list --max-entries 3`, `user info --uid …`, create/modify/rm lifecycle

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-submodules.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>