### PR TITLE
squid: os/bluestore/BlueFS: reserve the log-extension seq before releasing dirty.lock

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3268,11 +3268,13 @@ uint64_t BlueFS::_need_extend_log() {
 
 void BlueFS::_extend_log(uint64_t amount) {
   ceph_assert(ceph_mutex_is_locked(log.lock));
-  std::unique_lock<ceph::mutex> ll(log.lock, std::adopt_lock);
-  while (log_forbidden_to_expand.load() == true) {
-    log_cond.wait(ll);
-  }
-  ll.release();
+  // The caller waited out log_forbidden_to_expand BEFORE reserving seqs
+  // (see _flush_and_sync_log_LD) and has held log.lock ever since; the
+  // flag cannot be set anew without log.lock, so expanding is safe.
+  // Waiting here instead - after the reservation, releasing log.lock -
+  // would let another flusher append later seqs first and our reserved
+  // seqs would land out of order in the journal.
+  ceph_assert(log_forbidden_to_expand.load() == false);
   uint64_t allocated_before_extension = log.writer->file->fnode.get_allocated();
   amount = round_up_to(amount, super.block_size);
   int r = _allocate(
@@ -3395,24 +3397,45 @@ void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_rel
 
 int BlueFS::_flush_and_sync_log_LD(uint64_t want_seq)
 {
-  log.lock.lock();
+  std::unique_lock<ceph::mutex> ll(log.lock);
   dirty.lock.lock();
-  if (want_seq && want_seq <= dirty.seq_stable) {
-    dout(10) << __func__ << " want_seq " << want_seq << " <= seq_stable "
-      << dirty.seq_stable << ", done" << dendl;
+  uint64_t extend_amount;
+  while (true) {
+    if (want_seq && want_seq <= dirty.seq_stable) {
+      dout(10) << __func__ << " want_seq " << want_seq << " <= seq_stable "
+        << dirty.seq_stable << ", done" << dendl;
+      dirty.lock.unlock();
+      return 0;
+    }
+
+    ceph_assert(want_seq == 0 || want_seq <= dirty.seq_live); // illegal to request seq that was not created yet
+    // Compose log.t before advancing the seq so the extension decision
+    // below is exact; dirty.lock is held across both, so nothing can
+    // register under the current seq in between.
+    _consume_dirty(log.seq_live);
+    extend_amount = _need_extend_log();
+    if (extend_amount == 0 || !log_forbidden_to_expand.load()) {
+      break;
+    }
+    // An async compaction is switching to a new log and forbids its
+    // expansion. Wait that out *before* reserving any seq: parking with
+    // reserved seqs (as _extend_log()'s wait releases log.lock) would
+    // let another flusher flush the shared log.t under later seqs, and
+    // the parked seqs would then be appended out of order, which replay
+    // treats as end-of-log. Nothing is reserved yet, so waiting here is
+    // safe; on wakeup we re-evaluate from scratch - re-consuming is
+    // fine because files already encoded into log.t re-encode as empty
+    // deltas, while files dirtied during the wait get picked up.
+    // Flushers that fit the runway never enter this wait.
     dirty.lock.unlock();
-    log.lock.unlock();
-    return 0;
+    log_cond.wait(ll, [&] { return !log_forbidden_to_expand.load(); });
+    dirty.lock.lock();
   }
-  
-  ceph_assert(want_seq == 0 || want_seq <= dirty.seq_live); // illegal to request seq that was not created yet
   uint64_t seq =_log_advance_seq();
-  _consume_dirty(seq);
   // Reserve a dedicated seq for the log-extension transaction (if one is
   // needed) while dirty.lock is still held; otherwise a concurrent
   // _signal_dirty_to_log_D() could register a file under a seq that no
   // _consume_dirty() will ever visit (https://tracker.ceph.com/issues/79068).
-  uint64_t extend_amount = _need_extend_log();
   if (extend_amount) {
     ++dirty.seq_live;
     ++log.seq_live;
@@ -3428,7 +3451,7 @@ int BlueFS::_flush_and_sync_log_LD(uint64_t want_seq)
   _flush_bdev(log.writer);
   logger->set(l_bluefs_log_bytes, log.writer->file->fnode.size);
   //now log.lock is no longer needed
-  log.lock.unlock();
+  ll.unlock();
 
   _clear_dirty_set_stable_D(seq);
   _release_pending_allocations(to_release);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -723,6 +723,7 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 
   // initial txn
   ceph_assert(log.seq_live == 1);
+  log.t.reset(super.uuid);
   log.t.seq = 1;
   log.t.op_init();
   _flush_and_sync_log_LD();
@@ -1146,7 +1147,7 @@ void BlueFS::umount(bool avoid_compact)
   }
   _close_writer(log.writer);
   log.writer = NULL;
-  log.t.clear();
+  log.t.reset(super.uuid);
   // if we umount with pending release, we can possibly mount again
   // with pending release, and will release something that is not allocated
   for (auto& d: dirty.pending_release) {
@@ -1268,6 +1269,7 @@ int BlueFS::_open_super()
          << dendl;
     return -EIO;
   }
+  log.t.reset(super.uuid);
   dout(10) << __func__ << " superblock " << super.seq << dendl;
   dout(10) << __func__ << " log_fnode " << super.log_fnode << dendl;
   return 0;
@@ -2512,9 +2514,7 @@ uint64_t BlueFS::_make_initial_transaction(uint64_t start_seq,
                                            uint64_t expected_final_size,
                                            bufferlist* out)
 {
-  bluefs_transaction_t t0;
-  t0.seq = start_seq;
-  t0.uuid = super.uuid;
+  bluefs_transaction_t t0(super.uuid, start_seq);
   t0.op_init();
   t0.op_file_update_inc(fnode);
   t0.op_jump(start_seq, expected_final_size); // this is a fixed size op,
@@ -2581,14 +2581,11 @@ bool BlueFS::_should_start_compact_log_L_N()
   return true;
 }
 
-void BlueFS::_compact_log_dump_metadata_NF(uint64_t start_seq,
-                                        bluefs_transaction_t *t,
+void BlueFS::_compact_log_dump_metadata_NF(bluefs_transaction_t *t,
 					int bdev_update_flags,
                                         uint64_t capture_before_seq)
 {
   dout(20) << __func__ << dendl;
-  t->seq = start_seq;
-  t->uuid = super.uuid;
 
   std::lock_guard nl(nodes.lock);
 
@@ -2703,8 +2700,7 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool permit_dev_fallback,
   // log.t.seq is always set to current live seq
   ceph_assert(log.t.seq == log.seq_live);
   // Capturing entire state. Dump anything that has been stored there.
-  log.t.clear();
-  log.t.seq = log.seq_live;
+  log.t.reset(super.uuid, log.seq_live);
   // From now on, no changes to log.t are permitted until we finish rewriting log.
   // Can allow dirty to remain dirty - log.seq_live will not change.
 
@@ -2744,8 +2740,8 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool permit_dev_fallback,
 
 
   // 1.1 Build full compacted meta transaction
-  bluefs_transaction_t compacted_meta_t;
-  _compact_log_dump_metadata_NF(starter_seq + 1, &compacted_meta_t, flags, 0);
+  bluefs_transaction_t compacted_meta_t(super.uuid, starter_seq + 1);
+  _compact_log_dump_metadata_NF(&compacted_meta_t, flags, 0);
 
   // 1.2 Allocate the space required for the compacted meta transaction
   uint64_t compacted_meta_need =
@@ -3033,8 +3029,8 @@ void BlueFS::_compact_log_async_LD_LNF_D() //also locks FW for new_writer
   //
 
   // 2.1 Build full compacted meta transaction
-  bluefs_transaction_t compacted_meta_t;
-  _compact_log_dump_metadata_NF(starter_seq + 1, &compacted_meta_t, 0, seq_now);
+  bluefs_transaction_t compacted_meta_t(super.uuid, starter_seq + 1);
+  _compact_log_dump_metadata_NF(&compacted_meta_t, 0, seq_now);
 
   // now state is captured to compacted_meta_t,
   // current log can be used to write to,
@@ -3213,13 +3209,13 @@ uint64_t BlueFS::_log_advance_seq()
   //acquire new seq
   // this will became seq_stable once we write
   ceph_assert(dirty.seq_stable < dirty.seq_live);
+  ceph_assert(dirty.seq_live == log.seq_live);
+
   ceph_assert(log.t.seq == log.seq_live);
   uint64_t seq = log.seq_live;
-  log.t.uuid = super.uuid;
 
   ++dirty.seq_live;
   ++log.seq_live;
-  ceph_assert(dirty.seq_live == log.seq_live);
   return seq;
 }
 
@@ -3288,9 +3284,7 @@ void BlueFS::_extend_log(uint64_t amount) {
   ceph_assert(r == 0);
   dout(10) << "extended log by 0x" << std::hex << amount << " bytes " << dendl;
 
-  bluefs_transaction_t log_extend_transaction;
-  log_extend_transaction.seq = log.t.seq;
-  log_extend_transaction.uuid = log.t.uuid;
+  bluefs_transaction_t log_extend_transaction(super.uuid, log.t.seq);
   log_extend_transaction.op_file_update_inc(log.writer->file->fnode);
 
   bufferlist bl;
@@ -3312,7 +3306,6 @@ void BlueFS::_flush_and_sync_log_core()
   ceph_assert(ceph_mutex_is_locked(log.lock));
   dout(10) << __func__ << " " << log.t << dendl;
 
-
   bufferlist bl;
   bl.reserve(super.block_size);
   encode(log.t, bl);
@@ -3333,8 +3326,7 @@ void BlueFS::_flush_and_sync_log_core()
   log.writer->append(bl);
 
   // prepare log for new transactions
-  log.t.clear();
-  log.t.seq = log.seq_live;
+  log.t.reset(super.uuid, log.seq_live);
 
   uint64_t new_data = _flush_special(log.writer);
   vselector->add_usage(log.writer->file->vselector_hint, new_data);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2930,8 +2930,14 @@ void BlueFS::_compact_log_async_LD_LNF_D() //also locks FW for new_writer
   // lock log's run-time structures for a while
   log.lock.lock();
 
-  // Extend log in case of having a big transaction waiting before starting compaction.
-  _maybe_extend_log();
+  // Extension only happens on the flush path; if the runway is short for
+  // the pending transaction, flush it - that extends the log as a side
+  // effect (see _flush_and_sync_log_LD).
+  if (_need_extend_log() > 0) {
+    log.lock.unlock();
+    _flush_and_sync_log_LD();
+    log.lock.lock();
+  }
 
   // only one compaction allowed at one time
   bool old_is_comp = std::atomic_exchange(&log_is_compacting, true);
@@ -3241,21 +3247,23 @@ void BlueFS::_consume_dirty(uint64_t seq)
   }
 }
 
-int64_t BlueFS::_maybe_extend_log() {
+// Returns the amount to extend the log by, or 0 if the runway suffices.
+// Requires log.lock; call after log.t is fully composed for an exact estimate.
+uint64_t BlueFS::_need_extend_log() {
   uint64_t runway = log.writer->file->fnode.get_allocated() - log.writer->get_effective_write_pos();
-  // increasing the size of the log involves adding a OP_FILE_UPDATE_INC which its size will 
-  // increase with respect the number of extents. bluefs_min_log_runway should cover the max size 
+  // increasing the size of the log involves adding a OP_FILE_UPDATE_INC which its size will
+  // increase with respect the number of extents. bluefs_min_log_runway should cover the max size
   // a log can get.
   // inject new allocation in case log is too big
   size_t expected_log_size = 0;
   log.t.bound_encode(expected_log_size);
   if (expected_log_size + cct->_conf->bluefs_min_log_runway > runway) {
-    _extend_log(expected_log_size + cct->_conf->bluefs_max_log_runway);
-  } else if (runway < cct->_conf->bluefs_min_log_runway) {
-    _extend_log(cct->_conf->bluefs_max_log_runway);
+    return expected_log_size + cct->_conf->bluefs_max_log_runway;
   }
-  runway = log.writer->file->fnode.get_allocated() - log.writer->get_effective_write_pos();
-  return runway;
+  if (runway < cct->_conf->bluefs_min_log_runway) {
+    return cct->_conf->bluefs_max_log_runway;
+  }
+  return 0;
 }
 
 void BlueFS::_extend_log(uint64_t amount) {
@@ -3290,13 +3298,11 @@ void BlueFS::_extend_log(uint64_t amount) {
   log.writer->append(bl);
   ceph_assert(allocated_before_extension >= log.writer->get_effective_write_pos());
 
-  // before sync_core we advance the seq
-  {
-    std::unique_lock<ceph::mutex> l(dirty.lock);
-    dirty.seq_live++;
-    log.seq_live++;
-    log.t.seq++;
-  }
+  // The extension transaction consumed seq log.t.seq (reserved by the
+  // caller under dirty.lock); step log.t.seq so the upcoming main
+  // transaction takes the next slot. seq_live is deliberately not
+  // touched here.
+  log.t.seq++;
 }
 
 void BlueFS::_flush_and_sync_log_core()
@@ -3317,8 +3323,8 @@ void BlueFS::_flush_and_sync_log_core()
   logger->inc(l_bluefs_logged_bytes, bl.length());
 
   uint64_t runway = log.writer->file->fnode.get_allocated() - log.writer->get_effective_write_pos();
-  // ensure runway is big enough, this should be taken care of by _maybe_extend_log,
-  // but let's keep this here just in case.
+  // ensure runway is big enough, this should be taken care of by the
+  // _need_extend_log()/_extend_log() pair, but let's keep this here just in case.
   ceph_assert(bl.length() <= runway); 
 
 
@@ -3402,11 +3408,22 @@ int BlueFS::_flush_and_sync_log_LD(uint64_t want_seq)
   ceph_assert(want_seq == 0 || want_seq <= dirty.seq_live); // illegal to request seq that was not created yet
   uint64_t seq =_log_advance_seq();
   _consume_dirty(seq);
+  // Reserve a dedicated seq for the log-extension transaction (if one is
+  // needed) while dirty.lock is still held; otherwise a concurrent
+  // _signal_dirty_to_log_D() could register a file under a seq that no
+  // _consume_dirty() will ever visit (https://tracker.ceph.com/issues/79068).
+  uint64_t extend_amount = _need_extend_log();
+  if (extend_amount) {
+    ++dirty.seq_live;
+    ++log.seq_live;
+  }
   vector<interval_set<uint64_t>> to_release(dirty.pending_release.size());
   to_release.swap(dirty.pending_release);
   dirty.lock.unlock();
 
-  _maybe_extend_log();
+  if (extend_amount) {
+    _extend_log(extend_amount);
+  }
   _flush_and_sync_log_core();
   _flush_bdev(log.writer);
   logger->set(l_bluefs_log_bytes, log.writer->file->fnode.size);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1147,7 +1147,11 @@ void BlueFS::umount(bool avoid_compact)
   _close_writer(log.writer);
   log.writer = NULL;
   log.t.clear();
-
+  // if we umount with pending release, we can possibly mount again
+  // with pending release, and will release something that is not allocated
+  for (auto& d: dirty.pending_release) {
+    d.clear();
+  }
   vselector.reset(nullptr);
   _stop_alloc();
   nodes.file_map.clear();

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -616,8 +616,7 @@ private:
     RENAME_SLOW2DB = 4,
     RENAME_DB2SLOW = 8,
   };
-  void _compact_log_dump_metadata_NF(uint64_t start_seq,
-                                     bluefs_transaction_t *t,
+  void _compact_log_dump_metadata_NF(bluefs_transaction_t *t,
 				     int flags,
 				     uint64_t capture_before_seq);
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -591,7 +591,7 @@ private:
   void _wait_for_aio(FileWriter *h);  // safe to call without a lock
 #endif
 
-  int64_t _maybe_extend_log();
+  uint64_t _need_extend_log();
   void _extend_log(uint64_t amount);
   uint64_t _log_advance_seq();
   void _consume_dirty(uint64_t seq);

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -289,9 +289,10 @@ struct bluefs_transaction_t {
   ceph::buffer::list op_bl;     ///< encoded transaction ops
 
   bluefs_transaction_t() : seq(0) {}
+  bluefs_transaction_t(const uuid_d& _uuid, uint64_t s) : uuid(_uuid), seq(s) {}
 
-  void clear() {
-    *this = bluefs_transaction_t();
+  void reset(const uuid_d& uuid, uint64_t _seq = 0) {
+    *this = bluefs_transaction_t(uuid, _seq);
   }
   bool empty() const {
     return op_bl.length() == 0;


### PR DESCRIPTION
Parent tracker: https://tracker.ceph.com/issues/79068
Backport tracker: https://tracker.ceph.com/issues/79833
Backports: https://github.com/ceph/ceph/pull/62224/changes/09fd806e23f18c38619697b1d9d834d260cf54b0 This is an additional commit backport which originally lacks proper ticket but still worth having in squid. Plus not having it causes a backporting conflict . Hence bringing it in here.
Backports: https://github.com/ceph/ceph/pull/70892


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
