### PR TITLE
rgw/bucket-logging: fix stale shadow log objects

### DIFF
--- a/src/rgw/rgw_rest_bucket_logging.cc
+++ b/src/rgw/rgw_rest_bucket_logging.cc
@@ -225,23 +225,12 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
 
   void execute(optional_yield y) override {
 
-    std::unique_ptr<rgw::sal::Bucket> src_bucket;
-    {
-      const rgw_bucket src_bucket_id{s->bucket_tenant, s->bucket_name};
-      op_ret = driver->load_bucket(this, src_bucket_id,
-                                   &src_bucket, y);
-      if (op_ret < 0) {
-        ldpp_dout(this, 1) << "ERROR: failed to get bucket '" << src_bucket_id << "', ret = " << op_ret << dendl;
-        return;
-      }
-    }
-
     if (!configuration.enabled) {
-      op_ret = rgw::bucketlogging::source_bucket_cleanup(this, driver, src_bucket.get(), true, y, &old_obj);
+      op_ret = rgw::bucketlogging::source_bucket_cleanup(this, driver, s->bucket.get(), true, y, &old_obj);
       return;
     }
 
-    const auto src_bucket_id = src_bucket->get_key();
+    const rgw_bucket src_bucket_id{s->bucket_tenant, s->bucket_name};
     const auto& target_bucket_id = target_bucket->get_key();
     if (target_bucket_id == src_bucket_id) {
       // target bucket must be different from source bucket (cannot change later on)
@@ -250,11 +239,11 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
       return;
     }
     const auto& target_info = target_bucket->get_info();
-    if (target_info.zonegroup != src_bucket->get_info().zonegroup) {
+    if (target_info.zonegroup != s->bucket->get_info().zonegroup) {
       // target bucket must be in the same zonegroup as source bucket (cannot change later on)
       ldpp_dout(this, 1) << "ERROR: logging bucket '" << target_bucket_id << "' zonegroup '" <<
         target_info.zonegroup << "' is different from the source bucket '" << src_bucket_id  <<
-        "' zonegroup '" << src_bucket->get_info().zonegroup << "'" << dendl;
+        "' zonegroup '" << s->bucket->get_info().zonegroup << "'" << dendl;
       op_ret = -EINVAL;
       return;
     }
@@ -268,8 +257,9 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
     std::optional<rgw::bucketlogging::configuration> old_conf;
     bufferlist conf_bl;
     encode(configuration, conf_bl);
-    op_ret = retry_raced_bucket_write(this, src_bucket.get(), [this, &conf_bl, &src_bucket, &old_conf, y] {
-      auto& attrs = src_bucket->get_attrs();
+    auto src_bucket = s->bucket.get();
+    op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this, &conf_bl, &old_conf, y] {
+      auto& attrs = s->bucket->get_attrs();
       auto it = attrs.find(RGW_ATTR_BUCKET_LOGGING);
       if (it != attrs.end()) {
         try {
@@ -279,13 +269,13 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
           old_conf = std::move(tmp_conf);
         } catch (buffer::error& err) {
           ldpp_dout(this, 1) << "WARNING: failed to decode existing logging attribute '" << RGW_ATTR_BUCKET_LOGGING
-              << "' for bucket '" << src_bucket->get_key() << "', error: " << err.what() << dendl;
+              << "' for bucket '" << s->bucket->get_key() << "', error: " << err.what() << dendl;
         }
         if (!old_conf || (old_conf && *old_conf != configuration)) {
           // conf changed (or was unknown) - update
           it->second = conf_bl;
           update_mtime_attribute(this, attrs);
-          return src_bucket->merge_and_store_attrs(this, attrs, y);
+          return s->bucket->merge_and_store_attrs(this, attrs, y);
         }
         // nothing to update
         return 0;
@@ -293,7 +283,7 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
       // conf was added
       attrs.insert(std::make_pair(RGW_ATTR_BUCKET_LOGGING, conf_bl));
       update_mtime_attribute(this, attrs);
-      return src_bucket->merge_and_store_attrs(this, attrs, y);
+      return s->bucket->merge_and_store_attrs(this, attrs, y);
     }, y);
     if (op_ret < 0) {
       ldpp_dout(this, 1) << "ERROR: failed to set logging attribute '" << RGW_ATTR_BUCKET_LOGGING << "' to bucket '" <<
@@ -323,7 +313,7 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
             obj_name,
             this,
             region,
-            src_bucket.get(),
+            src_bucket,
             y,
             false, // rollover should happen even if commit failed
             &objv_tracker,

--- a/src/test/rgw/bucket_logging/test_bucket_logging.py
+++ b/src/test/rgw/bucket_logging/test_bucket_logging.py
@@ -769,6 +769,10 @@ def test_flush_empty_creates_empty_object(s3_client, logging_type):
     try:
         assert create_bucket_with_logging(s3_client, source_bucket, log_bucket, logging_type)
 
+        # The first log object will contain the record for REST.PUT.LOGGING
+        output, ret = admin(['bucket', 'logging', 'flush', '--bucket', source_bucket])
+        assert ret == 0, f"Flush failed with return code {ret}"
+
         output, ret = admin(['bucket', 'logging', 'flush', '--bucket', source_bucket])
         assert ret == 0, f"Flush failed with return code {ret}"
         assert output.strip()


### PR DESCRIPTION
Resolves an issue where disabling logging on a bucket creates a shadow log record object without an associated head object. Although this object records the REST.PUT.LOGGING operation, it remains inaccessible through object listings.

Fixes: https://tracker.ceph.com/issues/80362



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
