### PR TITLE
doc/rbd: include the snap create entry from the rbd(8) man page

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -637,8 +637,16 @@ Commands
   Delete an rbd image (including all data blocks). If the image has
   snapshots, this fails and nothing is deleted.
 
+.. The rbd-snap-create-begin and rbd-snap-create-end markers delimit text
+   that doc/rbd/rbd-snapshot.rst includes at build time. Keep them around
+   this entry.
+
+.. rbd-snap-create-begin
+
 :command:`snap create` *snap-spec*
   Create a new snapshot. Requires the snapshot name parameter to be specified.
+
+.. rbd-snap-create-end
 
 :command:`snap limit clear` *image-spec*
   Remove any previously set limit on the number of snapshots allowed on

--- a/doc/rbd/rbd-snapshot.rst
+++ b/doc/rbd/rbd-snapshot.rst
@@ -71,8 +71,19 @@ snapshots using the ``rbd`` command.
 Create Snapshot
 ---------------
 
-To create a snapshot, use the ``rbd snap create`` command and specify the pool
-name, the image name, and the snap name:
+To create a snapshot, use the ``rbd snap create`` command (see
+:doc:`rbd(8) </man/8/rbd>`):
+
+.. The command entry below is included from doc/man/8/rbd.rst, between
+   the rbd-snap-create-begin and rbd-snap-create-end markers. Edit the
+   command description there, not here, so this page and the man page
+   stay in sync.
+
+.. include:: ../man/8/rbd.rst
+   :start-after: .. rbd-snap-create-begin
+   :end-before: .. rbd-snap-create-end
+
+Specify the pool name, the image name, and the snap name:
 
 .. prompt:: bash $
 


### PR DESCRIPTION
Small trial of the man page as the single source for command reference, as discussed with Anthony D'Atri and Ville O. Tracker: https://tracker.ceph.com/issues/80355

The rbd snapshots page restated the `rbd snap create` command that the rbd(8) man page already documents. This change marks the entry in `doc/man/8/rbd.rst` with two RST comments and includes that slice into `doc/rbd/rbd-snapshot.rst` at build time, so the command description is written once and rendered on both the prose page and the man page. The markers are comments, so nothing new appears in the roff output. Author comments at both ends explain where the text comes from so nobody re-adds it by hand.

Checked on main with `admin/build-doc`: the man build is clean with `-W`, and the html build produces no new warnings. (The html build on main already emits one unrelated autodoc warning about `DriveGroupSpec`/`ArgumentSpec`, present without this change.)

Draft on purpose: the point is to see it rendered in the Read the Docs preview and decide whether to apply the pattern more widely. It fits rbd(8) and radosgw-admin(8) directly, since their man pages list commands as individual entries; ceph(8) is written in prose sections and would need a different approach.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
