### PR TITLE
qa: stop watchdog/thrashers on teardown

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -584,11 +584,24 @@ def ceph_clients(ctx, config):
 
 @contextlib.contextmanager
 def watchdog_setup(ctx, config):
-    ctx.ceph[config['cluster']].thrashers = []
-    ctx.ceph[config['cluster']].watched_processes = []
-    ctx.ceph[config['cluster']].watchdog = DaemonWatchdog(ctx, config)
-    ctx.ceph[config['cluster']].watchdog.start()
-    yield
+    cluster = config['cluster']
+    thrashers = []
+    ctx.ceph[cluster].thrashers = thrashers
+    ctx.ceph[cluster].watched_processes = []
+    watchdog = DaemonWatchdog(ctx, config)
+    ctx.ceph[cluster].watchdog = watchdog
+    watchdog.start()
+    try:
+        yield
+    finally:
+        log.info("Tearing down thrashers...")
+        for thrasher in thrashers:
+            thrasher.stop()
+        for thrasher in thrashers:
+            thrasher.join()
+        log.info("Tearing down watchdog...")
+        watchdog.stop()
+        watchdog.join()
 
 def get_mons(roles, ips, cluster_name,
              mon_bind_msgr2=False,

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1519,14 +1519,24 @@ def ceph_clients(ctx, config):
 
 @contextlib.contextmanager
 def watchdog_setup(ctx, config):
-    ctx.ceph[config['cluster']].thrashers = []
-    ctx.ceph[config['cluster']].watched_processes = []
-    if 'watchdog_setup' in config:
-        ctx.ceph[config['cluster']].watchdog = DaemonWatchdog(ctx, config)
-        ctx.ceph[config['cluster']].watchdog.start()
-    else:
-        ctx.ceph[config['cluster']].watchdog = None
-    yield
+    cluster = config['cluster']
+    thrashers = []
+    ctx.ceph[cluster].thrashers = thrashers
+    ctx.ceph[cluster].watched_processes = []
+    watchdog = DaemonWatchdog(ctx, config)
+    ctx.ceph[cluster].watchdog = watchdog
+    watchdog.start()
+    try:
+        yield
+    finally:
+        log.info("Tearing down thrashers...")
+        for thrasher in thrashers:
+            thrasher.stop()
+        for thrasher in thrashers:
+            thrasher.join()
+        log.info("Tearing down watchdog...")
+        watchdog.stop()
+        watchdog.join()
 
 @contextlib.contextmanager
 def ceph_initial():
@@ -1568,10 +1578,11 @@ def stop(ctx, config):
         ctx.daemons.get_daemon(type_, id_, cluster).stop()
         clusters.add(cluster)
     
-    if ctx.ceph[cluster].watchdog:
-        for cluster in clusters:
-            ctx.ceph[cluster].watchdog.stop()
-            ctx.ceph[cluster].watchdog.join()
+    for cluster in clusters:
+        watchdog = ctx.ceph[cluster].watchdog
+        if watchdog:
+            watchdog.stop()
+            watchdog.join()
 
     yield
 
@@ -1960,9 +1971,6 @@ def initialize_config(ctx, config):
     cluster_name = config['cluster']
     testdir = teuthology.get_testdir(ctx)
 
-    ctx.ceph[cluster_name].thrashers = []
-    # fixme: setup watchdog, ala ceph.py
-
     ctx.ceph[cluster_name].roleless = False  # see below
 
     first_ceph_cluster = False
@@ -2184,8 +2192,8 @@ def task(ctx, config):
             lambda: ceph_monitoring('grafana', ctx=ctx, config=config),
             lambda: ceph_clients(ctx=ctx, config=config),
             lambda: create_rbd_pool(ctx=ctx, config=config),
-            lambda: conf_epoch(ctx=ctx, config=config),
             lambda: watchdog_setup(ctx=ctx, config=config),
+            lambda: conf_epoch(ctx=ctx, config=config),
     ):
         try:
             if config.get('wait-for-healthy', True):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/79949





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
