### PR TITLE
doc/radosgw: bucketpolicy links to account principals section

### DIFF
--- a/doc/radosgw/account.rst
+++ b/doc/radosgw/account.rst
@@ -94,6 +94,8 @@ These identity policies are evaluated according to the rules in
 `Evaluating policies within a single account`_ and
 `Cross-account policy evaluation logic`_.
 
+.. _radosgw-account-principals:
+
 Principals
 ----------
 

--- a/doc/radosgw/bucketpolicy.rst
+++ b/doc/radosgw/bucketpolicy.rst
@@ -34,6 +34,9 @@ For example, one may use ``s3cmd`` to set or delete a policy thus::
 Limitations
 ===========
 
+See :ref:`Principals <radosgw-account-principals>` regarding
+the interactions between policy Principals and User Accounts.
+
 Bucket policies do not yet support string interpolation.
 
 For all requests, condition keys we support are:

--- a/doc/radosgw/bucketpolicy.rst
+++ b/doc/radosgw/bucketpolicy.rst
@@ -34,80 +34,6 @@ For example, one may use ``s3cmd`` to set or delete a policy thus::
 Limitations
 ===========
 
-Currently, we support only the following actions:
-
-- s3:AbortMultipartUpload
-- s3:CreateBucket
-- s3:DeleteBucketPolicy
-- s3:DeleteBucket
-- s3:DeleteBucketWebsite
-- s3:DeleteObject
-- s3:DeleteObjectVersion
-- s3:DeleteReplicationConfiguration
-- s3:GetAccelerateConfiguration
-- s3:GetBucketAcl
-- s3:GetBucketCORS
-- s3:GetBucketLocation
-- s3:GetBucketLogging
-- s3:GetBucketNotification
-- s3:GetBucketPolicy
-- s3:GetBucketRequestPayment
-- s3:GetBucketTagging
-- s3:GetBucketVersioning
-- s3:GetBucketWebsite
-- s3:GetLifecycleConfiguration
-- s3:GetObjectAcl
-- s3:GetObject
-- s3:GetObjectTorrent
-- s3:GetObjectVersionAcl
-- s3:GetObjectVersion
-- s3:GetObjectVersionTorrent
-- s3:GetReplicationConfiguration
-- s3:IPAddress
-- s3:NotIpAddress
-- s3:ListAllMyBuckets
-- s3:ListBucketMultipartUploads
-- s3:ListBucket
-- s3:ListBucketVersions
-- s3:ListMultipartUploadParts
-- s3:PutAccelerateConfiguration
-- s3:PutBucketAcl
-- s3:PutBucketCORS
-- s3:PutBucketLogging
-- s3:PutBucketNotification
-- s3:PutBucketPolicy
-- s3:PutBucketRequestPayment
-- s3:PutBucketTagging
-- s3:PutBucketVersioning
-- s3:PutBucketWebsite
-- s3:PutLifecycleConfiguration
-- s3:PutObjectAcl
-- s3:PutObject
-- s3:PutObjectVersionAcl
-- s3:PutReplicationConfiguration
-- s3:RestoreObject
-
-We do not yet support setting policies on users, groups, or roles.
-
-We use the RGW ‘tenant’ identifier in place of the Amazon twelve-digit
-account ID. In the future we may allow you to assign an account ID to
-a tenant, but for now if you want to use policies between AWS S3 and
-RGW S3 you will have to use the Amazon account ID as the tenant ID when
-creating users.
-
-Under AWS, all tenants share a single namespace. RGW gives every
-tenant its own namespace of buckets. There may be an option to enable
-an AWS-like 'flat' bucket namespace in future versions. At present, to
-access a bucket belonging to another tenant, address it as
-``tenant:bucket`` in the S3 request.
-
-In AWS, a bucket policy can grant access to another account, and that
-account owner can then grant access to individual users with user
-permissions. Since we do not yet support user, role, and group
-permissions, account owners will currently need to grant access
-directly to individual users, and granting an entire account access to
-a bucket grants access to all users in that account.
-
 Bucket policies do not yet support string interpolation.
 
 For all requests, condition keys we support are:
@@ -210,9 +136,6 @@ Object Related Operations
 |s3:DeleteObjectVersionTagging|                                                   |                   |
 +-----------------------------+---------------------------------------------------+-------------------+
 
-
-More may be supported soon as we integrate with the recently rewritten
-Authentication/Authorization subsystem.
 
 Swift
 =====


### PR DESCRIPTION
also removes outdated information from bucketpolicy.rst:

* the list of supported actions has not been regularly updated. when we add support for new APIs, we add the necessary support for their policy. so it isn't necessary to track support for policy separately, especially if it isn't going to be accurate
* users, groups, roles: these are supported now through the account feature
* Authentication/Authorization subsystem: this was not recently rewritten, and isn't worth mentioning

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
