### PR TITLE
mgr/cephadm: During mgr upgrade mgr fail happens two times which should happen once

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1484,6 +1484,10 @@ class CephadmUpgrade:
                     continue
 
             if self.mgr.daemon_is_self(d.daemon_type, d.daemon_id):
+                if correct_image:
+                    logger.debug('daemon %s.%s already on target image', d.daemon_type, d.daemon_id)
+                    done += 1
+                    continue
                 logger.info('Upgrade: Need to upgrade myself (mgr.%s)' %
                             self.mgr.get_mgr_id())
                 need_upgrade_self = True


### PR DESCRIPTION


Fixes: https://tracker.ceph.com/issues/80450
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

Testing logs:
```
[ceph: root@ceph-node-0 /]# ceph orch upgrade start quay.io/rh-ee-shbhosal/ceph:test1
Initiating upgrade to quay.io/rh-ee-shbhosal/ceph:test1
[ceph: root@ceph-node-0 /]# ceph orch upgrade status                                 
{
    "in_progress": true,
    "target_image": "quay.io/rh-ee-shbhosal/ceph:test1",
    "services_complete": [],
    "which": "Upgrading all daemon types on all hosts",
    "progress": "",
    "message": "Doing first pull of quay.io/rh-ee-shbhosal/ceph:test1 image",
    "is_paused": false
}
[ceph: root@ceph-node-0 /]# ceph orch upgrade status
There are no upgrades in progress currently.
[ceph: root@ceph-node-0 /]#


node0:
2026-09-10T11:49:17.985+0000 7fe9f3e006c0  0 log_channel(cephadm) log [DBG] : Upgrade: Checking mgr daemons
2026-09-10T11:49:17.985+0000 7fe9f3e006c0  0 [cephadm INFO cephadm.upgrade] Upgrade: Need to upgrade myself (mgr.ceph-node-0.yruywj)
2026-09-10T11:49:17.985+0000 7fe9f3e006c0  0 log_channel(cephadm) log [INF] : Upgrade: Need to upgrade myself (mgr.ceph-node-0.yruywj)
2026-09-10T11:49:17.985+0000 7fe9f3e006c0  0 log_channel(cephadm) log [DBG] : daemon mgr.ceph-node-1.oelrwx on correct image
2026-09-10T11:49:17.985+0000 7fe9f3e006c0  0 log_channel(cephadm) log [DBG] : daemon mgr.ceph-node-1.oelrwx not deployed by correct version
2026-09-10T11:49:17.986+0000 7fe9f3e006c0  0 log_channel(cephadm) log [DBG] : daemon mon.ceph-node-0 not correct (quay.io/rh-ee-shbhosal/ceph:test1, ['quay.io/rh-ee-shbhosal/ceph@sha256:73343887554e105832f6b1a64615f23e45908bde0391f4cb2726c57efd839512'], 21.3.0-2953-gca28ffa3)

node1:
2026-09-10T11:51:02.279+0000 7f0e15c006c0  0 log_channel(cephadm) log [DBG] : daemon mgr.ceph-node-0.yruywj on correct image
2026-09-10T11:51:02.279+0000 7f0e15c006c0  0 log_channel(cephadm) log [DBG] : daemon mgr.ceph-node-0.yruywj deployed by correct version
2026-09-10T11:51:02.279+0000 7f0e15c006c0  0 log_channel(cephadm) log [DBG] : daemon mgr.ceph-node-1.oelrwx on correct image
2026-09-10T11:51:02.279+0000 7f0e15c006c0  0 log_channel(cephadm) log [DBG] : daemon mgr.ceph-node-1.oelrwx already on target image
2026-09-10T11:51:02.280+0000 7f0e15c006c0  0 log_channel(cephadm) log [DBG] : daemon mgr.ceph-node-0.yruywj on correct image
2026-09-10T11:51:02.280+0000 7f0e15c006c0  0 log_channel(cephadm) log [DBG] : daemon mgr.ceph-node-0.yruywj deployed by correct version
2026-09-10T11:51:02.280+0000 7f0e15c006c0  0 log_channel(cephadm) log [DBG] : daemon mgr.ceph-node-1.oelrwx on correct image
2026-09-10T11:51:02.280+0000 7f0e15c006c0  0 log_channel(cephadm) log [DBG] : daemon mgr.ceph-node-1.oelrwx already on target image

```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
