### PR TITLE
[WIP] cephadm: centralize service dependency calculation

### DIFF
--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -1029,7 +1029,7 @@ class CephadmAgentHelpers:
                         f'(last_deps={last_deps} -> deps={deps}); '
                         f'pushing updated config via HTTP')
                     daemon_spec = service_registry.get_service(daemon_type_to_service(
-                        daemon_spec.daemon_type)).prepare_create(daemon_spec)
+                        daemon_spec.daemon_type)).prepare_create(daemon_spec, spec)
                     self.mgr.agent_helpers._request_agent_acks(
                         hosts={daemon_spec.host},
                         increment=True,

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3157,7 +3157,8 @@ Then run the following:
         # deploy a new keyring file
         if daemon_spec.daemon_type != 'osd':
             daemon_spec = service_registry.get_service(daemon_type_to_service(
-                daemon_spec.daemon_type)).prepare_create(daemon_spec)
+                daemon_spec.daemon_type)).prepare_create(
+                daemon_spec, self.spec_store.active_specs.get(daemon_spec.service_name))
         with self.async_timeout_handler(daemon_spec.host, f'cephadm deploy ({daemon_spec.daemon_type} daemon)'):
             self.wait_async(CephadmServe(self)._create_daemon(daemon_spec, reconfig=True))
 
@@ -3243,12 +3244,13 @@ Then run the following:
                 action = 'redeploy'  # to ensure proper behavior since we want redeploy
             if daemon_spec.daemon_type != 'osd':
                 daemon_spec = service_registry.get_service(daemon_type_to_service(
-                    daemon_spec.daemon_type)).prepare_create(daemon_spec)
+                    daemon_spec.daemon_type)).prepare_create(
+                    daemon_spec, self.spec_store.active_specs.get(daemon_spec.service_name))
             else:
                 # for OSDs, we still need to update config, just not carry out the full
                 # prepare_create function
                 daemon_spec.final_config, daemon_spec.deps = self.osd_service.generate_config(
-                    daemon_spec)
+                    daemon_spec, self.spec_store.active_specs.get(daemon_spec.service_name))
             with self.async_timeout_handler(daemon_spec.host, f'cephadm deploy ({daemon_spec.daemon_type} daemon)'):
                 return self.wait_async(
                     CephadmServe(self)._create_daemon(daemon_spec, reconfig=(action == 'reconfig'),
@@ -3935,7 +3937,7 @@ Then run the following:
 
         @forall_hosts
         def create_func_map(*args: Any) -> str:
-            daemon_spec = service_registry.get_service(daemon_type).prepare_create(*args)
+            daemon_spec = service_registry.get_service(daemon_type).prepare_create(*args, spec=spec)
             with self.async_timeout_handler(daemon_spec.host, f'cephadm deploy ({daemon_spec.daemon_type} daemon)'):
                 return self.wait_async(CephadmServe(self)._create_daemon(daemon_spec))
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3936,8 +3936,8 @@ Then run the following:
             daemons.append(sd)
 
         @forall_hosts
-        def create_func_map(*args: Any) -> str:
-            daemon_spec = service_registry.get_service(daemon_type).prepare_create(*args, spec=spec)
+        def create_func_map(daemon_spec: CephadmDaemonDeploySpec) -> str:
+            daemon_spec = service_registry.get_service(daemon_type).prepare_create(daemon_spec, spec)
             with self.async_timeout_handler(daemon_spec.host, f'cephadm deploy ({daemon_spec.daemon_type} daemon)'):
                 return self.wait_async(CephadmServe(self)._create_daemon(daemon_spec))
 

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1105,7 +1105,7 @@ class CephadmServe:
                     slot.daemon_type, daemon_id, slot.hostname))
 
                 try:
-                    daemon_spec = svc.prepare_create(daemon_spec)
+                    daemon_spec = svc.prepare_create(daemon_spec, spec)
                     with self.mgr.async_timeout_handler(slot.hostname, f'cephadm deploy ({daemon_spec.daemon_type} type dameon)'):
                         self.mgr.wait_async(self._create_daemon(daemon_spec))
                     r = True

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -340,12 +340,13 @@ class CephadmService(metaclass=ABCMeta):
         spec: Optional[ServiceSpec] = None,
         daemon_type: Optional[str] = None,
     ) -> List[str]:
+        """Return the complete dependency set for this service."""
+        deps = cls._get_dependencies(mgr, spec, daemon_type)
 
         ssl_enabled = getattr(spec, 'ssl', False)
         if not spec or not ssl_enabled:
-            return []
+            return sorted(deps)
 
-        deps = []
         cert_source = getattr(spec, 'certificate_source', None)
         if cert_source:
             deps.append(f'certificate_source: {cert_source}')
@@ -356,6 +357,20 @@ class CephadmService(metaclass=ABCMeta):
             deps.append(f'ssl_ca_cert: {str(utils.config_hash(spec.ssl_ca_cert))}')
 
         return sorted(deps)
+
+    @classmethod
+    def _get_dependencies(
+        cls,
+        mgr: "CephadmOrchestrator",
+        spec: Optional[ServiceSpec] = None,
+        daemon_type: Optional[str] = None,
+    ) -> List[str]:
+        """Return service-specific dependencies.
+
+        Services should override this hook rather than ``get_dependencies`` so
+        common dependencies are always included.
+        """
+        return []
 
     @classmethod
     def sorted_dependencies(

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1318,7 +1318,7 @@ class MgrService(CephService):
         return ports
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         return sorted(
@@ -1492,7 +1492,7 @@ class RgwService(CephService):
         return True
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []
@@ -1506,8 +1506,7 @@ class RgwService(CephService):
                 ssl_cert = '\n'.join(ssl_cert)
             deps.append(f'ssl-cert:{utils.config_hash(ssl_cert)}')
 
-        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
-        return sorted(deps + parent_deps)
+        return sorted(deps)
 
     def set_realm_zg_zone(self, spec: RGWSpec) -> None:
         assert self.TYPE == spec.service_type
@@ -2044,7 +2043,7 @@ class CephExporterService(CephService):
         return True
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
 
@@ -2143,7 +2142,7 @@ class CephadmAgent(CephService):
     TYPE = 'agent'
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         agent = mgr.http_server.agent

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1339,8 +1339,8 @@ class MgrService(CephService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         return sorted(
             [f'port:{p}' for p in cls._get_mgr_service_ports(mgr)]
             + [f'sd_port:{mgr.service_discovery_port}']
@@ -1525,8 +1525,8 @@ class RgwService(CephService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []
         # we keep the following deps calculation for backward compatibility
         # as old RGW specs use rgw_frontend_ssl_certificate instead of modern
@@ -2092,8 +2092,8 @@ class CephExporterService(CephService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
 
         deps = [f'secure_monitoring_stack:{mgr.secure_monitoring_stack}']
         deps += mgr.cache.get_daemons_by_types(['mgmt-gateway'])
@@ -2199,8 +2199,8 @@ class CephadmAgent(CephService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         agent = mgr.http_server.agent
         return sorted(
             [

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1087,7 +1087,8 @@ class CephService(CephadmService):
         if daemon_spec.config_get_files():
             cephadm_config.update({'files': daemon_spec.config_get_files()})
 
-        return cephadm_config, []
+        return cephadm_config, self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
 
     def post_remove(self, daemon: DaemonDescription, is_failed_deploy: bool) -> None:
         super().post_remove(daemon, is_failed_deploy=is_failed_deploy)
@@ -1351,8 +1352,7 @@ class MgrService(CephService):
             daemon_spec: CephadmDaemonDeploySpec,
             spec: Optional[ServiceSpec] = None,
     ) -> Tuple[Dict[str, Any], List[str]]:
-        config, _ = super().generate_config(daemon_spec, spec)
-        return config, self.get_dependencies(self.mgr)
+        return super().generate_config(daemon_spec, spec)
 
     def prepare_create(
             self,
@@ -1970,7 +1970,7 @@ class RgwService(CephService):
             spec: Optional[ServiceSpec] = None,
     ) -> Tuple[Dict[str, Any], List[str]]:
         svc_spec = cast(RGWSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
-        config, parent_deps = super().generate_config(daemon_spec, spec)
+        config, deps = super().generate_config(daemon_spec, svc_spec)
 
         if hasattr(svc_spec, 'rgw_exit_timeout_secs') and svc_spec.rgw_exit_timeout_secs:
             config['rgw_exit_timeout_secs'] = svc_spec.rgw_exit_timeout_secs
@@ -1982,8 +1982,7 @@ class RgwService(CephService):
         if d3n_cache:
             config['d3n_cache'] = d3n_cache.to_json()
 
-        rgw_deps = parent_deps + self.get_dependencies(self.mgr, svc_spec)
-        return config, rgw_deps
+        return config, deps
 
     def get_active_ports(self, service_name: str) -> List[int]:
         """
@@ -2134,7 +2133,6 @@ class CephExporterService(CephService):
         daemon_spec.keyring = keyring
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
         daemon_spec.final_config = merge_dicts(daemon_spec.final_config, exporter_config)
-        daemon_spec.deps = self.get_dependencies(self.mgr)
 
         return daemon_spec
 
@@ -2261,9 +2259,8 @@ class CephadmAgent(CephService):
             'listener.key': tls_creds.key,
         }
 
-        return config, sorted([str(self.mgr.get_mgr_ip()), str(agent.server_port),
-                               self.mgr.cert_mgr.get_root_ca(),
-                               str(self.mgr.get_module_option('device_enhanced_scan'))])
+        return config, self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
 
 
 def next_action_for_mgmt_stack_service(

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -706,12 +706,20 @@ class CephadmService(metaclass=ABCMeta):
         if cert_source != CertificateSource.CEPHADM_SIGNED.value:
             self.mgr.cert_mgr.try_rm_self_signed_cert_key_pair(svc_name, host)
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         self.prepare_certificates(daemon_spec)
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
         return daemon_spec
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         raise NotImplementedError()
 
     def config(self, spec: ServiceSpec) -> None:
@@ -1063,7 +1071,11 @@ class CephadmService(metaclass=ABCMeta):
 
 class CephService(CephadmService):
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         # Ceph.daemons (mon, mgr, mds, osd, etc)
         cephadm_config = self.get_config_and_keyring(
             daemon_spec.daemon_type,
@@ -1130,7 +1142,11 @@ class CephService(CephadmService):
 class MonService(CephService):
     TYPE = 'mon'
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         """
         Create a new monitor on the given host.
         """
@@ -1176,7 +1192,7 @@ class MonService(CephService):
         daemon_spec.ceph_conf = extra_config
         daemon_spec.keyring = keyring
 
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
 
         return daemon_spec
 
@@ -1229,8 +1245,12 @@ class MonService(CephService):
         # super().post_remove(daemon)
         pass
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
-        daemon_spec.final_config, daemon_spec.deps = super().generate_config(daemon_spec)
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
+        daemon_spec.final_config, daemon_spec.deps = super().generate_config(daemon_spec, spec)
 
         # realistically, we expect there to always be a mon spec
         # in a real deployment, but the way teuthology deploys some daemons
@@ -1326,11 +1346,19 @@ class MgrService(CephService):
             + [f'sd_port:{mgr.service_discovery_port}']
         )
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
-        config, _ = super().generate_config(daemon_spec)
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
+        config, _ = super().generate_config(daemon_spec, spec)
         return config, self.get_dependencies(self.mgr)
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         """
         Create a new manager instance on a host.
         """
@@ -1357,7 +1385,7 @@ class MgrService(CephService):
         daemon_spec.ports = ports + [self.mgr.service_discovery_port]
         daemon_spec.keyring = keyring
 
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
 
         return daemon_spec
 
@@ -1446,7 +1474,11 @@ class MdsService(CephService):
             'value': spec.service_id,
         })
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         mds_id, _ = daemon_spec.daemon_id, daemon_spec.host
 
@@ -1457,7 +1489,7 @@ class MdsService(CephService):
                                               'mds', 'allow'])
         daemon_spec.keyring = keyring
 
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
 
         return daemon_spec
 
@@ -1618,7 +1650,11 @@ class RgwService(CephService):
             cache_path=cache_path,
         )
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         super().prepare_certificates(daemon_spec)
         rgw_id, _ = daemon_spec.daemon_id, daemon_spec.host
@@ -1785,7 +1821,7 @@ class RgwService(CephService):
             })
 
         daemon_spec.keyring = keyring
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
 
         d3n_cache = daemon_spec.final_config.get('d3n_cache')
 
@@ -1928,9 +1964,13 @@ class RgwService(CephService):
     def config_dashboard(self, daemon_descrs: List[DaemonDescription]) -> None:
         self.mgr.trigger_connect_dashboard_rgw()
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         svc_spec = cast(RGWSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
-        config, parent_deps = super().generate_config(daemon_spec)
+        config, parent_deps = super().generate_config(daemon_spec, spec)
 
         if hasattr(svc_spec, 'rgw_exit_timeout_secs') and svc_spec.rgw_exit_timeout_secs:
             config['rgw_exit_timeout_secs'] = svc_spec.rgw_exit_timeout_secs
@@ -1986,7 +2026,11 @@ class RbdMirrorService(CephService):
     def allow_colo(self) -> bool:
         return True
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         daemon_id, _ = daemon_spec.daemon_id, daemon_spec.host
 
@@ -1996,7 +2040,7 @@ class RbdMirrorService(CephService):
 
         daemon_spec.keyring = keyring
 
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
 
         return daemon_spec
 
@@ -2018,7 +2062,11 @@ class RbdMirrorService(CephService):
 class CrashService(CephService):
     TYPE = 'crash'
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
 
@@ -2028,7 +2076,7 @@ class CrashService(CephService):
 
         daemon_spec.keyring = keyring
 
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
 
         return daemon_spec
 
@@ -2051,7 +2099,11 @@ class CephExporterService(CephService):
         deps += mgr.cache.get_daemons_by_types(['mgmt-gateway'])
         return sorted(deps)
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         super().prepare_certificates(daemon_spec)
         spec = cast(CephExporterSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
@@ -2080,7 +2132,7 @@ class CephExporterService(CephService):
             }
 
         daemon_spec.keyring = keyring
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
         daemon_spec.final_config = merge_dicts(daemon_spec.final_config, exporter_config)
         daemon_spec.deps = self.get_dependencies(self.mgr)
 
@@ -2120,7 +2172,11 @@ class CephfsMirrorService(CephService):
             # we shouldn't get here (mon will tell the mgr to respawn), but no
             # harm done if we do.
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
 
         ret, keyring, err = self.mgr.check_mon_command({
@@ -2133,7 +2189,7 @@ class CephfsMirrorService(CephService):
         })
 
         daemon_spec.keyring = keyring
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
         return daemon_spec
 
 
@@ -2155,9 +2211,13 @@ class CephadmAgent(CephService):
             ]
         )
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
-        super().prepare_create(daemon_spec)
+        super().prepare_create(daemon_spec, spec)
         daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
         daemon_spec.ports = [self.mgr.agent_starting_port]
 
@@ -2168,11 +2228,15 @@ class CephadmAgent(CephService):
         daemon_spec.keyring = keyring
         self.mgr.agent_cache.agent_keys[host] = keyring
 
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
 
         return daemon_spec
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         agent = self.mgr.http_server.agent
         try:
             assert agent

--- a/src/pybind/mgr/cephadm/services/container.py
+++ b/src/pybind/mgr/cephadm/services/container.py
@@ -1,7 +1,7 @@
 import logging
-from typing import List, Any, Tuple, Dict, cast
+from typing import List, Any, Tuple, Dict, cast, Optional
 
-from ceph.deployment.service_spec import CustomContainerSpec
+from ceph.deployment.service_spec import CustomContainerSpec, ServiceSpec
 from .service_registry import register_cephadm_service
 
 from .cephadmservice import CephadmService, CephadmDaemonDeploySpec
@@ -13,13 +13,13 @@ logger = logging.getLogger(__name__)
 class CustomContainerService(CephadmService):
     TYPE = 'container'
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) \
+    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec, spec: Optional[ServiceSpec] = None) \
             -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
         return daemon_spec
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) \
+    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec, spec: Optional[ServiceSpec] = None) \
             -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         deps: List[str] = []

--- a/src/pybind/mgr/cephadm/services/container.py
+++ b/src/pybind/mgr/cephadm/services/container.py
@@ -22,9 +22,9 @@ class CustomContainerService(CephadmService):
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec, spec: Optional[ServiceSpec] = None) \
             -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
-        deps: List[str] = []
         spec = cast(CustomContainerSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
         config: Dict[str, Any] = spec.config_json()
+        deps = self.get_dependencies(self.mgr, spec, daemon_spec.daemon_type)
         logger.debug(
             'Generated configuration for \'%s\' service: config-json=%s, dependencies=%s' %
             (self.TYPE, config, deps))

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -9,7 +9,7 @@ from ceph.deployment.utils import is_ipv6
 from mgr_util import build_url
 from cephadm import utils
 from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus
-from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService, CephadmService
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService
 from .service_registry import register_cephadm_service
 from cephadm.tlsobject_types import TLSCredentials
 from cephadm.schedule import get_placement_hosts
@@ -38,7 +38,7 @@ class IngressService(CephService):
         return 'haproxy_monitor_ssl_key'
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         if daemon_type == 'haproxy':
@@ -123,8 +123,7 @@ class IngressService(CephService):
             hosts = get_placement_hosts(spec, mgr.cache.get_schedulable_hosts(), mgr.cache.get_draining_hosts())
             deps.append(f'placement_hosts:{",".join(sorted(h.hostname for h in hosts))}')
 
-        parent_deps = CephadmService.get_dependencies(mgr, spec)
-        return sorted(deps + parent_deps)
+        return sorted(deps)
 
     def haproxy_generate_config(
             self,
@@ -299,7 +298,7 @@ class IngressService(CephService):
             monitor_ssl_cert = [tls_creds.cert, tls_creds.key]
             config_files['files']['stats_haproxy.pem'] = '\n'.join(monitor_ssl_cert)
 
-        return config_files, self.get_haproxy_dependencies(self.mgr, spec)
+        return config_files, self.get_dependencies(self.mgr, spec, 'haproxy')
 
     def get_stats_certs(
         self,
@@ -567,7 +566,7 @@ class IngressService(CephService):
             }
         }
 
-        return config_file, self.get_keepalived_dependencies(self.mgr, spec)
+        return config_file, self.get_dependencies(self.mgr, spec, 'keepalived')
 
     def get_monitoring_details(self, service_name: str, host: str) -> Tuple[Optional[str], Optional[int]]:
         spec = cast(IngressSpec, self.mgr.spec_store[service_name].spec)

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -71,8 +71,9 @@ class IngressService(CephService):
     def prepare_create(
             self,
             daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
     ) -> CephadmDaemonDeploySpec:
-        super().prepare_create(daemon_spec)
+        super().prepare_create(daemon_spec, spec)
         if daemon_spec.daemon_type == 'haproxy':
             return self.haproxy_prepare_create(daemon_spec)
         if daemon_spec.daemon_type == 'keepalived':
@@ -81,7 +82,8 @@ class IngressService(CephService):
 
     def generate_config(
             self,
-            daemon_spec: CephadmDaemonDeploySpec
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
     ) -> Tuple[Dict[str, Any], List[str]]:
         if daemon_spec.daemon_type == 'haproxy':
             return self.haproxy_generate_config(daemon_spec)

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -39,8 +39,8 @@ class IngressService(CephService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         if daemon_type == 'haproxy':
             return IngressService.get_haproxy_dependencies(mgr, spec)
         elif daemon_type == 'keepalived':

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -52,7 +52,11 @@ class IscsiService(CephService):
 
         return sorted(deps)
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
 
         super().prepare_certificates(daemon_spec)
@@ -91,7 +95,7 @@ class IscsiService(CephService):
 
         daemon_spec.keyring = keyring
         daemon_spec.extra_files = {'iscsi-gateway.cfg': igw_conf}
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
         daemon_spec.deps = self.get_dependencies(self.mgr, spec)
         return daemon_spec
 

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -41,8 +41,8 @@ class IscsiService(CephService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []
         if spec:
             iscsi_spec = cast(IscsiServiceSpec, spec)

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -40,7 +40,7 @@ class IscsiService(CephService):
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []
@@ -50,8 +50,7 @@ class IscsiService(CephService):
         else:
             deps = [mgr.get_mgr_ip()]
 
-        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
-        return sorted(deps + parent_deps)
+        return sorted(deps)
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -96,7 +96,6 @@ class IscsiService(CephService):
         daemon_spec.keyring = keyring
         daemon_spec.extra_files = {'iscsi-gateway.cfg': igw_conf}
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
-        daemon_spec.deps = self.get_dependencies(self.mgr, spec)
         return daemon_spec
 
     def config_dashboard(self, daemon_descrs: List[DaemonDescription]) -> None:

--- a/src/pybind/mgr/cephadm/services/jaeger.py
+++ b/src/pybind/mgr/cephadm/services/jaeger.py
@@ -32,8 +32,8 @@ class JaegerAgentService(CephadmService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []  # type: List[str]
         for dd in mgr.cache.get_daemons_by_type(JaegerCollectorService.TYPE):
             # scrape jaeger-collector nodes

--- a/src/pybind/mgr/cephadm/services/jaeger.py
+++ b/src/pybind/mgr/cephadm/services/jaeger.py
@@ -16,7 +16,11 @@ class ElasticSearchService(CephadmService):
     TYPE = 'elasticsearch'
     DEFAULT_SERVICE_PORT = 9200
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         return daemon_spec
 
@@ -39,7 +43,11 @@ class JaegerAgentService(CephadmService):
             deps.append(url)
         return sorted(deps)
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         collectors = []
         for dd in self.mgr.cache.get_daemons_by_type(JaegerCollectorService.TYPE):
@@ -81,7 +89,11 @@ class JaegerCollectorService(CephadmService):
     TYPE = 'jaeger-collector'
     DEFAULT_SERVICE_PORT = 14250
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         elasticsearch_nodes = get_elasticsearch_nodes(self, daemon_spec)
         daemon_spec.final_config = {'elasticsearch_nodes': ",".join(elasticsearch_nodes)}
@@ -93,7 +105,11 @@ class JaegerQueryService(CephadmService):
     TYPE = 'jaeger-query'
     DEFAULT_SERVICE_PORT = 16686
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         elasticsearch_nodes = get_elasticsearch_nodes(self, daemon_spec)
         daemon_spec.final_config = {'elasticsearch_nodes': ",".join(elasticsearch_nodes)}

--- a/src/pybind/mgr/cephadm/services/jaeger.py
+++ b/src/pybind/mgr/cephadm/services/jaeger.py
@@ -22,6 +22,8 @@ class ElasticSearchService(CephadmService):
             spec: Optional[ServiceSpec] = None,
     ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
+        daemon_spec.deps = self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
         return daemon_spec
 
 
@@ -57,7 +59,8 @@ class JaegerAgentService(CephadmService):
             url = build_url(host=dd.hostname, port=port).lstrip('/')
             collectors.append(url)
         daemon_spec.final_config = {'collector_nodes': ",".join(collectors)}
-        daemon_spec.deps = self.get_dependencies(self.mgr)
+        daemon_spec.deps = self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
         return daemon_spec
 
     def choose_next_action(
@@ -97,6 +100,8 @@ class JaegerCollectorService(CephadmService):
         assert self.TYPE == daemon_spec.daemon_type
         elasticsearch_nodes = get_elasticsearch_nodes(self, daemon_spec)
         daemon_spec.final_config = {'elasticsearch_nodes': ",".join(elasticsearch_nodes)}
+        daemon_spec.deps = self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
         return daemon_spec
 
 
@@ -113,6 +118,8 @@ class JaegerQueryService(CephadmService):
         assert self.TYPE == daemon_spec.daemon_type
         elasticsearch_nodes = get_elasticsearch_nodes(self, daemon_spec)
         daemon_spec.final_config = {'elasticsearch_nodes': ",".join(elasticsearch_nodes)}
+        daemon_spec.deps = self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
         return daemon_spec
 
 

--- a/src/pybind/mgr/cephadm/services/jaeger.py
+++ b/src/pybind/mgr/cephadm/services/jaeger.py
@@ -27,7 +27,7 @@ class JaegerAgentService(CephadmService):
     DEFAULT_SERVICE_PORT = 6799
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []  # type: List[str]

--- a/src/pybind/mgr/cephadm/services/mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/services/mgmt_gateway.py
@@ -24,11 +24,15 @@ class MgmtGatewayService(CephadmService):
     INTERNAL_SVC_TEMPLATE_PATH = 'services/mgmt-gateway/internal_server.conf.j2'
     INTERNAL_SERVICE_PORT = 29443
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         super().prepare_certificates(daemon_spec)
         self.mgr.cert_mgr.register_self_signed_cert_key_pair(MgmtGatewayService.TYPE, INTERNAL_CERT_LABEL)
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
         return daemon_spec
 
     def get_service_endpoints(self, service_name: str) -> List[str]:
@@ -88,7 +92,11 @@ class MgmtGatewayService(CephadmService):
         ]
         return sorted(deps)
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         svc_spec = cast(MgmtGatewaySpec, self.mgr.spec_store[daemon_spec.service_name].spec)
         scheme = 'https'

--- a/src/pybind/mgr/cephadm/services/mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/services/mgmt_gateway.py
@@ -154,7 +154,8 @@ class MgmtGatewayService(CephadmService):
             daemon_config["files"]["nginx.crt"] = tls_pair.cert
             daemon_config["files"]["nginx.key"] = tls_pair.key
 
-        return daemon_config, sorted(MgmtGatewayService.get_dependencies(self.mgr))
+        return daemon_config, self.get_dependencies(
+            self.mgr, svc_spec, daemon_spec.daemon_type)
 
     def post_remove(self, daemon: DaemonDescription, is_failed_deploy: bool) -> None:
         """

--- a/src/pybind/mgr/cephadm/services/mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/services/mgmt_gateway.py
@@ -76,8 +76,8 @@ class MgmtGatewayService(CephadmService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         # url_prefix for the following services depends on the presence of mgmt-gateway
         deps = [
             f'{d.name()}:{d.ports[0]}' if d.ports else d.name()

--- a/src/pybind/mgr/cephadm/services/mgmt_gateway.py
+++ b/src/pybind/mgr/cephadm/services/mgmt_gateway.py
@@ -71,7 +71,7 @@ class MgmtGatewayService(CephadmService):
         return sd_endpoints
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         # url_prefix for the following services depends on the presence of mgmt-gateway
@@ -86,8 +86,7 @@ class MgmtGatewayService(CephadmService):
             for service in ['mgr']
             for d in mgr.cache.get_daemons_by_service(service)
         ]
-        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
-        return sorted(deps + parent_deps)
+        return sorted(deps)
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -108,7 +108,7 @@ class GrafanaService(CephadmService):
         })
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
 
@@ -126,8 +126,7 @@ class GrafanaService(CephadmService):
         for service in ['prometheus', 'loki', 'mgmt-gateway', 'oauth2-proxy']:
             deps += [d.name() for d in mgr.cache.get_daemons_by_service(service)]
 
-        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
-        return sorted(deps + parent_deps)
+        return sorted(deps)
 
     def generate_prom_services(self, security_enabled: bool, mgmt_gw_enabled: bool) -> List[str]:
 
@@ -304,7 +303,7 @@ class AlertmanagerService(CephadmService):
         return self.get_certificates(daemon_spec, ips=host_ips, fqdns=host_fqdns)
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []
@@ -690,7 +689,7 @@ class PrometheusService(CephadmService):
         return r, self.get_dependencies(self.mgr, spec=spec)
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []  # type: List[str]
@@ -846,7 +845,7 @@ class NodeExporterService(CephadmService):
         return True
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []
@@ -927,7 +926,7 @@ class AlloyService(CephadmService):
     DEFAULT_SERVICE_PORT = 9080
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         return sorted(mgr.cache.get_daemons_by_types(['loki']))
@@ -964,7 +963,7 @@ class PromtailService(CephadmService):
     DEFAULT_SERVICE_PORT = 9080
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         return sorted(mgr.cache.get_daemons_by_types(['loki']))

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -109,8 +109,8 @@ class GrafanaService(CephadmService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
 
         deps = []  # type: List[str]
         security_enabled, mgmt_gw_enabled, _ = mgr._get_security_config()
@@ -197,9 +197,12 @@ class GrafanaService(CephadmService):
             }
         }
 
-        spec: GrafanaSpec = cast(GrafanaSpec, self.mgr.spec_store.active_specs[daemon_spec.service_name])
-        if 'dashboard' in self.mgr.get('mgr_map')['modules'] and spec.initial_admin_password:
-            self.mgr.check_mon_command({'prefix': 'dashboard set-grafana-api-password'}, inbuf=spec.initial_admin_password)
+        grafana_spec = cast(
+            GrafanaSpec,
+            spec if spec is not None else self.mgr.spec_store.active_specs[daemon_spec.service_name],
+        )
+        if 'dashboard' in self.mgr.get('mgr_map')['modules'] and grafana_spec.initial_admin_password:
+            self.mgr.check_mon_command({'prefix': 'dashboard set-grafana-api-password'}, inbuf=grafana_spec.initial_admin_password)
 
         # include dashboards, if present in the container
         if os.path.exists(grafana_dashboards_path):
@@ -209,7 +212,7 @@ class GrafanaService(CephadmService):
                     dashboard = f.read()
                     config_file['files'][f'/etc/grafana/provisioning/dashboards/{file_name}'] = dashboard
 
-        return config_file, self.get_dependencies(self.mgr, spec)
+        return config_file, self.get_dependencies(self.mgr, grafana_spec, daemon_spec.daemon_type)
 
     def get_active_daemon(self, daemon_descrs: List[DaemonDescription]) -> DaemonDescription:
         # Use the least-created one as the active daemon
@@ -308,8 +311,8 @@ class AlertmanagerService(CephadmService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []
         deps.append(f'secure_monitoring_stack:{mgr.secure_monitoring_stack}')
         deps += mgr.cache.get_daemons_by_types(['alertmanager', 'snmp-gateway', 'mgmt-gateway', 'oauth2-proxy'])
@@ -699,8 +702,8 @@ class PrometheusService(CephadmService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []  # type: List[str]
         deps.append(str(mgr.service_discovery_port))
         deps.append(f'secure_monitoring_stack:{mgr.secure_monitoring_stack}')
@@ -855,8 +858,8 @@ class NodeExporterService(CephadmService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         deps = []
         deps.append(f'secure_monitoring_stack:{mgr.secure_monitoring_stack}')
         deps += mgr.cache.get_daemons_by_types(['mgmt-gateway'])
@@ -944,8 +947,8 @@ class AlloyService(CephadmService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         return sorted(mgr.cache.get_daemons_by_types(['loki']))
 
     def prepare_create(
@@ -989,8 +992,8 @@ class PromtailService(CephadmService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         return sorted(mgr.cache.get_daemons_by_types(['loki']))
 
     def generate_config(

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -160,7 +160,11 @@ class GrafanaService(CephadmService):
         host_fqdns = [self.mgr.get_fqdn(daemon_spec.host), 'grafana_servers']
         return self.get_certificates(daemon_spec, ips=host_ips, fqdns=host_fqdns)
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
 
         tls_pair = self.get_grafana_certificates(daemon_spec)
@@ -321,7 +325,11 @@ class AlertmanagerService(CephadmService):
 
         return sorted(deps)
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         webhook_urls: List[str] = []
 
@@ -581,6 +589,7 @@ class PrometheusService(CephadmService):
     def generate_config(
             self,
             daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
     ) -> Tuple[Dict[str, Any], List[str]]:
 
         assert self.TYPE == daemon_spec.daemon_type
@@ -853,7 +862,11 @@ class NodeExporterService(CephadmService):
         deps += mgr.cache.get_daemons_by_types(['mgmt-gateway'])
         return sorted(deps)
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         deps = []
         deps += [d.name() for d in self.mgr.cache.get_daemons_by_service('mgmt-gateway')]
@@ -908,7 +921,11 @@ class LokiService(CephadmService):
     TYPE = 'loki'
     DEFAULT_SERVICE_PORT = 3100
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         deps: List[str] = []
 
@@ -931,12 +948,20 @@ class AlloyService(CephadmService):
                          daemon_type: Optional[str] = None) -> List[str]:
         return sorted(mgr.cache.get_daemons_by_types(['loki']))
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
         return daemon_spec
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         daemons = self.mgr.cache.get_daemons_by_service('loki')
         loki_host = ''
@@ -968,7 +993,11 @@ class PromtailService(CephadmService):
                          daemon_type: Optional[str] = None) -> List[str]:
         return sorted(mgr.cache.get_daemons_by_types(['loki']))
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         deps: List[str] = self.get_dependencies(self.mgr)
         daemons = self.mgr.cache.get_daemons_by_service('loki')
@@ -994,7 +1023,11 @@ class PromtailService(CephadmService):
 class SNMPGatewayService(CephadmService):
     TYPE = 'snmp-gateway'
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         deps: List[str] = []
 

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -212,7 +212,8 @@ class GrafanaService(CephadmService):
                     dashboard = f.read()
                     config_file['files'][f'/etc/grafana/provisioning/dashboards/{file_name}'] = dashboard
 
-        return config_file, self.get_dependencies(self.mgr, grafana_spec, daemon_spec.daemon_type)
+        return config_file, self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
 
     def get_active_daemon(self, daemon_descrs: List[DaemonDescription]) -> DaemonDescription:
         # Use the least-created one as the active daemon
@@ -386,7 +387,7 @@ class AlertmanagerService(CephadmService):
             if ip_to_bind_to:
                 daemon_spec.port_ips = {str(port): ip_to_bind_to}
 
-        deps = self.get_dependencies(self.mgr)
+        deps = self.get_dependencies(self.mgr, spec, daemon_spec.daemon_type)
         if security_enabled:
             alertmanager_user, alertmanager_password = self.mgr._get_alertmanager_credentials()
             tls_pair = self.get_alertmanager_certificates(daemon_spec)
@@ -698,7 +699,8 @@ class PrometheusService(CephadmService):
 
         self.configure_alerts(r)
 
-        return r, self.get_dependencies(self.mgr, spec=spec)
+        return r, self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
@@ -871,9 +873,6 @@ class NodeExporterService(CephadmService):
             spec: Optional[ServiceSpec] = None,
     ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
-        deps = []
-        deps += [d.name() for d in self.mgr.cache.get_daemons_by_service('mgmt-gateway')]
-        deps += [f'secure_monitoring_stack:{self.mgr.secure_monitoring_stack}']
         security_enabled, mgmt_gw_enabled, _ = self.mgr._get_security_config()
         if security_enabled:
             tls_pair = self.get_certificates(daemon_spec)
@@ -890,7 +889,8 @@ class NodeExporterService(CephadmService):
         else:
             r = {}
 
-        return r, deps
+        return r, self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
 
     def ok_to_stop(self,
                    daemon_ids: List[str],
@@ -930,14 +930,12 @@ class LokiService(CephadmService):
             spec: Optional[ServiceSpec] = None,
     ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
-        deps: List[str] = []
-
         yml = self.mgr.template.render('services/loki.yml.j2')
         return {
             "files": {
                 "loki.yml": yml
             }
-        }, sorted(deps)
+        }, self.get_dependencies(self.mgr, spec, daemon_spec.daemon_type)
 
 
 @register_cephadm_service
@@ -982,7 +980,7 @@ class AlloyService(CephadmService):
             "files": {
                 "config.alloy": alloy_config
             }
-        }, self.get_dependencies(self.mgr)
+        }, self.get_dependencies(self.mgr, spec, daemon_spec.daemon_type)
 
 
 @register_cephadm_service
@@ -1002,7 +1000,8 @@ class PromtailService(CephadmService):
             spec: Optional[ServiceSpec] = None,
     ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
-        deps: List[str] = self.get_dependencies(self.mgr)
+        deps: List[str] = self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
         daemons = self.mgr.cache.get_daemons_by_service('loki')
         loki_host = ''
         for i, dd in enumerate(daemons):
@@ -1032,8 +1031,6 @@ class SNMPGatewayService(CephadmService):
             spec: Optional[ServiceSpec] = None,
     ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
-        deps: List[str] = []
-
         spec = cast(SNMPGatewaySpec, self.mgr.spec_store[daemon_spec.service_name].spec)
         config = {
             "destination": spec.snmp_destination,
@@ -1072,7 +1069,8 @@ class SNMPGatewayService(CephadmService):
                     "snmp_v3_priv_password": priv_password,
                 })
 
+        deps = self.get_dependencies(self.mgr, spec, daemon_spec.daemon_type)
         logger.debug(
             f"Generated configuration for '{self.TYPE}' service. Dependencies={deps}")
 
-        return config, sorted(deps)
+        return config, deps

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -189,9 +189,13 @@ class NFSService(CephService):
 
         return sorted(deps)
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
         return daemon_spec
 
     def get_daemon_nodeid(self, service_name: str, rank: Optional[int]) -> str:
@@ -206,7 +210,11 @@ class NFSService(CephService):
             return f'nfs.{daemon_id}'
         return f'{service_name}'
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         super().prepare_certificates(daemon_spec)
         daemon_type = daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -410,7 +410,8 @@ class NFSService(CephService):
             logger.debug('Generated cephadm config-json: %s' % config)
             return config
 
-        return get_cephadm_config(), self.get_dependencies(self.mgr, nfs_spec, daemon_spec.daemon_type)
+        return get_cephadm_config(), self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
 
     def pre_daemon_service_config(self, spec: ServiceSpec) -> None:
         nfs_spec = cast(NFSServiceSpec, spec)

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -220,9 +220,12 @@ class NFSService(CephService):
         daemon_type = daemon_spec.daemon_type
         daemon_id = daemon_spec.daemon_id
         host = daemon_spec.host
-        spec = cast(NFSServiceSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
+        nfs_spec = cast(
+            NFSServiceSpec,
+            spec if spec is not None else self.mgr.spec_store[daemon_spec.service_name].spec,
+        )
 
-        nodeid = self.get_daemon_nodeid(spec.service_name(), daemon_spec.rank)
+        nodeid = self.get_daemon_nodeid(nfs_spec.service_name(), daemon_spec.rank)
 
         nfs_idmap_conf = '/etc/ganesha/idmap.conf'
 
@@ -234,7 +237,7 @@ class NFSService(CephService):
         self.mgr.log.info(
             'Ensuring %s is in the ganesha grace table for service %s', nodeid, daemon_spec.service_name
         )
-        self.run_grace_tool(spec, 'add', nodeid)
+        self.run_grace_tool(nfs_spec, 'add', nodeid)
 
         port = daemon_spec.ports[0] if daemon_spec.ports else 2049
         monitoring_ip, monitoring_port = self.get_monitoring_details(daemon_spec.service_name, host, daemon_spec)
@@ -244,11 +247,11 @@ class NFSService(CephService):
         rgw_keyring = self.create_rgw_keyring(daemon_spec)
         bind_addr = ''
 
-        if spec.virtual_ip and not spec.enable_haproxy_protocol:
+        if nfs_spec.virtual_ip and not nfs_spec.enable_haproxy_protocol:
             # keepalive_only mode: prioritize virtual_ip
-            bind_addr = spec.virtual_ip
-            daemon_spec.port_ips = {str(port): spec.virtual_ip}
-            # update daemon spec ip for prometheus, as monitoring will happen on this
+            bind_addr = nfs_spec.virtual_ip
+            daemon_spec.port_ips = {str(port): nfs_spec.virtual_ip}
+            # update daemon nfs_spec ip for prometheus, as monitoring will happen on this
             # ip, if no monitor ip specified
             daemon_spec.ip = bind_addr
         elif daemon_spec.ip:
@@ -260,7 +263,7 @@ class NFSService(CephService):
         else:
             logger.debug("using haproxy bind address: %r", bind_addr)
 
-        if spec.enable_rdma:
+        if nfs_spec.enable_rdma:
             from cephadm.serve import CephadmServe
             # During a cluster upgrade, prepare_create run on the asyncio
             # event-loop thread; a nested wait_async(cephadm list-rdma) there would
@@ -292,7 +295,7 @@ class NFSService(CephService):
             daemon_spec.port_ips.update({str(monitoring_port): monitoring_ip})
 
         ceph_nodes = []
-        hosts = get_placement_hosts(spec, self.mgr.cache.get_schedulable_hosts(), self.mgr.cache.get_draining_hosts())
+        hosts = get_placement_hosts(nfs_spec, self.mgr.cache.get_schedulable_hosts(), self.mgr.cache.get_draining_hosts())
         for host in hosts:
             host_ip = self.mgr.inventory.get_addr(host.hostname)
             ceph_nodes.append(host_ip)
@@ -300,24 +303,24 @@ class NFSService(CephService):
         cluster_qos_port = None
         if daemon_spec.ports and len(daemon_spec.ports) > 2:
             cluster_qos_port = daemon_spec.ports[2]
-        elif spec.cluster_qos_port:
-            cluster_qos_port = spec.cluster_qos_port
+        elif nfs_spec.cluster_qos_port:
+            cluster_qos_port = nfs_spec.cluster_qos_port
 
         # generate the ganesha config
         rdma_port = None
-        if spec.enable_rdma and daemon_spec.ports and len(daemon_spec.ports) > 3:
+        if nfs_spec.enable_rdma and daemon_spec.ports and len(daemon_spec.ports) > 3:
             rdma_port = daemon_spec.ports[3]
-        elif spec.enable_rdma:
-            rdma_port = spec.rdma_port
+        elif nfs_spec.enable_rdma:
+            rdma_port = nfs_spec.rdma_port
 
         def get_ganesha_conf() -> str:
             context: Dict[str, Any] = {
                 "user": rados_user,
                 "nodeid": nodeid,
                 "pool": POOL_NAME,
-                "namespace": spec.service_id,
+                "namespace": nfs_spec.service_id,
                 "rgw_user": rgw_user,
-                "url": f'rados://{POOL_NAME}/{spec.service_id}/{spec.rados_config_name()}',
+                "url": f'rados://{POOL_NAME}/{nfs_spec.service_id}/{nfs_spec.rados_config_name()}',
                 # fall back to default NFS port if not present in daemon_spec
                 "port": port,
                 "monitoring_addr": monitoring_ip,
@@ -326,38 +329,38 @@ class NFSService(CephService):
                 "bind_addr": bind_addr,
                 "haproxy_hosts": [],
                 "nfs_idmap_conf": nfs_idmap_conf,
-                "enable_nlm": str(spec.enable_nlm).lower(),
-                "enable_rdma": spec.enable_rdma,
+                "enable_nlm": str(nfs_spec.enable_nlm).lower(),
+                "enable_rdma": nfs_spec.enable_rdma,
                 "rdma_port": rdma_port,
                 "cluster_id": self.mgr._cluster_fsid,
-                "tls_add": spec.ssl,
-                "tls_ciphers": spec.tls_ciphers,
-                "tls_min_version": spec.tls_min_version,
-                "tls_ktls": spec.tls_ktls,
-                "tls_debug": spec.tls_debug,
+                "tls_add": nfs_spec.ssl,
+                "tls_ciphers": nfs_spec.tls_ciphers,
+                "tls_min_version": nfs_spec.tls_min_version,
+                "tls_ktls": nfs_spec.tls_ktls,
+                "tls_debug": nfs_spec.tls_debug,
                 "ceph_nodes": ceph_nodes,
-                "protocols": "3, 4" if spec.enable_nfsv3 else "4",
+                "protocols": "3, 4" if nfs_spec.enable_nfsv3 else "4",
                 "use_old_nodeid": False if nodeid.isdigit() else True,
-                "enable_client_object_cache": spec.enable_client_object_cache,
+                "enable_client_object_cache": nfs_spec.enable_client_object_cache,
                 "client_object_cache_size": (
-                    with_units_to_int(str(spec.client_object_cache_size))
-                    if spec.client_object_cache_size is not None else None
+                    with_units_to_int(str(nfs_spec.client_object_cache_size))
+                    if nfs_spec.client_object_cache_size is not None else None
                 ),
                 "client_object_cache_max_dirty": (
-                    with_units_to_int(str(spec.client_object_cache_max_dirty))
-                    if spec.client_object_cache_max_dirty is not None else None
+                    with_units_to_int(str(nfs_spec.client_object_cache_max_dirty))
+                    if nfs_spec.client_object_cache_max_dirty is not None else None
                 ),
             }
-            if spec.enable_haproxy_protocol:
+            if nfs_spec.enable_haproxy_protocol:
                 context["haproxy_hosts"] = self._haproxy_hosts()
-                if spec.virtual_ip and spec.virtual_ip not in context["haproxy_hosts"]:
-                    context["haproxy_hosts"].append(spec.virtual_ip)
+                if nfs_spec.virtual_ip and nfs_spec.virtual_ip not in context["haproxy_hosts"]:
+                    context["haproxy_hosts"].append(nfs_spec.virtual_ip)
                 logger.debug("selected haproxy_hosts: %r", context["haproxy_hosts"])
             return self.mgr.template.render('services/nfs/ganesha.conf.j2', context)
 
         # generate the idmap config
         def get_idmap_conf() -> str:
-            idmap_conf = spec.idmap_conf
+            idmap_conf = nfs_spec.idmap_conf
             output = ''
             if idmap_conf is not None:
                 cp = ConfigParser()
@@ -373,17 +376,17 @@ class NFSService(CephService):
         def get_cephadm_config() -> Dict[str, Any]:
             config: Dict[str, Any] = {}
             config['pool'] = POOL_NAME
-            config['namespace'] = spec.service_id
+            config['namespace'] = nfs_spec.service_id
             config['userid'] = rados_user
             config['extra_args'] = ['-N', 'NIV_EVENT']
             config['files'] = {
                 'ganesha.conf': get_ganesha_conf(),
                 'idmap.conf': get_idmap_conf()
             }
-            if spec.ssl:
+            if nfs_spec.ssl:
                 tls_creds = self.get_certificates(
                     daemon_spec,
-                    ips=self.get_certificate_ips(spec, daemon_spec),
+                    ips=self.get_certificate_ips(nfs_spec, daemon_spec),
                     ca_cert_required=True,
                 )
                 config['files'].update({
@@ -403,11 +406,11 @@ class NFSService(CephService):
                 'user': rgw_user,
                 'keyring': rgw_keyring,
             }
-            config['enable_rdma'] = spec.enable_rdma
+            config['enable_rdma'] = nfs_spec.enable_rdma
             logger.debug('Generated cephadm config-json: %s' % config)
             return config
 
-        return get_cephadm_config(), self.get_dependencies(self.mgr, spec)
+        return get_cephadm_config(), self.get_dependencies(self.mgr, nfs_spec, daemon_spec.daemon_type)
 
     def pre_daemon_service_config(self, spec: ServiceSpec) -> None:
         nfs_spec = cast(NFSServiceSpec, spec)

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -148,7 +148,7 @@ class NFSService(CephService):
         create_ganesha_pool(self.mgr)
 
     @classmethod
-    def get_dependencies(
+    def _get_dependencies(
         cls,
         mgr: "CephadmOrchestrator",
         spec: Optional[ServiceSpec] = None,
@@ -187,8 +187,7 @@ class NFSService(CephService):
                     f'{nfs_spec.client_object_cache_max_dirty}'
                 )
 
-        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
-        return sorted(deps + parent_deps)
+        return sorted(deps)
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/services/node_proxy.py
+++ b/src/pybind/mgr/cephadm/services/node_proxy.py
@@ -41,8 +41,8 @@ class NodeProxy(CephService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         root_cert = ''
         server_port = ''
         try:

--- a/src/pybind/mgr/cephadm/services/node_proxy.py
+++ b/src/pybind/mgr/cephadm/services/node_proxy.py
@@ -19,7 +19,11 @@ if TYPE_CHECKING:
 class NodeProxy(CephService):
     TYPE = 'node-proxy'
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
 
@@ -31,7 +35,7 @@ class NodeProxy(CephService):
         daemon_spec.keyring = keyring
         self.mgr.node_proxy_cache.update_keyring(host, keyring)
 
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
 
         return daemon_spec
 
@@ -48,7 +52,11 @@ class NodeProxy(CephService):
             pass
         return sorted([mgr.get_mgr_ip(), server_port, root_cert])
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         # node-proxy is re-using the agent endpoint and therefore
         # needs similar checks to see if the endpoint is ready.
         self.agent_endpoint = self.mgr.http_server.agent

--- a/src/pybind/mgr/cephadm/services/node_proxy.py
+++ b/src/pybind/mgr/cephadm/services/node_proxy.py
@@ -36,7 +36,7 @@ class NodeProxy(CephService):
         return daemon_spec
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         root_cert = ''

--- a/src/pybind/mgr/cephadm/services/node_proxy.py
+++ b/src/pybind/mgr/cephadm/services/node_proxy.py
@@ -80,7 +80,8 @@ class NodeProxy(CephService):
         }
         config = {'node-proxy.json': json.dumps(cfg)}
 
-        return config, self.get_dependencies(self.mgr)
+        return config, self.get_dependencies(
+            self.mgr, spec, daemon_spec.daemon_type)
 
     def handle_hw_monitoring_setting(self) -> bool:
         # function to apply or remove node-proxy service spec depending

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -5,7 +5,7 @@ from typing import List, cast, Optional, NamedTuple
 from ipaddress import ip_address, IPv6Address
 
 from mgr_module import HandleCommandResult
-from ceph.deployment.service_spec import NvmeofServiceSpec, CertificateSource
+from ceph.deployment.service_spec import NvmeofServiceSpec, CertificateSource, ServiceSpec
 
 from orchestrator import (
     OrchestratorError,
@@ -116,7 +116,11 @@ class NvmeofService(CephService):
             'root_ca_cert': tls_creds.ca_cert,
         })
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
 
         spec = cast(NvmeofServiceSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
@@ -181,7 +185,7 @@ class NvmeofService(CephService):
         if spec.encryption_key:
             daemon_spec.extra_files['encryption_key'] = spec.encryption_key
 
-        daemon_spec.final_config, _ = self.generate_config(daemon_spec)
+        daemon_spec.final_config, _ = self.generate_config(daemon_spec, spec)
         daemon_spec.deps = self.get_dependencies(self.mgr, spec, daemon_spec.daemon_type)
         return daemon_spec
 

--- a/src/pybind/mgr/cephadm/services/oauth2_proxy.py
+++ b/src/pybind/mgr/cephadm/services/oauth2_proxy.py
@@ -90,7 +90,8 @@ class OAuth2ProxyService(CephadmService):
             }
         }
 
-        return daemon_config, sorted(OAuth2ProxyService.get_dependencies(self.mgr))
+        return daemon_config, self.get_dependencies(
+            self.mgr, svc_spec, daemon_spec.daemon_type)
 
     def post_remove(self, daemon: DaemonDescription, is_failed_deploy: bool) -> None:
         """

--- a/src/pybind/mgr/cephadm/services/oauth2_proxy.py
+++ b/src/pybind/mgr/cephadm/services/oauth2_proxy.py
@@ -18,10 +18,14 @@ class OAuth2ProxyService(CephadmService):
     TYPE = 'oauth2-proxy'
     SVC_TEMPLATE_PATH = 'services/oauth2-proxy/oauth2-proxy.conf.j2'
 
-    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+    def prepare_create(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
-        super().prepare_create(daemon_spec)
-        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        super().prepare_create(daemon_spec, spec)
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
         return daemon_spec
 
     @classmethod
@@ -59,7 +63,11 @@ class OAuth2ProxyService(CephadmService):
         # if empty list provided, return empty Daemon Desc
         return DaemonDescription()
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         svc_spec = cast(OAuth2ProxySpec, self.mgr.spec_store[daemon_spec.service_name].spec)
         allowlist_domains = copy(svc_spec.allowlist_domains) or []

--- a/src/pybind/mgr/cephadm/services/oauth2_proxy.py
+++ b/src/pybind/mgr/cephadm/services/oauth2_proxy.py
@@ -30,8 +30,8 @@ class OAuth2ProxyService(CephadmService):
 
     @classmethod
     def _get_dependencies(cls, mgr: "CephadmOrchestrator",
-                         spec: Optional[ServiceSpec] = None,
-                         daemon_type: Optional[str] = None) -> List[str]:
+                          spec: Optional[ServiceSpec] = None,
+                          daemon_type: Optional[str] = None) -> List[str]:
         # adding dependency as redirect_url calculation depends on the mgmt-gateway
         deps = [
             f'{d.name()}:{d.ports[0]}' if d.ports else d.name()

--- a/src/pybind/mgr/cephadm/services/oauth2_proxy.py
+++ b/src/pybind/mgr/cephadm/services/oauth2_proxy.py
@@ -25,7 +25,7 @@ class OAuth2ProxyService(CephadmService):
         return daemon_spec
 
     @classmethod
-    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+    def _get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
         # adding dependency as redirect_url calculation depends on the mgmt-gateway
@@ -34,8 +34,7 @@ class OAuth2ProxyService(CephadmService):
             for service in ['mgmt-gateway']
             for d in mgr.cache.get_daemons_by_service(service)
         ]
-        parent_deps = super().get_dependencies(mgr, spec, daemon_type)
-        return sorted(deps + parent_deps)
+        return sorted(deps)
 
     def get_service_ips_and_hosts(self, service_name: str) -> List[str]:
         entries = set()

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -6,6 +6,7 @@ from typing import List, Dict, Any, Set, Tuple, cast, Optional, TYPE_CHECKING
 
 from ceph.deployment import translate
 from ceph.deployment.drive_group import DriveGroupSpec
+from ceph.deployment.service_spec import ServiceSpec
 from ceph.deployment.drive_selection import DriveSelection
 from ceph.deployment.inventory import Device
 from ceph.utils import datetime_to_str, str_to_datetime
@@ -235,7 +236,7 @@ class OSDService(CephService):
                     daemon_type='osd',
                     network='',  # required arg but only really needed for mons
                 )
-                daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+                daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
                 self._apply_osd_config_to_daemon(str(osd_id), post_create_cfg or {})
 
                 await CephadmServe(self.mgr)._create_daemon(
@@ -279,7 +280,7 @@ class OSDService(CephService):
                 daemon_type='osd',
                 network='',  # required arg but only really needed for mons
             )
-            daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+            daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec, spec)
             self._apply_osd_config_to_daemon(osd_id, post_create_cfg or {})
             await CephadmServe(self.mgr)._create_daemon(
                 daemon_spec,
@@ -506,8 +507,12 @@ class OSDService(CephService):
         if not is_failed_deploy:
             super().post_remove(daemon, is_failed_deploy=is_failed_deploy)
 
-    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
-        config, parent_deps = super().generate_config(daemon_spec)
+    def generate_config(
+            self,
+            daemon_spec: CephadmDaemonDeploySpec,
+            spec: Optional[ServiceSpec] = None,
+    ) -> Tuple[Dict[str, Any], List[str]]:
+        config, parent_deps = super().generate_config(daemon_spec, spec)
         if daemon_spec.service_name in self.mgr.spec_store:
             svc_spec = cast(DriveGroupSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
 

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -308,7 +308,7 @@ class SMBService(CephService):
 
         logger.debug('smb generate_config: %r', config_blobs)
         self._configure_cluster_meta(smb_spec, daemon_spec)
-        deps = sorted(self.get_dependencies(self.mgr, smb_spec))
+        deps = self.get_dependencies(self.mgr, smb_spec, daemon_spec.daemon_type)
         return config_blobs, deps
 
     def _cert_or_uri(self, data: Optional[str]) -> Optional[str]:

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -142,12 +142,13 @@ class SMBService(CephService):
         return None
 
     def prepare_create(
-        self, daemon_spec: CephadmDaemonDeploySpec
+        self, daemon_spec: CephadmDaemonDeploySpec,
+        spec: Optional[ServiceSpec] = None,
     ) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
         logger.debug('smb prepare_create')
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(
-            daemon_spec
+            daemon_spec, spec
         )
         return daemon_spec
 
@@ -223,7 +224,8 @@ class SMBService(CephService):
         return self._lookup_rgw_creds_uri(self.mgr, cluster_id)
 
     def generate_config(
-        self, daemon_spec: CephadmDaemonDeploySpec
+        self, daemon_spec: CephadmDaemonDeploySpec,
+        spec: Optional[ServiceSpec] = None,
     ) -> Tuple[Dict[str, Any], List[str]]:
         logger.debug('smb generate_config')
         assert self.TYPE == daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -525,7 +525,7 @@ class SMBService(CephService):
         return ip
 
     @classmethod
-    def get_dependencies(
+    def _get_dependencies(
         cls,
         mgr: 'CephadmOrchestrator',
         spec: Optional[ServiceSpec] = None,

--- a/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 from cephadm.services.service_registry import service_registry
 from cephadm.services.monitoring import GrafanaService
+from cephadm.services.cephadmservice import CephadmService
 from orchestrator import OrchestratorError
 
 
@@ -49,7 +50,26 @@ class FakeMgr:
         return '1.2.3.4'
 
 
+class ServiceWithDependencies(CephadmService):
+    @classmethod
+    def _get_dependencies(cls, mgr, spec=None, daemon_type=None):
+        return ['service-specific']
+
+
 class TestCephadmService:
+    def test_get_dependencies_combines_service_and_common_dependencies(self):
+        mgr = FakeMgr()
+        spec = MagicMock()
+        spec.ssl = True
+        spec.certificate_source = 'cephadm-signed'
+        spec.ssl_cert = None
+        spec.ssl_key = None
+        spec.ssl_ca_cert = None
+
+        deps = ServiceWithDependencies.get_dependencies(mgr, spec)
+
+        assert deps == ['certificate_source: cephadm-signed', 'service-specific']
+
     def test_set_value_on_dashboard(self):
         # pylint: disable=protected-access
         mgr = FakeMgr()

--- a/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
@@ -57,6 +57,8 @@ class ServiceWithDependencies(CephadmService):
 
 
 class ServiceWithConfig(CephadmService):
+    TYPE = 'test'
+
     def generate_config(self, daemon_spec, spec=None):
         self.seen_spec = spec
         return {}, []

--- a/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
@@ -56,6 +56,12 @@ class ServiceWithDependencies(CephadmService):
         return ['service-specific']
 
 
+class ServiceWithConfig(CephadmService):
+    def generate_config(self, daemon_spec, spec=None):
+        self.seen_spec = spec
+        return {}, []
+
+
 class TestCephadmService:
     def test_get_dependencies_combines_service_and_common_dependencies(self):
         mgr = FakeMgr()
@@ -76,6 +82,16 @@ class TestCephadmService:
 
         for service in service_registry.get_all_services():
             assert 'get_dependencies' not in service.__class__.__dict__
+
+    def test_prepare_create_passes_spec_to_generate_config(self):
+        mgr = FakeMgr()
+        service = ServiceWithConfig(mgr)
+        daemon_spec = MagicMock()
+        spec = MagicMock()
+
+        service.prepare_create(daemon_spec, spec)
+
+        assert service.seen_spec is spec
 
     def test_set_value_on_dashboard(self):
         # pylint: disable=protected-access

--- a/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 from cephadm.services.service_registry import service_registry
 from cephadm.services.monitoring import GrafanaService
-from cephadm.services.cephadmservice import CephadmService
+from cephadm.services.cephadmservice import CephadmService, CephService
 from orchestrator import OrchestratorError
 
 
@@ -56,6 +56,17 @@ class ServiceWithDependencies(CephadmService):
         return ['service-specific']
 
 
+class CephServiceWithDependencies(CephService):
+    TYPE = 'test'
+
+    @classmethod
+    def _get_dependencies(cls, mgr, spec=None, daemon_type=None):
+        return ['service-specific']
+
+    def get_config_and_keyring(self, *args, **kwargs):
+        return {}
+
+
 class ServiceWithConfig(CephadmService):
     TYPE = 'test'
 
@@ -94,6 +105,27 @@ class TestCephadmService:
         service.prepare_create(daemon_spec, spec)
 
         assert service.seen_spec is spec
+
+    def test_generate_config_uses_canonical_dependencies(self):
+        mgr = FakeMgr()
+        service = CephServiceWithDependencies(mgr)
+        daemon_spec = MagicMock()
+        daemon_spec.daemon_type = 'test'
+        daemon_spec.daemon_id = 'a'
+        daemon_spec.host = 'host1'
+        daemon_spec.keyring = None
+        daemon_spec.ceph_conf = None
+        daemon_spec.config_get_files.return_value = {}
+        spec = MagicMock()
+        spec.ssl = True
+        spec.certificate_source = 'cephadm-signed'
+        spec.ssl_cert = None
+        spec.ssl_key = None
+        spec.ssl_ca_cert = None
+
+        _, deps = service.generate_config(daemon_spec, spec)
+
+        assert deps == ['certificate_source: cephadm-signed', 'service-specific']
 
     def test_set_value_on_dashboard(self):
         # pylint: disable=protected-access

--- a/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
@@ -70,6 +70,13 @@ class TestCephadmService:
 
         assert deps == ['certificate_source: cephadm-signed', 'service-specific']
 
+    def test_registered_services_use_common_dependency_handler(self):
+        mgr = FakeMgr()
+        service_registry.init_services(mgr)
+
+        for service in service_registry.get_all_services():
+            assert 'get_dependencies' not in service.__class__.__dict__
+
     def test_set_value_on_dashboard(self):
         # pylint: disable=protected-access
         mgr = FakeMgr()

--- a/src/pybind/mgr/cephadm/tests/services/test_smb.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_smb.py
@@ -233,9 +233,9 @@ def test_smb_get_dependencies(cephadm_module):
 
     deps = SMBService.get_dependencies(cephadm_module, spec, spec.service_type)
     assert deps == [
-        'smb+meta:ceph_cluster_config.exo=sha256:859b001f76df4d184b858b9c3e323ca8ff85a311414d0405f4484d17aa481ef3',
         'smb+field:features=domain',
         'smb+field:rgw_creds_uri=rados:mon-config-key:smb/config/foxtrot/config.smb.rgw',
+        'smb+meta:ceph_cluster_config.exo=sha256:859b001f76df4d184b858b9c3e323ca8ff85a311414d0405f4484d17aa481ef3',
     ]
 
 


### PR DESCRIPTION
## Description

Cephadm service dependency handling is currently inconsistent across service implementations.

`CephadmService.get_dependencies()` contains common dependency logic, but individual services can override `get_dependencies()` directly. Some services call `super().get_dependencies()`, while others do not. As a result, common dependencies can be unintentionally skipped.

There is also a risk of divergence between the dependencies calculated during reconciliation and the dependencies persisted after daemon deployment/reconfiguration.

## Proposed enhancement

Refactor dependency handling so that:

* `CephadmService.get_dependencies()` becomes the single authoritative dependency calculation entry point.
* Services provide only service-specific dependencies through a separate `_get_dependencies()` hook.
* Common dependencies are always added centrally, without requiring services to call `super()`.
* Daemon dependencies persisted after deployment/reconfiguration are calculated through the same canonical path used during reconciliation.

## Benefits

* Prevents services from accidentally skipping common dependencies.
* Ensures `curr_deps` and persisted `last_deps` are calculated consistently.
* Makes future common dependency types easier and safer to add.
* Reduces service-specific dependency boilerplate and maintenance risk.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
