### PR TITLE
crimson/os/seastore/omap: dedup non-log keys in a single chain traversal

### DIFF
--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -893,7 +893,7 @@ LogManager::omap_rm_keys(
 	nullptr);
     } else {
       for (auto& p : key_set) {
-	co_await remove_kv(t, log_root.addr, p, nullptr);
+	co_await remove_kv(t, addr, p, nullptr);
       }
     }
   };

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -892,7 +892,13 @@ LogManager::omap_rm_keys(
 	*key_set.rbegin(),
 	nullptr);
     } else {
-      for (auto& p : key_set) {
+      // Not a range, but still only one traversal: remove_kv_set() matches
+      // the whole set as it walks the chain.
+      pending_keys_t pending(
+	std::vector<std::string_view>(key_set.begin(), key_set.end()));
+      std::vector<std::string> multi_block_keys;
+      co_await remove_kv_set(t, addr, pending, multi_block_keys, nullptr);
+      for (auto& p : multi_block_keys) {
 	co_await remove_kv(t, addr, p, nullptr);
       }
     }

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.cc
@@ -189,18 +189,41 @@ LogManager::omap_set_keys(
     }
   }
 
+  /*
+   * A non-log key must not be left duplicated in the chain, so the previous
+   * instance of every such key has to be removed before the new one is
+   * appended. Do all of them up front in a single backward traversal:
+   * removing them one at a time rescans the chain per key - and a key that is
+   * not there at all always walks it to the end - which is O(keys * chain
+   * length). A pgmeta transaction setting thousands of missing/... keys pays
+   * that cost in full.
+   */
+  std::vector<std::string_view> dup_keys;
+  for (const auto &p : kvs) {
+    if (!is_log_key(p.first)) {
+      // kvs was moved into this coroutine's frame and std::map keys are
+      // stable, so a view into one stays valid for the traversal.
+      dup_keys.emplace_back(p.first);
+    }
+  }
+  if (!dup_keys.empty()) {
+    pending_keys_t pending(std::move(dup_keys));
+    std::vector<std::string> multi_block_keys;
+    co_await remove_kv_set(t, log_root.addr, pending, multi_block_keys, nullptr);
+    for (const auto &key : multi_block_keys) {
+      co_await remove_kv(t, log_root.addr, key, nullptr);
+    }
+    // reload ext, it may have been mutated by the removals above
+    CachedExtentRef node = co_await resync_log_node(ext);
+    ext = node->template cast<LogNode>();
+  }
+
   std::map<std::string, ceph::bufferlist> dup_kvs;
   if (kvs.size() > BATCH_CREATE_SIZE) {
     LogNodeRef e = ext;
     LogNodeRef dup_e;
     laddr_t dup_tail = co_await get_dup_addr_from_root(t, ext->get_laddr());
     for (auto &p : kvs) {
-      if (!is_log_key(p.first)) {
-	co_await remove_kv(t, log_root.addr, p.first, nullptr);
-	// reload latest log list e because e was updated if the key is in e
-	CachedExtentRef node = co_await resync_log_node(e);
-	e = node->template cast<LogNode>();
-      }
       LogNodeRef cur = e;
       if (is_dup_log_key(p.first)) {
 	if (!dup_e) {
@@ -254,10 +277,6 @@ LogManager::omap_set_keys(
     if (is_dup_log_key(p.first)) {
       dup_kvs[p.first] = p.second;
       continue;
-    }
-    if (!is_log_key(p.first)) {
-      // remove duplicate keys first
-      co_await remove_kv(t, log_root.addr, p.first, nullptr);
     }
     laddr_t last_addr = log_root.addr;
     co_await set_log_node_entry(p.first, p.second);
@@ -646,7 +665,79 @@ LogManager::remove_kv(Transaction &t, laddr_t dst, const std::string &key, LogNo
 }
 
 LogManager::omap_rm_key_ret
-LogManager::remove_kvs(Transaction &t, laddr_t dst, 
+LogManager::remove_kv_set(
+  Transaction &t,
+  laddr_t dst,
+  pending_keys_t &keys,
+  std::vector<std::string> &multi_block_keys,
+  LogNodeRef prev)
+{
+  LOG_PREFIX(LogManager::remove_kv_set);
+  DEBUGT("key size={}, dst={}", t, keys.size(), dst);
+
+  // Iterative rather than recursive: the chain can hold a hundred nodes or
+  // more, and there is nothing to do on the way back up.
+  std::vector<std::string_view> found;
+  while (dst != L_ADDR_NULL && !keys.empty()) {
+    auto extent = co_await log_load_extent<LogNode>(
+      t, dst, BEGIN_KEY, END_KEY);
+    if (extent == nullptr) {
+      co_return;
+    }
+    laddr_t prev_addr = extent->get_prev_addr();
+
+    if (extent->has_multi_block_kv()) {
+      // The value spans a run of LogNodes; hand the whole key over to
+      // remove_kv() instead of unlinking the chunks here.
+      auto key = extent->get_first_key();
+      if (keys.take(key)) {
+	multi_block_keys.emplace_back(key);
+      }
+      prev = extent;
+      dst = prev_addr;
+      continue;
+    }
+
+    // One pass over the node answers the lookup for every key still pending.
+    // found holds views into the node's buffer, which extent keeps alive;
+    // removing an entry only flips bits in the deletion bitmap, so they stay
+    // valid while we act on them below.
+    found.clear();
+    extent->for_each_live_entry([&](const auto &ent, uint32_t index) -> bool {
+      auto key = ent.get_key_view();
+      if (keys.take(key)) {
+	found.push_back(key);
+      }
+      return keys.empty();
+    });
+    LogNodeRef p = extent;
+    if (!found.empty()) {
+      auto mut = tm.get_mutable_extent(t, extent)->template cast<LogNode>();
+      for (const auto &key : found) {
+	// Non-log keys are never duplicated across the chain, so the entry
+	// removed here is the only one - which is why take() above could
+	// strike the key off before we got here.
+	mut->remove_entry(key);
+      }
+      DEBUGT("removed {} keys from {}, {} remaining",
+	t, found.size(), *mut, keys.size());
+      p = mut;
+      if (mut->is_removable()) {
+	co_await remove_node(t, mut, prev);
+	if (prev != nullptr) {
+	  p = co_await log_load_extent<LogNode>(
+	    t, prev->get_laddr(), BEGIN_KEY, END_KEY);
+	}
+      }
+    }
+    prev = p;
+    dst = prev_addr;
+  }
+  co_return;
+}
+
+LogManager::omap_rm_key_ret
+LogManager::remove_kvs(Transaction &t, laddr_t dst,
   std::optional<std::string> first, 
   std::optional<std::string> last,
   LogNodeRef prev)

--- a/src/crimson/os/seastore/omap_manager/log/log_manager.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_manager.h
@@ -2,7 +2,10 @@
 // vim: ts=8 sw=2 smarttab
 #pragma once
 
+#include <algorithm>
+#include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "include/denc.h"
@@ -18,6 +21,60 @@ class LogNode;
 using LogNodeRef = TCachedExtentRef<LogNode>;
 constexpr uint8_t OW_SIZE = 2;
 constexpr uint8_t BATCH_CREATE_SIZE = 50;
+
+/**
+ * pending_keys_t
+ *
+ * The set of keys remove_kv_set() is still looking for. It is probed once per
+ * live entry of every LogNode it walks - a chain of a hundred nodes holding
+ * ~62 entries each is thousands of probes per traversal - so the layout
+ * matters more than the interface:
+ *
+ *  - the keys are views into storage the caller already owns, so building the
+ *    set copies no strings and allocates once,
+ *  - they sit in a single sorted vector, so a probe is a binary search over
+ *    contiguous memory rather than a walk down a red-black tree whose nodes
+ *    (and, for keys past the SSO limit, whose key buffers) are scattered,
+ *  - striking a key off flips a bit instead of shifting the tail, so clearing
+ *    all K keys is O(K) rather than the O(K^2) a flat_set erase() would cost.
+ *
+ * The referenced keys must outlive the pending_keys_t.
+ */
+class pending_keys_t {
+public:
+  explicit pending_keys_t(std::vector<std::string_view> &&keys)
+    : keys(std::move(keys)) {
+    // Sources are ordered containers, so this is a scan in the common case.
+    std::sort(this->keys.begin(), this->keys.end());
+    assert(std::adjacent_find(this->keys.begin(), this->keys.end()) ==
+      this->keys.end());
+    live.assign(this->keys.size(), true);
+    remaining = this->keys.size();
+  }
+
+  bool empty() const { return remaining == 0; }
+  size_t size() const { return remaining; }
+
+  // Strike @key off the set, reporting whether it was still in it.
+  bool take(std::string_view key) {
+    auto iter = std::lower_bound(keys.begin(), keys.end(), key);
+    if (iter == keys.end() || *iter != key) {
+      return false;
+    }
+    auto index = iter - keys.begin();
+    if (!live[index]) {
+      return false;
+    }
+    live[index] = false;
+    --remaining;
+    return true;
+  }
+
+private:
+  std::vector<std::string_view> keys;
+  std::vector<bool> live;
+  size_t remaining = 0;
+};
 
 /*
  * 
@@ -257,7 +314,37 @@ public:
 
   omap_rm_key_ret remove_kv(Transaction &t, laddr_t dst, const std::string &key,
     LogNodeRef prev);
-  
+
+  /**
+   * remove_kv_set
+   *
+   * Batched form of remove_kv() for an arbitrary (non-contiguous) key set:
+   * traverses the prev chain from @dst exactly once instead of once per key,
+   * and stops as soon as every key has been accounted for. Removing K keys
+   * with remove_kv() costs O(K * chain length) - and a miss always walks the
+   * whole chain - which dominates large pgmeta transactions.
+   *
+   * Unlike remove_kvs(), this does not delete a key range: only keys present
+   * in @keys are removed, so keys that merely sort between them are left
+   * alone.
+   *
+   * @param t                Transaction context.
+   * @param dst              Logical address of the LogNode to start from.
+   * @param keys             In/out. Keys to remove; each key found and
+   *                         removed is struck off, so on return the set holds
+   *                         the keys that were not present.
+   * @param multi_block_keys Out. Keys whose value spans several LogNodes.
+   *                         These are not touched here; the caller must pass
+   *                         each of them to remove_kv(), which knows how to
+   *                         unlink an entire chunk chain.
+   * @param prev             The successor of @dst in the forward direction
+   *                         (nullptr if @dst is the tail).
+   */
+  omap_rm_key_ret remove_kv_set(Transaction &t, laddr_t dst,
+    pending_keys_t &keys,
+    std::vector<std::string> &multi_block_keys,
+    LogNodeRef prev);
+
   /**
    * remove_kvs
    *

--- a/src/crimson/os/seastore/omap_manager/log/log_node.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.cc
@@ -154,8 +154,7 @@ void LogNode::set_bitmap(d_bitmap_t map) {
   append_remove(bl);
 }
 
-template <typename F>
-void LogNode::for_each_live_entry(F&& fn) {
+d_bitmap_t LogNode::get_live_bitmap() {
   d_bitmap_t bitmap;
   if (auto p = maybe_get_delta_buffer()) {
     if (auto ret = p->get_latest_d_bitmap()) {
@@ -165,18 +164,7 @@ void LogNode::for_each_live_entry(F&& fn) {
   } else {
     bitmap = get_d_bitmap();
   }
-
-  uint32_t index = 0;
-  auto iter = iter_begin();
-  while (iter != iter_end()) {
-    if (!bitmap.is_set(index)) {
-      if (fn(*iter, index)) {
-	return;
-      }
-    }
-    ++iter;
-    ++index;
-  }
+  return bitmap;
 }
 
 void LogNode::list(const std::optional<std::string> &first,

--- a/src/crimson/os/seastore/omap_manager/log/log_node.cc
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.cc
@@ -236,13 +236,13 @@ LogNode::get_value_ret LogNode::get_value(const std::string &key, copy_t c)
     std::nullopt);
 }
 
-bool LogNode::remove_entry(const std::string key)
+bool LogNode::remove_entry(std::string_view key)
 {
   auto iter = iter_begin();
   uint32_t index = 0;
   bool removed = false;
   while(iter != iter_end()) {
-    if (iter->get_key() == key) {
+    if (iter->get_key_view() == key) {
       set_cur_bitmap(index, index);
       // Duplicate keys may exist if the old entry was removed.
       removed = true;

--- a/src/crimson/os/seastore/omap_manager/log/log_node.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.h
@@ -908,8 +908,31 @@ struct LogNode
   range_t has_between(const std::optional<std::string>& start,
     const std::optional<std::string>& end);
 
+  // The deletion bitmap in effect for this transaction, i.e. including any
+  // pending delta.
+  d_bitmap_t get_live_bitmap();
+
+  /*
+   * Invoke fn(entry, index) for every entry of this node that is not marked
+   * deleted, stopping early if fn returns true. Defined here rather than in
+   * the .cc so that callers outside log_node.cc can scan a node without
+   * materialising its keys.
+   */
   template <typename F>
-  void for_each_live_entry(F&& fn);
+  void for_each_live_entry(F&& fn) {
+    d_bitmap_t bitmap = get_live_bitmap();
+    uint32_t index = 0;
+    auto iter = iter_begin();
+    while (iter != iter_end()) {
+      if (!bitmap.is_set(index)) {
+	if (fn(*iter, index)) {
+	  return;
+	}
+      }
+      ++iter;
+      ++index;
+    }
+  }
 
   void list(const std::optional<std::string> &first,
     const std::optional<std::string> &last,

--- a/src/crimson/os/seastore/omap_manager/log/log_node.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "include/denc.h"
@@ -452,10 +453,16 @@ public:
     }
 
   public:
-    std::string get_key() const {
-      return std::string(
+    // Valid as long as the node's buffer is alive. Prefer this over get_key()
+    // on scan paths: get_key() heap-allocates for every entry it touches.
+    std::string_view get_key_view() const {
+      return std::string_view(
 	get_node_val_ptr(),
 	get_node_key().key_len);
+    }
+
+    std::string get_key() const {
+      return std::string(get_key_view());
     }
 
     ceph::bufferlist get_val() const {
@@ -846,7 +853,7 @@ struct LogNode
   void append_remove(ceph::bufferlist bl);
 
   // Remove all matching keys in LogNode
-  bool remove_entry(const std::string key);
+  bool remove_entry(std::string_view key);
 
   void set_cur_bitmap(uint32_t begin, uint32_t end);
   d_bitmap_t get_cur_bitmap();

--- a/src/crimson/os/seastore/omap_manager/log/log_node.h
+++ b/src/crimson/os/seastore/omap_manager/log/log_node.h
@@ -988,6 +988,11 @@ struct LogNode
     return (capacity() - get_entry_size(ksize, 0));
   }
 
+  // Only valid on a non-empty node, as with has_multi_block_kv().
+  std::string_view get_first_key() const {
+    return iter_begin()->get_key_view();
+  }
+
   bool is_first_multi_block(const std::string &key) const {
     auto iter = iter_begin();
     return (iter->get_chunk_idx() == 1 && iter->get_key() == key);


### PR DESCRIPTION

LogManager::omap_set_keys() must remove the previous instance of every non-log key before appending the new one. It did so by calling remove_kv() once per key, and each of those calls walks the LogNode prev chain from the tail — to the end of the chain when the key isn't there at all. The cost is O(keys × chain length), which a pgmeta transaction setting thousands of missing/... keys pays in full. In teuthology job 543877 this showed up as a single SeaStore transaction taking 64.8s (33,097 remove_kv() calls, 1.9M node visits, per-key scans growing from 53 to 99 nodes), holding PG 1.2 in Activating and tripping a slow requests cluster warning that failed the job.

This series replaces the per-key removals with remove_kv_set(), which matches the whole key set as it walks the chain once and stops as soon as every key is accounted for. Supporting changes: a zero-copy LogNode::get_key_view() so scanning a node doesn't heap-allocate a std::string per entry, for_each_live_entry() moved to the header so callers outside log_node.cc can use it, and a pending_keys_t set (sorted string_view vector plus tombstone bits) sized for the K≈10²–10⁴ keys seen here. The same routine also replaces the per-key loop in omap_rm_keys()' non-contiguous fallback, which additionally fixes a bug there: it searched from log_root.addr rather than the chain it was given, so dup_ keys were never found and never removed. Each commit compiles on its own; unittest-seastore (omap/pgmeta/attr) and unittest-omap-manager pass.

Fixes: https://tracker.ceph.com/issues/80405