### PR TITLE
build: add optional Google TCMalloc support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,7 +464,21 @@ set(ALLOCATOR "" CACHE STRING
   "specify memory allocator to use. currently tcmalloc, tcmalloc_minimal, \
 jemalloc, and libc is supported. if not specified, will try to find tcmalloc, \
 and then jemalloc. If neither of then is found. use the one in libc.")
-if(ALLOCATOR)
+option(GOOGLE_TCMALLOC "Build Google's TCMalloc instead of gperftools" OFF)
+if(GOOGLE_TCMALLOC)
+  if(ALLOCATOR AND NOT ALLOCATOR STREQUAL "tcmalloc")
+    message(FATAL_ERROR "GOOGLE_TCMALLOC requires ALLOCATOR=tcmalloc")
+  endif()
+  if(WITH_ASAN OR WITH_ASAN_LEAK OR WITH_TSAN OR WITH_CRIMSON)
+    message(FATAL_ERROR
+      "GOOGLE_TCMALLOC is incompatible with ASAN, LeakSanitizer, TSAN, and Crimson")
+  endif()
+  include(BuildGoogleTCMalloc)
+  build_google_tcmalloc()
+  set(ALLOCATOR tcmalloc)
+  set(ALLOC_LIBS google_tcmalloc)
+  set(HAVE_GOOGLE_TCMALLOC ON)
+elseif(ALLOCATOR)
   if(${ALLOCATOR} MATCHES "tcmalloc(_minimal)?")
     find_package(gperftools 2.6.2 REQUIRED)
     set(ALLOC_LIBS gperftools::${ALLOCATOR})
@@ -480,7 +494,7 @@ elseif(WITH_ASAN)
   # Force libc: tcmalloc/jemalloc still export operator new/delete even when the
   # sanitizer shadows malloc, so sanitizer-allocated memory is freed via tcmalloc and SIGSEGVs.
   set(ALLOCATOR "libc")
-else(ALLOCATOR)
+else()
   find_package(gperftools 2.6.2)
   set(HAVE_LIBTCMALLOC ${gperftools_FOUND})
   if(NOT gperftools_FOUND)
@@ -499,7 +513,7 @@ else(ALLOCATOR)
     endif()
     set(ALLOCATOR "libc")
   endif(gperftools_FOUND)
