### PR TITLE
osd: re-check readability while a pg is laggy

### DIFF
--- a/qa/standalone/osd/osd-lease-laggy.sh
+++ b/qa/standalone/osd/osd-lease-laggy.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Clyso Technologies Inc. <https://www.clyso.com>
+#
+# Author: Dan van der Ster <dan.vanderster@clyso.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7148" # git grep '\<7148\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth_cluster_required=none "
+    CEPH_ARGS+="--auth_service_required=none --auth_client_required=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    # Keep the read lease short so the test does not have to wait out the
+    # 16s default.  grace 5 * ratio 0.8 => a 4s lease, renewed every 2s.
+    CEPH_ARGS+="--osd-heartbeat-grace=5 "
+    CEPH_ARGS+="--osd-pool-default-read-lease-ratio=0.8 "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+# A pg that latches PG_STATE_LAGGY must be able to recover on its own.
+#
+# PG_STATE_LAGGY is set from PrimaryLogPG::check_laggy() and cleared only from
+# PrimaryLogPG::recheck_readable().  For an acting set larger than one the only
+# caller of recheck_readable() used to be PeeringState::proc_lease_ack(), so if
+# lease renewal stalled -- no more leases sent, therefore no more acks -- the pg
+# stayed laggy and every client op sat in waiting_for_readable until the next
+# interval change, i.e. until an OSD was restarted.
+#
+# osd_debug_drop_pg_lease_renewals simulates that stall by discarding the
+# RenewLease timer events instead of arming them.
+function TEST_laggy_pg_recovers_when_lease_renewal_stalls() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
+
+    create_pool test 1 1 || return 1
+    ceph osd pool set test size 3 || return 1
+    ceph osd pool set test min_size 2 || return 1
+    wait_for_clean || return 1
+
+    local pgid
+    pgid=$(get_pg test SOMETHING) || return 1
+
+    # baseline: writes work
+    timeout 30 rados -p test put obj-before /etc/group || return 1
+
+    # Break the renewal chain everywhere.  The already-armed event fires once
+    # more, re-arms into the void, and from then on no lease is sent.
+    ceph tell 'osd.*' injectargs '--osd_debug_drop_pg_lease_renewals=true' || return 1
+
+    # Let the outstanding lease expire (4s lease, renewed every 2s).
+    sleep 10
+
+    # This write finds mnow > readable_until, so check_laggy() latches
+    # PG_STATE_LAGGY and parks the op in waiting_for_readable.  With the
+    # safety net in place the pg schedules its own CheckReadable, notices the
+    # renewal chain has stalled, restarts it and requeues the op.  Without it
+    # the op never completes and this times out.
+    timeout 120 rados -p test put obj-after /etc/group || return 1
+
+    # And the pg must not be left permanently marked laggy.
+    local tries=0
+    while ceph pg $pgid query | jq -r '.state' | grep -q laggy ; do
+        tries=$((tries + 1))
+        if [ $tries -gt 60 ] ; then
+            echo "pg $pgid still laggy after recovering"
+            ceph pg $pgid query
+            return 1
+        fi
+        sleep 1
+    done
+
+    # Reads must work too, and the object we wrote while laggy must be intact.
+    timeout 30 rados -p test get obj-after $dir/obj-after || return 1
+    cmp /etc/group $dir/obj-after || return 1
+
+    ceph tell 'osd.*' injectargs '--osd_debug_drop_pg_lease_renewals=false' || return 1
+    wait_for_clean || return 1
+}
+
+main osd-lease-laggy "$@"
+
+# Local Variables:
+# compile-command: "cd ../.. ; make -j4 && \
+#   test/osd/osd-lease-laggy.sh"
+# End:

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -251,6 +251,18 @@ options:
   level: advanced
   desc: Asserts that no clone-objects were added to a snap after we start trimming it
   default: false
