### PR TITLE
jfw rgw bucket logging

### DIFF
--- a/src/rgw/rgw_rest_bucket_logging.cc
+++ b/src/rgw/rgw_rest_bucket_logging.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 sts=2 expandtab
 
 #include "common/dout.h"
+#include "common/dout_fmt.h"
 #include "rgw_op.h"
 #include "rgw_rest.h"
 #include "rgw_rest_s3.h"
@@ -39,6 +40,87 @@ namespace {
     encode(mtime, mtime_bl);
     attrs[RGW_ATTR_BUCKET_LOGGING_MTIME] = std::move(mtime_bl);
     ldpp_dout(dpp, 20) << "INFO: logging config modified at: " << mtime << dendl;
+  }
+
+  void decode_mtime_attribute(const DoutPrefixProvider *dpp, const rgw_bucket& bucket_id,
+                              const rgw::sal::Attrs& attrs,
+                              std::optional<ceph::real_time>& mtime)
+  {
+    if (const auto mtime_it = attrs.find(RGW_ATTR_BUCKET_LOGGING_MTIME);
+        mtime_it != attrs.end()) {
+      try {
+        ceph::real_time tmp_mtime;
+        decode(tmp_mtime, mtime_it->second);
+        mtime = std::move(tmp_mtime);
+      } catch (buffer::error& err) {
+        ldpp_dout(dpp, 5) << "WARNING: failed to decode logging mtime attribute '"
+          << RGW_ATTR_BUCKET_LOGGING_MTIME << "' for bucket '" << bucket_id
+          << "', error: " << err.what() << dendl;
+      }
+
+      return;
+    }
+
+    ldpp_dout(dpp, 5) << "WARNING: no logging mtime attribute '"
+      << RGW_ATTR_BUCKET_LOGGING_MTIME << "' for bucket '" << bucket_id << "'" << dendl;
+  }
+
+  void update_logging_sources_or_warn(const DoutPrefixProvider *dpp,
+                                      std::unique_ptr<rgw::sal::Bucket>& target_bucket,
+                                      const rgw_bucket& src_bucket_id, const bool add,
+                                      const int log_level, optional_yield y)
+  {
+    if (const auto r = rgw::bucketlogging::update_bucket_logging_sources(
+          dpp, target_bucket, src_bucket_id, add, y);
+        r < 0) {
+      const auto& target_bucket_id = target_bucket->get_key();
+      ldpp_dout_fmt(dpp, log_level,
+                    "WARNING: failed to update logging sources for target bucket '{}' "
+                    "and source bucket '{}', ret = {}",
+                    fmt::streamed(target_bucket_id), fmt::streamed(src_bucket_id), r);
+    }
+  }
+
+  int flush_pending_logging_object(const DoutPrefixProvider *dpp, rgw::sal::Driver *driver,
+                                   const rgw::bucketlogging::configuration& conf,
+                                   std::unique_ptr<rgw::sal::Bucket>& target_bucket,
+                                   rgw::sal::Bucket& src_bucket, std::string& last_committed,
+                                   optional_yield y)
+  {
+    RGWObjVersionTracker objv_tracker;
+    std::string obj_name;
+
+    const auto& target_bucket_id = target_bucket->get_key();
+    if (const auto r = target_bucket->get_logging_object_name(
+          obj_name, conf.target_prefix, y, dpp, nullptr);
+        r < 0 && r != -ENOENT) {
+      ldpp_dout_fmt(dpp, 1,
+                    "ERROR: failed to get name of logging object of logging bucket '{}' and prefix '{}', ret = {}",
+                    fmt::streamed(target_bucket_id), conf.target_prefix, r);
+
+      return r;
+    }
+
+    const auto region = driver->get_zone()->get_zonegroup().get_api_name();
+    const auto rollover_ret = rgw::bucketlogging::rollover_logging_object(
+      conf, target_bucket, obj_name, dpp, region, &src_bucket, y,
+      false, // rollover should happen even if commit failed
+      &objv_tracker, false, &last_committed);
+    if (rollover_ret < 0) {
+      ldpp_dout_fmt(dpp, 1,
+                    "WARNING: failed to flush pending logging object '{}' "
+                    "to target bucket '{}' when updating logging configuration of bucket '{}', ret = {}",
+                    obj_name, fmt::streamed(target_bucket_id),
+                    fmt::streamed(src_bucket.get_key()), rollover_ret);
+      return 0;
+    }
+
+    ldpp_dout_fmt(dpp, 20,
+                  "INFO: flushed pending logging object '{}' to target bucket '{}' "
+                  "when updating logging configuration of bucket '{}'",
+                  last_committed, fmt::streamed(target_bucket_id), fmt::streamed(src_bucket.get_key()));
+
+    return 0;
   }
 }
 