-endif(ALLOCATOR)
+endif()
 if(NOT ALLOCATOR STREQUAL "libc")
   add_compile_options(
     $<$<COMPILE_LANGUAGE:CXX>:-fno-builtin-malloc>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,11 @@ set(ALLOCATOR "" CACHE STRING
 jemalloc, and libc is supported. if not specified, will try to find tcmalloc, \
 and then jemalloc. If neither of then is found. use the one in libc.")
 option(GOOGLE_TCMALLOC "Build Google's TCMalloc instead of gperftools" OFF)
+option(GOOGLE_TCMALLOC_THP
+  "Allow transparent huge pages with Google's TCMalloc" OFF)
+if(GOOGLE_TCMALLOC_THP AND NOT GOOGLE_TCMALLOC)
+  message(FATAL_ERROR "GOOGLE_TCMALLOC_THP requires GOOGLE_TCMALLOC=ON")
+endif()
 if(GOOGLE_TCMALLOC)
   if(ALLOCATOR AND NOT ALLOCATOR STREQUAL "tcmalloc")
     message(FATAL_ERROR "GOOGLE_TCMALLOC requires ALLOCATOR=tcmalloc")

--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ The default build type is ``RelWithDebInfo`` once `.git` does not exist.
 The `-D` flag can be used with `cmake` to speed up the process of building Ceph
 and to customize the build.
 
+#### Building with Google's TCMalloc
+
+Pass `-DGOOGLE_TCMALLOC=ON` to build the official `google/tcmalloc` allocator
+instead of gperftools. This requires a native Linux x86_64 or aarch64 build
+without ASAN, LeakSanitizer, TSAN, or Crimson. The default is `OFF`.
+CMake uses Bazel 8.5.1 or Bazelisk from `PATH`, or downloads a pinned Bazel
+binary with SHA256 verification. Set `GOOGLE_TCMALLOC_BAZEL` to override its
+path. Bazel downloads pinned TCMalloc sources and their build dependencies.
+OSD memory autotuning and heap stats/release commands support both allocators;
+gperftools profiler commands, release rates, and property writes remain legacy-only.
+
 #### Building without RADOS Gateway
 
 The RADOS Gateway is built by default. To build Ceph without the RADOS Gateway,

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ path. Bazel downloads pinned TCMalloc sources and their build dependencies.
 OSD memory autotuning and heap stats/release commands support both allocators;
 gperftools profiler commands, release rates, and property writes remain legacy-only.
 
+Pass `-DGOOGLE_TCMALLOC=ON -DGOOGLE_TCMALLOC_THP=ON` to allow transparent
+huge pages (THP). `GOOGLE_TCMALLOC_THP` defaults to `OFF` and requires
+`GOOGLE_TCMALLOC=ON`. When enabled, Ceph skips `PR_SET_THP_DISABLE` at
+startup regardless of the runtime `thp` setting. The kernel's THP policy
+still controls whether huge pages can be used.
+
 #### Building without RADOS Gateway
 
 The RADOS Gateway is built by default. To build Ceph without the RADOS Gateway,

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2683,8 +2683,9 @@ fi
 %files rgw-standalone
 %dir %{_docdir}/ceph
 %doc %{_docdir}/ceph/sample.ceph.conf
+%license %{_docdir}/ceph/COPYING-APACHE2
 %dir %{_libdir}/ceph
-%{_libdir}/ceph/libceph-common.so.*
+%{_libdir}/ceph/libceph*.so.*
 %{_bindir}/rgw-standalone
 %{_bindir}/rgw-standalone-admin
 %dir %{_localstatedir}/lib/ceph/radosgw
@@ -2823,9 +2824,10 @@ fi
 %endif
 
 %files -n librados2
+%license %{_docdir}/ceph/COPYING-APACHE2
 %{_libdir}/librados.so.*
 %dir %{_libdir}/ceph
-%{_libdir}/ceph/libceph-common.so.*
+%{_libdir}/ceph/libceph*.so.*
 %if %{with lttng}
 %{_libdir}/librados_tp.so.*
 %endif

--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -186,8 +186,8 @@ function(do_build_boost root_dir version)
     set(boost_sha256 af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89)
     string(REPLACE "." "_" boost_version_underscore ${boost_version} )
     list(APPEND boost_url
-      https://download.ceph.com/qa/boost_${boost_version_underscore}.tar.bz2
       https://archives.boost.io//release/${boost_version}/source/boost_${boost_version_underscore}.tar.bz2
+      https://download.ceph.com/qa/boost_${boost_version_underscore}.tar.bz2
       https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/boost_${boost_version_underscore}.tar.bz2)
     set(source_dir
       URL ${boost_url}

--- a/cmake/modules/BuildFIO.cmake
+++ b/cmake/modules/BuildFIO.cmake
@@ -9,7 +9,10 @@ function(build_fio)
       ${alloc_lib_path} DIRECTORY)
     get_filename_component(alloc_lib_name
       ${alloc_lib_path} NAME)
-    set(FIO_EXTLIBS "EXTLIBS='-L${alloc_lib_dir} -l:${alloc_lib_name}'")
+    if(GOOGLE_TCMALLOC)
+      set(alloc_rpath "-Wl,-rpath,${alloc_lib_dir} ")
+    endif()
+    set(FIO_EXTLIBS "EXTLIBS='-L${alloc_lib_dir} ${alloc_rpath}-l:${alloc_lib_name}'")
   endif()
 
   include(FindMake)
@@ -39,6 +42,7 @@ function(build_fio)
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
     BUILD_COMMAND ${make_cmd} fio EXTFLAGS=-Wno-format-truncation "${FIO_EXTLIBS}"
     INSTALL_COMMAND cp <BINARY_DIR>/fio ${CMAKE_BINARY_DIR}/bin
+    DEPENDS ${ALLOC_LIBS}
     LOG_CONFIGURE ON
     LOG_BUILD ON
     LOG_INSTALL ON

--- a/cmake/modules/BuildGoogleTCMalloc.cmake
+++ b/cmake/modules/BuildGoogleTCMalloc.cmake
@@ -1,0 +1,86 @@
+function(build_google_tcmalloc)
+  if(NOT LINUX OR CMAKE_CROSSCOMPILING OR
+      NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|aarch64|arm64)$")
+    message(FATAL_ERROR "GOOGLE_TCMALLOC requires native Linux x86_64 or aarch64")
+  endif()
+  set(tcmalloc_BINARY_DIR "${CMAKE_BINARY_DIR}/google-tcmalloc")
+  file(MAKE_DIRECTORY "${tcmalloc_BINARY_DIR}")
+  foreach(file MODULE.bazel BUILD.bazel)
+    configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/GoogleTCMalloc/${file}"
+      "${tcmalloc_BINARY_DIR}/${file}" COPYONLY)
+  endforeach()
+  foreach(file google_tcmalloc.cc google_tcmalloc.h)
+    configure_file("${CMAKE_SOURCE_DIR}/src/perfglue/${file}"
+      "${tcmalloc_BINARY_DIR}/perfglue/${file}" COPYONLY)
+  endforeach()
+  set(bazel_version 8.5.1)
+  find_program(GOOGLE_TCMALLOC_BAZEL NAMES bazel-8.5.1 bazelisk bazel)
+  if(NOT GOOGLE_TCMALLOC_BAZEL)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)$")
+      set(bazel_arch x86_64)
+      set(bazel_sha256 61d89402f0368e64b6c827be5de79d8e65382e8124c3cbb97325611a1851392e)
+    else()
+      set(bazel_arch arm64)
+      set(bazel_sha256 b7f2a85595e8a87d54843bc656c1e379fd9b8c1b5f783dc41717c1d7eb7cc49f)
+    endif()
+    set(GOOGLE_TCMALLOC_BAZEL "${tcmalloc_BINARY_DIR}/bazel")
+    file(DOWNLOAD
+      "https://github.com/bazelbuild/bazel/releases/download/${bazel_version}/bazel-${bazel_version}-linux-${bazel_arch}"
+      "${GOOGLE_TCMALLOC_BAZEL}"
+      EXPECTED_HASH "SHA256=${bazel_sha256}" TLS_VERIFY ON)
+    file(CHMOD "${GOOGLE_TCMALLOC_BAZEL}"
+      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+      GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+  endif()
+  set(bazel_command ${CMAKE_COMMAND} -E env
+    "USE_BAZEL_VERSION=${bazel_version}"
+    "BAZELISK_HOME=${tcmalloc_BINARY_DIR}/bazelisk"
+    "${GOOGLE_TCMALLOC_BAZEL}")
+  execute_process(COMMAND ${bazel_command} --version
+    WORKING_DIRECTORY "${tcmalloc_BINARY_DIR}"
+    OUTPUT_VARIABLE bazel_output OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE bazel_result)
+  if(NOT bazel_result EQUAL 0 OR NOT bazel_output STREQUAL "bazel ${bazel_version}")
+    message(FATAL_ERROR
+      "GOOGLE_TCMALLOC_BAZEL must point to Bazel ${bazel_version} or Bazelisk")
+  endif()
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(bazel_mode dbg)
+  else()
+    set(bazel_mode opt)
+  endif()
+  if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    list(APPEND bazel_options --copt=-g)
+  elseif(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+    list(APPEND bazel_options --copt=-Os)
+  endif()
+  if(WITH_STATIC_LIBSTDCXX)
+    list(APPEND bazel_options --linkopt=-static-libstdc++ --linkopt=-static-libgcc)
+  endif()
+  set(tcmalloc_LIBRARY "${tcmalloc_BINARY_DIR}/libceph_tcmalloc.so.0")
+  include(ExternalProject)
+  ExternalProject_Add(google_tcmalloc_ext
+    SOURCE_DIR "${tcmalloc_BINARY_DIR}"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ${bazel_command}
+      --batch --ignore_all_rc_files
+      "--output_user_root=${tcmalloc_BINARY_DIR}/bazel-root"
+      build -c ${bazel_mode} --cxxopt=-std=c++20 --strip=never
+      "--repo_env=CC=${CMAKE_CXX_COMPILER}"
+      ${bazel_options} --symlink_prefix=ceph-bazel- //:libceph_tcmalloc.so.0
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${tcmalloc_BINARY_DIR}/ceph-bazel-bin/libceph_tcmalloc.so.0"
+      "${tcmalloc_LIBRARY}"
+    BUILD_IN_SOURCE TRUE
+    BUILD_ALWAYS TRUE
+    BUILD_BYPRODUCTS "${tcmalloc_LIBRARY}"
+    INSTALL_COMMAND ""
+    LOG_BUILD ON
+    LOG_OUTPUT_ON_FAILURE ON)
+  add_library(google_tcmalloc SHARED IMPORTED)
+  add_dependencies(google_tcmalloc google_tcmalloc_ext)
+  set_target_properties(google_tcmalloc PROPERTIES
+    IMPORTED_LOCATION "${tcmalloc_LIBRARY}"
+    IMPORTED_SONAME libceph_tcmalloc.so.0)
+  install(FILES "${tcmalloc_LIBRARY}" DESTINATION ${CMAKE_INSTALL_LIBDIR}/ceph)
+endfunction()

--- a/cmake/modules/GoogleTCMalloc/BUILD.bazel
+++ b/cmake/modules/GoogleTCMalloc/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+cc_binary(
+    name = "libceph_tcmalloc.so.0",
+    srcs = [
+        "perfglue/google_tcmalloc.cc",
+        "perfglue/google_tcmalloc.h",
+    ],
+    linkopts = ["-Wl,-soname,libceph_tcmalloc.so.0", "-Wl,--exclude-libs,libstdc++.a"],
+    linkshared = True,
+    linkstatic = True,
+    deps = [
+        "@com_google_tcmalloc//tcmalloc",
+        "@com_google_tcmalloc//tcmalloc:malloc_extension",
+    ],
+)

--- a/cmake/modules/GoogleTCMalloc/COPYING-APACHE2
+++ b/cmake/modules/GoogleTCMalloc/COPYING-APACHE2
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/cmake/modules/GoogleTCMalloc/MODULE.bazel
+++ b/cmake/modules/GoogleTCMalloc/MODULE.bazel
@@ -1,0 +1,12 @@
+module(name = "ceph_tcmalloc")
+bazel_dep(name = "rules_cc", version = "0.2.9")
+bazel_dep(name = "tcmalloc", version = "0", repo_name = "com_google_tcmalloc")
+single_version_override(
+    module_name = "abseil-cpp",
+    version = "20260526.0",
+)
+git_override(
+    module_name = "tcmalloc",
+    remote = "https://github.com/google/tcmalloc.git",
+    commit = "3baafb6d19b0c7e695a31322b33e5cb5d61c93fa",
+)

--- a/debian/librados2.install
+++ b/debian/librados2.install
@@ -1,3 +1,4 @@
-usr/lib/ceph/libceph-common.so.*
+usr/lib/ceph/libceph*.so.*
 usr/lib/librados.so.*
 usr/lib/librados_tp.so.*
+usr/share/doc/ceph/COPYING-APACHE2

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -684,6 +684,9 @@ else()
 endif()
 
 target_link_libraries(ceph-common ${ceph_common_deps})
+if(GOOGLE_TCMALLOC)
+  target_link_libraries(ceph-common google_tcmalloc)
+endif()
 if(ENABLE_COVERAGE)
   target_link_libraries(ceph-common gcov)
 endif(ENABLE_COVERAGE)
@@ -848,7 +851,7 @@ if(WITH_FUSE)
 endif()
 set_target_properties(ceph-osd PROPERTIES
   POSITION_INDEPENDENT_CODE ${EXE_LINKER_USE_PIE}
-  INSTALL_RPATH "")
+  INSTALL_RPATH "$<$<BOOL:${GOOGLE_TCMALLOC}>:${CEPH_INSTALL_FULL_PKGLIBDIR}>")
 install(TARGETS ceph-osd DESTINATION bin)
 
 endif(NOT WIN32)
@@ -1196,6 +1199,7 @@ endif(WITH_RADOSGW)
 
 install(FILES
   sample.ceph.conf
+  ${CMAKE_SOURCE_DIR}/cmake/modules/GoogleTCMalloc/COPYING-APACHE2
   DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 # Now create a usable config.h

--- a/src/common/PriorityCache.cc
+++ b/src/common/PriorityCache.cc
@@ -123,8 +123,18 @@ namespace PriorityCache
     uint64_t mapped = 0;
 
     ceph_heap_release_free_memory();
-    ceph_heap_get_numeric_property("generic.heap_size", &heap_size);
-    ceph_heap_get_numeric_property("tcmalloc.pageheap_unmapped_bytes", &unmapped);
+#ifdef HAVE_GOOGLE_TCMALLOC
+    // Google's generic.heap_size already excludes unmapped memory.
+    constexpr auto heap_property = "generic.virtual_memory_used";
+#else
+    constexpr auto heap_property = "generic.heap_size";
+#endif
+    if (ceph_using_tcmalloc() &&
+        (!ceph_heap_get_numeric_property(heap_property, &heap_size) ||
+         !ceph_heap_get_numeric_property("tcmalloc.pageheap_unmapped_bytes", &unmapped) ||
+         heap_size < unmapped)) {
+      return;
+    }
     mapped = heap_size - unmapped;
 
     uint64_t new_size = tuned_mem;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -384,7 +384,7 @@ global_init(const std::map<std::string,std::string> *defaults,
   if (prctl(PR_SET_DUMPABLE, 1) == -1) {
     cerr << "warning: unable to set dumpable flag: " << cpp_strerror(errno) << std::endl;
   }
-#  if defined(PR_SET_THP_DISABLE)
+#  if defined(PR_SET_THP_DISABLE) && !defined(GOOGLE_TCMALLOC_THP)
   if (!g_conf().get_val<bool>("thp") && prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0) == -1) {
     cerr << "warning: unable to disable THP: " << cpp_strerror(errno) << std::endl;
   }

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -114,6 +114,7 @@
 /* Define if you have tcmalloc */
 #cmakedefine HAVE_LIBTCMALLOC
 #cmakedefine HAVE_GOOGLE_TCMALLOC
+#cmakedefine GOOGLE_TCMALLOC_THP
 #cmakedefine LIBTCMALLOC_MISSING_ALIGNED_ALLOC
 
 /* AsyncMessenger RDMA conditional compilation */

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -113,6 +113,7 @@
 
 /* Define if you have tcmalloc */
 #cmakedefine HAVE_LIBTCMALLOC
+#cmakedefine HAVE_GOOGLE_TCMALLOC
 #cmakedefine LIBTCMALLOC_MISSING_ALIGNED_ALLOC
 
 /* AsyncMessenger RDMA conditional compilation */

--- a/src/perfglue/CMakeLists.txt
+++ b/src/perfglue/CMakeLists.txt
@@ -3,7 +3,7 @@ if(ALLOCATOR STREQUAL "tcmalloc")
     heap_profiler.cc)
   target_link_libraries(heap_profiler
     legacy-option-headers
-    gperftools::tcmalloc)
+    ${ALLOC_LIBS})
 else()
   add_library(heap_profiler STATIC
     disabled_heap_profiler.cc)

