### PR TITLE
tentacle: Bump NFS Version in Ceph

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -14,7 +14,7 @@ ARG CEPH_SHA1
 ARG CEPH_GIT_REPO
 
 # (optional) Define the baseurl= for the ganesha.repo
-ARG GANESHA_REPO_BASEURL="https://buildlogs.centos.org/centos/\$releasever-stream/storage/\$basearch/nfsganesha-5/"
+ARG GANESHA_REPO_BASEURL="https://buildlogs.centos.org/centos/\$releasever-stream/storage/\$basearch/nfsganesha-9/"
 
 # (optional) Set to "crimson" to install crimson packages.
 ARG OSD_FLAVOR="default"


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/67906
parent tracker: https://tracker.ceph.com/issues/75630

The parent tracker has an empty `Backport` field, so no backport tracker issue
exists for this. Happy to open one, or to have the field set, if that is
preferred — filing this manually because the gap has a user-visible effect on
tentacle that is easy to mistake for a Ceph bug.

## Why this matters on tentacle

`main` moved the NFS-Ganesha repo from `nfsganesha-5` to `nfsganesha-9` in
#67906. `tentacle` was never updated, so images built from this branch still
ship **NFS-Ganesha 5.9**.

Ganesha answers `OP_GET_DIR_DELEGATION` (opcode 46) with `OP_ILLEGAL` up to and
including 9.10, and with `nfs4_op_notsupp` from **9.11** onwards
(`[NFS4_OP_GET_DIR_DELEGATION].funct` in `src/Protocols/NFS/nfs4_Compound.c`).

Recent Linux NFS clients request a directory delegation, and `OP_ILLEGAL` is not
a valid answer to an operation the client knows about, so the reply fails XDR
decoding and surfaces as `EREMOTEIO`:

```
nfs4_xdr_bad_operation: xid=0xfbdfcf11  operation=10044, expected=46
nfs4_getattr:           error=-121 (EREMOTEIO)
```

The effect is intermittent `readdir` failures against a `ceph nfs` cluster: the
entries are all correct and the count is right, but `ls` exits non-zero part of
the time. Measured on one cluster, 30 rounds of `ls` from a 6.8 client passed,
while 15 rounds from a 7.0 client failed twice. It looks like a Ceph or Rook
problem and is neither.

## Verification

- `buildlogs.centos.org/centos/9-stream/storage/x86_64/nfsganesha-9/` resolves
  and carries 9.2 through **9.16**, so the build picks up a version well past
  the 9.11 boundary. (`repodata/repomd.xml` returns 200; the same is true for
  the mirror.stream copy of the SIG repo.)
- Ganesha 9.16 runs against Ceph 20.2.4 in production here: an overlay on
  `quay.io/ceph/ceph:v20.2.4` with the SIG's `nfs-ganesha-9` packages upgraded in
  place. `dnf` resolves it as seven Ganesha packages plus `libntirpc`, touching
  no Ceph package. OpenStack Manila drives that cluster through
  `ceph nfs export apply`, and a ReadWriteMany volume mounted by two pods on
  different nodes reads and writes correctly.

## Note

This is a straight cherry-pick; the one-line change applies to `tentacle`
without conflict. The commit keeps its original author and sign-off.
