### PR TITLE
doc/cephfs: design for credential isolation in snapshot mirroring

### DIFF
--- a/doc/dev/cephfs-mirroring-multi-tenant-credential-exchange.rst
+++ b/doc/dev/cephfs-mirroring-multi-tenant-credential-exchange.rst
@@ -1,0 +1,263 @@
+======================================================================================
+CephFS Snapshot Mirroring: Multi-Tenant Credential Management & Isolation Architecture
+======================================================================================
+
+Overview & Problem Statement
+============================
+
+CephFS snapshot mirroring currently relies on a cluster-wide CephX credential that grants broad read/write
+capabilities across the filesystem root (``/``). When replication scales across thousands of multi-tenant
+subvolumes, this model presents critical trade-offs:
+
+1. **Unbounded Blast Radius:** A compromised mirror daemon or leaked peer credential grants access across
+   all shares and metadata on the secondary cluster.
+2. **Key-Management Anti-Patterns:** Having ``ceph-mgr`` act as a dynamic key-minting proxy to issue
+   path-scoped keys reintroduces privilege escalation risks (e.g., service keys with MGR execution
+   permissions requesting arbitrary path access).
+3. **The Target Path Creation Dilemma:** If a credential is strictly path-jailed to a destination
+   subvolume (e.g., ``mds 'allow rwps path=/volumes/.../subvol_B'``), the mirror daemon lacks permissions
+   to execute ``mkdir`` in parent directories, preventing automated target directory creation.
+4. **Metadata & UUID Divergence:** Manually creating secondary subvolumes leads to layout mismatches
+   (UUIDs, pool namespaces, subvolume versions), breaking predictable pathing across clusters.
+
+This document outlines a two-track architecture that enforces least-privilege, path-jailed isolation for
+orchestrated environments while maintaining an operational :math:`O(1)` setup for standalone
+CLI/``cephadm`` deployments without permitting key-minting in ``ceph-mgr``.
+
+Threat Model & Guiding Principles
+=================================
+
+* **Least-Privilege Data Path:** Mirror daemons must only possess access to the specific paths they are
+  actively synchronizing.
+* **Control Plane vs. Data Plane Separation:** Key minting and directory lifecycle management belong
+  strictly to the control plane (MON and MGR).
+* **No Dynamic Key-Minting in MGR:** ``ceph-mgr`` modules must never act as un-jailed proxies into the MON
+  auth subsystem. MGR modules track replication, balance workloads, and package tokens, but do not mint credentials.
+
+Two-Tier Dynamic Credential Resolution
+======================================
+
+To prevent storing thousands of per-directory credentials in the primary monitor's ``config-key`` store
+(which causes monitor store bloat), the primary cluster does not store per-subvolume keys
+locally. Instead, it uses a two-tier dynamic exchange via a cluster-level **Super-Key** :
+
+1. **Tier 1: Cluster-Level Peer Control Key ("Super-Key")**
+
+   * A single, pre-shared CephX identity per cluster pairing (e.g., ``client.mirror_peer.<peer_uuid>``).
+   * Authorized strictly for MON discovery/read access (``mon 'allow r'``) and the specific credential
+     resolution endpoint on the secondary MGR.
+   * Uses ``MgrCap`` argument constraints to lock down invocation by filesystem and pairing identity:
+
+     .. code-block:: text
+
+        [client.mirror_peer.<peer_uuid>]
+        caps mon = "allow r" caps mgr = "allow command 'fs mirror peer_resolve_credentials' fs_name=<fs> peer_uuid=<peer_uuid>"
+
+   * Contains **zero MDS and OSD capabilities**.
+
+2. **Tier 2: Pre-Created Path-Jailed Subvolume Keys**
+   * Dedicated path-scoped credentials created directly on the secondary MON during subvolume replication
+     onboarding.
+   * **Entity Naming Stability:** Entities avoid volatile subvolume internal UUIDs (which cause orphaned
+     keys on subvolume teardown or recreate with ``--retain-snapshots``). They follow a deterministic
+     hierarchical convention:
+
+     .. code-block:: text
+
+        client.mirror.<peer_uuid>.<group_name>.<subvol_name>
+
+   * Scoped strictly to the target subvolume path (``mds 'allow rwps path=/volumes/<group>/<subvol>'``)
+     and matching data pools/namespaces.
+
+Track 1: Orchestrated Environments (CSI, Rook, Dashboard)
+=========================================================
+
+For multi-tenant orchestrated environments, structural directory provisioning and key minting are
+delegated to the control plane before data replication begins.
+
+.. code-block:: text
+
+   [ Primary Cluster ]                                      [ Secondary Cluster ]
+   ┌─────────────────────────┐                             ┌─────────────────────────┐
+   │ Control Plane / CSI     │                             │ Control Plane / CSI     │
+   └────────────┬────────────┘                             └────────────┬────────────┘
+                │ 1. Export Template                                    │
+                │    (UUID, version, pools)                             │
+                ├──────────────────────( Base64 Token )────────────────►│
+                │                                                       │ 2. Create Target Subvol
+                │                                                       │    via Template
+                │                                                       │ 3. Mint Path-Jailed Key
+                │                                                       │    on Secondary MON
+                │                                                       │
+   ┌────────────┴────────────┐                             ┌────────────┴────────────┐
+   │ cephfs-mirror Daemon    │                             │ ceph-mgr (Handshake)    │
+   └────────────┬────────────┘                             └────────────┬────────────┘
+                │                                                       │
+                │ 4. Handshake via Super-Key (No MDS/OSD Caps)          │
+                │    "peer_resolve_credentials fs_name=...              │
+                │     peer_uuid=... group=... subvolume=..."            │
+                ├──────────────────────────────────────────────────────►│
+                │                                                       │ 5. Fetch pre-created
+                │                                                       │    path-jailed key
+                │ 6. Return Scoped Credential                           │
+                │◄──────────────────────────────────────────────────────┤
+                │                                                       │
+                ▼                                                       ▼
+   ┌─────────────────────────┐      Data Synchronization   ┌────────────────────────────┐
+   │ Borrow/Init Libcephfs   ├────────────────────────────►│ Pre-created Target Dir     │
+   │ Context with Scoped Key │      (allow rwps path=...)  │ (/volumes/<group>/<subvol>)│
+   └─────────────────────────┘                             └────────────────────────────┘
+
+Peer Registration & Super-Key Setup
+-----------------------------------
+
+When setting up cross-cluster replication, the orchestrator establishes the peer pairing identity:
+
+1. A unique ``peer_uuid`` is assigned to the relationship and recorded in the primary cluster's peer
+   table.
+2. The orchestrator creates the Super-Key directly on the secondary MON:
+
+   .. code-block:: bash
+
+      ceph auth get-or-create client.mirror_peer.<peer_uuid> \
+          mon 'allow r' \
+          mgr 'allow command "fs mirror peer_resolve_credentials" fs_name=<sec_fs> peer_uuid=<peer_uuid>'
+
+3. The primary imports this key and associates it with the secondary peer record.
+
+Subvolume Template Generation
+-----------------------------
+
+To guarantee that the secondary subvolume matches the primary's internal subvolume version, UUID, pool
+layout, and pool namespaces, the primary cluster exports a serialized, opaque template:
+
+.. code-block:: bash
+
+   ceph fs subvolume template export <vol> <subvol> [--group_name <group>]
+
+* The output is encoded as an opaque base64 string (containing JSON metadata: ``version``, ``uuid``,
+  ``data_pool``, ``pool_namespace``, ``quota_bytes``, and modes).
+* Base64 encoding avoids escaping issues across shell wrappers, Kubernetes CRDs (``VolumeReplication``),
+  and automation APIs.
+
+Matched Subvolume Creation on Secondary
+---------------------------------------
+
+The orchestrator (Rook/CSI tooling, or Ceph Dashboard) ingests the base64 token directly on the secondary
+cluster before synchronization begins:
+
+.. code-block:: bash
+
+   ceph fs subvolume create <vol> <subvol> --template <base64_token> [--group_name <group>]
+
+The secondary cluster instantiates the directory and metadata using the exact UUID and parameters
+extracted from the template.
+
+Direct MON Key Provisioning
+---------------------------
+
+When a subvolume is scheduled for replication, the orchestrator generates the secondary subvolume using
+the template metadata and registers the stable CephX identity on the secondary MON:
+
+.. code-block:: bash
+
+   ceph auth get-or-create client.mirror.<peer_uuid>.<group>.<subvol_name> \
+       mon 'allow r' \
+       mds 'allow rwps path=/volumes/<group>/<subvol_name>' \
+       osd 'allow rw pool=<sec_data_pool> namespace=<ns> tag cephfs data=/volumes/<group>/<subvol_name>'
+
+Because the entity name is tied to ``<peer_uuid>.<group>.<subvol_name>`` rather than an ephemeral
+subvolume UUID, deleting and recreating the underlying volume cleanly updates or reuses the credential
+entry without accumulating orphaned keys in the secondary MON database.
+
+Dynamic Credential Resolution
+-----------------------------
+
+When a sync job is scheduled on the primary:
+
+1. The ``cephfs-mirror`` worker presents the Super-Key (``client.mirror_peer.<peer_uuid>``) to the
+   secondary MGR endpoint:
+
+   .. code-block:: bash
+
+      ceph --id mirror_peer.<peer_uuid> fs mirror peer_resolve_credentials \
+          --fs_name <sec_fs> \
+          --peer_uuid <peer_uuid> \
+          --group_name <group> \
+          --subvolume <subvol_name>
+
+2. The secondary MGR verifies that the caller's ``peer_uuid`` matches its ``MgrCap`` constraints.
+3. The MGR performs a local read of ``client.mirror.<peer_uuid>.<group>.<subvol_name>`` and returns the
+   keyring and capability specification to the daemon.
+4. The mirror daemon initializes or borrows an active ``libcephfs`` mount context using the path-scoped
+   key to replicate the snapshot into the target subvolume.
+
+Track 2: Standalone CLI & cephadm Environments
+==============================================
+
+Standalone deployments lack an external orchestrator to automate per-subvolume rituals. To retain an
+:math:`O(1)` administrative experience without delegating auth-minting authority to ``ceph-mgr``, the
+bootstrap token mechanism is revised:
+
+.. code-block:: text
+
+   [ Secondary Operator ]                                   [ Primary Operator ]
+             │                                                       │
+             ├── 1. Mint Key via MON:                                │
+             │      ceph fs authorize <fs> client.mirror_peer \      │
+             │          /volumes rwps                                │
+             │                                                       │
+             ├── 2. Package via MGR (Read-Only Fetch):               │
+             │      ceph fs mirror peer_bootstrap_create ...         │
+             │                                                       │
+             └───────────────────( Bootstrap Token )────────────────►│
+                                                                     │
+                                                                     └── 3. Import Token:
+                                                                            ceph fs mirror peer_bootstrap_import ...
+
+1. **Pre-Creation on MON:** The administrator explicitly provisions the key on the secondary cluster using
+   direct MON authentication:
+
+   .. code-block:: bash
+
+      ceph fs authorize <sec_fs> client.mirror_peer /volumes rwps
+
+   Caps can be scoped to the ``/volumes`` prefix to prevent access to underlying filesystem metadata.
+
+2. **Fetch-Only MGR Packaging:** The MGR interface ``peer_bootstrap_create`` is stripped of ``auth
+   get-or-create`` write privileges. It only executes a read-only fetch for the pre-existing entity name
+   and encodes it into the bootstrap token.
+
+3. **Primary Import:** The operator imports the token on the primary cluster via ``peer_bootstrap_import``
+   as before.
+
+Mirror Daemon Runtime: Libcephfs Connection Pooling
+===================================================
+
+Holding persistent, concurrent ``libcephfs`` connections across thousands of mirrored subvolumes is not
+viable. The ``cephfs-mirror`` daemon will manage scoped mounts using an active handle pool:
+
+* **Worker-Bound Concurrency:** Active mounts are bounded by the existing worker concurrency configuration
+  (``cephfs_mirror_max_concurrent_directory_syncs``).
+* **Handle Lifecycle (Borrow / Cooldown / Evict):**
+
+  * When a sync job is scheduled, the worker thread requests a handle matching the target path/identity.
+  * If a handle exists, it is reused (avoiding auth and session negotiation). If not, a new ``libcephfs``
+    context is initialized using the scoped CephX key.
+  * Upon sync completion, the handle enters an idle pool.
+  * An idle-timeout and LRU eviction policy tears down idle contexts to reclaim MDS capabilities and
+    memory.
+
+Future Direction: Daemon-to-Daemon Push Replication
+===================================================
+
+The long-term architectural alternative to direct ``libcephfs`` cross-cluster mounting is a native
+daemon-to-daemon receiver protocol:
+
+* **Architecture:** Primary and secondary mirror daemons communicate directly over a dedicated,
+  authenticated RPC channel.
+* **Security Decoupling:** The primary daemon never authenticates against the secondary CephX layer. Local
+  daemons run with local filesystem permissions, eliminating the transmission of CephX storage credentials
+  across clusters.
+* **Bi-directional Mirroring:** Provides a clean peer-to-peer foundation for bidirectional snapshot
+  replication without symmetric credential exchange.


### PR DESCRIPTION
Add a design document detailing multi-tenant credential management and path-jailed isolation for CephFS snapshot mirroring.

The proposal replaces cluster-wide root credentials and eliminates dynamic key-minting in ceph-mgr via a two-track model:

- Orchestrated (Rook/CSI, Dashboard): Uses exported base64 subvolume templates to pre-create matching secondary directory layouts, paired with orchestrator-provisioned path-jailed MON keys.
- Standalone (cephadm/CLI): Preserves an O(1) bootstrap token workflow by pre-authorizing keys on the MON and restricting MGR to read-only token packaging.

Also covers cephfs-mirror libcephfs connection pooling and future daemon- to-daemon RPC replication.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
