### PR TITLE
tools/osdmaptool: add --create-osds to osdmaptool for offline capacit…

### DIFF
--- a/doc/man/8/osdmaptool.rst
+++ b/doc/man/8/osdmaptool.rst
@@ -131,6 +131,18 @@ Options
 
    mark an osd as in (but do not persist)
 
+.. option:: --create-osds <count>
+
+   add *count* osds to the map, with ids starting at the current ``max_osd``,
+   each marked as existing, up and in (but do not persist without --save).
+
+   This widens a captured OSD map so that placement can be simulated for OSDs
+   the cluster does not have yet. The new OSDs are not added to the CRUSH map
+   and are assigned no uuid, so they take no data until a CRUSH map that places
+   them is supplied with --import-crush. Because --import-crush refuses a CRUSH
+   map whose ``max_devices`` exceeds ``max_osd``, --create-osds is applied first
+   when both are given.
+
 .. option:: --tree
 
    Displays a hierarchical tree of the map.

--- a/src/test/cli/osdmaptool/create-osds.t
+++ b/src/test/cli/osdmaptool/create-osds.t
@@ -1,0 +1,63 @@
+  $ osdmaptool --createsimple 3 om --with-default-pool
+  osdmaptool: osdmap file 'om'
+  osdmaptool: writing epoch 1 to om
+#
+# creation is reported, and is not persisted without --save
+#
+  $ osdmaptool om --create-osds 2
+  osdmaptool: osdmap file 'om'
+  created osd.3 through osd.4, max_osd is now 5
+  $ osdmaptool --print om | grep max_osd
+  osdmaptool: osdmap file 'om'
+  max_osd 3
+  $ osdmaptool om --create-osds 2 --save
+  osdmaptool: osdmap file 'om'
+  created osd.3 through osd.4, max_osd is now 5
+  osdmaptool: writing epoch 2 to om
+  $ osdmaptool --print om | grep max_osd
+  osdmaptool: osdmap file 'om'
+  max_osd 5
+#
+# a new osd exists, is up and is in, which is what placement requires of it
+#
+  $ osdmaptool --print om | grep ^osd.4
+  osdmaptool: osdmap file 'om'
+  osd.4 up   in  weight 1 * exists,up (glob)
+#
+# a count below one is refused
+#
+  $ osdmaptool om --create-osds 0
+  osdmaptool: --create-osds requires a count greater than 0
+  [1]
+#
+# --import-crush refuses a crush map wider than max_osd. --create-osds is what
+# makes importing one possible, and it is applied first within a single invocation.
+#
+  $ osdmaptool --createsimple 6 omwide --with-default-pool
+  osdmaptool: osdmap file 'omwide'
+  osdmaptool: writing epoch 1 to omwide
+  $ osdmaptool omwide --export-crush oc
+  osdmaptool: osdmap file 'omwide'
+  osdmaptool: exported crush map to oc
+  $ osdmaptool --createsimple 3 omnarrow --with-default-pool
+  osdmaptool: osdmap file 'omnarrow'
+  osdmaptool: writing epoch 1 to omnarrow
+  $ osdmaptool omnarrow --import-crush oc
+  osdmaptool: osdmap file 'omnarrow'
+  osdmaptool: crushmap max_devices 6 > osdmap max_osd 3
+  [1]
+  $ osdmaptool omnarrow --create-osds 3 --import-crush oc
+  osdmaptool: osdmap file 'omnarrow'
+  created osd.3 through osd.5, max_osd is now 6
+  osdmaptool: imported * byte crush map from oc (glob)
+  osdmaptool: writing epoch 3 to omnarrow
+#
+# pgs are placed on an osd the map did not contain before, which is the point
+#
+  $ osdmaptool omnarrow --mark-up-in --test-map-pgs | grep '^osd\.5'
+  osdmaptool: osdmap file 'omnarrow'
+  osd\.5\t[1-9][0-9]*\t.* (re)
+#
+# cleanup
+#
+  $ rm -f om omwide omnarrow oc

--- a/src/test/cli/osdmaptool/help.t
+++ b/src/test/cli/osdmaptool/help.t
@@ -35,6 +35,7 @@
      --tree                  displays a tree of the map
      --test-crush [--range-first <first> --range-last <last>] map pgs to acting osds
      --adjust-crush-weight <osdid:weight>[,<osdid:weight>,<...>] change <osdid> CRUSH <weight> (but do not persist)
