### PR TITLE
mds: delay cache rejoin OP_WEAK until peer is in rejoin

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -4074,7 +4074,9 @@ void MDCache::rejoin_start(MDSContext *rejoin_done_)
  *
  * we start out by sending rejoins to everyone in the recovery set.
  *
- * if we are rejoin, send for all regions in our cache.
+ * if we are rejoin, send OP_WEAK for all regions in our cache, but only
+ * to peers that have already reached rejoin (or later). peers still in
+ * replay/resolve/reconnect are skipped and retried when they catch up.
  * if we are active|stopping, send only to nodes that are rejoining.
  */
 void MDCache::rejoin_send_rejoins()
@@ -4101,16 +4103,29 @@ void MDCache::rejoin_send_rejoins()
   }
 
   map<mds_rank_t, ref_t<MMDSCacheRejoin>> rejoins;
+  bool delayed = false;
 
-
-  // if i am rejoining, send a rejoin to everyone.
+  // if i am rejoining, send a rejoin to everyone already in rejoin or later.
   // otherwise, just send to others who are rejoining.
   for (const auto& rank : recovery_set) {
     if (rank == mds->get_nodeid())  continue;  // nothing to myself!
     if (rejoin_sent.count(rank)) continue;     // already sent a rejoin to this node!
-    if (mds->is_rejoin())
+    if (mds->is_rejoin()) {
+      auto st = mds->mdsmap->get_state(rank);
+      if (st < MDSMap::STATE_REJOIN) {
+	// Do not send OP_WEAK to replay/resolve/reconnect peers. Failed
+	// (STATE_NULL) ranks are skipped without delaying: they will be
+	// retried after handle_mds_failure() clears rejoin_sent.
+	if (st >= MDSMap::STATE_REPLAY) {
+	  dout(7) << "rejoin_send_rejoins peer mds." << rank
+		  << " not yet rejoin (state "
+		  << ceph_mds_state_name(st) << "), delaying OP_WEAK" << dendl;
+	  delayed = true;
+	}
+	continue;
+      }
       rejoins[rank] = make_message<MMDSCacheRejoin>(MMDSCacheRejoin::OP_WEAK);
-    else if (mds->mdsmap->is_rejoin(rank))
+    } else if (mds->mdsmap->is_rejoin(rank))
       rejoins[rank] = make_message<MMDSCacheRejoin>(MMDSCacheRejoin::OP_STRONG);
   }
 
@@ -4162,7 +4177,15 @@ void MDCache::rejoin_send_rejoins()
     ceph_assert(dir->is_subtree_root());
     if (dir->is_ambiguous_dir_auth()) {
       // exporter is recovering, importer is survivor.
-      ceph_assert(rejoins.count(dir->authority().first));
+      if (!rejoins.count(dir->authority().first)) {
+	if (!rejoin_sent.count(dir->authority().first)) {
+	  dout(7) << "rejoin_send_rejoins delaying ambiguous subtree " << *dir
+		  << " until exporter mds." << dir->authority().first
+		  << " is sent a rejoin" << dendl;
+	  delayed = true;
+	}
+	continue;
+      }
       ceph_assert(!rejoins.count(dir->authority().second));
       continue;
     }
@@ -4298,7 +4321,7 @@ void MDCache::rejoin_send_rejoins()
     mds->send_message_mds(p.second, p.first);
   }
   rejoin_ack_gather.insert(mds->get_nodeid());   // we need to complete rejoin_gather_finish, too
-  rejoins_pending = false;
+  rejoins_pending = delayed;
 
   // nothing?
   if (mds->is_rejoin() && rejoin_gather.empty()) {
@@ -4506,9 +4529,16 @@ void MDCache::handle_cache_rejoin_weak(const cref_t<MMDSCacheRejoin> &weak)
     }
 
     encode(imported_caps, ack->imported_caps);
+  } else if (!mds->is_rejoin()) {
+    // A delayed OP_WEAK can arrive while we are still in resolve/reconnect.
+    // Defer until rejoin_start() rather than asserting. See
+    // https://tracker.ceph.com/issues/54840
+    dout(7) << "handle_cache_rejoin_weak from mds." << from
+	    << " while in " << ceph_mds_state_name(mds->get_state())
+	    << ", waiting for rejoin" << dendl;
+    mds->wait_for_rejoin(new C_MDS_RetryMessage(mds, weak));
+    return;
   } else {
-    ceph_assert(mds->is_rejoin());
-
     // we may have already received a strong rejoin from the sender.
     rejoin_scour_survivor_replicas(from, NULL, acked_inodes, gather_locks);
     ceph_assert(gather_locks.empty());

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2511,14 +2511,20 @@ void MDSRankDispatcher::handle_mds_map(
       set<mds_rank_t> olddis, dis;
       oldmap.get_mds_set_lower_bound(olddis, MDSMap::STATE_REJOIN);
       mdsmap->get_mds_set_lower_bound(dis, MDSMap::STATE_REJOIN);
+      bool send_rejoins = false;
       for (const auto& r : dis) {
 	if (r == whoami)
 	  continue; // not me
 	if (!olddis.count(r) || restart.count(r)) {  // newly so?
 	  mdcache->kick_discovers(r);
 	  mdcache->kick_open_ino_peers(r);
+	  send_rejoins = true;
 	}
       }
+      // Retry OP_WEAK that was skipped while this peer was still in
+      // resolve/reconnect. See https://tracker.ceph.com/issues/54840
+      if (send_rejoins)
+	mdcache->rejoin_send_rejoins();
     }
   }
 


### PR DESCRIPTION
A deferred rejoin_send_rejoins() can send OP_WEAK while a peer is still in resolve or reconnect, crashing the receiver on
ceph_assert(mds->is_rejoin()). Defer handling until rejoin_start(), skip sending OP_WEAK to peers below STATE_REJOIN, keep rejoins_pending, and retry when a peer reaches rejoin.

Fixes: https://tracker.ceph.com/issues/54840

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
