### PR TITLE
osd: pwlc was able to retain values larger than the last_update

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -311,6 +311,18 @@ void PGLog::proc_replica_log(
   if (lu < oinfo.last_update) {
     dout(10) << " peer osd." << from << " last_update now " << lu << dendl;
     oinfo.last_update = lu;
+    for (auto &[shard, versionrange] : oinfo.partial_writes_last_complete) {
+      auto & [fromversion, toversion] = versionrange;
+      if (toversion > oinfo.last_update) {
+        dout(10) << __func__ << " peer osd." << from << ": rolling pwlc back "
+                    "for shard " << shard << " from " << toversion << " to "
+                 << oinfo.last_update << dendl;
+        toversion = oinfo.last_update;
+      }
+      if (fromversion > toversion) {
+        fromversion = toversion;
+      }
+    }
   }
 
   if (omissing.have_missing()) {


### PR DESCRIPTION
In certain scenarios during peering, it was possible for us to tell other nodes they needed to roll back their last update when we have divergent entries. PGLog::proc_replica_log is one of these places where we merge divergent entries and potentially roll back the last update, however what we do not do when we do this is modify the pwlc in like we do in proc_master_log when this happens. Because of this, this means we have the potential to have a pwlc with a newer version in it than the agreed upon latest update, which it is then possible to be propogated out to non-primary shards causing each of those shards to assert as I saw in my local test. I've put together this fix which limits the the value of proc_master_log after deciding on a new value for last_update.

Below is the summary of the timeline where I observed this:

* (osd.1, shard 0) 45.472 write (tid=15010, 0~4096) started on primary, which would be 536’12007 (and two more which would be 536’12009)
* (osd.1, shard 0) 45.501 new peering interval started
* (osd.1, shard 0) 45.502 write (tid=15010) cancelled
* (osd.1, shard 0) 48.668 rollback pwlc for shard 1 to 536'12006,536'12006
* (osd.1, shard 0) 48.668 rollback pwlc for shard 2 to 536'12006,536'12006
* (osd.1, shard 0) 48.668 rollback pwlc for shard 3 to 536'12006,536'12006
* (osd.1, shard 0) 48.680 rollback pg from 536’12008 to 536’12006
* (osd.1, shard 0) 48.710 GetMissing::react(MLogRec) received from osd.4, containing info version log((532'11853,536'12008], crt=536'12003)
* (osd.1, shard 0) 48.713 _merge_object_divergent_entries determines that rollback to 536’12006 is possible for osd.4 and sets in memory copy of osd.4’s last update to 536’12006
* (osd.1, shard 0) 48.714 update_peer_info sets pwlc to 536’12008 on the current shard using the pwlc of the incoming shard
* (osd.0, shard 3) 52.742 Stray::react(MLogRec) received, containing info version 536’12006
* (osd.0, shard 3) 52.748 apply_pwlc, setting last_update and last_complete from 536’12006 to 536’12008
* (osd.2, shard 1) 52.759 Stray::react(MLogRec) received, containing info version 536’12006
* (osd.2, shard 1) 52.759 apply_pwlc, setting last_update and last_complete from 536’11854 to 536’12008
* (osd.2, shard 1) 52.765 apply_pwlc, setting last_update and last_complete from 536’12006 to 536’12008
* (osd.3, shard 2) 52.858 Stray::react(MLogRec) received, containing info version 536’12006
* (osd.3, shard 2) 52.865 apply_pwlc, setting last_update and last_complete from 536’12006 to 536’12008
* (osd.1, shard 0) 53.398 write (tid=15013, 0~4096) started on primary, will be version 544’12007
* (osd.1, shard 0) 53.400 cache_ready creates Transactions for ALL shards because first_write_in_interval is true, so non-primaries get sent a transaction which includes a setattr for the OI and nothing else
* (osd.0, shard 3) 53.401 dequeue_op tid=15013
* (osd.3, shard 2) 53.401 dequeue_op tid=15013
* (osd.2, shard 1) 53.401 dequeue_op tid=15013
* (osd.0, shard 3) 53.452 Assert on osd.0 when trying to append log at version 544’12007
* (osd.2, shard 1) 53.454 Assert on osd.2 when trying to append log at version 544’12007
* (osd.3, shard 2) 53.456 Assert on osd.3 when trying to append log at version 544’12007

Tracker ticket: https://tracker.ceph.com/issues/80360

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
