### PR TITLE
codeowners: keep subsystem reviewers on their own doc paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,12 @@
+# doc-writers: general rules first, so the more specific rules below
+# (which also list @ceph/doc-writers) take precedence and request both teams
+AUTHORS                                         @ceph/doc-writers
+CodingStyle                                     @ceph/doc-writers
+COPYING*                                        @ceph/doc-writers
+/doc/                                           @ceph/doc-writers
+README*                                         @ceph/doc-writers
+*.rst                                           @ceph/doc-writers
+
 # Dashboard team to review dashboard related code
 /src/pybind/mgr/dashboard                       @ceph/dashboard
 /qa/suites/rados/dashboard                      @ceph/dashboard
@@ -5,7 +14,7 @@
 /qa/tasks/mgr/test_module_selftest.py           @ceph/dashboard
 /qa/tasks/mgr/dashboard                         @ceph/dashboard
 /monitoring                                     @ceph/dashboard
-/doc/mgr/dashboard.rst                          @ceph/dashboard
+/doc/mgr/dashboard.rst                          @ceph/dashboard @ceph/doc-writers
 
 # For Orchestrator related PRs
 /src/cephadm                                    @ceph/orchestrators
@@ -24,31 +33,25 @@
 /qa/tasks/mgr/test_orchestrator_cli.py          @ceph/orchestrators
 /qa/tasks/mgr/test_cephadm_orchestrator.py      @ceph/orchestrators
 /qa/suites/orch                                 @ceph/orchestrators
-/doc/mgr/orchestrator.rst                       @ceph/orchestrators
-/doc/mgr/orchestrator_modules.rst               @ceph/orchestrators
-/doc/cephadm                                    @ceph/orchestrators
-/doc/dev/cephadm                                @ceph/orchestrators
-/doc/man/8/cephadm.rst                          @ceph/orchestrators
+/doc/mgr/orchestrator.rst                       @ceph/orchestrators @ceph/doc-writers
+/doc/mgr/orchestrator_modules.rst               @ceph/orchestrators @ceph/doc-writers
+/doc/cephadm                                    @ceph/orchestrators @ceph/doc-writers
+/doc/dev/cephadm                                @ceph/orchestrators @ceph/doc-writers
+/doc/man/8/cephadm.rst                          @ceph/orchestrators @ceph/doc-writers
 
 /qa/suites/orch/rook                            @ceph/rook
 /src/pybind/mgr/rook                            @ceph/rook
-/doc/mgr/rook.rst                               @ceph/rook
+/doc/mgr/rook.rst                               @ceph/rook @ceph/doc-writers
 
 #ceph-volume
 /src/ceph-volume                                @ceph/ceph-volume
-/doc/ceph-volume                                @ceph/ceph-volume
+/doc/ceph-volume                                @ceph/ceph-volume @ceph/doc-writers
 
 # crimson
 /src/crimson                                    @ceph/crimson
 /src/test/crimson                               @ceph/crimson
 
-# doc-writers
-AUTHORS                                         @ceph/doc-writers
-CodingStyle                                     @ceph/doc-writers
-COPYING*                                        @ceph/doc-writers
-/doc/                                           @ceph/doc-writers
-README*                                         @ceph/doc-writers
-*.rst                                           @ceph/doc-writers
+# csi
 /doc/csi/                                       @ceph/doc-writers @ceph/ceph-csi-maintainers
 
 # core


### PR DESCRIPTION
CODEOWNERS uses last-match-wins. The general `/doc/` and `*.rst` rules for @ceph/doc-writers came after the subsystem-specific doc rules, so a change under `doc/cephadm`, `doc/ceph-volume`, `doc/mgr/dashboard.rst` or `doc/mgr/rook.rst` requested review only from doc-writers and silently dropped the subsystem team.

This moves the general doc-writers rules to the top of the file and lists @ceph/doc-writers alongside the subsystem team on each specific doc rule, so both teams are requested. The core and csi rules already did this. No paths or teams are removed.

Noticed while auditing doc review routing; Anthony D'Atri suggested fixing it.

Fixes: https://tracker.ceph.com/issues/80356

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
