### PR TITLE
node-proxy: don't crash on empty Redfish logout

### DIFF
--- a/src/ceph-node-proxy/ceph_node_proxy/main.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/main.py
@@ -210,7 +210,10 @@ def handler(signum: Any, frame: Any, t_mgr: "NodeProxyManager") -> None:
         and t_mgr.system.client is not None
     ):
         t_mgr.log.info("Logging out from RedFish API")
-        t_mgr.system.client.logout()
+        try:
+            t_mgr.system.client.logout()
+        except Exception as e:
+            t_mgr.log.error("Can't log out from RedFish API: %s", e)
     raise SystemExit(0)
 
 

--- a/src/ceph-node-proxy/ceph_node_proxy/redfish_client.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/redfish_client.py
@@ -93,13 +93,14 @@ class RedFishClient(BaseClient):
         result: Dict[str, Any] = {}
         try:
             if self.is_logged_in():
-                _, _data, _status_code = self.query(
+                _, _data, _ = self.query(
                     method="DELETE",
                     headers={"X-Auth-Token": self.token},
                     endpoint=self.location,
                 )
-                result = json.loads(_data)
-        except URLError:
+                if _data:
+                    result = json.loads(_data)
+        except (URLError, json.JSONDecodeError):
             self.log.error(f"Can't log out from {self.url}")
 
         self.location = ""

--- a/src/ceph-node-proxy/tests/test_redfish_client.py
+++ b/src/ceph-node-proxy/tests/test_redfish_client.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock, patch
+
+from ceph_node_proxy.redfish_client import RedFishClient
+
+
+def _logged_in_client() -> RedFishClient:
+    client = RedFishClient(host="bmc", username="u", password="p")
+    client.token = "tok"
+    client.location = "/redfish/v1/SessionService/Sessions/1"
+    return client
+
+
+def test_logout_empty_body() -> None:
+    client = _logged_in_client()
+    with (
+        patch.object(client, "is_logged_in", return_value=True),
+        patch.object(client, "query", return_value=(MagicMock(), "", 204)),
+    ):
+        result = client.logout()
+    assert result == {}
+    assert client.token == ""
+    assert client.location == ""
+
+
+def test_logout_json_body() -> None:
+    client = _logged_in_client()
+    with (
+        patch.object(client, "is_logged_in", return_value=True),
+        patch.object(client, "query", return_value=(MagicMock(), '{"ok": true}', 200)),
+    ):
+        result = client.logout()
+    assert result == {"ok": True}
+    assert client.token == ""
+    assert client.location == ""
+
+
+def test_logout_invalid_json_body() -> None:
+    client = _logged_in_client()
+    with (
+        patch.object(client, "is_logged_in", return_value=True),
+        patch.object(client, "query", return_value=(MagicMock(), "not-json", 200)),
+    ):
+        result = client.logout()
+    assert result == {}
+    assert client.token == ""
+    assert client.location == ""


### PR DESCRIPTION
A session DELETE often comes back as 204 with no body. json.loads() raised on SIGTERM and the unit ended up failed.

Skip empty payloads, catch JSONDecodeError, and keep the SIGTERM handler from leaking that exception so we still exit cleanly.

Fixes: https://tracker.ceph.com/issues/80361


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
