### PR TITLE
Ok to stop check for osd redeploy or reconfig

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -99,6 +99,7 @@ from cephadmlib.container_engines import (
 )
 from cephadmlib.data_utils import (
     dict_get_join,
+    parse_ini_section,
     get_legacy_daemon_fsid,
     is_fsid,
     normalize_image_digest,
@@ -675,8 +676,21 @@ def create_daemon_dirs(
             and key_path_exists
             and key_path_content != keyring
         ):
-            # need to update keyring with ceph-bluestore-tool
-            update_bluestore_label_osd_keyring = True
+            # The raw keyring strings differ, but the difference may only be
+            # caps (e.g. existing keyring has no caps while the new one does).
+            # Extract just the bare key value from both sides and only trigger
+            # the bluestore-label update when the key itself has changed.
+            existing_key = parse_ini_section(key_path_content, ident.daemon_name, 'key')
+            new_key = parse_ini_section(keyring, ident.daemon_name, 'key')
+            if existing_key and new_key and existing_key != new_key:
+                # need to update keyring with ceph-bluestore-tool
+                update_bluestore_label_osd_keyring = True
+            else:
+                logger.debug(
+                    'OSD keyring key value unchanged (only caps differ); '
+                    'skipping bluestore-label keyring update for %s',
+                    ident.daemon_id,
+                )
         with write_new(keyring_path, owner=(uid, gid)) as f:
             f.write(keyring)
         if update_bluestore_label_osd_keyring:

--- a/src/cephadm/cephadmlib/data_utils.py
+++ b/src/cephadm/cephadmlib/data_utils.py
@@ -64,6 +64,32 @@ def read_config(fn):
     return cp
 
 
+def parse_ini_section(
+    text: str, entity: str, option: Optional[str] = None
+) -> Optional[Any]:
+    """Parse text as INI and return data from entity.
+
+    If option is given, return the value of that option (str or
+    None when not found).  If option is omitted, return a plain
+    dict of all options in the section (empty dict when the section
+    exists but has no options), or None when the section is absent
+    or the text cannot be parsed.
+    """
+    parser = ConfigParser(interpolation=None)
+    try:
+        parser.read_string(text)
+    except Exception:
+        return None
+
+    if not parser.has_section(entity):
+        return None
+
+    if option is not None:
+        return parser.get(entity, option, fallback=None)
+
+    return dict(parser.items(entity))
+
+
 def try_convert_datetime(s):
     # type: (str) -> Optional[str]
     # This is super irritating because

--- a/src/cephadm/tests/test_deploy.py
+++ b/src/cephadm/tests/test_deploy.py
@@ -446,6 +446,92 @@ def test_deploy_ceph_osd_container(cephadm_fs, funkypatch):
     assert _make_run_dir.call_args[0][2] == 8765
 
 
+def test_deploy_ceph_osd_keyring_caps_only_diff_no_bluestore_update(cephadm_fs, funkypatch):
+    """When the existing OSD keyring and the incoming keyring have the same key
+    value but differ only in capability lines, the bluestore-label keyring
+    update must NOT be triggered."""
+    from cephadmlib.daemons.ceph import OSD
+
+    mocks = _common_patches(funkypatch)
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+
+    KEYRING_WITHOUT_CAPS = '[osd.4]\nkey = AQAb9J9qhylHBBAAb6cTQ0KqWZMCI/6ray1Umg==\n'
+    KEYRING_WITH_CAPS = (
+        '[osd.4]\n'
+        '\tkey = AQAb9J9qhylHBBAAb6cTQ0KqWZMCI/6ray1Umg==\n'
+        '\tcaps mgr = "allow profile osd"\n'
+        '\tcaps mon = "allow profile osd"\n'
+        '\tcaps osd = "allow *"\n'
+    )
+
+    # Pre-populate the keyring on disk (without caps)
+    basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/osd.4')
+    basedir.mkdir(parents=True, exist_ok=True)
+    (basedir / 'keyring').write_text(KEYRING_WITHOUT_CAPS)
+
+    with mock.patch.object(OSD, 'rotate_osd_lv_keyring') as _rotate:
+        with with_cephadm_ctx([]) as ctx:
+            ctx.container_engine = mock_podman()
+            ctx.fsid = fsid
+            ctx.name = 'osd.4'
+            ctx.image = 'quay.io/ceph/ceph:latest'
+            ctx.reconfig = False
+            ctx.allow_ptrace = False
+            ctx.osd_fsid = '00000000-0000-0000-0000-000000000000'
+            ctx.config_blobs = {
+                'config': 'XXXXXXX',
+                # incoming keyring has the same key but now includes caps
+                'keyring': KEYRING_WITH_CAPS,
+            }
+            ctx.limit_core_infinity = False
+            _cephadm._common_deploy(ctx)
+
+    # The new keyring (with caps) must be written to disk
+    with open(basedir / 'keyring') as f:
+        assert f.read() == KEYRING_WITH_CAPS
+    # rotate_osd_lv_keyring must NOT have been called because only caps changed
+    _rotate.assert_not_called()
+
+
+def test_deploy_ceph_osd_keyring_key_changed_triggers_bluestore_update(cephadm_fs, funkypatch):
+    """When the existing OSD keyring has a different key value than the incoming
+    keyring, the bluestore-label keyring update MUST be triggered."""
+    from cephadmlib.daemons.ceph import OSD
+
+    mocks = _common_patches(funkypatch)
+    fsid = 'b01dbeef-701d-9abe-0000-e1e5a47004a7'
+
+    OLD_KEYRING = '[osd.4]\nkey = AQAb9J9qhylHBBAAb6cTQ0KqWZMCI/6ray1Umg==\n'
+    NEW_KEYRING = '[osd.4]\nkey = AQAf9J9q/JuvFhAAts2n0E559zSx9hu2K8v9Fg==\n'
+
+    # Pre-populate the keyring on disk (old key)
+    basedir = pathlib.Path(f'/var/lib/ceph/{fsid}/osd.4')
+    basedir.mkdir(parents=True, exist_ok=True)
+    (basedir / 'keyring').write_text(OLD_KEYRING)
+
+    with mock.patch.object(OSD, 'rotate_osd_lv_keyring') as _rotate:
+        with with_cephadm_ctx([]) as ctx:
+            ctx.container_engine = mock_podman()
+            ctx.fsid = fsid
+            ctx.name = 'osd.4'
+            ctx.image = 'quay.io/ceph/ceph:latest'
+            ctx.reconfig = False
+            ctx.allow_ptrace = False
+            ctx.osd_fsid = '00000000-0000-0000-0000-000000000000'
+            ctx.config_blobs = {
+                'config': 'XXXXXXX',
+                'keyring': NEW_KEYRING,
+            }
+            ctx.limit_core_infinity = False
+            _cephadm._common_deploy(ctx)
+
+    # The new keyring must be written to disk
+    with open(basedir / 'keyring') as f:
+        assert f.read() == NEW_KEYRING
+    # rotate_osd_lv_keyring MUST have been called because the key itself changed
+    _rotate.assert_called_once()
+
+
 def test_deploy_ceph_osd_container_crimson(cephadm_fs, funkypatch):
     mocks = _common_patches(funkypatch)
     _make_run_dir = funkypatch.patch('cephadmlib.file_utils.make_run_dir')

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1345,6 +1345,25 @@ class CephadmServe:
             if action:
                 if scheduled_action == 'redeploy' and action == 'reconfig':
                     action = 'redeploy'
+                # For OSD redeploy/reconfig that was NOT explicitly scheduled by
+                # the user (i.e. scheduled_action was None), check ok-to-stop
+                # before proceeding.  A redeploy/reconfig stops the OSD; running
+                # it when the cluster cannot afford to lose that OSD risks data
+                # unavailability.  If the OSD is not safe to stop right now,
+                # defer the action to the next serve-loop iteration.
+                if (
+                    dd.daemon_type == 'osd'
+                    and action in ('redeploy', 'reconfig')
+                    and not scheduled_action
+                ):
+                    r = svc_obj.ok_to_stop([dd.daemon_id])
+                    if r.retval:
+                        self.log.info(
+                            'Skipping %s of %s (not ok-to-stop: %s); '
+                            'will retry next serve loop',
+                            action, dd.name(), r.stderr,
+                        )
+                        continue
                 try:
                     daemon_spec = CephadmDaemonDeploySpec.from_daemon_description(dd)
                     reconfig_extras: dict[str, Any] = {}

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -627,6 +627,107 @@ class TestCephadm(object):
                 assert cephadm_module.cache.get_scheduled_daemon_action('test', daemon_name) is None
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_osd_check_daemons_skip_when_not_ok_to_stop(
+        self, _run_cephadm, cephadm_module: CephadmOrchestrator
+    ):
+        """_check_daemons must NOT act on an OSD that needs an autonomous
+        reconfig/redeploy when the cluster reports it is not ok-to-stop.
+        The action must be deferred to the next serve-loop iteration."""
+        from mgr_module import HandleCommandResult
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test'):
+            with with_osd_daemon(cephadm_module, _run_cephadm, 'test', 1) as dd:
+                # No scheduled action — the action will be derived autonomously
+                # (extra ceph config changed → reconfig).
+                assert cephadm_module.cache.get_scheduled_daemon_action(
+                    'test', dd.name()) is None
+
+                cephadm_module._set_extra_ceph_conf('[osd]\ndebug_osd=5')
+
+                # Simulate ok-to-stop returning failure.
+                with mock.patch.object(
+                    cephadm_module.osd_service,
+                    'ok_to_stop',
+                    return_value=HandleCommandResult(
+                        retval=-1, stdout='', stderr='not safe to stop osd.1'
+                    ),
+                ) as mock_ok_to_stop:
+                    with mock.patch.object(
+                        cephadm_module, '_daemon_action'
+                    ) as mock_daemon_action:
+                        CephadmServe(cephadm_module)._check_daemons()
+
+                # ok-to-stop must have been checked
+                mock_ok_to_stop.assert_called_once_with(['1'])
+                # the daemon action must NOT have been called
+                mock_daemon_action.assert_not_called()
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_osd_check_daemons_proceeds_when_ok_to_stop(
+        self, _run_cephadm, cephadm_module: CephadmOrchestrator
+    ):
+        """_check_daemons MUST act on an OSD that needs an autonomous
+        reconfig/redeploy when the cluster confirms it is ok-to-stop."""
+        from mgr_module import HandleCommandResult
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test'):
+            with with_osd_daemon(cephadm_module, _run_cephadm, 'test', 1) as dd:
+                assert cephadm_module.cache.get_scheduled_daemon_action(
+                    'test', dd.name()) is None
+
+                cephadm_module._set_extra_ceph_conf('[osd]\ndebug_osd=5')
+
+                # Simulate ok-to-stop returning success.
+                with mock.patch.object(
+                    cephadm_module.osd_service,
+                    'ok_to_stop',
+                    return_value=HandleCommandResult(
+                        retval=0, stdout='osd.1 is safe to restart', stderr=''
+                    ),
+                ) as mock_ok_to_stop:
+                    with mock.patch.object(
+                        cephadm_module, '_daemon_action'
+                    ) as mock_daemon_action:
+                        CephadmServe(cephadm_module)._check_daemons()
+
+                # ok-to-stop must have been checked
+                mock_ok_to_stop.assert_called_once_with(['1'])
+                # the daemon action MUST have been called
+                mock_daemon_action.assert_called_once()
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_osd_check_daemons_scheduled_action_skips_ok_to_stop(
+        self, _run_cephadm, cephadm_module: CephadmOrchestrator
+    ):
+        """When a user explicitly schedules a redeploy/reconfig for an OSD via
+        'ceph orch daemon redeploy osd.X', the ok-to-stop guard must NOT block
+        it — the user made an explicit decision."""
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test'):
+            with with_osd_daemon(cephadm_module, _run_cephadm, 'test', 1) as dd:
+                # Explicitly schedule a redeploy (user-initiated).
+                cephadm_module._schedule_daemon_action(dd.name(), 'redeploy')
+                assert cephadm_module.cache.get_scheduled_daemon_action(
+                    'test', dd.name()) == 'redeploy'
+
+                with mock.patch.object(
+                    cephadm_module.osd_service,
+                    'ok_to_stop',
+                ) as mock_ok_to_stop:
+                    with mock.patch.object(
+                        cephadm_module, '_daemon_action'
+                    ) as mock_daemon_action:
+                        CephadmServe(cephadm_module)._check_daemons()
+
+                # ok-to-stop must NOT have been consulted for a user-scheduled action
+                mock_ok_to_stop.assert_not_called()
+                # the daemon action must still have run
+                mock_daemon_action.assert_called_once()
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
     def test_daemon_check_extra_config(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
 


### PR DESCRIPTION

1. Older version of ceph stores the osd keyring without the caps entries. During reconfiguration, the existing keyring is compared against the incoming keyring, which contains the caps. This causes ceph to incorrectly detect a keyring change and rotate the keyring even though the underlying key is the same. To fix this, the comparison is now based on the actual key value rather than the complete keyring content.
2. When an osd is reconfigured or redeployed due to a monmap change, the current implementation does not check ok-to-stop for that osd before performing the operation. This behavior has been fixed by adding an ok-to-stop check before the reconfiguration or redeployment.

    
Fixes: https://tracker.ceph.com/issues/80399
    
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

Testing done - performed a staggered upgrade from tentacle to the private image
```
[ceph: root@ceph-node-0 /]# ceph orch upgrade start  quay.io/rh-ee-shbhosal/ceph:test1 --daemon-types mgr,mon
Initiating upgrade to quay.io/rh-ee-shbhosal/ceph:test1
[ceph: root@ceph-node-0 /]# ceph orch upgrade status                                                         
{
    "in_progress": true,
    "target_image": "quay.io/rh-ee-shbhosal/ceph@sha256:358eb4ad32da875ee363d53f5880d39dc1eb4209267000f47024b25e6c69a087",
    "services_complete": [],
    "which": "Upgrading daemons of type(s) mgr,mon",
    "progress": "0/5 daemons upgraded",
    "message": "Doing first pull of quay.io/rh-ee-shbhosal/ceph:test1 image",
    "is_paused": false
}

[ceph: root@ceph-node-0 /]# ceph orch upgrade status
There are no upgrades in progress currently.
[ceph: root@ceph-node-0 /]# ceph -s
  cluster:
    id:     6ffb6fb8-ac2c-11f1-a219-525400b2a2fc
    health: HEALTH_WARN
            Monitors are configured to allow auth using insecure key types
            Monitors are configured to allow creation of insecure key types
 
  services:
    mon: 3 daemons, quorum ceph-node-0,ceph-node-1,ceph-node-2 (age 2m) [leader: ceph-node-0]
    mgr: ceph-node-1.hmnfip(active, since 2m), standbys: ceph-node-0.owhrif
    osd: 21 osds: 21 up (since 41m), 21 in (since 43m)
 
  data:
    pools:   1 pools, 1 pgs
    objects: 2 objects, 449 KiB
    usage:   595 MiB used, 104 GiB / 105 GiB avail
    pgs:     1 active+clean
 
[ceph: root@ceph-node-0 /]# 

[ceph: root@ceph-node-0 /]# ceph orch upgrade start  quay.io/rh-ee-shbhosal/ceph:test1 --daemon-types osd,crash
Initiating upgrade to quay.io/rh-ee-shbhosal/ceph:test1
[ceph: root@ceph-node-0 /]# ceph -s
  cluster:
    id:     6ffb6fb8-ac2c-11f1-a219-525400b2a2fc
    health: HEALTH_WARN
            Monitors are configured to allow creation of insecure key types
            (muted: AUTH_INSECURE_KEYS_ALLOWED)
 
  services:
    mon: 3 daemons, quorum ceph-node-0,ceph-node-1,ceph-node-2 (age 3m) [leader: ceph-node-0]
    mgr: ceph-node-1.hmnfip(active, since 3m), standbys: ceph-node-0.owhrif
    osd: 21 osds: 21 up (since 42m), 21 in (since 44m)
         flags noautoscale
 
  data:
    pools:   1 pools, 1 pgs
    objects: 2 objects, 449 KiB
    usage:   595 MiB used, 104 GiB / 105 GiB avail
    pgs:     1 active+clean
 
  progress:
    Upgrade to quay.io/rh-ee-shbhosal/ceph:test1 (0s)
      [............................] 
 
[ceph: root@ceph-node-0 /]# date
Wed Sep  9 09:46:32 UTC 2026
[ceph: root@ceph-node-0 /]# ceph orch upgrade status
There are no upgrades in progress currently.
[ceph: root@ceph-node-0 /]# ceph -s
  cluster:
    id:     6ffb6fb8-ac2c-11f1-a219-525400b2a2fc
    health: HEALTH_WARN
            Monitors are configured to allow auth using insecure key types
            Monitors are configured to allow creation of insecure key types
 
  services:
    mon: 3 daemons, quorum ceph-node-0,ceph-node-1,ceph-node-2 (age 7m) [leader: ceph-node-0]
    mgr: ceph-node-0.owhrif(active, since 7m), standbys: ceph-node-1.hmnfip
    osd: 21 osds: 21 up (since 2m), 21 in (since 52m)
 
  data:
    pools:   1 pools, 1 pgs
    objects: 2 objects, 449 KiB
    usage:   1.0 GiB used, 104 GiB / 105 GiB avail
    pgs:     1 active+clean
 
[ceph: root@ceph-node-0 /]# ceph health details
details not valid:  details not in detail
Invalid command: unused arguments: ['details']
health [<detail:detail>] :  show cluster health
Error EINVAL: invalid command
[ceph: root@ceph-node-0 /]# ceph health detail 
HEALTH_WARN Monitors are configured to allow auth using insecure key types; Monitors are configured to allow creation of insecure key types
[WRN] AUTH_INSECURE_KEYS_ALLOWED: Monitors are configured to allow auth using insecure key types
    insecure cipher aes allowed for auth
[WRN] AUTH_INSECURE_KEYS_CREATABLE: Monitors are configured to allow creation of insecure key types
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph versions
{
    "mon": {
        "ceph version 21.3.0-2953-gca28ffa3 (ca28ffa3fdd2bb702d984f0648a3bf9fa42d8836) umbrella (dev - RelWithDebInfo)": 3
    },
    "mgr": {
        "ceph version 21.3.0-2953-gca28ffa3 (ca28ffa3fdd2bb702d984f0648a3bf9fa42d8836) umbrella (dev - RelWithDebInfo)": 2
    },
    "osd": {
        "ceph version 21.3.0-2953-gca28ffa3 (ca28ffa3fdd2bb702d984f0648a3bf9fa42d8836) umbrella (dev - RelWithDebInfo)": 21
    },
    "overall": {
        "ceph version 21.3.0-2953-gca28ffa3 (ca28ffa3fdd2bb702d984f0648a3bf9fa42d8836) umbrella (dev - RelWithDebInfo)": 26
    }
}
[ceph: root@ceph-node-0 /]# 

```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
