### PR TITLE
RGW: support IAM account rate limiter

### DIFF
--- a/src/rgw/driver/daos/rgw_sal_daos.cc
+++ b/src/rgw/driver/daos/rgw_sal_daos.cc
@@ -2378,6 +2378,7 @@ void DaosStore::get_quota(RGWQuota& quota) {
 
 void DaosStore::get_ratelimit(RGWRateLimitInfo& bucket_ratelimit,
                               RGWRateLimitInfo& user_ratelimit,
+                              RGWRateLimitInfo& account_ratelimit,
                               RGWRateLimitInfo& anon_ratelimit) {
   return;
 }

--- a/src/rgw/driver/daos/rgw_sal_daos.h
+++ b/src/rgw/driver/daos/rgw_sal_daos.h
@@ -973,6 +973,7 @@ class DaosStore : public StoreDriver {
   virtual void get_quota(RGWQuota& quota) override;
   virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit,
                              RGWRateLimitInfo& user_ratelimit,
+                             RGWRateLimitInfo& account_ratelimit,
                              RGWRateLimitInfo& anon_ratelimit) override;
   virtual int set_buckets_enabled(const DoutPrefixProvider* dpp,
                                   std::vector<rgw_bucket>& buckets,

--- a/src/rgw/driver/motr/rgw_sal_motr.cc
+++ b/src/rgw/driver/motr/rgw_sal_motr.cc
@@ -3386,6 +3386,7 @@ int MotrStore::register_to_service_map(const DoutPrefixProvider *dpp, const stri
 
 void MotrStore::get_ratelimit(RGWRateLimitInfo& bucket_ratelimit,
                               RGWRateLimitInfo& user_ratelimit,
+                              RGWRateLimitInfo& account_ratelimit,
                               RGWRateLimitInfo& anon_ratelimit)
 {
   return;

--- a/src/rgw/driver/motr/rgw_sal_motr.h
+++ b/src/rgw/driver/motr/rgw_sal_motr.h
@@ -1036,7 +1036,7 @@ class MotrStore : public StoreDriver {
     virtual int log_op(const DoutPrefixProvider *dpp, std::string& oid, bufferlist& bl) override;
     virtual int register_to_service_map(const DoutPrefixProvider *dpp, const std::string& daemon_type,
         const std::map<std::string, std::string>& meta) override;
-    virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& anon_ratelimit) override;
+    virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& account_ratelimit, RGWRateLimitInfo& anon_ratelimit) override;
     virtual void get_quota(RGWQuota& quota) override;
     virtual int set_buckets_enabled(const DoutPrefixProvider *dpp, std::vector<rgw_bucket>& buckets, bool enabled) override;
     virtual int get_sync_policy_handler(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -704,7 +704,7 @@ public:
   virtual int register_to_service_map(const DoutPrefixProvider *dpp, const std::string& daemon_type,
 				      const std::map<std::string, std::string>& meta) override { return 0; }
   virtual void get_quota(RGWQuota& quota) override { return ; }
-  virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& anon_ratelimit) override { return; }
+  virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& account_ratelimit, RGWRateLimitInfo& anon_ratelimit) override { return; }
   virtual int set_buckets_enabled(const DoutPrefixProvider* dpp, std::vector<rgw_bucket>& buckets, bool enabled, optional_yield y) override { return 0; } // TODO: implement
   virtual int get_sync_policy_handler(const DoutPrefixProvider* dpp,
 				      std::optional<rgw_zone_id> zone,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2489,11 +2489,12 @@ void RadosStore::get_quota(RGWQuota& quota)
     quota.user_quota = svc()->quota->get_user_quota();
 }
 
-void RadosStore::get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& anon_ratelimit)
+void RadosStore::get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& account_ratelimit, RGWRateLimitInfo& anon_ratelimit)
 {
   bucket_ratelimit = svc()->zone->get_current_period().get_config().bucket_ratelimit;
   user_ratelimit = svc()->zone->get_current_period().get_config().user_ratelimit;
   anon_ratelimit = svc()->zone->get_current_period().get_config().anon_ratelimit;
+  account_ratelimit = svc()->zone->get_current_period().get_config().account_ratelimit;
 }
 
 int RadosStore::set_buckets_enabled(const DoutPrefixProvider* dpp, vector<rgw_bucket>& buckets, bool enabled, optional_yield y)

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -352,7 +352,7 @@ class RadosStore : public StoreDriver {
     virtual int register_to_service_map(const DoutPrefixProvider *dpp, const std::string& daemon_type,
 				const std::map<std::string, std::string>& meta) override;
     virtual void get_quota(RGWQuota& quota) override;
-    virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& anon_ratelimit) override;
+    virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& account_ratelimit, RGWRateLimitInfo& anon_ratelimit) override;
     virtual int set_buckets_enabled(const DoutPrefixProvider* dpp, std::vector<rgw_bucket>& buckets, bool enabled, optional_yield y) override;
     virtual int get_sync_policy_handler(const DoutPrefixProvider* dpp,
 					std::optional<rgw_zone_id> zone,

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -6,9 +6,9 @@
  */
 
 #include <cerrno>
+#include <optional>
 #include <string>
 #include <sstream>
-#include <optional>
 #include <iostream>
 
 #include <boost/asio/co_spawn.hpp>
@@ -1768,6 +1768,57 @@ int set_user_ratelimit(OPT opt_cmd, std::unique_ptr<rgw::sal::User>& user,
   return 0;
 }
 
+int set_account_ratelimit(OPT opt_cmd, rgw_account_id& account_id,
+                     int64_t max_read_ops, int64_t max_write_ops, int64_t max_list_ops,
+                     int64_t max_delete_ops, int64_t max_read_bytes, int64_t max_write_bytes,
+                     bool have_max_read_ops, bool have_max_write_ops, bool have_max_list_ops,
+                     bool have_max_delete_ops, bool have_max_read_bytes, bool have_max_write_bytes)
+{
+  RGWAccountInfo account_info;
+  rgw::sal::Attrs account_attrs;
+  RGWObjVersionTracker tracker;
+  int r = driver->load_account_by_id(dpp(), null_yield, account_id, account_info,
+                              account_attrs, tracker);
+  if (r < 0) {
+    cerr << "could not get account info for account=" << account_id << ": " << cpp_strerror(-r) << std::endl;
+    return -r;
+  }
+  RGWRateLimitInfo account_ratelimit_info;
+  auto iter = account_attrs.find(RGW_ATTR_RATELIMIT);
+  if (iter != account_attrs.end()) {
+    try {
+      bufferlist& bl = iter->second;
+      auto biter = bl.cbegin();
+      decode(account_ratelimit_info, biter);
+    } catch (buffer::error& err) {
+      ldpp_dout(dpp(), 0) << "ERROR: failed to decode rate limit" << dendl;
+      return -EIO;
+    }
+  }
+
+  bool ratelimit_configured = set_ratelimit_info(account_ratelimit_info, opt_cmd, max_read_ops, max_write_ops, max_list_ops,
+                         max_delete_ops, max_read_bytes, max_write_bytes,
+                         have_max_read_ops, have_max_write_ops, have_max_list_ops,
+                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes);
+  if (!ratelimit_configured) {
+    ldpp_dout(dpp(), 0) << "ERROR: no rate limit values have been specified" << dendl;
+    return -EINVAL;
+  }
+
+  bufferlist bl;
+  account_ratelimit_info.encode(bl);
+  account_attrs[RGW_ATTR_RATELIMIT] = bl;
+  constexpr bool exclusive = false;
+  r = driver->store_account(dpp(), null_yield, exclusive, account_info, &account_info,
+                              account_attrs, tracker);
+  if (r < 0) {
+    cerr << "could not store account info for account=" << account_id << ": " << cpp_strerror(-r) << std::endl;
+    return -r;
+  }
+
+  return 0;
+}
+
 int show_user_ratelimit(std::unique_ptr<rgw::sal::User>& user, Formatter *formatter)
 {
   RGWRateLimitInfo ratelimit_info;
@@ -1818,6 +1869,38 @@ int show_bucket_ratelimit(rgw::sal::Driver* driver, const string& tenant_name,
   }
   formatter->open_object_section("bucket_ratelimit");
   encode_json("bucket_ratelimit", ratelimit_info, formatter);
+  formatter->close_section();
+  formatter->flush(cout);
+  cout << std::endl;
+  return 0;
+}
+
+int show_account_ratelimit(rgw::sal::Driver* driver, const rgw_account_id& account_id,
+                          Formatter *formatter)
+{
+  RGWAccountInfo account_info;
+  rgw::sal::Attrs account_attrs;
+  RGWObjVersionTracker tracker;
+  int r = driver->load_account_by_id(dpp(), null_yield, account_id, account_info,
+                              account_attrs, tracker);
+  if (r < 0) {
+    cerr << "could not get account info for account=" << account_id << ": " << cpp_strerror(-r) << std::endl;
+    return -r;
+  }
+  RGWRateLimitInfo account_ratelimit_info;
+  auto iter = account_attrs.find(RGW_ATTR_RATELIMIT);
+  if (iter != account_attrs.end()) {
+    try {
+      bufferlist& bl = iter->second;
+      auto biter = bl.cbegin();
+      decode(account_ratelimit_info, biter);
+    } catch (buffer::error& err) {
+      ldpp_dout(dpp(), 0) << "ERROR: failed to decode rate limit" << dendl;
+      return -EIO;
+    }
+  }
+  formatter->open_object_section("account_ratelimit");
+  encode_json("account_ratelimit", account_ratelimit_info, formatter);
   formatter->close_section();
   formatter->flush(cout);
   cout << std::endl;
@@ -5345,6 +5428,13 @@ int main(int argc, const char **argv)
                          have_max_read_ops, have_max_write_ops, have_max_list_ops,
                          have_max_delete_ops, have_max_read_bytes, have_max_write_bytes);
           encode_json("user_ratelimit", period_config.user_ratelimit, formatter.get());
+        } else if (ratelimit_scope == "account") {
+          ratelimit_configured = set_ratelimit_info(period_config.account_ratelimit, opt_cmd,
+                         max_read_ops, max_write_ops, max_list_ops, max_delete_ops,
+                         max_read_bytes, max_write_bytes,
+                         have_max_read_ops, have_max_write_ops, have_max_list_ops,
+                         have_max_delete_ops, have_max_read_bytes, have_max_write_bytes);
+          encode_json("account_ratelimit", period_config.account_ratelimit, formatter.get());
         } else if (ratelimit_scope == "anonymous") {
           ratelimit_configured = set_ratelimit_info(period_config.anon_ratelimit, opt_cmd,
                          max_read_ops, max_write_ops, max_list_ops,max_delete_ops,
@@ -5357,6 +5447,7 @@ int main(int argc, const char **argv)
           encode_json("bucket_ratelimit", period_config.bucket_ratelimit, formatter.get());
           encode_json("user_ratelimit", period_config.user_ratelimit, formatter.get());
           encode_json("anonymous_ratelimit", period_config.anon_ratelimit, formatter.get());
+          encode_json("account_ratelimit", period_config.account_ratelimit, formatter.get());
         } else {
           cerr << "ERROR: invalid rate limit scope specification. Please specify "
               "either --ratelimit-scope=bucket, or --ratelimit-scope=user or --ratelimit-scope=anonymous" << std::endl;
@@ -12107,8 +12198,8 @@ next:
   bool ratelimit_op_set = (opt_cmd == OPT::RATELIMIT_SET || opt_cmd == OPT::RATELIMIT_ENABLE || opt_cmd == OPT::RATELIMIT_DISABLE);
   bool ratelimit_op_get = opt_cmd == OPT::RATELIMIT_GET;
   if (ratelimit_op_set) {
-    if (bucket_name.empty() && rgw::sal::User::empty(user)) {
-      cerr << "ERROR: bucket name or uid is required for ratelimit operation" << std::endl;
+    if (bucket_name.empty() && rgw::sal::User::empty(user) && account_id.empty()) {
+      cerr << "ERROR: bucket name or uid or account id is required for ratelimit operation" << std::endl;
       return EINVAL;
     }
 
@@ -12132,12 +12223,22 @@ next:
         cerr << "ERROR: invalid ratelimit scope specification. Please specify either --ratelimit-scope=bucket, or --ratelimit-scope=user" << std::endl;
         return EINVAL;
       }
+    } else if (!account_id.empty()) {
+      if (ratelimit_scope == "account") {
+        return set_account_ratelimit(opt_cmd, account_id, max_read_ops, max_write_ops, max_list_ops, max_delete_ops,
+                         max_read_bytes, max_write_bytes,
+                         have_max_read_ops, have_max_write_ops, have_max_list_ops, have_max_delete_ops,
+                         have_max_read_bytes, have_max_write_bytes);
+      } else {
+        cerr << "ERROR: invalid ratelimit scope specification. Please specify either --ratelimit-scope=bucket, or --ratelimit-scope=user" << std::endl;
+        return EINVAL;
+      }
     }
   }
 
   if (ratelimit_op_get) {
-    if (bucket_name.empty() && rgw::sal::User::empty(user)) {
-      cerr << "ERROR: bucket name or uid is required for ratelimit operation" << std::endl;
+    if (bucket_name.empty() && rgw::sal::User::empty(user) && account_id.empty()) {
+      cerr << "ERROR: bucket name or uid or account id is required for ratelimit operation" << std::endl;
       return EINVAL;
     }
 
@@ -12158,6 +12259,15 @@ next:
         cerr << "ERROR: invalid ratelimit scope specification. Please specify either --ratelimit-scope=bucket, or --ratelimit-scope=user" << std::endl;
         return EINVAL;
       }
+    } else if (!account_id.empty()) {
+      if (ratelimit_scope == "account") {
+        int ret = show_account_ratelimit(driver, account_id, formatter.get());
+        if (ret < 0) {
+          std::cerr << "ERROR: failed to get a ratelimit for user id: '" << user->get_id() << "', errno: " << cpp_strerror(-ret) << std::endl;
+        }
+        return ret;
+      }
+      
     }
   }
 

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -552,6 +552,7 @@ rgw::auth::Strategy::apply(const DoutPrefixProvider *dpp, const rgw::auth::Strat
        * in the authorization phase (RGWOp::verify_permissions). */
       s->user = applier->load_acct_info(dpp);
       s->perm_mask = applier->get_perm_mask();
+      s->account = applier->get_account();
 
       /* This is the single place where we pass req_state as a pointer
        * to non-const and thus its modification is allowed. In the time

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1320,9 +1320,11 @@ struct req_state : DoutPrefixProvider {
   std::shared_ptr<RateLimiter> ratelimit_data;
   RGWRateLimitInfo user_ratelimit;
   RGWRateLimitInfo bucket_ratelimit;
+  RGWRateLimitInfo account_ratelimit;
   int64_t ratelimit_retry_after{0};
   std::string ratelimit_bucket_marker;
   std::string ratelimit_user_name;
+  std::optional<RGWAccountInfo> account;
   bool content_started{false};
   RGWFormat format{RGWFormat::PLAIN};
   ceph::Formatter *formatter{nullptr};

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -99,18 +99,46 @@ bool rate_limit(rgw::sal::Driver* driver, req_state* s) {
   std::string userfind;
   RGWRateLimitInfo global_user;
   RGWRateLimitInfo global_bucket;
+  RGWRateLimitInfo global_account;
   RGWRateLimitInfo global_anon;
   RGWRateLimitInfo* bucket_ratelimit;
   RGWRateLimitInfo* user_ratelimit;
-  driver->get_ratelimit(global_bucket, global_user, global_anon);
+  RGWRateLimitInfo* account_ratelimit;
+  driver->get_ratelimit(global_bucket, global_user, global_account, global_anon);
   bucket_ratelimit = &global_bucket;
   user_ratelimit = &global_user;
+  account_ratelimit = &global_account;
   s->user->get_id().to_str(userfind);
   userfind = "u" + userfind;
   s->ratelimit_user_name = userfind;
   std::string bucketfind = !rgw::sal::Bucket::empty(s->bucket.get()) ? "b" + s->bucket->get_marker() : "";
   s->ratelimit_bucket_marker = bucketfind;
   const char *method = s->info.method;
+
+  if (s->account) {
+    RGWAccountInfo account_info;
+    rgw::sal::Attrs account_attrs;
+    RGWObjVersionTracker tracker;
+    int r = driver->load_account_by_id(s, null_yield, s->account->id, account_info,
+                                account_attrs, tracker);
+    if (r < 0) {
+      ldpp_dout(s, 0) << "could not get account info for account=" << s->account->id << ": " << cpp_strerror(-r) << dendl;
+      return -r;
+    }
+    RGWRateLimitInfo account_ratelimit_info;
+    auto iter = account_attrs.find(RGW_ATTR_RATELIMIT);
+    if (iter != account_attrs.end()) {
+      try {
+        bufferlist& bl = iter->second;
+        auto biter = bl.cbegin();
+        decode(account_ratelimit_info, biter);
+      } catch (buffer::error& err) {
+        ldpp_dout(s, 0) << "ERROR: failed to decode rate limit" << dendl;
+        return -EIO;
+      }
+    }
+    account_ratelimit = &account_ratelimit_info;
+  }
 
   bool is_sts_user = (s->auth.identity && s->auth.identity->get_identity_type() == TYPE_ROLE);
   if (is_sts_user) {
@@ -140,8 +168,18 @@ bool rate_limit(rgw::sal::Driver* driver, req_state* s) {
   if (s->user->get_id().id == RGW_USER_ANON_ID && global_anon.enabled) {
     *user_ratelimit = global_anon;
   }
+
+  // Check account-level rate limiting
+  int64_t limit_account = 0;
   int64_t limit_bucket = 0;
-  int64_t limit_user = s->ratelimit_data->should_rate_limit(method, s->ratelimit_user_name, s->time, user_ratelimit, s->info.request_params);
+  int64_t limit_user = 0;
+  
+  limit_account = s->ratelimit_data->should_rate_limit(method, s->account->id, s->time, account_ratelimit, s->info.request_params);
+
+  // Only check user/bucket limits if account limit allows
+  if (!limit_account) {
+    limit_user = s->ratelimit_data->should_rate_limit(method, s->ratelimit_user_name, s->time, user_ratelimit, s->info.request_params);
+  }
 
   if(!rgw::sal::Bucket::empty(s->bucket.get()))
   {
@@ -160,20 +198,37 @@ bool rate_limit(rgw::sal::Driver* driver, req_state* s) {
         return -EIO;
       }
     }
-    if (!limit_user) {
+    if (!limit_user && !limit_account) {
       limit_bucket = s->ratelimit_data->should_rate_limit(method, s->ratelimit_bucket_marker, s->time, bucket_ratelimit, s->info.request_params);
     }
   }
-  if(limit_bucket && !limit_user) {
+
+  // Token giveback logic: if a lower-level limit blocks, give back tokens to higher levels
+  if (!limit_account && (limit_bucket || limit_user)) {
+    // Give back account tokens
+    std::string account_key = s->account->id;
+    s->ratelimit_data->giveback_tokens(method, account_key, s->info.request_params, account_ratelimit);
+  }
+  if (!limit_account && !limit_user && limit_bucket) {
+    // Give back user tokens
     s->ratelimit_data->giveback_tokens(method, s->ratelimit_user_name, s->info.request_params, user_ratelimit);
   }
+
+  s->account_ratelimit = *account_ratelimit;
   s->user_ratelimit = *user_ratelimit;
   s->bucket_ratelimit = *bucket_ratelimit;
-  int64_t delay = limit_user ? limit_user : limit_bucket;
+
+  int64_t delay = limit_bucket;
+  if (limit_account) {
+    delay = limit_account;
+  } else if (limit_user) {
+    delay = limit_user;
+  }
+
   if (delay > 0) {
     s->ratelimit_retry_after = delay;
   }
-  return (limit_user || limit_bucket);
+  return (limit_account || limit_user || limit_bucket);
 }
 
 int rgw_process_authenticated(RGWHandler_REST * const handler,

--- a/src/rgw/rgw_rest_ratelimit.cc
+++ b/src/rgw/rgw_rest_ratelimit.cc
@@ -2,10 +2,12 @@
 // vim: ts=8 sw=2 sts=2 expandtab ft=cpp
 
 #include "rgw_rest_ratelimit.h"
+
 #include "rgw_sal.h"
 #include "rgw_sal_config.h"
-#include "rgw_process_env.h"
 #include "rgw_op.h"
+#include "rgw_process_env.h"
+#include "rgw_zone.h"
 
 class RGWOp_Ratelimit_Info : public RGWRESTOp {
 int check_caps(const RGWUserCaps& caps) override {
@@ -118,6 +120,7 @@ void RGWOp_Ratelimit_Info::execute(optional_yield y)
     encode_json("bucket_ratelimit", period_config.bucket_ratelimit, s->formatter);
     encode_json("user_ratelimit", period_config.user_ratelimit, s->formatter);
     encode_json("anonymous_ratelimit", period_config.anon_ratelimit, s->formatter);
+    encode_json("account_ratelimit", period_config.account_ratelimit, s->formatter);
     s->formatter->close_section();
     flusher.flush();
     return;
@@ -378,6 +381,16 @@ void RGWOp_Ratelimit_Set::execute(optional_yield y)
                          have_max_list_ops, max_list_ops, have_max_delete_ops, max_delete_ops,
                          have_enabled, enabled, ratelimit_configured, ratelimit_info);
       period_config.user_ratelimit = ratelimit_info;
+      op_ret = cfgstore->write_period_config(s, y, false, realm_id, period_config);
+      return;
+    }
+    if (ratelimit_scope == "account") {
+      ratelimit_info = period_config.account_ratelimit;
+      set_ratelimit_info(have_max_read_ops, max_read_ops, have_max_write_ops, max_write_ops,
+                         have_max_read_bytes, max_read_bytes, have_max_write_bytes, max_write_bytes,
+                         have_max_list_ops, max_list_ops, have_max_delete_ops, max_delete_ops,
+                         have_enabled, enabled, ratelimit_configured, ratelimit_info);
+      period_config.account_ratelimit = ratelimit_info;
       op_ret = cfgstore->write_period_config(s, y, false, realm_id, period_config);
       return;
     }

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -622,7 +622,8 @@ class Driver {
     /** Get default quota info.  Used as fallback if a user or bucket has no quota set*/
     virtual void get_quota(RGWQuota& quota) = 0;
     /** Get global rate limit configuration*/
-    virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& anon_ratelimit) = 0;
+    virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit,
+      RGWRateLimitInfo& account_ratelimit, RGWRateLimitInfo& anon_ratelimit) = 0;
     /** Enable or disable a set of bucket.  e.g. if a User is suspended */
     virtual int set_buckets_enabled(const DoutPrefixProvider* dpp, std::vector<rgw_bucket>& buckets, bool enabled, optional_yield y) = 0;
     /** Get a new request ID */

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -2020,7 +2020,11 @@ namespace rgw::sal {
     return 0;
   }
 