--- a/src/perfglue/google_tcmalloc.cc
+++ b/src/perfglue/google_tcmalloc.cc
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include "google_tcmalloc.h"
+#include "tcmalloc/malloc_extension.h"
+#include <cstdio>
+#include <limits>
+
+void ceph_tcmalloc_get_stats(char *buf, int length)
+{
+  if (length > 0) {
+    auto stats = tcmalloc::MallocExtension::GetStats();
+    std::snprintf(buf, length, "%s", stats.c_str());
+  }
+}
+
+void ceph_tcmalloc_release_free_memory()
+{
+  tcmalloc::MallocExtension::ReleaseMemoryToSystem(
+    std::numeric_limits<size_t>::max());
+}
+
+bool ceph_tcmalloc_get_numeric_property(const char *property, size_t *value)
+{
+  auto result = tcmalloc::MallocExtension::GetNumericProperty(property);
+  if (!result) {
+    return false;
+  }
+  *value = *result;
+  return true;
+}

--- a/src/perfglue/google_tcmalloc.h
+++ b/src/perfglue/google_tcmalloc.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+#include <cstddef>
+
+extern "C" {
+void ceph_tcmalloc_get_stats(char *buf, int length);
+void ceph_tcmalloc_release_free_memory();
+bool ceph_tcmalloc_get_numeric_property(const char *property, size_t *value);
+}

