### PR TITLE
mds: populate rejoin_gather for newly active ranks

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -3234,6 +3234,26 @@ void MDCache::handle_mds_recovery(mds_rank_t who)
 void MDCache::set_recovery_set(set<mds_rank_t>& s) 
 {
   dout(7) << "set_recovery_set " << s << dendl;
+
+  // A newly created survivor (creating -> active) never observed peer
+  // failures, so handle_mds_failure() did not populate rejoin_gather.
+  // Likewise, a rank already in rejoin may not have a newly active
+  // survivor in gather. Expect a rejoin from any new recovery peer.
+  for (auto rank : s) {
+    if (rank == mds->get_nodeid() || recovery_set.count(rank))
+      continue;
+    auto st = mds->mdsmap->get_state(rank);
+    if (st >= MDSMap::STATE_REPLAY && st <= MDSMap::STATE_REJOIN) {
+      dout(7) << "set_recovery_set expecting rejoin from mds." << rank
+	      << " (" << ceph_mds_state_name(st) << ")" << dendl;
+      rejoin_gather.insert(rank);
+    } else if (mds->is_rejoin() &&
+	       mds->mdsmap->is_clientreplay_or_active_or_stopping(rank)) {
+      dout(7) << "set_recovery_set expecting rejoin from survivor mds."
+	      << rank << dendl;
+      rejoin_gather.insert(rank);
+    }
+  }
   recovery_set = s;
 }
 
@@ -4097,6 +4117,15 @@ void MDCache::rejoin_send_rejoins()
   ceph_assert(!migrator->is_exporting());
 
   if (!mds->is_rejoin()) {
+    // Survivor: expect OP_WEAK from peers that are currently rejoining.
+    // Fresh ranks that skipped handle_mds_failure() otherwise crash on
+    // rejoin_gather.count(from) when the first OP_WEAK arrives.
+    for (const auto& rank : recovery_set) {
+      if (rank == mds->get_nodeid())
+	continue;
+      if (mds->mdsmap->is_rejoin(rank))
+	rejoin_gather.insert(rank);
+    }
     disambiguate_other_imports();
   }
 
@@ -4473,6 +4502,25 @@ void MDCache::handle_cache_rejoin_weak(const cref_t<MMDSCacheRejoin> &weak)
 {
   mds_rank_t from = mds_rank_t(weak->get_source().num());
 
+  if (!rejoin_gather.count(from)) {
+    auto st = mds->mdsmap->get_state(from);
+    // OP_WEAK is sent by a recovering peer. A newly active survivor may
+    // not have that peer in rejoin_gather yet; add and continue. Anything
+    // else is a duplicate or stray message.
+    if (st >= MDSMap::STATE_REPLAY && st <= MDSMap::STATE_REJOIN) {
+      dout(7) << "handle_cache_rejoin_weak from mds." << from
+	      << " not in rejoin_gather " << rejoin_gather
+	      << ", adding" << dendl;
+      rejoin_gather.insert(from);
+      recovery_set.insert(from);
+    } else {
+      dout(7) << "handle_cache_rejoin_weak ignoring from mds." << from
+	      << " (not in rejoin_gather " << rejoin_gather
+	      << ", state " << ceph_mds_state_name(st) << ")" << dendl;
+      return;
+    }
+  }
+
   // possible response(s)
   ref_t<MMDSCacheRejoin> ack;      // if survivor
   set<vinodeno_t> acked_inodes;  // if survivor
@@ -4788,6 +4836,23 @@ void MDCache::handle_cache_rejoin_strong(const cref_t<MMDSCacheRejoin> &strong)
       return;
     }
     ceph_abort_msg("got unexpected rejoin message during recovery");
+  }
+
+  if (!rejoin_gather.count(from)) {
+    // A survivor that appeared after rejoin_start() (e.g. max_mds scale-up)
+    // was never inserted into rejoin_gather.
+    if (mds->mdsmap->is_clientreplay_or_active_or_stopping(from) ||
+	mds->mdsmap->is_rejoin(from)) {
+      dout(7) << "handle_cache_rejoin_strong from mds." << from
+	      << " not in rejoin_gather " << rejoin_gather
+	      << ", adding" << dendl;
+      rejoin_gather.insert(from);
+      recovery_set.insert(from);
+    } else {
+      dout(7) << "handle_cache_rejoin_strong ignoring from mds." << from
+	      << " (not in rejoin_gather " << rejoin_gather << ")" << dendl;
+      return;
+    }
   }
 
   // assimilate any potentially dirty scatterlock state

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2038,6 +2038,9 @@ void MDSRank::reconnect_done()
 void MDSRank::rejoin_joint_start()
 {
   dout(1) << "rejoin_joint_start" << dendl;
+  // Refresh recovery_set so a creating->active rank picks up peers already
+  // in recovery, and a recovering rank picks up newly active survivors.
+  calc_recovery_set();
   mdcache->rejoin_send_rejoins();
 }
 void MDSRank::rejoin_start()
@@ -2160,6 +2163,9 @@ void MDSRank::active_start()
   mdcache->reissue_all_caps();
 
   finish_contexts(g_ceph_context, waiting_for_active);  // kick waiters
+
+  if (mdsmap->is_degraded())
+    calc_recovery_set();
 
   quiesce_agent_setup();
 }


### PR DESCRIPTION
A rank that goes creating -> active during max_mds scale-up never observes peer failures, so rejoin_gather stays empty while recovery_set is not. OP_WEAK then hits ceph_assert(rejoin_gather.count(from)). Grow gather from set_recovery_set and the survivor rejoin send path, refresh the recovery set at joint start, and add or ignore a missing sender instead of crashing.

Fixes: https://tracker.ceph.com/issues/80402
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