@@ -78,36 +160,28 @@ public:
       }
     }
     const auto src_bucket_id = src_bucket->get_key();
-    if (auto iter = src_bucket->get_attrs().find(RGW_ATTR_BUCKET_LOGGING); iter != src_bucket->get_attrs().end()) {
+    const auto& attrs = src_bucket->get_attrs();
+    if (const auto iter = attrs.find(RGW_ATTR_BUCKET_LOGGING); iter != attrs.end()) {
       try {
         configuration.enabled = true;
         decode(configuration, iter->second);
-        if (auto mtime_it = src_bucket->get_attrs().find(RGW_ATTR_BUCKET_LOGGING_MTIME);
-            mtime_it != src_bucket->get_attrs().end()) {
-          try {
-            ceph::real_time tmp_mtime;
-            decode(tmp_mtime, mtime_it->second);
-            mtime = std::move(tmp_mtime);
-          } catch (buffer::error& err) {
-            ldpp_dout(this, 5) << "WARNING: failed to decode logging mtime attribute '" << RGW_ATTR_BUCKET_LOGGING_MTIME
-              << "' for bucket '" << src_bucket_id << "', error: " << err.what() << dendl;
-          }
-        } else {
-          ldpp_dout(this, 5) << "WARNING: no logging mtime attribute '" << RGW_ATTR_BUCKET_LOGGING_MTIME
-            << "' for bucket '" << src_bucket_id << "'" << dendl;
-        }
+        decode_mtime_attribute(this, src_bucket_id, attrs, mtime);
       } catch (buffer::error& err) {
-        ldpp_dout(this, 1) << "WARNING: failed to decode logging attribute '" << RGW_ATTR_BUCKET_LOGGING
-          << "' for bucket '" << src_bucket_id << "', error: " << err.what() << dendl;
+        ldpp_dout(this, 1) << "WARNING: failed to decode logging attribute '"
+          << RGW_ATTR_BUCKET_LOGGING << "' for bucket '" << src_bucket_id
+          << "', error: " << err.what() << dendl;
         op_ret = -EIO;
         return;
       }
-    } else {
-      ldpp_dout(this, 5) << "WARNING: no logging configuration on bucket '" << src_bucket_id << "'" << dendl;
+
+      ldpp_dout(this, 20) << "INFO: found logging configuration on bucket '"
+        << src_bucket_id << "'. configuration: " << configuration.to_json_str()
+        << dendl;
       return;
     }
-    ldpp_dout(this, 20) << "INFO: found logging configuration on bucket '" << src_bucket_id << "'"
-      << "'. configuration: " << configuration.to_json_str() << dendl;
+
+    ldpp_dout(this, 5) << "WARNING: no logging configuration on bucket '"
+      << src_bucket_id << "'" << dendl;
   }
 
   void send_response() override {
@@ -135,7 +209,7 @@ public:
 // actual configuration is XML encoded in the body of the message
 class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
   // following data members are set in verify_permission()
-  // and usd in execute()
+  // and used in execute()
   rgw::bucketlogging::configuration configuration;
   std::unique_ptr<rgw::sal::Bucket> target_bucket;
   std::string old_obj; // used when conf change triggers a rollover
@@ -146,11 +220,10 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
     }
 
     const auto max_size = s->cct->_conf->rgw_max_put_param_size;