--- a/src/perfglue/heap_profiler.cc
+++ b/src/perfglue/heap_profiler.cc
@@ -17,11 +17,15 @@
 
 #include "acconfig.h"
 
+#ifdef HAVE_GOOGLE_TCMALLOC
+#include "google_tcmalloc.h"
+#else
 // Use the newer gperftools header locations if available.
 // If not, fall back to the old (gperftools < 2.0) locations.
 
 #include <gperftools/heap-profiler.h>
 #include <gperftools/malloc_extension.h>
+#endif
 
 #include "common/environment.h"
 #include "common/LogClient.h"
@@ -48,38 +52,60 @@ void ceph_heap_profiler_init()
 
 void ceph_heap_profiler_stats(char *buf, int length)
 {
+#ifdef HAVE_GOOGLE_TCMALLOC
+  ceph_tcmalloc_get_stats(buf, length);
+#else
   MallocExtension::instance()->GetStats(buf, length);
+#endif
 }
 
 void ceph_heap_release_free_memory()
 {
+#ifdef HAVE_GOOGLE_TCMALLOC
+  ceph_tcmalloc_release_free_memory();
+#else
   MallocExtension::instance()->ReleaseFreeMemory();
+#endif
 }
 
 double ceph_heap_get_release_rate()
 {
+#ifdef HAVE_LIBTCMALLOC
   return MallocExtension::instance()->GetMemoryReleaseRate();
+#else
+  return 0;
+#endif
 }
 
 void ceph_heap_set_release_rate(double val)
 {
+#ifdef HAVE_LIBTCMALLOC
   MallocExtension::instance()->SetMemoryReleaseRate(val);
+#endif
 }
 
 bool ceph_heap_get_numeric_property(
   const char *property, size_t *value)
 {
+#ifdef HAVE_GOOGLE_TCMALLOC
+  return ceph_tcmalloc_get_numeric_property(property, value);
+#else
   return MallocExtension::instance()->GetNumericProperty(
     property,
     value);
+#endif
 }
 
 bool ceph_heap_set_numeric_property(
   const char *property, size_t value)
 {
+#ifdef HAVE_GOOGLE_TCMALLOC
+  return false;
+#else
   return MallocExtension::instance()->SetNumericProperty(
     property,
     value);
+#endif
 }
 
 bool ceph_heap_profiler_running()
