### PR TITLE
mgr/cephadm: show NO DATA when a host is missing a hardware category

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1984,10 +1984,8 @@ class NodeProxyCache:
         _result = {}
 
         for host in hosts:
-            try:
-                _result[host] = self.data[host]['status'][endpoint]
-            except KeyError:
-                raise KeyError(f'Invalid host {host} or component {endpoint}.')
+            status = self.data[host].get('status', {})
+            _result[host] = status.get(endpoint, {})
         return _result
 
     def firmware(self, **kw: Any) -> Dict[str, Any]:

--- a/src/pybind/mgr/cephadm/tests/test_node_proxy.py
+++ b/src/pybind/mgr/cephadm/tests/test_node_proxy.py
@@ -399,3 +399,32 @@ class TestNodeProxyCacheSave:
         key, value = cache.mgr.set_store.call_args[0]
         assert 'host01' in key
         assert json.loads(value) == data
+
+
+class TestNodeProxyCacheCommon:
+    def _make_cache(self) -> NodeProxyCache:
+        mgr = MagicMock()
+        mgr.get_store = MagicMock(return_value='{}')
+        mgr.set_store = MagicMock()
+        mgr.inventory = {}
+        cache = NodeProxyCache(mgr)
+        cache.data = {
+            'at4n1': {'sn': '1', 'status': {'storage': {}, 'fcm': {'local': {'nvme0n1': {}}}}},
+            'at4n2': {'sn': '2', 'status': {'storage': {}, 'fans': {}}},
+        }
+        return cache
+
+    def test_common_includes_hosts_missing_component(self):
+        cache = self._make_cache()
+        result = cache.common('fcm')
+        assert result['at4n1'] == {'local': {'nvme0n1': {}}}
+        assert result['at4n2'] == {}
+
+    def test_common_hostname_without_component_returns_empty(self):
+        cache = self._make_cache()
+        assert cache.common('fcm', hostname='at4n2') == {'at4n2': {}}
+
+    def test_common_hostname_with_component(self):
+        cache = self._make_cache()
+        result = cache.common('fcm', hostname='at4n1')
+        assert result == {'at4n1': {'local': {'nvme0n1': {}}}}

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -635,7 +635,12 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
 
         fields = mapping.get(category, ())
         for host in data.keys():
-            for sys_id, details in data[host].items():
+            host_data = data[host] or {}
+            if not any(host_data.values()):
+                # HOST + 'NO DATA' already fill the first two columns...
+                table.add_row([host, 'NO DATA'] + [''] * (len(table.field_names) - 2))
+                continue
+            for sys_id, details in host_data.items():
                 for k, v in details.items():
                     row = []
                     for field in fields:


### PR DESCRIPTION
NodeProxyCache.common() raised a KeyError as soon as one host had no data for the requested category. `ceph orch hardware status --category fcm` then failed on mixed clusters where a node-proxy had not posted that component yet.

Return an empty payload for those hosts and print a NO DATA row so the host still shows up in the table.

Fixes: https://tracker.ceph.com/issues/80453


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
