### PR TITLE
mgr/dashboard: allow Fast EC pools as primary pool for RBD

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -135,9 +135,15 @@ def get_daemon_health(daemon):
     return health
 
 
+def _is_rbd_capable_pool(pool):
+    if pool.get('type', 1) == 1:
+        return True
+    return 'supports_omap' in pool.get('flags_names', '')
+
+
 def get_pools(daemons):  # pylint: disable=R0912, R0915
     pool_names = [pool['pool_name'] for pool in CephService.get_pool_list('rbd')
-                  if pool.get('type', 1) == 1]
+                  if _is_rbd_capable_pool(pool)]
     pool_stats = _get_pool_stats(pool_names)
     _update_pool_stats(daemons, pool_stats)
     return pool_stats
@@ -403,7 +409,7 @@ def _update_syncing_image_data(mirror_image, image):
 @ViewCache()
 def _get_content_data():  # pylint: disable=R0914
     pool_names = [pool['pool_name'] for pool in CephService.get_pool_list('rbd')
-                  if pool.get('type', 1) == 1]
+                  if _is_rbd_capable_pool(pool)]
     _, data = get_daemons_and_pools()
     daemons = data.get('daemons', [])
     pool_stats = data.get('pools', {})

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -129,7 +129,8 @@ describe('RbdFormComponent', () => {
         getPool('two', 'replicated', '', ['rbd']),
         getPool('three', 'replicated', '', ['rbd']),
         getPool('four', 'erasure', '', ['rbd']),
-        getPool('four', 'erasure', 'ec_overwrites', ['rbd'])
+        getPool('four', 'erasure', 'ec_overwrites', ['rbd']),
+        getPool('five', 'erasure', 'ec_overwrites,supports_omap', ['rbd'])
       ];
       spyOn(TestBed.inject(PoolService), 'list').and.callFake(() => of(mock.pools));
       rbdServiceGetSpy = spyOn(TestBed.inject(RbdService), 'get');
@@ -185,12 +186,12 @@ describe('RbdFormComponent', () => {
 
       it('should be enabled with more than 1 pool', () => {
         component['handleExternalData'](mock);
-        expect(component.allDataPools.length).toBe(3);
+        expect(component.allDataPools.length).toBe(4);
         expect(component.rbdForm.get('useDataPool').disabled).toBe(false);
 
         mock.pools.pop();
         component['handleExternalData'](mock);
-        expect(component.allDataPools.length).toBe(2);
+        expect(component.allDataPools.length).toBe(3);
         expect(component.rbdForm.get('useDataPool').disabled).toBe(false);
       });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -432,7 +432,7 @@ export class RbdFormComponent extends CdForm implements OnInit {
     const dataPools = [];
     for (const pool of data) {
       if (this.rbdService.isRBDPool(pool)) {
-        if (pool.type === 'replicated') {
+        if (this.rbdService.isRBDCapablePool(pool)) {
           pools.push(pool);
           dataPools.push(pool);
         } else if (pool.type === 'erasure' && pool.flags_names.indexOf('ec_overwrites') !== -1) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-form/rbd-namespace-form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-form/rbd-namespace-form-modal.component.ts
@@ -101,10 +101,10 @@ export class RbdNamespaceFormModalComponent extends BaseModal implements OnInit 
 
   ngOnInit() {
     if (this.poolPermission.read) {
-      this.poolService.list(['pool_name', 'type', 'application_metadata']).then((resp) => {
+      this.poolService.list(['pool_name', 'type', 'flags_names', 'application_metadata']).then((resp) => {
         const pools: Pool[] = [];
         for (const pool of resp) {
-          if (this.rbdService.isRBDPool(pool) && pool.type === 'replicated') {
+          if (this.rbdService.isRBDPool(pool) && this.rbdService.isRBDCapablePool(pool)) {
             pools.push(pool);
           }
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-list/rbd-namespace-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-list/rbd-namespace-list.component.ts
@@ -81,9 +81,9 @@ export class RbdNamespaceListComponent implements OnInit {
   }
 
   refresh() {
-    this.poolService.list(['pool_name', 'type', 'application_metadata']).then((pools: any) => {
+    this.poolService.list(['pool_name', 'type', 'flags_names', 'application_metadata']).then((pools: any) => {
       pools = pools.filter(
-        (pool: any) => this.rbdService.isRBDPool(pool) && pool.type === 'replicated'
+        (pool: any) => this.rbdService.isRBDPool(pool) && this.rbdService.isRBDCapablePool(pool)
       );
       const promises: Observable<any>[] = [];
       pools.forEach((pool: any) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.spec.ts
@@ -170,6 +170,32 @@ describe('RbdService', () => {
     });
   });
 
+  describe('isRBDCapablePool', () => {
+    it('should return true for replicated pools', () => {
+      expect(service.isRBDCapablePool({ type: 'replicated', flags_names: '' })).toBe(true);
+    });
+
+    it('should return true for erasure pools with supports_omap', () => {
+      expect(
+        service.isRBDCapablePool({ type: 'erasure', flags_names: 'ec_overwrites,supports_omap' })
+      ).toBe(true);
+    });
+
+    it('should return false for erasure pools without supports_omap', () => {
+      expect(
+        service.isRBDCapablePool({ type: 'erasure', flags_names: 'ec_overwrites' })
+      ).toBe(false);
+    });
+
+    it('should return false for erasure pools with no flags', () => {
+      expect(service.isRBDCapablePool({ type: 'erasure', flags_names: '' })).toBe(false);
+    });
+
+    it('should handle missing flags_names', () => {
+      expect(service.isRBDCapablePool({ type: 'erasure' })).toBe(false);
+    });
+  });
+
   describe('should parse image spec', () => {
     it('with namespace', () => {
       const imageSpec = ImageSpec.fromString('mypool/myns/myimage');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.ts
@@ -26,6 +26,11 @@ export class RbdService extends ApiClient {
     return _.indexOf(pool.application_metadata, 'rbd') !== -1 && !pool.pool_name.includes('/');
   }
 
+  isRBDCapablePool(pool: any): boolean {
+    return pool.type === 'replicated' ||
+      (pool.type === 'erasure' && (pool.flags_names || '').includes('supports_omap'));
+  }
+
   create(rbd: any) {
     return this.http.post('api/block/image', rbd, { observe: 'response' });
   }

--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -13,7 +13,7 @@ from .. import mgr
 from ..controllers.orchestrator import Orchestrator
 from ..controllers.rbd_mirroring import RbdMirroring, \
     RbdMirroringPoolBootstrap, RbdMirroringStatus, RbdMirroringSummary, \
-    get_daemons, get_pools
+    get_daemons, get_pools, _is_rbd_capable_pool
 from ..controllers.summary import Summary
 from ..services import progress
 from ..tests import ControllerTestCase
@@ -169,6 +169,24 @@ class GetDaemonAndPoolsTest(unittest.TestCase):
             ),
         ]
         return test_cases
+
+
+class IsRbdCapablePoolTest(unittest.TestCase):
+    def test_replicated_pool(self):
+        self.assertTrue(_is_rbd_capable_pool({'type': 1}))
+
+    def test_replicated_pool_default(self):
+        self.assertTrue(_is_rbd_capable_pool({}))
+
+    def test_ec_pool_without_omap(self):
+        self.assertFalse(_is_rbd_capable_pool({'type': 3, 'flags_names': 'ec_overwrites'}))
+
+    def test_ec_pool_with_omap(self):
+        self.assertTrue(_is_rbd_capable_pool(
+            {'type': 3, 'flags_names': 'ec_overwrites,supports_omap'}))
+
+    def test_ec_pool_no_flags(self):
+        self.assertFalse(_is_rbd_capable_pool({'type': 3}))
 
 
 class RbdMirroringControllerTest(ControllerTestCase):


### PR DESCRIPTION
Fast EC pools (ec_optimizations enabled) now support OMAP, removing the historical blocker for using EC pools as the primary pool for RBD images and mirroring.


Fixes: https://tracker.ceph.com/issues/79661





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
