### PR TITLE
tentacle: mds: tolerate stale version in CDir::mark_dirty

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1446,7 +1446,19 @@ void CDir::mark_dirty(LogSegmentRef const& ls, version_t pv)
   ceph_assert(is_auth());
 
   if (pv) {
-    ceph_assert(get_version() < pv);
+    if (unlikely(get_version() >= pv)) {
+      // When multiple mutations project the same directory and
+      // their journal commits complete out of order, a later
+      // projection may already have advanced get_version() past
+      // the pv of an earlier one.  This is harmless: the dir is
+      // already dirty at a newer version, and the dentry/inode
+      // versions are already set by their own mark_dirty before
+      // reaching here.  Skip the stale version mark.
+      dout(10) << __func__ << " version already advanced, "
+               << "get_version()=" << get_version() << " pv=" << pv
+               << " " << *this << dendl;
+      return;
+    }
     ceph_assert(pv <= projected_version);
     ceph_assert(!projected_fnode.empty() &&
 	        pv <= projected_fnode.front()->version);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80157

---

backport of https://github.com/ceph/ceph/pull/70904
parent tracker: https://tracker.ceph.com/issues/79136

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh