### PR TITLE
qa/distros: reinstall nvme-cli on ubuntu nodes

### DIFF
--- a/qa/distros/all/ubuntu_22.04.yaml
+++ b/qa/distros/all/ubuntu_22.04.yaml
@@ -1,3 +1,17 @@
 os_type: ubuntu
 os_version: "22.04"
 ktype: distro
+tasks:
+- pexec:
+    all:
+    # Work around mismatched /etc/nvme/hostnqn and hostid that make
+    # `nvme connect -t loop` fail with:
+    #   Failed to write to /dev/nvme-fabrics: Invalid argument
+    #   nvme_fabrics: found same hostid ... but different hostnqn ...
+    # Purge so Debian conffiles are removed and regenerated on install.
+    # Same approach as centos 9 / rocky. nvmetcli is not packaged on Ubuntu.
+    # See https://tracker.ceph.com/issues/71816
+    # See https://tracker.ceph.com/issues/67684
+    - sudo rm -f /etc/nvme/hostnqn /etc/nvme/hostid
+    - sudo env DEBIAN_FRONTEND=noninteractive apt-get purge -y nvme-cli
+    - sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y nvme-cli

--- a/qa/distros/all/ubuntu_24.04.yaml
+++ b/qa/distros/all/ubuntu_24.04.yaml
@@ -1,3 +1,17 @@
 os_type: ubuntu
 os_version: "24.04"
 ktype: distro
+tasks:
+- pexec:
+    all:
+    # Work around mismatched /etc/nvme/hostnqn and hostid that make
+    # `nvme connect -t loop` fail with:
+    #   Failed to write to /dev/nvme-fabrics: Invalid argument
+    #   nvme_fabrics: found same hostid ... but different hostnqn ...
+    # Purge so Debian conffiles are removed and regenerated on install.
+    # Same approach as centos 9 / rocky. nvmetcli is not packaged on Ubuntu.
+    # See https://tracker.ceph.com/issues/71816
+    # See https://tracker.ceph.com/issues/67684
+    - sudo rm -f /etc/nvme/hostnqn /etc/nvme/hostid
+    - sudo env DEBIAN_FRONTEND=noninteractive apt-get purge -y nvme-cli
+    - sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y nvme-cli


### PR DESCRIPTION
## Summary
- Reinstall `nvme-cli` on Ubuntu 22.04 and 24.04 test nodes, matching the existing centos 9 / rocky workaround.
- Ubuntu `nvme-loop` jobs fail with `Failed to write to /dev/nvme-fabrics: Invalid argument` because `/etc/nvme/hostnqn` and `hostid` are mismatched. Dropping `-q hostnqn` is not enough; nvme-cli still uses the broken files.
- Purge (not just remove) so Debian conffiles are deleted and regenerated as a matching pair. `nvmetcli` is not packaged on Ubuntu, so only `nvme-cli` is reinstalled.

Fixes: https://tracker.ceph.com/issues/71816

## Test plan
- [ ] Confirm `orch:cephadm` Ubuntu 24.04 `nvme-loop` jobs get past `nvme connect -t loop -n lv_1`
- [ ] Confirm Ubuntu 22.04 `nvme-loop` jobs still pass
- [ ] Check a failed-before node that `hostnqn` and `hostid` UUIDs match after the pexec step

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [x] Affects Orchestrator, opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [ ] Includes bug reproducer
  - [x] No tests