-  void DBStore::get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& anon_ratelimit)
+  void DBStore::get_ratelimit(
+      RGWRateLimitInfo& bucket_ratelimit,
+      RGWRateLimitInfo& user_ratelimit,
+      RGWRateLimitInfo& account_ratelimit,
+      RGWRateLimitInfo& anon_ratelimit)
   {
     return;
   }

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -947,7 +947,11 @@ public:
       virtual int log_op(const DoutPrefixProvider *dpp, std::string& oid, bufferlist& bl) override;
       virtual int register_to_service_map(const DoutPrefixProvider *dpp, const std::string& daemon_type,
           const std::map<std::string, std::string>& meta) override;
-      virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit, RGWRateLimitInfo& user_ratelimit, RGWRateLimitInfo& anon_ratelimit) override;
+      virtual void get_ratelimit(
+          RGWRateLimitInfo& bucket_ratelimit,
+          RGWRateLimitInfo& user_ratelimit,
+          RGWRateLimitInfo& account_ratelimit,
+          RGWRateLimitInfo& anon_ratelimit) override;
       virtual void get_quota(RGWQuota& quota) override;
     virtual int set_buckets_enabled(const DoutPrefixProvider *dpp, std::vector<rgw_bucket>& buckets, bool enabled, optional_yield y) override;
       virtual int get_sync_policy_handler(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -525,11 +525,14 @@ void FilterDriver::get_quota(RGWQuota& quota)
   return next->get_quota(quota);
 }
 
