### PR TITLE
exporter: use service_unique_id from perf dump as RGW instance_id

### DIFF
--- a/src/exporter/DaemonMetricCollector.cc
+++ b/src/exporter/DaemonMetricCollector.cc
@@ -107,6 +107,27 @@ void DaemonMetricCollector::parse_asok_metrics(
     json_object counter_schema =
         boost::json::parse(counter_schema_response).as_object();
 
+    // If the daemon was started with --service_unique_id, it exposes a
+    // "service_unique_id" perf group whose single counter name IS the unique ID.
+    // Prefer this over filename-based parsing so Rook and cephadm deployments
+    // that share entity names still get distinct instance labels.
+    std::string service_unique_id;
+    if (counter_dump.contains("service_unique_id")) {
+      try {
+        auto &sid_array = counter_dump["service_unique_id"].as_array();
+        if (!sid_array.empty()) {
+          auto &counters = sid_array[0].as_object().at("counters").as_object();
+          if (!counters.empty()) {
+            auto it = counters.begin();
+            service_unique_id = {it->key().begin(), it->key().end()};
+          }
+        }
+      } catch (const std::exception &e) {
+        dout(1) << "Failed to extract service_unique_id for " << daemon_name
+                << ": " << e.what() << dendl;
+      }
+    }
+
     for (auto &perf_group_item : counter_schema) {
       std::string perf_group = {perf_group_item.key().begin(),
                                 perf_group_item.key().end()};
@@ -137,7 +158,7 @@ void DaemonMetricCollector::parse_asok_metrics(
                                                counter.key().end()};
               std::string counter_name = perf_group + "_" + counter_name_init;
 
-              auto extra_labels = get_extra_labels(daemon_name);
+              auto extra_labels = get_extra_labels(daemon_name, service_unique_id);
               if (extra_labels.empty()) {
                 dout(1) << "Unable to parse instance_id from daemon_name: "
                         << daemon_name << dendl;
@@ -416,7 +437,8 @@ std::string DaemonMetricCollector::asok_request(AdminSocketClient &asok,
   return response;
 }
 
-labels_t DaemonMetricCollector::get_extra_labels(std::string daemon_name) {
+labels_t DaemonMetricCollector::get_extra_labels(std::string daemon_name,
+                                                  const std::string &service_unique_id) {
   labels_t labels;
   const std::string ceph_daemon_prefix = "ceph-";
   const std::string ceph_client_prefix = "client.";
@@ -428,23 +450,29 @@ labels_t DaemonMetricCollector::get_extra_labels(std::string daemon_name) {
   }
   // In vstart cluster socket files for rgw are stored as radosgw.<instance_id>.asok
   if (daemon_name.find("radosgw") != std::string::npos) {
-    std::size_t pos = daemon_name.find_last_of('.');
-    std::string tmp = daemon_name.substr(pos+1);
-    labels["instance_id"] = quote(tmp);
-  }
-  else if (daemon_name.find("rgw") != std::string::npos) {
-    // fetch intance_id for e.g. "hrgsea" from daemon_name=rgw.foo.ceph-node-00.hrgsea.2.94739968030880
-    std::vector<std::string> elems;
-    std::stringstream ss;
-    ss.str(daemon_name);
-    std::string item;
-    while (std::getline(ss, item, '.')) {
-        elems.push_back(item);
-    }
-    if (elems.size() >= 4) {
-      labels["instance_id"] = quote(elems[3]);
+    if (!service_unique_id.empty()) {
+      labels["instance_id"] = quote(service_unique_id);
     } else {
-      return labels_t();
+      std::size_t pos = daemon_name.find_last_of('.');
+      labels["instance_id"] = quote(daemon_name.substr(pos + 1));
+    }
+  } else if (daemon_name.find("rgw") != std::string::npos) {
+    if (!service_unique_id.empty()) {
+      labels["instance_id"] = quote(service_unique_id);
+    } else {
+      // fetch instance_id for e.g. "hrgsea" from daemon_name=rgw.foo.ceph-node-00.hrgsea.2.94739968030880
+      std::vector<std::string> elems;
+      std::stringstream ss;
+      ss.str(daemon_name);
+      std::string item;
+      while (std::getline(ss, item, '.')) {
+        elems.push_back(item);
+      }
+      if (elems.size() >= 4) {
+        labels["instance_id"] = quote(elems[3]);
+      } else {
+        return labels_t();
+      }
     }
   } else {
     labels.insert({"ceph_daemon", quote(daemon_name)});

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -37,7 +37,8 @@ class DaemonMetricCollector {
 public:
   void main();
   std::string get_metrics();
-  labels_t get_extra_labels(std::string daemon_name);
+  labels_t get_extra_labels(std::string daemon_name,
+                            const std::string &service_unique_id = "");
   void dump_asok_metrics(bool sort_metrics, int64_t counter_prio,
                          bool sockClientsPing, std::string &dump_response,
                          std::string &schema_response,

--- a/src/test/exporter/test_exporter.cc
+++ b/src/test/exporter/test_exporter.cc
@@ -749,6 +749,17 @@ TEST(Exporter, check_labels_and_metric_name) {
   // This is a special case, the daemon name is not of the required size for fetching instance_id.
   // So no labels should be added.
   ASSERT_TRUE(fail_result.empty());
+
+  // When service_unique_id is provided it takes priority over filename parsing,
+  // regardless of how many dots the store/realm name contains (e.g. Rook).
+  std::string rook_daemon_name = "ceph-client.rgw.my.store.test.a.1.94334785460384";
+  labels_t rook_result = collector.get_extra_labels(rook_daemon_name, "rook-ceph-rgw-my-store-pod-abc111");
+  ASSERT_EQ(rook_result, labels_t({{"instance_id", "\"rook-ceph-rgw-my-store-pod-abc111\""}}));
+
+  // Without service_unique_id, standard cephadm filename parsing is unchanged.
+  std::string cephadm_daemon_name = "ceph-client.rgw.foo.ceph-node-00.hrgsea.2.94739968030880";
+  labels_t cephadm_result = collector.get_extra_labels(cephadm_daemon_name, "");
+  ASSERT_EQ(cephadm_result, labels_t({{"instance_id", "\"hrgsea\""}}));
 }
 
 enum LabelType {


### PR DESCRIPTION
When a daemon is started with --service_unique_id, prefer that value over filename-based instance_id parsing. This fixes metric collisions in Rook deployments where multiple RGW pods share the same entity name and produce identical socket filenames. Falls back to existing elems[3] parsing for standard cephadm deployments where no service_unique_id is set.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
