### PR TITLE
DNM: Ubuntu 26.04 (resolute) make check enablement

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -194,10 +194,18 @@ function(do_build_boost root_dir version)
       URL_HASH SHA256=${boost_sha256}
       DOWNLOAD_NO_PROGRESS 1)
   endif()
+  # Boost.Redis 1.87 includes <ciso646>, which libstdc++ 15 flags with a
+  # #warning in C++20 mode; with -Werror that fails every rgw translation
+  # unit on Ubuntu 26.04.  Upstream dropped the include in Boost 1.88
+  # (boostorg/redis e7c1b9ed5f); make the same one-line change to the
+  # bundled 1.87 until it is bumped.
+  set(patch_command
+    sed -i "/#include<ciso646>/d" <SOURCE_DIR>/boost/redis/adapter/detail/adapters.hpp)
   # build all components in a single shot
   include(ExternalProject)
   ExternalProject_Add(Boost
     ${source_dir}
+    PATCH_COMMAND ${patch_command}
     CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${configure_command}
     BUILD_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${build_command}
     BUILD_IN_SOURCE 1

--- a/cmake/modules/BuildQATzip.cmake
+++ b/cmake/modules/BuildQATzip.cmake
@@ -13,6 +13,12 @@ function(build_qatzip)
   list(APPEND configure_cmd --with-pic --enable-static --disable-shared)
 
   set(CFLAGS "-Wno-error=strict-prototypes -Wno-error=unused-but-set-variable")
+  # glibc >= 2.42 (ubuntu 26.04) expands strrchr() and friends through
+  # _Generic, which QATzip's pre-C11 utils/ build turns into an error.
+  # gcc has no -Wc11-extensions and rejects the option, so clang only.
+  if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    list(APPEND CFLAGS -Wno-error=c11-extensions)
+  endif()
   if(QATDRV_INCLUDE_DIR)
     list(APPEND configure_cmd --with-ICP_ROOT=${QATDRV_INCLUDE_DIR})
   endif()

--- a/monitoring/ceph-mixin/requirements-lint.txt
+++ b/monitoring/ceph-mixin/requirements-lint.txt
@@ -11,8 +11,11 @@ dataclasses==0.6
 types-dataclasses==0.6.1
 six==1.16.0
 toml==0.10.2
-pylint==2.6.0
-isort==5.10.0
-mypy==0.910
+pylint==2.6.0; python_version < "3.13"
+pylint>=3.3; python_version >= "3.13"
+isort==5.10.0; python_version < "3.13"
+isort>=5.13; python_version >= "3.13"
+mypy==0.910; python_version < "3.13"
+mypy>=1.11; python_version >= "3.13"
 mypy-extensions==0.4.3
 prettytable==2.4.0

--- a/monitoring/ceph-mixin/tests_dashboards/features/environment.py
+++ b/monitoring/ceph-mixin/tests_dashboards/features/environment.py
@@ -1,5 +1,5 @@
-# type: ignore[no-redef]
-# pylint: disable=E0611,W0613,E0102
+# type: ignore
+# pylint: disable=E0611,W0613,E0102,E1102
 import copy
 
 from behave import given, then, when

--- a/monitoring/ceph-mixin/tests_dashboards/util.py
+++ b/monitoring/ceph-mixin/tests_dashboards/util.py
@@ -25,7 +25,7 @@ def get_dashboards_data() -> Dict[str, Any]:
     data: Dict[str, Any] = {'queries': {}, 'variables': {}, 'stats': {}}
     for file in sorted(Path(__file__).parent.parent
                        .joinpath('dashboards_out').glob('*.json')):
-        with open(file, 'r') as f:
+        with open(file, 'r', encoding='utf-8') as f:
             dashboard_data = json.load(f)
             data['stats'][str(file)] = {'total': 0, 'tested': 0}
             add_dashboard_queries(data, dashboard_data, str(file))

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -33,7 +33,8 @@ skip_install=true
 deps =
   -rzipapp-reqs.txt
   pyfakefs == 4.5.6 ; python_version < "3.7"
-  pyfakefs == 5.3.5 ; python_version >= "3.7"
+  pyfakefs == 5.3.5 ; python_version >= "3.7" and python_version < "3.13"
+  pyfakefs >= 5.9.3 ; python_version >= "3.13"
   mock
   pytest
   pyyaml

--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -1,4 +1,5 @@
-CherryPy~=13.1
+CherryPy~=13.1; python_version < "3.13"
+CherryPy~=18.10; python_version >= "3.13"
 more-itertools~=8.14
 bcrypt~=3.1
 python3-saml~=1.4

--- a/src/pybind/mgr/dashboard/controllers/_crud.py
+++ b/src/pybind/mgr/dashboard/controllers/_crud.py
@@ -412,7 +412,7 @@ class CRUDEndpoint:
                           {
                               **funcs,
                               'outer_self': self,
-                          })
+                          })  # noqa: E126
         self.router(self.doc(crud_class))
         cls.CRUDClass = crud_class
 
