### PR TITLE
umbrella: crimson/osd/pg: keep pg_committed_to from going backwards

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1101,7 +1101,7 @@ PG::interruptible_future<> PG::complete_error_log(const ceph_tid_t& rep_tid,
   log_update.waiting_on.erase(pg_whoami);
   if (log_update.waiting_on.empty()) {
     log_entry_update_waiting_on.erase(rep_tid);
-    peering_state.complete_write(version, last_complete);
+    complete_write(version, last_complete);
     logger().debug("complete_error_log: write complete,"
                    " erasing rep_tid {}", rep_tid);
   } else {
@@ -1111,7 +1111,7 @@ PG::interruptible_future<> PG::complete_error_log(const ceph_tid_t& rep_tid,
       log_update.all_committed.get_shared_future()
     ).then_interruptible([this, last_complete, rep_tid, version] {
       logger().debug("complete_error_log: rep_tid {} awaited ", rep_tid);
-      peering_state.complete_write(version, last_complete);
+      complete_write(version, last_complete);
       ceph_assert(!log_entry_update_waiting_on.contains(rep_tid));
       return seastar::now();
     });

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -721,6 +721,20 @@ public:
   }
 
   void complete_write(eversion_t v, eversion_t lc) {
+    // Crimson can finish different client writes out of at_version order
+    // (repop replies / local vs remote). PeeringState::complete_write()
+    // assigns pg_committed_to and last_complete_ondisk unconditionally, so a
+    // late older completion would move those watermarks backwards and can
+    // trip ceph_assert(trim_to <= get_pg_committed_to()) in log_operation().
+    // A higher all-shard commit already covers every lower version, so drop
+    // the stale completion instead of applying it.
+    // See https://tracker.ceph.com/issues/72342
+    if (v < peering_state.get_pg_committed_to()) {
+      LOG_PREFIX(PG::complete_write);
+      SUBDEBUGDPP(osd, "dropping stale completion v {} lc {} pct {}",
+		  *this, v, lc, peering_state.get_pg_committed_to());
+      return;
+    }
     peering_state.complete_write(v, lc);
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80321

---

backport of https://github.com/ceph/ceph/pull/70648
parent tracker: https://tracker.ceph.com/issues/72342

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh