### PR TITLE
tentacle: rgw/http: skip pause/resume when the request already finished

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -474,6 +474,10 @@ void RGWHTTPClient::_set_write_paused(bool pause)
   ceph_assert(ceph_mutex_is_locked(req_data->lock));
   
   RGWHTTPManager *mgr = req_data->mgr;
+  if (!mgr) {
+    // request already finished; nothing to pause/resume
+    return;
+  }
   if (pause == req_data->write_paused) {
     return;
   }
@@ -489,6 +493,10 @@ void RGWHTTPClient::_set_read_paused(bool pause)
   ceph_assert(ceph_mutex_is_locked(req_data->lock));
   
   RGWHTTPManager *mgr = req_data->mgr;
+  if (!mgr) {
+    // request already finished; nothing to pause/resume
+    return;
+  }
   if (pause == req_data->read_paused) {
     return;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80331

---

backport of https://github.com/ceph/ceph/pull/69774
parent tracker: https://tracker.ceph.com/issues/77741

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh