### PR TITLE
exporter: fix RGW sync metrics for zone names with special chars

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1900,10 +1900,13 @@ class Module(MgrModule, OrchestratorClientMixin):
         """
         new_metrics = {}
         for metric_path, metrics in self.metrics.items():
-            # Address RGW sync perf. counters.
-            match = re.search(r'^data-sync-from-(.*)\.', metric_path)
+            # Address RGW sync perf. counters. Zone names may contain
+            # characters such as hyphens and underscores.
+            match = re.match(r'^data-sync-from-(.+)\.(\w+)$', metric_path)
             if match:
-                new_path = re.sub('from-([^.]*)', 'from-zone', metric_path)
+                zone_name = match.group(1)
+                counter_name = match.group(2)
+                new_path = 'data-sync-from-zone.' + counter_name
                 if new_path not in new_metrics:
                     new_metrics[new_path] = Metric(
                         metrics.mtype,
@@ -1912,7 +1915,7 @@ class Module(MgrModule, OrchestratorClientMixin):
                         cast(LabelValues, metrics.labelnames) + ('source_zone',)
                     )
                 for label_values, value in metrics.value.items():
-                    new_metrics[new_path].set(value, label_values + (match.group(1),))
+                    new_metrics[new_path].set(value, label_values + (zone_name,))
 
         self.metrics.update(new_metrics)
 

--- a/src/pybind/mgr/prometheus/test_module.py
+++ b/src/pybind/mgr/prometheus/test_module.py
@@ -471,3 +471,89 @@ class HardwareMetricsTest(TestCase):
         self.module._process_processors(self.status, self.hostname)
         for labels in self.module.metrics['hardware_cpu_cores'].value:
             self.assertEqual(len(labels), 5)
+
+
+class RgwSyncMetricsTest(TestCase):
+    def setUp(self):
+        from prometheus.module import Module
+        self.module = mock.MagicMock(spec=Module)
+        self.module.metrics = {}
+        self.module.add_fixed_name_metrics = Module.add_fixed_name_metrics.__get__(
+            self.module)
+
+    def _add_sync_metric(self, zone_name: str, counter: str,
+                         value: float = 1.0) -> str:
+        """Insert a raw RGW sync perf-counter metric and return its path."""
+        path = 'data-sync-from-{}.{}'.format(zone_name, counter)
+        m = Metric('counter', path, 'test desc', ('instance_id',))
+        m.set(value, ('rgw.0',))
+        self.module.metrics[path] = m
+        return path
+
+    def test_hyphenated_zone_name(self):
+        """Zone names with hyphens are recognised and the full name extracted."""
+        self._add_sync_metric('zone-a', 'fetch_bytes')
+        self.module.add_fixed_name_metrics()
+        self.assertIn('data-sync-from-zone.fetch_bytes', self.module.metrics)
+        fixed = self.module.metrics['data-sync-from-zone.fetch_bytes']
+        self.assertIn('source_zone', fixed.labelnames)
+        label_idx = fixed.labelnames.index('source_zone')
+        zones = {lv[label_idx] for lv in fixed.value}
+        self.assertEqual(zones, {'zone-a'})
+
+    def test_multi_hyphenated_zone_name(self):
+        """Zone names with multiple hyphens must be extracted in full."""
+        self._add_sync_metric('zone2-zg1-realm1', 'fetch_bytes')
+        self.module.add_fixed_name_metrics()
+        fixed = self.module.metrics['data-sync-from-zone.fetch_bytes']
+        label_idx = fixed.labelnames.index('source_zone')
+        zones = {lv[label_idx] for lv in fixed.value}
+        self.assertEqual(zones, {'zone2-zg1-realm1'})
+
+    def test_underscore_zone_name(self):
+        """Zone names with underscores are recognised and the full name extracted."""
+        self._add_sync_metric('my_zone', 'fetch_bytes')
+        self.module.add_fixed_name_metrics()
+        self.assertIn('data-sync-from-zone.fetch_bytes', self.module.metrics)
+        fixed = self.module.metrics['data-sync-from-zone.fetch_bytes']
+        label_idx = fixed.labelnames.index('source_zone')
+        zones = {lv[label_idx] for lv in fixed.value}
+        self.assertEqual(zones, {'my_zone'})
+
+    def test_underscore_zone_name_long(self):
+        """Long zone names with underscores (reviewer's exact test case)."""
+        zone = 'A_ZONE_WITHUNDERSCORE_IN_THE_NAME'
+        self._add_sync_metric(zone, 'fetch_bytes')
+        self.module.add_fixed_name_metrics()
+        fixed = self.module.metrics['data-sync-from-zone.fetch_bytes']
+        label_idx = fixed.labelnames.index('source_zone')
+        zones = {lv[label_idx] for lv in fixed.value}
+        self.assertEqual(zones, {zone})
+
+    def test_longrunavg_counters_get_separate_fixed_paths(self):
+        """poll_latency_sum and poll_latency_count must each get their own path."""
+        self._add_sync_metric('my_zone', 'poll_latency_sum')
+        self._add_sync_metric('my_zone', 'poll_latency_count')
+        self.module.add_fixed_name_metrics()
+        self.assertIn('data-sync-from-zone.poll_latency_sum', self.module.metrics)
+        self.assertIn('data-sync-from-zone.poll_latency_count', self.module.metrics)
+
+    def test_multiple_zones_merged_under_fixed_path(self):
+        """Metrics from different source zones share one fixed path, distinguished by label."""
+        self._add_sync_metric('zone-a', 'fetch_bytes', 10.0)
+        self._add_sync_metric('zone_b', 'fetch_bytes', 20.0)
+        self.module.add_fixed_name_metrics()
+        fixed = self.module.metrics['data-sync-from-zone.fetch_bytes']
+        label_idx = fixed.labelnames.index('source_zone')
+        zones = {lv[label_idx] for lv in fixed.value}
+        self.assertEqual(zones, {'zone-a', 'zone_b'})
+
+    def test_non_sync_metric_not_affected(self):
+        """Metrics that are not RGW sync counters must not be modified."""
+        unrelated = Metric('counter', 'rgw.op_put_obj', '', ('instance_id',))
+        unrelated.set(5.0, ('rgw.0',))
+        self.module.metrics['rgw.op_put_obj'] = unrelated
+        self.module.add_fixed_name_metrics()
+        # No new data-sync-from-zone.* key should appear for non-sync metrics
+        sync_keys = [k for k in self.module.metrics if k.startswith('data-sync-from-zone')]
+        self.assertEqual(sync_keys, [])


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/80400
Signed-off-by: Anurag Raut <anuragtraut08@ibm.com>

PR Description

This PR fixes RGW sync metric path handling for zone names containing special characters, such as underscores.

The Prometheus module previously relied on regex-based parsing of the metric path, which could ambiguously separate the zone name from the counter name. The fix explicitly separates the zone name and counter suffix when normalizing RGW sync metrics, preserving the complete zone name as the `source_zone` label.

Regression tests cover hyphenated and underscore-containing zone names, multiple zones, counter suffixes, and unrelated metrics.

The implementation was verified with:

* `python3 -m flake8 module.py test_module.py`
* `tox -e py3 -- prometheus/test_module.py -v`
* `40 tests passed`
* Focused RGW sync tests: `7 passed`



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