-    bufferlist data;
-    int ret = 0;
-    if (std::tie(ret, data) = read_all_input(s, max_size, false); ret < 0) {
-      ldpp_dout(this, 1) << "ERROR: failed to read XML logging payload, ret = " << ret << dendl;
-      return ret;
+    auto [r, data] = read_all_input(s, max_size, false);
+    if (r < 0) {
+      ldpp_dout(this, 1) << "ERROR: failed to read XML logging payload, ret = " << r << dendl;
+      return r;
     }
     if (data.length() == 0) {
       ldpp_dout(this, 1) << "ERROR: XML logging payload missing" << dendl;
@@ -158,7 +231,7 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
     }
 
     RGWXMLDecoder::XMLParser parser;
-    if (!parser.init()){
+    if (!parser.init()) {
       ldpp_dout(this, 1) << "ERROR: failed to initialize XML parser" << dendl;
       return -EINVAL;
     }
@@ -180,30 +253,35 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
     }
 
     rgw_bucket target_bucket_id;
-    if (const auto ret = rgw::bucketlogging::get_bucket_id(configuration.target_bucket, s->bucket_tenant, target_bucket_id); ret < 0) {
-      ldpp_dout(this, 1) << "ERROR: failed to parse logging bucket '" << configuration.target_bucket << "', ret = " << ret << dendl;
-      return ret;
+    if (const auto r = rgw::bucketlogging::get_bucket_id(configuration.target_bucket, s->bucket_tenant, target_bucket_id); r < 0) {
+      ldpp_dout_fmt(this, 1, "ERROR: failed to parse logging bucket '{}', ret = {}",
+                    configuration.target_bucket, r);
+
+      return r;
     }
 
-    if (const auto ret = driver->load_bucket(this, target_bucket_id,
-                                 &target_bucket, y); ret < 0) {
-      ldpp_dout(this, 1) << "ERROR: failed to get logging bucket '" << target_bucket_id << "', ret = " << ret << dendl;
-      return ret;
+    if (const auto r = driver->load_bucket(this, target_bucket_id, &target_bucket, y); r < 0) {
+      ldpp_dout_fmt(this, 1, "ERROR: failed to get logging bucket '{}', ret = {}",
+                    fmt::streamed(target_bucket_id), r);
+
+      return r;
     }
 
     return 0;
   }
 
   int verify_permission(optional_yield y) override {
+    if (!s->auth.identity->is_owner_of(s->bucket->get_info().owner)) {
+      ldpp_dout_fmt(this, 1,
+                    "ERROR: user '{}' is not the owner of bucket '{}'. owner is '{}'",
+                    fmt::streamed(s->auth.identity->get_aclowner().id),
+                    s->bucket_name, fmt::streamed(s->bucket->get_info().owner));
+      return -EACCES;
+    }
+
     auto [has_s3_existing_tag, has_s3_resource_tag] = rgw_check_policy_condition(this, s, false);
     if (has_s3_resource_tag)
       rgw_iam_add_buckettags(this, s);
-
-    if (!s->auth.identity->is_owner_of(s->bucket->get_info().owner)) {
-      ldpp_dout(this, 1) << "ERROR: user '" << s->auth.identity->get_aclowner().id << "' is not the owner of bucket '" <<
-        s->bucket_name << "'. owner is '" << s->bucket->get_info().owner << "'" << dendl;
-      return -EACCES;
-    }
 
     if (!verify_bucket_permission(this, s, rgw::IAM::s3PutBucketLogging)) {
       return -EACCES;
@@ -245,7 +323,9 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
     const auto& target_bucket_id = target_bucket->get_key();
     if (target_bucket_id == src_bucket_id) {
       // target bucket must be different from source bucket (cannot change later on)
-      ldpp_dout(this, 1) << "ERROR: logging bucket '" << target_bucket_id << "' must be different from source bucket" << dendl;
+      ldpp_dout_fmt(this, 1,
+                    "ERROR: logging bucket '{}' must be different from source bucket",
+                    fmt::streamed(target_bucket_id));
       op_ret = -EINVAL;
       return;
     }
@@ -278,10 +358,11 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
           decode(tmp_conf, it->second);
           old_conf = std::move(tmp_conf);
         } catch (buffer::error& err) {
-          ldpp_dout(this, 1) << "WARNING: failed to decode existing logging attribute '" << RGW_ATTR_BUCKET_LOGGING
-              << "' for bucket '" << src_bucket->get_key() << "', error: " << err.what() << dendl;
+          ldpp_dout(this, 1) << "WARNING: failed to decode existing logging attribute '"
+            << RGW_ATTR_BUCKET_LOGGING << "' for bucket '" << src_bucket->get_key()
+            << "', error: " << err.what() << dendl;
         }
-        if (!old_conf || (old_conf && *old_conf != configuration)) {
+        if (!old_conf || *old_conf != configuration) {
           // conf changed (or was unknown) - update
           it->second = conf_bl;
           update_mtime_attribute(this, attrs);
@@ -296,67 +377,70 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
       return src_bucket->merge_and_store_attrs(this, attrs, y);
     }, y);
     if (op_ret < 0) {
-      ldpp_dout(this, 1) << "ERROR: failed to set logging attribute '" << RGW_ATTR_BUCKET_LOGGING << "' to bucket '" <<
-        src_bucket_id << "', ret = " << op_ret << dendl;
+      ldpp_dout_fmt(this, 1,
+                    "ERROR: failed to set logging attribute '{}' to bucket '{}', ret = {}",
+                    RGW_ATTR_BUCKET_LOGGING, fmt::streamed(src_bucket_id), op_ret);
       return;
     }
     if (!old_conf) {
-      ldpp_dout(this, 20) << "INFO: new logging configuration added to bucket '" << src_bucket_id << "'. configuration: " <<
-        configuration.to_json_str() << dendl;
-      if (const auto ret = rgw::bucketlogging::update_bucket_logging_sources(this, target_bucket, src_bucket_id, true, y); ret < 0) {
-        ldpp_dout(this, 1) << "WARNING: failed to add source bucket '" << src_bucket_id << "' to logging sources of logging bucket '" <<
-          target_bucket_id << "', ret = " << ret << dendl;
-      }
-    } else if (*old_conf != configuration) {
-      // conf changed - do cleanup
-      RGWObjVersionTracker objv_tracker;
-      std::string obj_name;
-      if (int ret = target_bucket->get_logging_object_name(obj_name, old_conf->target_prefix, y, this, nullptr); ret < 0 && ret != -ENOENT) {
-        ldpp_dout(this, 1) << "ERROR: failed to get name of logging object of logging bucket '" <<
-        target_bucket_id << "' and prefix '" << configuration.target_prefix << "', ret = " << ret << dendl;
-        op_ret = ret;
+      ldpp_dout_fmt(this, 20,
+                    "INFO: new logging configuration added to bucket '{}'. configuration: {}",
+                    fmt::streamed(src_bucket_id), configuration.to_json_str());
+      update_logging_sources_or_warn(this, target_bucket, src_bucket_id, true, 1, y);
+      return;
+    }
+
+    if (*old_conf == configuration) {
+      ldpp_dout(this, 20) << "INFO: logging configuration of bucket '"
+        << src_bucket_id << "' did not change" << dendl;
+      return;
+    }
+
+    // conf changed - do cleanup
+    const bool target_changed = old_conf->target_bucket != configuration.target_bucket;
+    if (!target_changed) {
+      op_ret = flush_pending_logging_object(this, driver, *old_conf, target_bucket, *src_bucket, old_obj, y);
+      if (op_ret < 0) {
         return;
       }
-      const auto region = driver->get_zone()->get_zonegroup().get_api_name();
-      if (const auto ret = rollover_logging_object(*old_conf,
-            target_bucket,
-            obj_name,
-            this,
-            region,
-            src_bucket.get(),
-            y,
-            false, // rollover should happen even if commit failed
-            &objv_tracker,
-            false,
-            &old_obj); ret < 0) {
-        ldpp_dout(this, 1) << "WARNING: failed to flush pending logging object '" << obj_name << "'"
-            << " to target bucket '" << target_bucket_id << "'. "
-            << "' when updating logging configuration of bucket '" << src_bucket->get_key() << ". error: " << ret << dendl;
-      } else {
-        ldpp_dout(this, 20) << "INFO: flushed pending logging object '" << old_obj
-          << "' to target bucket '" << target_bucket_id << "' when updating logging configuration of bucket '"
-          << src_bucket->get_key() << "'" << dendl;
-      }
-      if (old_conf->target_bucket != configuration.target_bucket) {
-        rgw_bucket old_target_bucket_id;
-        if (const auto ret = rgw::bucketlogging::get_bucket_id(old_conf->target_bucket, s->bucket_tenant, old_target_bucket_id); ret < 0) {
-          ldpp_dout(this, 1) << "ERROR: failed to parse logging bucket '" << old_conf->target_bucket << "', ret = " << ret << dendl;
-          return;
-        }
-        if (const auto ret = rgw::bucketlogging::update_bucket_logging_sources(this, driver, old_target_bucket_id, src_bucket_id, false, y); ret < 0) {
-          ldpp_dout(this, 1) << "WARNING: failed to remove source bucket '" << src_bucket_id << "' from logging sources of original logging bucket '" <<
-            old_target_bucket_id << "', ret = " << ret << dendl;
-        }
-        if (const auto ret = rgw::bucketlogging::update_bucket_logging_sources(this, target_bucket, src_bucket_id, true, y); ret < 0) {
-          ldpp_dout(this, 1) << "WARNING: failed to add source bucket '" << src_bucket_id << "' to logging sources of logging bucket '" <<
-            target_bucket_id << "', ret = " << ret << dendl;
-        }
-      }
-      ldpp_dout(this, 20) << "INFO: wrote logging configuration to bucket '" << src_bucket_id << "'. configuration: " <<
-        configuration.to_json_str() << dendl;
-    } else {
-      ldpp_dout(this, 20) << "INFO: logging configuration of bucket '" << src_bucket_id << "' did not change" << dendl;
+
+      ldpp_dout(this, 20) << "INFO: wrote logging configuration to bucket '"
+        << src_bucket_id << "'. configuration: " << configuration.to_json_str()
+        << dendl;
+      return;
     }
+
+    rgw_bucket old_target_bucket_id;
+    op_ret = rgw::bucketlogging::get_bucket_id(old_conf->target_bucket, s->bucket_tenant, old_target_bucket_id);
+    if (op_ret < 0) {
+      ldpp_dout_fmt(this, 1, "ERROR: failed to parse logging bucket '{}', ret = {}",
+                    old_conf->target_bucket, op_ret);
+      return;
+    }
+
+    std::unique_ptr<rgw::sal::Bucket> old_target_bucket;
+    if (const auto r = driver->load_bucket(this, old_target_bucket_id, &old_target_bucket, y); r < 0) {
+      ldpp_dout_fmt(this, 1,
+                    "WARNING: failed to flush pending logging object when updating "
+                    "logging configuration of bucket '{}' because original target bucket '{}' "
+                    "could not be loaded, ret = {}",
+                    fmt::streamed(src_bucket_id), fmt::streamed(old_target_bucket_id), r);
+    }
+
+    if (old_target_bucket) {
+      op_ret = flush_pending_logging_object(this, driver, *old_conf, old_target_bucket, *src_bucket, old_obj, y);
+      if (op_ret < 0) {
+        return;
+      }
+
+      update_logging_sources_or_warn(this, old_target_bucket, src_bucket_id, false, 1, y);
+    }
+
+    update_logging_sources_or_warn(this, target_bucket, src_bucket_id, true, 1, y);
+
+    ldpp_dout(this, 20) << "INFO: wrote logging configuration to bucket '"
+      << src_bucket_id << "'. configuration: " << configuration.to_json_str()
+      << dendl;
   }
 
   void send_response() override {
@@ -376,7 +460,7 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
 // Post /<bucket name>/?logging
 class RGWPostBucketLoggingOp : public RGWDefaultResponseOp {
   // following data members are set in verify_permission()
-  // and usd in execute()
+  // and used in execute()
   rgw::bucketlogging::configuration configuration;
   std::unique_ptr<rgw::sal::Bucket> target_bucket;
   std::unique_ptr<rgw::sal::Bucket> source_bucket;
@@ -419,33 +503,35 @@ class RGWPostBucketLoggingOp : public RGWDefaultResponseOp {
   void execute(optional_yield y) override {
     const auto& target_bucket_id = target_bucket->get_key();
     // make sure that the logging source attribute is up-to-date
-    if (const auto ret = rgw::bucketlogging::update_bucket_logging_sources(this, target_bucket, source_bucket->get_key(), true, y); ret < 0) {
-      ldpp_dout(this, 5) << "WARNING: failed to update logging sources attribute '" << RGW_ATTR_BUCKET_LOGGING_SOURCES
-        << "' in logging target '" << target_bucket_id << "'. error: " << ret << dendl;
-    }
+    update_logging_sources_or_warn(this, target_bucket, source_bucket->get_key(), true, 5, y);
     std::string obj_name;
     RGWObjVersionTracker objv_tracker;
     op_ret = target_bucket->get_logging_object_name(obj_name, configuration.target_prefix, y, this, &objv_tracker);
     if (op_ret < 0 && op_ret != -ENOENT) {
-      ldpp_dout(this, 1) << "ERROR: failed to get pending logging object name from logging bucket '" << target_bucket_id <<
-        "'. error: " << op_ret << dendl;
+      ldpp_dout_fmt(this, 1,
+                    "ERROR: failed to get pending logging object name from logging bucket '{}', ret = {}",
+                    fmt::streamed(target_bucket_id), op_ret);
       return;
     }
     if (op_ret == -ENOENT) {
       // no pending object - nothing to flush
-      ldpp_dout(this, 5) << "INFO: no pending logging object in logging bucket '" << target_bucket_id << "'. new object should be created" << dendl;
+      ldpp_dout_fmt(this, 5,
+                    "INFO: no pending logging object in logging bucket '{}'. new object should be created",
+                    fmt::streamed(target_bucket_id));
     }
     const auto region = driver->get_zone()->get_zonegroup().get_api_name();
     op_ret = rgw::bucketlogging::rollover_logging_object(configuration, target_bucket, obj_name, this, region, source_bucket.get(), y, true, &objv_tracker, false, &old_obj);
     if (op_ret < 0) {
-      ldpp_dout(this, 1) << "ERROR: failed to flush pending logging object '" << obj_name << "'"
-          << " to logging bucket '" << target_bucket_id << "'. "
-          << " last committed object is '" << old_obj <<
-          "'. error: " << op_ret << dendl;
+      ldpp_dout_fmt(this, 1,
+                    "ERROR: failed to flush pending logging object '{}' to logging bucket '{}'. "
+                    "last committed object is '{}', ret = {}",
+                    obj_name, fmt::streamed(target_bucket_id), old_obj, op_ret);
       return;
     }
-    ldpp_dout(this, 20) << "INFO: flushed pending logging object '" << old_obj
-                << "' to logging bucket '" << target_bucket_id << "'" << dendl;
+
+    ldpp_dout_fmt(this, 20,
+                  "INFO: flushed pending logging object '{}' to logging bucket '{}'",
+                  old_obj, fmt::streamed(target_bucket_id));
   }
 
   void send_response() override {
@@ -471,4 +557,3 @@ RGWOp* RGWHandler_REST_BucketLogging_S3::create_put_op() {
 RGWOp* RGWHandler_REST_BucketLogging_S3::create_get_op() {
   return new RGWGetBucketLoggingOp();
 }
-

--- a/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
+++ b/src/test/rgw/s3-tests/s3tests/functional/test_s3.py
@@ -19776,6 +19776,82 @@ def _bucket_logging_conf_update(logging_type, update_value, concurrency):
 @pytest.mark.bucket_logging
 @pytest.mark.bucket_logging_cleanup
 @pytest.mark.fails_on_aws
+def test_bucket_logging_target_change_flushes_old_target():
+    if not _has_bucket_logging_extension():
+        pytest.skip('ceph extension to bucket logging not supported at client')
+
+    client = get_client()
+    src_bucket_name = get_new_bucket_name()
+    get_new_bucket_resource(name=src_bucket_name)
+    old_log_bucket_name = get_new_bucket_name()
+    get_new_bucket_resource(name=old_log_bucket_name)
+    new_log_bucket_name = get_new_bucket_name()
+    get_new_bucket_resource(name=new_log_bucket_name)
+
+    old_prefix = 'old-log/'
+    new_prefix = 'new-log/'
+    _set_log_bucket_policy(client, old_log_bucket_name,
+                           [src_bucket_name], [old_prefix])
+    _set_log_bucket_policy(client, new_log_bucket_name,
+                           [src_bucket_name], [new_prefix])
+
+    logging_enabled = {'TargetBucket': old_log_bucket_name,
+                       'ObjectRollTime': expected_object_roll_time*10,
+                       'LoggingType': 'Journal',
+                       'TargetPrefix': old_prefix}
+    response = client.put_bucket_logging(Bucket=src_bucket_name,
+                                         BucketLoggingStatus={
+                                             'LoggingEnabled': logging_enabled,
+                                         })
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    old_src_names = ['old-target-object' + str(j) for j in range(3)]
+    for name in old_src_names:
+        client.put_object(Bucket=src_bucket_name, Key=name, Body=randcontent())
+
+    response = client.list_objects_v2(Bucket=old_log_bucket_name)
+    assert _get_keys(response) == []
+
+    logging_enabled['TargetBucket'] = new_log_bucket_name
+    logging_enabled['TargetPrefix'] = new_prefix
+    result = client.put_bucket_logging(Bucket=src_bucket_name,
+                                       BucketLoggingStatus={
+                                           'LoggingEnabled': logging_enabled,
+                                       })
+    flushed_obj = _verify_flushed_on_put(result)
+    assert flushed_obj.startswith(old_prefix)
+
+    response = client.list_objects_v2(Bucket=old_log_bucket_name)
+    keys = _get_keys(response)
+    assert keys == [flushed_obj]
+
+    response = client.get_object(Bucket=old_log_bucket_name, Key=flushed_obj)
+    body = _get_body(response)
+    assert _verify_records(body, src_bucket_name, 'REST.PUT.OBJECT', old_src_names,
+                           'Journal', len(old_src_names), exact_match=True)
+
+    response = client.list_objects_v2(Bucket=new_log_bucket_name)
+    assert _get_keys(response) == []
+
+    new_src_names = ['new-target-object']
+    for name in new_src_names:
+        client.put_object(Bucket=src_bucket_name, Key=name, Body=randcontent())
+
+    flushed_obj = _flush_logs(client, src_bucket_name)
+    response = client.list_objects_v2(Bucket=new_log_bucket_name)
+    keys = _get_keys(response)
+    assert keys == [flushed_obj]
+    assert flushed_obj.startswith(new_prefix)
+
+    response = client.get_object(Bucket=new_log_bucket_name, Key=flushed_obj)
+    body = _get_body(response)
+    assert _verify_records(body, src_bucket_name, 'REST.PUT.OBJECT', new_src_names,
+                           'Journal', len(new_src_names), exact_match=True)
+
+
+@pytest.mark.bucket_logging
+@pytest.mark.bucket_logging_cleanup
+@pytest.mark.fails_on_aws
 def test_bucket_logging_conf_updating_roll_s():
     _bucket_logging_conf_update('Standard', 'roll_time', False)
 


### PR DESCRIPTION
RGW bucket logging simplification, formatting, and possible performance changes.

rgw: flush bucket logs to old target on config change
    
When a bucket logging configuration changed target buckets, RGW rolled over the pending log object through the newly configured target bucket while using the old configuration. Pending records for the old target could be left behind, and the response could name an object that was not written to the new target.
    
see: https://tracker.ceph.com/issues/78902
see: https://tracker.ceph.com/issues/79049
    
Assisted-by: Codex:GPT-5
Signed-off-by: Jesse F. Williamson <jfw@ibm.com>

- **rgw: flush bucket logs to old target on config change**
- **rgw: streamline bucket logging operations**