-void FilterDriver::get_ratelimit(RGWRateLimitInfo& bucket_ratelimit,
-				RGWRateLimitInfo& user_ratelimit,
-				RGWRateLimitInfo& anon_ratelimit)
+void FilterDriver::get_ratelimit(
+    RGWRateLimitInfo& bucket_ratelimit,
+    RGWRateLimitInfo& user_ratelimit,
+    RGWRateLimitInfo& account_ratelimit,
+    RGWRateLimitInfo& anon_ratelimit)
 {
-  return next->get_ratelimit(bucket_ratelimit, user_ratelimit, anon_ratelimit);
+  return next->get_ratelimit(
+      bucket_ratelimit, user_ratelimit, account_ratelimit, anon_ratelimit);
 }
 
 int FilterDriver::set_buckets_enabled(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -397,9 +397,11 @@ public:
 				      const std::map<std::string,
 				      std::string>& meta) override;
   virtual void get_quota(RGWQuota& quota) override;
-  virtual void get_ratelimit(RGWRateLimitInfo& bucket_ratelimit,
-			     RGWRateLimitInfo& user_ratelimit,
-			     RGWRateLimitInfo& anon_ratelimit) override;
+  virtual void get_ratelimit(
+      RGWRateLimitInfo& bucket_ratelimit,
+      RGWRateLimitInfo& user_ratelimit,
+      RGWRateLimitInfo& account_ratelimit,
+      RGWRateLimitInfo& anon_ratelimit) override;
   virtual int set_buckets_enabled(const DoutPrefixProvider* dpp,
 				  std::vector<rgw_bucket>& buckets,
 				  bool enabled, optional_yield y) override;

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -456,6 +456,7 @@ void RGWPeriodConfig::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("user_ratelimit", user_ratelimit, obj);
   JSONDecoder::decode_json("bucket_ratelimit", bucket_ratelimit, obj);
   JSONDecoder::decode_json("anonymous_ratelimit", anon_ratelimit, obj);