+- name: osd_debug_drop_pg_lease_renewals
+  type: bool
+  level: dev
+  desc: Silently drop scheduled PG lease renewals (testing only)
+  long_desc: When set, PG::schedule_renew_lease() does not arm the renewal timer,
+    which simulates a lost RenewLease peering event.  Used by
+    qa/standalone/osd/osd-lease-laggy.sh to verify that a laggy PG still recovers
+    when the lease renewal chain stalls.
+  default: false
+  flags:
+  - runtime
+  with_legacy: true
 - name: osd_scrub_begin_hour
   type: int
   level: advanced

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1618,6 +1618,11 @@ HeartbeatStampsRef PG::get_hb_stamps(int peer)
 
 void PG::schedule_renew_lease(epoch_t lpr, ceph::timespan delay)
 {
+  if (cct->_conf->osd_debug_drop_pg_lease_renewals) {
+    dout(10) << __func__ << " dropping renewal for " << info.pgid
+	     << " (osd_debug_drop_pg_lease_renewals)" << dendl;
+    return;
+  }
   auto spgid = info.pgid;
   auto o = osd;
   osd->mono_timer.add_event(

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1407,6 +1407,39 @@ void PeeringState::proc_renew_lease()
   schedule_renew_lease();
 }
 
+void PeeringState::schedule_laggy_recheck()
+{
+  if (!is_primary()) {
+    return;
+  }
+  psdout(20) << "scheduling readable recheck in " << (readable_interval / 2)
+	     << dendl;
+  pl->queue_check_readable(last_peering_reset, readable_interval / 2);
+}
+
+void PeeringState::recheck_lease_renewal()
+{
+  if (!is_primary() ||
+      !HAVE_FEATURE(upacting_features, SERVER_OCTOPUS)) {
+    return;
+  }
+  // Renewal runs every readable_interval/2, so the bound we last sent should
+  // always be comfortably in the future.  If it has expired outright the
+  // renewal chain is not keeping up: proc_renew_lease() re-arms itself and
+  // nothing else re-arms it, so a single discarded RenewLease event (stale
+  // last_peering_reset, or delivery outside Active) leaves this pg unable to
+  // ever renew again -- and therefore stuck in PG_STATE_LAGGY until the next
+  // interval change.  Restart the chain rather than wait for that.
+  auto mnow = pl->get_mnow();
+  if (mnow < readable_until_ub_sent) {
+    return;
+  }
+  psdout(1) << "lease renewal stalled (mnow " << mnow
+	    << " >= readable_until_ub_sent " << readable_until_ub_sent
+	    << "), restarting renewal" << dendl;
+  proc_renew_lease();
+}
+
 void PeeringState::recalc_readable_until()
 {
   ceph_assert(is_primary());
@@ -7127,6 +7160,7 @@ boost::statechart::result PeeringState::Active::react(const MLeaseAck& la)
 boost::statechart::result PeeringState::Active::react(const CheckReadable &evt)
 {
   DECLARE_LOCALS;
+  ps->recheck_lease_renewal();
   pl->recheck_readable();
   return discard_event();
 }

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -2269,6 +2269,12 @@ public:
   void proc_lease_ack(int from, const pg_lease_ack_t& la);
   void proc_renew_lease();
 
+  /// [primary] arrange for recheck_readable() to run again while we are laggy
+  void schedule_laggy_recheck();
+
+  /// [primary] restart lease renewal if the renewal chain has stalled
+  void recheck_lease_renewal();
+
   pg_lease_ack_t get_lease_ack() {
     return pg_lease_ack_t(readable_until_ub_from_primary);
   }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -880,6 +880,14 @@ bool PrimaryLogPG::check_laggy(OpRequestRef& op)
     dout(0) << __func__ << " " << msg << dendl;
     osd->clog->warn() << msg;
 
+    // Unlike PG_STATE_WAIT -- which is bounded by prior_readable_until_ub and
+    // gets its own CheckReadable event from AllReplicasActivated -- LAGGY is
+    // otherwise only ever cleared from PeeringState::proc_lease_ack().  If
+    // lease renewal has stalled no ack will arrive, and nothing else would
+    // re-examine this pg before the next interval change.  Arrange for
+    // recheck_readable() to run again on its own.
+    recovery_state.schedule_laggy_recheck();
+
     publish_stats_to_osd();
   }
   dout(10) << __func__ << " not readable" << dendl;
@@ -929,9 +937,11 @@ void PrimaryLogPG::recheck_readable()
     if (ru == ceph::signedspan::zero()) {
       dout(10) << __func__ << " still laggy (mnow " << mnow
 	       << ", readable_until zero)" << dendl;
+      recovery_state.schedule_laggy_recheck();
     } else if (mnow >= ru) {
       dout(10) << __func__ << " still laggy (mnow " << mnow
 	       << " >= readable_until " << ru << ")" << dendl;
+      recovery_state.schedule_laggy_recheck();
     } else {
       dout(10) << __func__ << " no longer laggy (mnow " << mnow
 	       << " < readable_until " << ru << ")" << dendl;


### PR DESCRIPTION
A PG that latches PG_STATE_LAGGY has nothing scheduled that will ever before this session (show) re-evaluate it: check_laggy() stops testing readable_until once the flag is set, and for an acting set larger than one the only path that clears it is proc_lease_ack(). So if lease renewal stalls -- proc_renew_lease() re-arms itself and nothing else re-arms it, so a single discarded RenewLease event is enough -- no lease is sent, no ack arrives, and the PG stays laggy with every client op parked in waiting_for_readable until the next interval change. The OSD keeps heartbeating throughout, so it is never marked down and in practice only an OSD restart recovers it. This schedules a CheckReadable when LAGGY is set and while it persists, and lets that re-check restart a stalled renewal chain once readable_until_ub_sent has expired. The accompanying standalone test reproduces the wedge with a dev-only injection that discards the renewal timer arming: without the fix the post-expiry write blocks until the test times out; with it the PG clears laggy ~2s later and the write completes.

Fixes: https://tracker.ceph.com/issues/80404

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
