### PR TITLE
common/options: build option tables in place

### DIFF
--- a/src/common/options/y2c.py
+++ b/src/common/options/y2c.py
@@ -154,12 +154,12 @@ def add_verbatim(verbatim):
     return verbatim + '\n'
 
 
-def yaml_to_cxx(opt, indent):
+def yaml_to_cxx(opt, indent, head, terminator):
     name = opt['name']
     typ = opt['type']
     ctyp = type_to_cxx(typ)
     level = level_to_cxx(opt['level'])
-    cxx = f'Option("{name}", {ctyp}, {level})\n'
+    cxx = head.format(name=name, ctyp=ctyp, level=level)
     cxx += set_desc(opt.get('desc'))
     cxx += set_long_desc(opt.get('long_desc'))
     cxx += set_default(opt.get('default'), typ)
@@ -177,14 +177,9 @@ def yaml_to_cxx(opt, indent):
         cxx += '\n'
     else:
         cxx = cxx.rstrip()
-    cxx += ',\n'
-    if indent > 0:
-        indented = []
-        for line in cxx.split('\n'):
-            if line:
-                indented.append(' ' * indent + line + '\n')
-        cxx = ''.join(indented)
-    return cxx
+    cxx += terminator
+    pad = ' ' * indent
+    return ''.join(f'{pad}{line}\n' for line in cxx.split('\n') if line)
 
 
 def type_to_h(t):
@@ -207,9 +202,10 @@ TEMPLATE_CC = '''#include "common/options.h"
 {headers}
 
 std::vector<Option> get_{name}_options() {{
-  return std::vector<Option>({{
+  std::vector<Option> result;
+  result.reserve({count});
 @body@
-  }});
+  return result;
 }}
 '''
 
@@ -237,8 +233,12 @@ class UniqueKeySafeLoader(yaml.SafeLoader):
 def translate(opts):
     if opts.raw:
         prelude, epilogue = '', ''
+        head = 'Option("{name}", {ctyp}, {level})\n'
+        terminator = ',\n'
     else:
         prelude, epilogue = TEMPLATE_CC.split('@body@')
+        head = 'result.emplace_back("{name}", {ctyp}, {level})\n'
+        terminator = ';\n'
 
     if opts.name:
         name = opts.name
@@ -252,11 +252,13 @@ def translate(opts):
          open(opts.legacy, 'w') as h_file:
         yml = yaml.load(infile, Loader=UniqueKeySafeLoader)
         headers = yml.get('headers', '')
-        cc_file.write(prelude.format(name=name, headers=headers))
         options = yml['options']
+        cc_file.write(prelude.format(name=name, headers=headers,
+                                     count=len(options)))
         for option in options:
             try:
-                cc_file.write(yaml_to_cxx(option, opts.indent) + '\n')
+                cc_file.write(yaml_to_cxx(option, opts.indent, head,
+                                          terminator) + '\n')
                 if option.get('with_legacy', False):
                     h_file.write(yaml_to_h(option) + '\n')
             except ValueError as e:


### PR DESCRIPTION
y2c.py generates each get_{name}_options() as one braced list:
```c++
  return std::vector<Option>({ Option(...)..., Option(...)..., ... });
```
This is expensive in two ways.

Every Option backing the initializer_list is live at once in a single frame. `-fstack-usage` reports 746192 bytes for `get_global_options()` (857 entries) and 404736 for `get_rgw_options()` (458), far larger than any other function in these libraries.

`initializer_list` elements are `const`, so vector cannot move out of them. Every Option is built on the stack, copied to the heap, then destroyed, duplicating each name, description, tag and service string.

Use `reserve()` and `emplace_back()` instead. `emplace_back()` returns a reference to the new element, so the `.set_...()` chain applies to it directly: each Option is built in the vector, with no stack temporary and no copy.

On x86-64 (gcc 14.2.0, `-O2` `-fstack-clash-protection` `-fstack-protector-strong`) `get_global_options()` goes from a 746192 to a 1136 byte frame, from 445856 to 85884 bytes of `.text`, and compiles in 3.5s instead of 18.8s. `get_rgw_options()` goes from 404736 to 3792 bytes of frame.

The frame size also breaks unwinding on arm64. A frame that large makes gcc emit stack-clash probing as a loop, and gcc 14 (up to at least Debian's 14.2.0-19) gets the unwind info for that loop wrong by the callee-save size [0]. gdb, C++ exceptions, and full tcmalloc taking a heap-growth backtrace then read garbage instead of the return address. Where pointer authentication is enforced this traps, and `ceph-mon/ceph-osd` have been seen dying with SIGILL at startup, even for `--version` [1]. A small frame avoids the probing loop without waiting for a compiler fix to reach stable distros.

The generated definitions do not change: `--raw` output (for pasting option definitions elsewhere, not used by the build) and the generated legacy option headers are byte-identical across all 13 tables, and the .cc differs only in how each Option is appended.

[0] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119610
[1] https://bugzilla.proxmox.com/show_bug.cgi?id=7941





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
