### PR TITLE
build: heal podman invalid internal status

### DIFF
--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -230,6 +230,52 @@ def _cmdstr(cmd):
     return " ".join(shlex.quote(c) for c in cmd)
 
 
+def _podman_requires_system_migrate(output):
+    text = output.lower()
+    return (
+        "invalid internal status" in text
+        and "podman system migrate" in text
+    )
+
+
+def _podman_preflight(ctx):
+    """Detect and self-heal a known podman failure mode where an
+    interrupted or version-skewed store reports an invalid internal
+    status until `podman system migrate` is run.
+    """
+    if ctx._podman_preflight_done:
+        return
+    if "podman" not in ctx.container_engine:
+        ctx._podman_preflight_done = True
+        return
+
+    ctx._podman_preflight_done = True
+    info_cmd = [ctx.container_engine, "info"]
+    res = subprocess.run(info_cmd, capture_output=True, text=True)
+    if res.returncode == 0:
+        return
+
+    output = f"{res.stdout}\n{res.stderr}"
+    if not _podman_requires_system_migrate(output):
+        log.warning("podman runtime preflight failed: %s", res.stderr.strip())
+        return
+
+    log.warning(
+        "podman reported invalid internal status; attempting self-heal with 'podman system migrate'"
+    )
+    migrate_cmd = [ctx.container_engine, "system", "migrate"]
+    mig = subprocess.run(migrate_cmd, capture_output=True, text=True)
+    if mig.returncode != 0:
+        log.warning("podman system migrate failed: %s", mig.stderr.strip())
+        return
+
+    res2 = subprocess.run(info_cmd, capture_output=True, text=True)
+    if res2.returncode == 0:
+        log.info("podman runtime preflight recovered after system migrate")
+    else:
+        log.warning("podman info still failing after migrate: %s", res2.stderr.strip())
+
+
 def _run(cmd, *args, **kwargs):
     ctx = kwargs.pop("ctx", None)
     if ctx and ctx.dry_run:
@@ -237,6 +283,10 @@ def _run(cmd, *args, **kwargs):
         # because we can not return a result (as we did nothing)
         # raise a specific exception to be caught by higher layer
         raise DidNotExecute(cmd)
+
+    cmd0 = str(cmd[0]) if cmd else ""
+    if ctx and "podman" in cmd0:
+        _podman_preflight(ctx)
 
     log.info("Executing command: %s", _cmdstr(cmd))
     return subprocess.run(cmd, *args, **kwargs)
@@ -411,6 +461,7 @@ class Context:
     def __init__(self, cli):
         self.cli = cli
         self._engine = None
+        self._podman_preflight_done = False
         self.distro_cache_name = ""
         self.current_srpm = None
 


### PR DESCRIPTION
Add a podman preflight check before invoking container commands. If podman reports an invalid internal status and suggests `podman system migrate`, the script now attempts the self-heal automatically and re-checks the runtime. This avoids failures caused by interrupted or skewed podman stores during containerized builds. This especially fixes issues that arise from OOM kills not needing manual intervention to repair.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
