### PR TITLE
workflows: clear needs-ci-approval when ci-approved is added

### DIFF
--- a/.github/workflows/author-ci-perms.yml
+++ b/.github/workflows/author-ci-perms.yml
@@ -2,7 +2,7 @@ name: Check PR Author Permissions
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   check-permissions:
@@ -20,6 +20,63 @@ jobs:
             const issueNumber = pr.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+
+            // Handle the 'labeled' event separately and exit early: the
+            // revocation logic below must not run when someone has just
+            // granted approval, or it would strip the new 'ci-approved' label.
+            if (context.payload.action === 'labeled') {
+              if (context.payload.label.name !== 'ci-approved') {
+                return;
+              }
+              // Labels only need triage permission, a lower bar than the
+              // write access required of authors whose CI runs
+              // automatically; hold approvers to the same bar.  Lookup
+              // failures count as no permission, like the author check.
+              const sender = context.payload.sender.login;
+              let senderPermission = 'none';
+              try {
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
+                  username: sender,
+                });
+                senderPermission = response.data.permission;
+              } catch (error) {
+                console.log(`Failed to fetch permissions for ${sender}: ${error.message}`);
+              }
+              if (['admin', 'write'].includes(senderPermission)) {
+                if (pr.labels.some(label => label.name === 'needs-ci-approval')) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner,
+                      repo,
+                      issue_number: issueNumber,
+                      name: 'needs-ci-approval',
+                    });
+                  } catch (error) {
+                    console.log('Failed to remove needs-ci-approval label:', error);
+                  }
+                }
+              } else {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    name: 'ci-approved',
+                  });
+                } catch (error) {
+                  console.log('Failed to remove ci-approved label:', error);
+                }
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: `@${sender} \`ci-approved\` can only be granted by someone with write access to ceph/ceph; the label has been removed.`,
+                });
+              }
+              return;
+            }
 
             let permission = 'none';
             try {


### PR DESCRIPTION
When a Ceph developer adds the `ci-approved` label to an external contributor's PR, nothing currently removes the `needs-ci-approval` marker: the `ceph-pr-pipeline-trigger` Jenkins job attempts it, but its status token lacks permission to modify labels and the failure is silent, so PRs end up wearing both labels (e.g. #69804).

Handle the `labeled` event in `author-ci-perms.yml` instead, where the Actions token already manages both labels.

Since labels can be added with triage permission — a lower bar than the write access this workflow requires of authors whose CI runs automatically — the handler only honors `ci-approved` when the person who added it has write/admin permission; otherwise it removes the label and comments why. The Jenkins trigger applies the same sender check to decide whether the label starts a run (ceph/ceph-build#2712).

Notes for reviewers:

- The handler exits before the existing revocation logic. Without the early return, the workflow running on the `labeled` event would see a non-writer author and immediately strip the `ci-approved` label that was just added.
- Label additions other than `ci-approved` hit the same early return and are a no-op.
- Permission-lookup failures count as no permission (fail closed), matching the author check.
- The Jenkins trigger also attempts the `needs-ci-approval` removal; whichever side wins, the loser's DELETE 404s harmlessly.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests