### PR TITLE
tentacle: qa/cephfs: wait for MgrMap client registration before mgr fail

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -8933,6 +8933,23 @@ class TestMisc(TestVolumesHelper):
             mgr_sessions = [s for s in all_sessions if s.get('auth_name', {}).get('type') == 16]
             return all_sessions, mgr_sessions
 
+        def session_nonces(sessions):
+            nonces = set()
+            for s in sessions:
+                addr = (s.get('entity') or {}).get('addr') or {}
+                if 'nonce' in addr:
+                    nonces.add(addr['nonce'])
+            return nonces
+
+        def mgr_map_client_nonces():
+            mgr_map = self.mgr_cluster.get_mgr_map()
+            nonces = set()
+            for client in mgr_map.get('active_clients', []):
+                for addr in client.get('addrvec', []):
+                    if 'nonce' in addr:
+                        nonces.add(addr['nonce'])
+            return nonces
+
         # Ensure we start with only mgr sessions (if any)
         all_s, mgr_s = get_mgr_sessions()
         self.assertEqual(len(all_s), len(mgr_s), f"Non-mgr sessions found: {all_s}")
@@ -8949,6 +8966,16 @@ class TestMisc(TestVolumesHelper):
 
         # Store IDs for eviction check
         mgr_session_ids = [s['id'] for s in mgr_sessions]
+
+        # ceph mgr fail blocklists MgrMap.active_clients from the last
+        # beacon. Wait until the mon has learned the current CephFS
+        # client addrs so eviction is not raced by a stale client list.
+        needed_nonces = session_nonces(mgr_sessions)
+        self.assertTrue(needed_nonces,
+                        f"Missing session nonces in: {mgr_sessions}")
+        self.wait_until_true(
+            lambda: needed_nonces.issubset(mgr_map_client_nonces()),
+            timeout=30)
 
         # Fail the mgr
         mgr_id = self.mgr_cluster.get_active_id()


### PR DESCRIPTION
test_mgr_eviction expects that failing the active mgr evicts its CephFS MDS sessions. Eviction depends on ceph mgr fail blocklisting MgrMap.active_clients, which the mon only learns from mgr beacons.

After subvolume create, the volumes module registers the new libcephfs client address in the mgr process immediately, but that address may not be in MgrMap yet until the next beacon (mgr_tick_period, default 2s). If mgr fail runs in that window, the mon blocklists a stale client list and the live MDS session is never blocklisted. The failed mgr then respawns without a clean CephFS close, so the session lingers past the test's 30s wait (MDS session_timeout is ~61s).

Fix the race by waiting until each mgr MDS session nonce appears in mgr dump active_clients before calling mgr fail, so blocklisting covers the sessions the test asserts are evicted.

Fixes: https://tracker.ceph.com/issues/76047

(backport tracker: https://tracker.ceph.com/issues/80163)
(cherry picked from commit 13da5431ece1a77105889af404d8f8fcf920b812)


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