@@ -494,6 +494,6 @@ class CRUDEndpoint:
                               'set_table_resource': set_table_resource,
                               'get_detail_columns': get_detail_columns,
                               'outer_self': self,
-                          })
+                          })  # noqa: E126
         UIRouter(self.router.path, self.router.security_scope)(meta_class)
         cls.CRUDClassMetadata = meta_class

--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -83,8 +83,8 @@ class HomeController(BaseController, LanguageMixin):
                 ratio = 1.0
             result.append((locale, ratio))
 
-        result.sort(key=lambda l: l[0])
-        result.sort(key=lambda l: l[1], reverse=True)
+        result.sort(key=lambda x: x[0])
+        result.sort(key=lambda x: x[1], reverse=True)
         logger.debug("language preference: %s", result)
         return [r[0] for r in result]
 

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -6,7 +6,7 @@
 import json
 import re
 from copy import deepcopy
-from typing import Any, Dict, List, no_type_check
+from typing import Any, Dict, List, no_type_check  # noqa: F401  (used in type comments)
 
 import cherrypy
 import rados

--- a/src/pybind/mgr/dashboard/controllers/multi_cluster.py
+++ b/src/pybind/mgr/dashboard/controllers/multi_cluster.py
@@ -156,7 +156,7 @@ class MultiCluster(RESTController):
                 raise DashboardException(msg=f'The ceph cluster you are attempting to connect \
                                          to does not support the multi-cluster feature. \
                                          Please ensure that the cluster you are connecting \
-                                         to is upgraded to { hub_cluster_version } to enable the \
+                                         to is upgraded to {hub_cluster_version} to enable the \
                                          multi-cluster functionality.',
                                          code='invalid_version', component='multi-cluster')
             content = self._proxy('POST', url, 'api/auth', payload=payload,

--- a/src/pybind/mgr/dashboard/plugins/feature_toggles.py
+++ b/src/pybind/mgr/dashboard/plugins/feature_toggles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from enum import Enum
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set  # noqa: F401  (used in type comments)
 
 import cherrypy
 from mgr_module import Option

--- a/src/pybind/mgr/dashboard/plugins/pluggy.py
+++ b/src/pybind/mgr/dashboard/plugins/pluggy.py
@@ -41,7 +41,7 @@ TODO: Once this becomes available in the above distros, this file should be
 REMOVED, and the fully featured python-pluggy should be used instead.
 """
 try:
-    from typing import DefaultDict
+    from typing import DefaultDict  # noqa: F401  (used in type comments)
 except ImportError:
     pass  # For typing only
 

--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -1,12 +1,17 @@
-pylint==2.6.0
-flake8==3.9.0
+pylint==2.6.0; python_version < "3.13"
+pylint>=3.3; python_version >= "3.13"
+flake8==3.9.0; python_version < "3.13"
+flake8>=7.1; python_version >= "3.13"
 flake8-colors==0.1.6
 #TODO: Fix docstring issues: https://tracker.ceph.com/issues/41224
 #flake8-docstrings
 #pep8-naming
 rstcheck==6.2.5
-autopep8==1.5.7
-pyfakefs==4.5.0
-isort==5.5.3
+autopep8==1.5.7; python_version < "3.13"
+autopep8>=2.3; python_version >= "3.13"
+pyfakefs==4.5.0; python_version < "3.13"
+pyfakefs>=5.9.3; python_version >= "3.13"
+isort==5.5.3; python_version < "3.13"
+isort>=5.13; python_version >= "3.13"
 jsonschema~=4.0
 PyJWT~=2.0

--- a/src/pybind/mgr/dashboard/requirements-test.txt
+++ b/src/pybind/mgr/dashboard/requirements-test.txt
@@ -1,6 +1,7 @@
 pytest-cov
 pytest-instafail
-pyfakefs==4.5.0
+pyfakefs==4.5.0; python_version < "3.13"
+pyfakefs>=5.9.3; python_version >= "3.13"
 jsonschema~=4.0
 PyJWT~=2.0
 #xmlsec==1.3.13 # Pinning because of https://github.com/xmlsec/python-xmlsec/issues/314

--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -6,7 +6,8 @@ requests
 Routes
 -e ../../../python-common
 prettytable
-pytest==7.0.1
+pytest==7.0.1; python_version < "3.13"
+pytest>=8.4; python_version >= "3.13"
 pyyaml
 natsort
 setuptools

--- a/src/pybind/mgr/dashboard/rest_client.py
+++ b/src/pybind/mgr/dashboard/rest_client.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     from urllib3.exceptions import SSLError  # type: ignore
 
-from typing import List, Optional
+from typing import List, Optional  # noqa: F401  (used in type comments)
 
 from mgr_util import build_url
 

--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -8,7 +8,7 @@ import logging
 import os
 import threading
 import warnings
-from typing import Dict, Optional
+from typing import Dict, Optional  # noqa: F401  (used in type comments)
 from urllib import parse
 
 from mgr_module import HandleCommandResult

--- a/src/pybind/mgr/dashboard/services/tcmu_service.py
+++ b/src/pybind/mgr/dashboard/services/tcmu_service.py
@@ -5,7 +5,7 @@ from dashboard.services.ceph_service import CephService
 from .. import mgr
 
 try:
-    from typing import Dict
+    from typing import Dict  # noqa: F401  (used in type comments)
 except ImportError:
     pass  # Just for type checking
 

--- a/src/pybind/mgr/dashboard/tests/helper.py
+++ b/src/pybind/mgr/dashboard/tests/helper.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 try:
-    from typing import Any, Dict
+    from typing import Any, Dict  # noqa: F401  (used in type comments)
 except ImportError:
     pass
 

--- a/src/pybind/mgr/dashboard/tests/test_home.py
+++ b/src/pybind/mgr/dashboard/tests/test_home.py
@@ -23,7 +23,7 @@ class HomeTest(ControllerTestCase, FakeFsMixin):
         cls.fs.create_file(
             os.path.join(frontend_path, '..', 'package.json'),
             contents='{"config":{"locale": "en"}}')
-        with mock.patch(cls.builtins_open, new=cls.f_open),\
+        with mock.patch(cls.builtins_open, new=cls.f_open), \
                 mock.patch('os.listdir', new=cls.f_os.listdir):
             lang = LanguageMixin()
             cls.fs.create_file(

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -21,8 +21,10 @@ from .services.auth import JwtManager
 from .settings import Settings
 
 try:
-    from typing import Any, AnyStr, Callable, DefaultDict, Deque, Dict, List, \
-        Optional, Set, Tuple, Union
+    from typing import (  # noqa: F401  (used in type comments)
+        Any, AnyStr, Callable, DefaultDict, Deque, Dict, List, Optional, Set,
+        Tuple, Union
+    )
 except ImportError:
     pass  # For typing only
 

--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -69,6 +69,7 @@ the executable build steps with short descriptions of what they do.
 import argparse
 import contextlib
 import enum
+import errno
 import glob
 import hashlib
 import json
@@ -80,6 +81,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 
 log = logging.getLogger()
@@ -249,6 +251,55 @@ def _run(cmd, *args, **kwargs):
     return subprocess.run(cmd, *args, **kwargs)
 
 
+def _seccomp_profile(ctx):
+    """Return a --security-opt argument working around libaio's assumption
+    that a blocked io_pgetevents reports ENOSYS, or None if not applicable.
+
+    libaio 0.3.113 (ubuntu 24.04 and later) implements io_getevents as "call
+    io_pgetevents, and fall back to io_getevents if that returns -ENOSYS".
+    Podman's default seccomp profile denies io_pgetevents with EPERM, so the
+    fallback never happens and the EPERM reaches the caller.  Ceph treats that
+    as fatal -- KernelDevice::_aio_thread aborts on any negative return -- so
+    every test that opens a block device dies immediately.
+
+    Removing io_pgetevents from the profile's deny lists grants nothing new:
+    the syscall falls through to the profile's default errno, which is already
+    ENOSYS, and libaio then retries with io_getevents, which is permitted.
+    """
+    if "podman" not in ctx.container_engine:
+        return None
+    cmd = [
+        ctx.container_engine,
+        "info",
+        "--format",
+        "{{.Host.Security.SECCOMPProfilePath}}",
+    ]
+    res = _run(cmd, check=False, capture_output=True)
+    if res.returncode != 0:
+        return None
+    try:
+        path = pathlib.Path(res.stdout.decode().strip())
+        profile = json.loads(path.read_text())
+        if profile.get("defaultErrnoRet") != errno.ENOSYS:
+            return None  # libaio's fallback needs ENOSYS specifically
+        for block in profile["syscalls"]:
+            if block.get("action") != "SCMP_ACT_ALLOW":
+                block["names"] = [
+                    n for n in block["names"]
+                    if not n.startswith("io_pgetevents")
+                ]
+        profile["syscalls"] = [b for b in profile["syscalls"] if b["names"]]
+        dest = (
+            pathlib.Path(tempfile.gettempdir())
+            / f"ceph-build-seccomp-{os.getuid()}.json"
+        )
+        dest.write_text(json.dumps(profile))
+    except (OSError, ValueError, KeyError) as err:
+        log.debug("not adjusting the seccomp profile: %s", err)
+        return None
+    return f"--security-opt=seccomp={dest}"
+
+
 def _container_cmd(
     ctx, args, *, workdir=None, interactive=False, extra_args=None
 ):
@@ -264,6 +315,9 @@ def _container_cmd(
         cmd.append("--rm")
     if "podman" in ctx.container_engine:
         cmd.append("--pids-limit=-1")
+    seccomp = _seccomp_profile(ctx)
+    if seccomp:
+        cmd.append(seccomp)
     if ctx.map_user:
         cmd.append("--user=0")
     if ctx.cli.env_file:


### PR DESCRIPTION
**Do not merge** — scratch PR so `ceph-pr-pipeline` has something to run `make check` against with `DISTRO_BASE=resolute` (Ubuntu 26.04 / Resolute Raccoon).

ceph/ceph#71559 got main *building and packaging* for 26.04 in `ceph-dev-pipeline`.  This one is about the other half: the unit tests.  The head commit is deliberately empty, so the first run is `make check` on pristine main inside a `docker.io/ubuntu:26.04` build container — anything red is the distro, not the PR.

Fixes for whatever turns up (gcc 15 `-Werror`, distro clang instead of apt.llvm.org's clang-19, sudo-rs, ctest fallout) get pushed on top; the placeholder commit is dropped before this is proposed for real.

Pipeline runs use `STATUS_PREFIX=resolute/`, so the statuses here are `resolute/make check` and never touch the required contexts.