+  JSONDecoder::decode_json("account_ratelimit", account_ratelimit, obj);
 }
 
 void RGWPeriodConfig::dump(Formatter *f) const
@@ -465,6 +466,7 @@ void RGWPeriodConfig::dump(Formatter *f) const
   encode_json("user_ratelimit", user_ratelimit, f);
   encode_json("bucket_ratelimit", bucket_ratelimit, f);
   encode_json("anonymous_ratelimit", anon_ratelimit, f);
+  encode_json("account_ratelimit", account_ratelimit, f);
 }
 
 void RGWZoneGroup::dump(Formatter *f) const

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -431,25 +431,30 @@ struct RGWPeriodConfig
   RGWRateLimitInfo bucket_ratelimit;
   // rate limit unauthenticated user
   RGWRateLimitInfo anon_ratelimit;
+  RGWRateLimitInfo account_ratelimit;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(quota.bucket_quota, bl);
     encode(quota.user_quota, bl);
     encode(bucket_ratelimit, bl);
     encode(user_ratelimit, bl);
     encode(anon_ratelimit, bl);
+    encode(account_ratelimit, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(quota.bucket_quota, bl);
     decode(quota.user_quota, bl);
     if (struct_v >= 2) {
       decode(bucket_ratelimit, bl);
       decode(user_ratelimit, bl);
       decode(anon_ratelimit, bl);
+    }
+    if (struct_v >= 3) {
+      decode(account_ratelimit, bl);
     }
     DECODE_FINISH(bl);
   }


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
