### PR TITLE
rbd: do not fail ls -l and du on partially removed images

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -529,6 +529,45 @@ test_trash() {
     remove_images
 }
 
+test_trash_partially_removed() {
+    echo "testing listing of partially removed images..."
+    remove_images
+
+    ceph osd pool create rbd2 8
+    rbd pool init rbd2
+
+    rbd create $RBD_CREATE_ARGS -s 1 test1
+    rbd create $RBD_CREATE_ARGS -s 64M --data-pool rbd2 test2
+    rbd bench --io-type write --io-size 4M --io-total 32M test2
+
+    # moving the image to the trash only updates objects in rbd, while the
+    # trim deletes its data objects in rbd2. so without write access to rbd2,
+    # "rbd rm" moves the image to the trash and then fails to trim it
+    local keyring
+    keyring=$(mktemp)
+    ceph auth get-or-create client.rbd_rm_ro mon 'profile rbd' \
+        osd 'profile rbd pool=rbd, profile rbd-read-only pool=rbd2' > $keyring
+    expect_fail rbd --id rbd_rm_ro --keyring $keyring rm test2
+    rbd ls | grep test2
+    expect_fail rbd info test2
+
+    rbd ls -l
+    rbd ls -l | grep 'test1.*1 MiB.*2'
+    rbd ls -l --format json
+    rbd du
+    rbd du | grep test1
+    expect_fail rbd du test2
+
+    rbd rm test2
+    rbd ls | expect_fail grep test2
+    rbd ls -l
+
+    ceph auth rm client.rbd_rm_ro
+    rm -f $keyring
+    ceph osd pool rm rbd2 rbd2 --yes-i-really-really-mean-it
+    remove_images
+}
+
 test_purge() {
     echo "testing trash purge..."
     remove_images
@@ -2088,6 +2127,7 @@ test_others
 test_locking
 test_clone
 test_trash
+test_trash_partially_removed
 test_purge
 test_deep_copy_clone
 test_clone_v2

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -553,11 +553,22 @@ test_trash_partially_removed() {
 
     rbd ls -l
     rbd ls -l | grep 'test1.*1 MiB.*2'
+    rbd ls -l 2>&1 >/dev/null | grep 'test2 is being removed'
     rbd ls -l --format json
     rbd du
     rbd du | grep test1
+    rbd du 2>&1 >/dev/null | grep 'test2 is being removed'
     expect_fail rbd du test2
 
+    rbd create $RBD_CREATE_ARGS -s 2 test2
+    rbd ls -l
+    test "$(rbd ls -l | grep -c test2)" = 1
+    rbd du
+    test "$(rbd du | grep -c test2)" = 1
+    rbd du test2
+
+    rbd rm test2
+    rbd ls | grep test2
     rbd rm test2
     rbd ls | expect_fail grep test2
     rbd ls -l

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -1004,6 +1004,26 @@ std::string image_id(librbd::Image& image) {
   return id;
 }
 
+void warn_if_image_being_removed(librbd::RBD &rbd, librados::IoCtx &io_ctx,
+                                 const std::string &name,
+                                 const std::string &id) {
+  if (id.empty()) {
+    return;
+  }
+  librbd::trash_image_info_t info;
+  if (rbd.trash_get(io_ctx, id.c_str(), &info) < 0 ||
+      info.source != RBD_TRASH_IMAGE_SOURCE_REMOVING) {
+    return;
+  }
+  std::string spec = io_ctx.get_pool_name() + "/";
+  if (!io_ctx.get_namespace().empty()) {
+    spec += io_ctx.get_namespace() + "/";
+  }
+  spec += name;
+  std::cerr << "rbd: image " << spec << " is being removed, run \"rbd rm "
+            << spec << "\" if its removal was interrupted" << std::endl;
+}
+
 std::string mirror_image_mode(librbd::mirror_image_mode_t mode) {
   switch (mode) {
     case RBD_MIRROR_IMAGE_MODE_JOURNAL:

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -244,6 +244,10 @@ bool is_not_user_snap_namespace(librbd::Image* image,
 
 std::string image_id(librbd::Image& image);
 
+void warn_if_image_being_removed(librbd::RBD &rbd, librados::IoCtx &io_ctx,
+                                 const std::string &name,
+                                 const std::string &id);
+
 std::string mirror_image_mode(
     librbd::mirror_image_mode_t mirror_image_mode);
 std::string mirror_image_state(

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -133,15 +133,17 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
     if (imgname != NULL && image_spec.name != imgname) {
       continue;
     }
-    found = true;
 
     librbd::Image image;
     r = rbd.open_read_only(io_ctx, image, image_spec.name.c_str(), NULL);
+    if (r == -ENOENT) {
+      r = 0;
+      continue;
+    }
+    found = true;
     if (r < 0) {
-      if (r != -ENOENT) {
-        std::cerr << "rbd: error opening " << image_spec.name << ": "
-                  << cpp_strerror(r) << std::endl;
-      }
+      std::cerr << "rbd: error opening " << image_spec.name << ": "
+                << cpp_strerror(r) << std::endl;
       continue;
     }
 

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -137,7 +137,15 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
     librbd::Image image;
     r = rbd.open_read_only(io_ctx, image, image_spec.name.c_str(), NULL);
     if (r == -ENOENT) {
+      utils::warn_if_image_being_removed(rbd, io_ctx, image_spec.name,
+                                         image_spec.id);
       r = 0;
+      continue;
+    }
+    if (r == 0 && !image_spec.id.empty() &&
+        utils::image_id(image) != image_spec.id) {
+      utils::warn_if_image_being_removed(rbd, io_ctx, image_spec.name,
+                                         image_spec.id);
       continue;
     }
     found = true;

--- a/src/tools/rbd/action/List.cc
+++ b/src/tools/rbd/action/List.cc
@@ -264,6 +264,9 @@ int do_list(const std::string &pool_name, const std::string& namespace_name,
 	  if (r < 0) {
 	    std::cerr << "rbd: error opening " << comp->name << ": "
                       << cpp_strerror(r) << std::endl;
+	    if (r == -ENOENT) {
+	      r = 0;
+	    }
 
 	    // in any event, continue to next image
 	    comp->state = STATE_IDLE;

--- a/src/tools/rbd/action/List.cc
+++ b/src/tools/rbd/action/List.cc
@@ -262,20 +262,27 @@ int do_list(const std::string &pool_name, const std::string& namespace_name,
 	  r = comp->completion->get_return_value();
 	  comp->completion->release();
 	  if (r < 0) {
-	    std::cerr << "rbd: error opening " << comp->name << ": "
-                      << cpp_strerror(r) << std::endl;
 	    if (r == -ENOENT) {
+	      utils::warn_if_image_being_removed(rbd, ioctx, comp->name,
+	                                         comp->id);
 	      r = 0;
+	    } else {
+	      std::cerr << "rbd: error opening " << comp->name << ": "
+	                << cpp_strerror(r) << std::endl;
 	    }
 
 	    // in any event, continue to next image
 	    comp->state = STATE_IDLE;
 	    continue;
 	  }
-	  r = list_process_image(&rados, comp, lflag, f, tbl);
-	  if (r < 0) {
+	  if (comp->id.empty() || utils::image_id(comp->img) == comp->id) {
+	    r = list_process_image(&rados, comp, lflag, f, tbl);
+	    if (r < 0) {
 	      std::cerr << "rbd: error processing image " << comp->name << ": "
-                        << cpp_strerror(r) << std::endl;
+	                << cpp_strerror(r) << std::endl;
+	    }
+	  } else {
+	    utils::warn_if_image_being_removed(rbd, ioctx, comp->name, comp->id);
 	  }
 	  comp->completion = new librbd::RBD::AioCompletion(nullptr, nullptr);
 	  r = comp->img.aio_close(comp->completion);


### PR DESCRIPTION
"rbd rm" first moves the image to the trash, which removes the `rbd_id` object for its name, and only then trims the data. If the removal is interrupted after the move, the image stays in the trash with source `REMOVING`. `list2()` still returns it, after all the regular images, but it can no longer be opened by name: opening it fails with `-ENOENT`.

"rbd ls -l" prints an error for such an image and moves on, and "rbd du" skips it silently, but both leave the `-ENOENT` in `r`. These images come last, so usually nothing overwrites it, and the command exits with an error after printing a complete listing. Callers that check the exit status fail as well. Proxmox VE's RBD storage plugin runs "rbd ls -l --format json", so every operation that lists the pool fails until someone finishes the removal by hand [0].

Don't let `-ENOENT` from opening an image fail either command. For "rbd du <image>", only count the image as found once it has been opened, so a partially removed image is reported as not found instead of being printed as an empty table.

Tested with the following steps on a vstart cluster:
```shell
  ceph osd pool create rbd 8
  rbd pool init rbd
  ceph osd pool create data 8
  rbd pool init data
  rbd create -s 64M --data-pool data rbd/victim
  rbd bench --io-type write --io-size 4M --io-total 32M rbd/victim
  ceph auth get-or-create client.rm_ro mon 'profile rbd' \
    osd 'profile rbd pool=rbd, profile rbd-read-only pool=data' \
    -o keyring.rm_ro
  rbd --id rm_ro --keyring keyring.rm_ro rm rbd/victim
  rbd ls -l; echo $?
  rbd ls -l --format json; echo $?
  rbd du; echo $?
  rbd du victim; echo $?
```
The client can't write to the data pool, so "rbd rm" moves the image to the trash and then fails to trim it. Before this change, "rbd ls -l", "rbd ls -l --format json" and "rbd du" print the listing and exit with 2. With it they exit with 0, and "rbd du victim" reports the image as not found. `test_trash_partially_removed` in `cli_generic.sh` runs the same steps: it fails without this change and passes with it.

[0] https://bugzilla.proxmox.com/show_bug.cgi?id=7817

Fixes: https://tracker.ceph.com/issues/52910


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