@@ -91,6 +117,7 @@ bool ceph_heap_profiler_running()
 #endif
 }
 
+#ifdef HAVE_LIBTCMALLOC
 static void get_profile_name(char *profile_name, int profile_name_len)
 {
 #if __GNUC__ && __GNUC__ >= 8
@@ -116,6 +143,7 @@ static void get_profile_name(char *profile_name, int profile_name_len)
 #pragma GCC diagnostic pop
 #endif
 }
+#endif
 
 void ceph_heap_profiler_start()
 {
@@ -164,9 +192,6 @@ void ceph_heap_profiler_handle_command(const std::vector<std::string>& cmd,
   } else if (cmd.size() == 1 && cmd[0] == "stop_profiler") {
     ceph_heap_profiler_stop();
     out << g_conf()->name << " stopped profiler";
-  } else if (cmd.size() == 1 && cmd[0] == "release") {
-    ceph_heap_release_free_memory();
-    out << g_conf()->name << " releasing free RAM back to system.";
   } else if (cmd.size() == 1 && cmd[0] == "get_release_rate") {
     out << g_conf()->name << " release rate: " 
 	<< std::setprecision(4) << ceph_heap_get_release_rate() << "\n";
@@ -181,7 +206,10 @@ void ceph_heap_profiler_handle_command(const std::vector<std::string>& cmd,
     }
   } else
 #endif
-  if (cmd.size() == 1 && cmd[0] == "stats") {
+  if (cmd.size() == 1 && cmd[0] == "release") {
+    ceph_heap_release_free_memory();
+    out << g_conf()->name << " releasing free RAM back to system.";
+  } else if (cmd.size() == 1 && cmd[0] == "stats") {
     char heap_stats[HEAP_PROFILER_STATS_SIZE];
     ceph_heap_profiler_stats(heap_stats, sizeof(heap_stats));
     out << g_conf()->name << " tcmalloc heap stats:"


### PR DESCRIPTION
Add `-DGOOGLE_TCMALLOC=ON` to select Google's official TCMalloc on native Linux x86_64 and aarch64 builds. Integrate a pinned TCMalloc revision and Bazel version, with a verified Bazel download when needed. The option defaults to OFF.

Adapt OSD memory accounting, heap statistics, and memory release to support both Google TCMalloc and legacy gperftools. Include the required shared-library linkage, FIO integration, packaging, and license handling.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
