### PR TITLE
mgr/dashboard: fix create-cluster create services cephadm e2e test

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/create-cluster.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/create-cluster.po.ts
@@ -4,16 +4,28 @@ import { HostsPageHelper } from './hosts.po';
 import { ServicesPageHelper } from './services.po';
 
 export class OnboardingHelper extends PageHelper {
-  pages = { index: { url: '#/add-storage?welcome=true', id: 'cd-create-cluster' } };
+  pages = { index: { url: '#/add-storage', id: 'cd-create-cluster' } };
 
   onboarding() {
-    cy.get('cd-create-cluster').should('contain.text', 'Welcome to Ceph Dashboard');
-    cy.get('[aria-label="Add Storage"]').first().click({ force: true });
-    cy.get('cd-tearsheet').should('exist');
+    cy.get('cd-create-cluster').then(($cluster) => {
+      if ($cluster.find('cd-tearsheet').length) {
+        return;
+      }
+      cy.get('cd-create-cluster').should('contain.text', 'Welcome to Ceph Dashboard');
+      cy.get('[aria-label="Add Storage"]').first().click({ force: true });
+      cy.get('cd-tearsheet').should('exist');
+    });
   }
 
   selectStep(stepLabel: string) {
     cy.get('cd-tearsheet cds-progress-indicator').contains(stepLabel).click();
+  }
+
+  openWizardStep(stepLabel: string) {
+    cy.visit('/');
+    this.navigateTo();
+    this.onboarding();
+    this.selectStep(stepLabel);
   }
 
   clickNext() {
@@ -56,10 +68,19 @@ export class CreateClusterServicePageHelper extends ServicesPageHelper {
   };
 
   columnIndex = {
-    service_name: 1,
-    placement: 2,
-    running: 3,
-    size: 4,
-    last_refresh: 5
+    service_name: 2,
+    placement: 3
   };
+
+  checkExist(serviceName: string, exist: boolean) {
+    this.existTableCell(serviceName, exist);
+  }
+
+  expectPlacementCount(serviceName: string, expectedCount: string) {
+    this.getTableRow(serviceName)
+      .find(`[cdstabledata]:nth-child(${this.columnIndex.placement})`)
+      .should(($cell) => {
+        expect($cell.text()).to.include(`count:${expectedCount}`);
+      });
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/services.po.ts
@@ -26,7 +26,11 @@ export class ServicesPageHelper extends PageHelper {
   }
 
   private selectServiceType(serviceType: string) {
-    return this.selectOption('service_type', serviceType);
+    return this.selectOption('service_type', serviceType, true);
+  }
+
+  private setServiceCount(count: number) {
+    cy.get('cds-number#count input').clear().type(String(count));
   }
 
   clickServiceTab(serviceName: string, tabName: string) {
@@ -51,14 +55,14 @@ export class ServicesPageHelper extends PageHelper {
           cy.get('#service_id').type('foo');
           unmanaged
             ? cy.get('cds-checkbox#unmanaged input[type="checkbox"]').check({ force: true })
-            : cy.get('#count').clear().type(String(count));
+            : this.setServiceCount(count);
           break;
 
         case 'ingress':
           if (unmanaged) {
             cy.get('cds-checkbox#unmanaged input[type="checkbox"]').check({ force: true });
           }
-          this.selectOption('backend_service', 'rgw.foo');
+          this.selectOption('backend_service', 'rgw.foo', true);
           cy.get('#service_id').should('have.value', 'rgw.foo');
           cy.get('#virtual_ip').type('192.168.100.1/24');
           cy.get('#frontend_port').type('8081');
@@ -69,14 +73,14 @@ export class ServicesPageHelper extends PageHelper {
           cy.get('#service_id').type('testnfs');
           unmanaged
             ? cy.get('cds-checkbox#unmanaged input[type="checkbox"]').check({ force: true })
-            : cy.get('#count').clear().type(String(count));
+            : this.setServiceCount(count);
           break;
 
         case 'smb':
           cy.get('#service_id').type('testsmb');
           unmanaged
             ? cy.get('cds-checkbox#unmanaged input[type="checkbox"]').check({ force: true })
-            : cy.get('#count').clear().type(String(count));
+            : this.setServiceCount(count);
           cy.get('#cluster_id').type('cluster_foo');
           cy.get('#config_uri').type('rados://.smb/foo/scc.toml');
           break;
@@ -117,7 +121,7 @@ export class ServicesPageHelper extends PageHelper {
           cy.get('#service_id').type('test');
           unmanaged
             ? cy.get('cds-checkbox#unmanaged input[type="checkbox"]').check({ force: true })
-            : cy.get('#count').clear().type(String(count));
+            : this.setServiceCount(count);
           break;
       }
       cy.wait(1000);
@@ -126,7 +130,7 @@ export class ServicesPageHelper extends PageHelper {
     if (exist) {
       cy.get('#service_id').should('have.class', 'ng-invalid');
     } else {
-      // back to service list
+      cy.get('cd-service-form').should('not.exist');
       cy.get(`${this.pages.index.id}`);
     }
   }
@@ -136,9 +140,10 @@ export class ServicesPageHelper extends PageHelper {
     cy.get(`${this.pages.create.id}`).within(() => {
       cy.get('cds-select#service_type select').should('be.disabled');
       cy.get('#service_id').should('be.disabled');
-      cy.get('#count').clear().type(daemonCount);
+      this.setServiceCount(Number(daemonCount));
       cy.get('cd-submit-button').click();
     });
+    cy.get('cd-service-form').should('not.exist');
   }
 
   checkServiceStatus(daemon: string, expectedStatus = 'running') {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/03-create-cluster-create-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/03-create-cluster-create-services.e2e-spec.ts
@@ -14,10 +14,7 @@ describe('Create cluster create services page', () => {
 
   beforeEach(() => {
     cy.login();
-    onboardingPage.navigateTo();
-    onboardingPage.onboarding();
-
-    onboardingPage.selectStep('Create Services');
+    onboardingPage.openWizardStep('Create Services');
   });
 
   it('should check if title contains Create Services', () => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/page-helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/page-helper.po.ts
@@ -250,7 +250,7 @@ export abstract class PageHelper {
     }
     return cy.contains(
       `[cdstablerow] [cdstabledata]:nth-child(${columnIndex})`,
-      new RegExp(`^${exactContent}$`)
+      new RegExp(`^${exactContent.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`)
     );
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-step-3/create-cluster-step-3.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-step-3/create-cluster-step-3.component.html
@@ -8,12 +8,12 @@
     cdsCol
     [columnNumbers]="{ sm: 4, md: 8, lg: 16 }"
   >
-    <h4 18n>Create Services</h4>
+    <h4 i18n>Create Services</h4>
 
     <cd-services
       [hasDetails]="false"
       [hiddenServices]="['mon', 'mgr', 'crash', 'agent']"
-      [hiddenColumns]="['status.running', 'status.size', 'status.last_refresh']"
+      [hiddenColumns]="['status', 'status.last_refresh', 'status.ports', 'certificate.status']"
       [routedModal]="false"
     ></cd-services>
   </div>


### PR DESCRIPTION
Fix MDS service creation in the add-storage wizard e2e flow by updating Carbon form interactions, correcting the i18n attribute typo, and using row-based table assertions in the create-cluster helper.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