+     --create-osds <count>   add <count> osds to the map, marked up and in, with ids starting at max_osd (but do not persist)
      --save                  write modified osdmap with upmap or crush-adjust changes
      --read <file>           calculate pg upmap entries to balance pg primaries
      --read-pool <poolname>  specify which pool the read balancer should adjust

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -71,6 +71,7 @@ void usage()
   cout << "   --tree                  displays a tree of the map" << std::endl;
   cout << "   --test-crush [--range-first <first> --range-last <last>] map pgs to acting osds" << std::endl;
   cout << "   --adjust-crush-weight <osdid:weight>[,<osdid:weight>,<...>] change <osdid> CRUSH <weight> (but do not persist)" << std::endl;
+  cout << "   --create-osds <count>   add <count> osds to the map, marked up and in, with ids starting at max_osd (but do not persist)" << std::endl;
   cout << "   --save                  write modified osdmap with upmap or crush-adjust changes" << std::endl;
   cout << "   --read <file>           calculate pg upmap entries to balance pg primaries" << std::endl;
   cout << "   --read-pool <poolname>  specify which pool the read balancer should adjust" << std::endl;
@@ -167,6 +168,7 @@ int main(int argc, const char **argv)
   int range_last = -1;
   int pool = -1;
   bool mark_up_in = false;
+  int create_osds = 0;
   int marked_out = -1;
   int marked_up = -1;
   int marked_in = -1;
@@ -300,6 +302,15 @@ int main(int argc, const char **argv)
       }
     } else if (ceph_argparse_witharg(args, i, &val, err, "--adjust-crush-weight", (char*)NULL)) {
       adjust_crush_weight = val;
+    } else if (ceph_argparse_witharg(args, i, &create_osds, err, "--create-osds", (char*)NULL)) {
+      if (!err.str().empty()) {
+        cerr << err.str() << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      if (create_osds < 1) {
+        cerr << me << ": --create-osds requires a count greater than 0" << std::endl;
+        exit(EXIT_FAILURE);
+      }
     } else if (ceph_argparse_flag(args, i, "--save", (char*)NULL)) {
       save = true;
     } else if (ceph_argparse_flag(args, i, "--vstart", (char*)NULL)) {
@@ -429,6 +440,26 @@ int main(int argc, const char **argv)
     cout << "marking OSD@" << marked_up << " as up" << std::endl;
     int id = marked_up;
     osdmap.set_weight(id, CEPH_OSD_IN);
+  }
+
+  if (create_osds > 0) {
+    int first = osdmap.get_max_osd();
+    int64_t want = (int64_t)first + create_osds;
+    if (want > cct->_conf->mon_max_osd) {
+      cerr << me << ": cannot create " << create_osds << " osd(s): max_osd would become "
+	   << want << ", which is > mon_max_osd (" << cct->_conf->mon_max_osd << ")"
+	   << std::endl;
+      exit(1);
+    }
+    osdmap.set_max_osd((int)want);
+    for (int id = first; id < (int)want; id++) {
+      osdmap.set_weight(id, CEPH_OSD_IN);
+      osdmap.set_state(id, osdmap.get_state(id) | CEPH_OSD_UP);
+    }
+    cout << "created osd." << first << " through osd." << (want - 1)
+	 << ", max_osd is now " << want << std::endl;
+    if (save)
+      modified = true;
   }
 
   for_each_substr(adjust_crush_weight, ",", [&](auto osd_to_adjust) {
@@ -927,7 +958,8 @@ skip_upmap:
       export_crush.empty() && import_crush.empty() && 
       test_map_pg.empty() && test_map_object.empty() &&
       !test_map_pgs && !test_map_pgs_dump && !test_map_pgs_dump_all &&
-      adjust_crush_weight.empty() && !upmap && !upmap_cleanup && !read) {
+      adjust_crush_weight.empty() && create_osds <= 0 &&
+      !upmap && !upmap_cleanup && !read) {
     cerr << me << ": no action specified?" << std::endl;
     usage();
   }


### PR DESCRIPTION
Simulating capacity expansion offline requires importing an updated crushmap that references new OSD IDs. Currently, this fails because osdmaptool rejects any crush map whose device range exceeds the osdmap's max_osd, and even if that check were skipped, new OSD entries default to out with no state bits set, making them invisible for CRUSH placement.

--create-osds <count> extends the osdmap with the requested number of OSD entries marked up and in before the crushmap is imported, allowing placement simulation to work as expected.

Fixes: https://tracker.ceph.com/issues/80386

<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
