### PR TITLE
test/rgw/amqp: do not drop replies already popped for a multiple ack

### DIFF
--- a/src/test/rgw/amqp_mock.cc
+++ b/src/test/rgw/amqp_mock.cc
@@ -311,15 +311,20 @@ int amqp_simple_wait_frame_noblock(amqp_connection_state_t state, amqp_frame_t *
     usleep(tv->tv_sec*1000000+tv->tv_usec);
     // read from queue
     if (g_multiple) {
-      // pop multiples and reply once at the end
+      // pop up to "tag skip" replies and reply once for the last one popped.
+      // replies already popped must not be dropped if the queue runs out
+      // before that, otherwise their callbacks are never invoked
+      auto popped = 0U;
       for (auto i = 0U; i < g_tag_skip; ++i) {
-        if (REPLY_ACK && !state->ack_list.pop(state->ack)) {
-          // queue is empty
-          return AMQP_STATUS_TIMEOUT;
-        } else if (!REPLY_ACK && !state->nack_list.pop(state->nack)) {
-          // queue is empty
-          return AMQP_STATUS_TIMEOUT;
+        if (!(REPLY_ACK ? state->ack_list.pop(state->ack) :
+                          state->nack_list.pop(state->nack))) {
+          break;
         }
+        ++popped;
+      }
+      if (popped == 0) {
+        // queue is empty
+        return AMQP_STATUS_TIMEOUT;
       }
       if (REPLY_ACK) {
         state->ack.multiple = g_multiple;


### PR DESCRIPTION
The mock's "multiple" path pops `g_tag_skip` replies and answers once for the last one. When the queue runs out first it returns `AMQP_STATUS_TIMEOUT` and drops the replies it has already popped. Nothing ever acks those delivery tags, so their callbacks stay pending. It also leaves `g_multiple` set, so the mock takes the same path again and keeps dropping replies for the rest of the test binary, including in tests that never asked for a multiple ack.

A pending callback makes `wait_until_drained()` spin until the 30 second `max_idle_time` expires. The manager then erases the connection, and `~connection_t()` fires the orphaned callbacks with `RGW_AMQP_STATUS_CONNECTION_CLOSED` (-4098):
```
  test_rgw_amqp.cc:70: Expected equality of these values:
    0
    rc
      Which is: -4098
```
Whether this happens depends on how the manager thread's reads interleave with the test thread's publishes. If every message is queued before the first read, the pop of `g_tag_skip` replies succeeds and nothing is lost. That is the usual outcome on x86_64, which is why the tests pass there and fail on a loaded arm64 builder [0].

Pop up to `g_tag_skip` replies and answer for the last one actually popped. Return `AMQP_STATUS_TIMEOUT` only when the queue is empty. The mock now answers whenever it popped anything, so reset_multiple() always runs and `g_multiple` no longer leaks into later tests.

Fixes: https://tracker.ceph.com/issues/80434


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
