### PR TITLE
mgr/cephadm: improve daemon termination controls

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3650,16 +3650,32 @@ def command_unit(ctx: CephadmContext) -> int:
     unit_name = lookup_unit_name_by_daemon_name(
         ctx, ident.fsid, ident.daemon_name
     )
-    command = ['systemctl', ctx.command, unit_name]
+    if ctx.command == 'kill':
+        commands = [
+            ['systemctl', 'stop', '--no-block', unit_name],
+            [
+                'systemctl',
+                'kill',
+                '--kill-whom=all',
+                '--signal=SIGKILL',
+                unit_name,
+            ],
+        ]
+    else:
+        commands = [['systemctl', ctx.command, unit_name]]
     if ctx.dry_run:
-        print(' '.join(shlex.quote(arg) for arg in command))
+        for command in commands:
+            print(' '.join(shlex.quote(arg) for arg in command))
         return 0
-    _, _, code = call(
-        ctx,
-        command,
-        verbosity=CallVerbosity.VERBOSE,
-        desc='',
-    )
+    for command in commands:
+        _, _, code = call(
+            ctx,
+            command,
+            verbosity=CallVerbosity.VERBOSE,
+            desc='',
+        )
+        if code:
+            return code
     return code
 
 

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1782,7 +1782,8 @@ class HostCache():
             'reconfig': 3,
             'redeploy': 4,
             'stop': 5,
-            'rotate-key': 6,
+            'kill': 6,
+            'rotate-key': 7,
         }
         existing_action = self.scheduled_daemon_actions.get(host, {}).get(daemon_name, None)
         if existing_action and priorities[existing_action] > priorities[action]:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -124,6 +124,8 @@ except ImportError as e:
 
 logger = logging.getLogger(__name__)
 
+KILL_SUPPORTED_SERVICE_TYPES = {'rbd-mirror'}
+
 T = TypeVar('T')
 
 DEFAULT_SSH_CONFIG = """
@@ -3122,6 +3124,13 @@ Then run the following:
         if service_name not in self.spec_store.all_specs.keys():
             raise OrchestratorError(f'Invalid service name "{service_name}".'
                                     + ' View currently running services using "ceph orch ls"')
+        spec = self.spec_store.all_specs[service_name]
+
+        if action == 'kill' and spec.service_type not in KILL_SUPPORTED_SERVICE_TYPES:
+            raise OrchestratorError(
+                f'kill action is not supported for {spec.service_type} services'
+            )
+        
         if action == 'stop' and service_name.split('.')[0].lower() in ['mgr', 'mon', 'osd']:
             return [f'Stopping entire {service_name} service is prohibited.']
 
@@ -3259,6 +3268,7 @@ Then run the following:
             'start': ['reset-failed', 'start'],
             'stop': ['stop'],
             'restart': ['reset-failed', 'restart'],
+            'kill': ['kill'],
         }
         name = daemon_spec.name()
         for a in actions[action]:
@@ -3305,12 +3315,17 @@ Then run the following:
         assert d.daemon_id is not None
         assert d.hostname
 
+        if action == 'kill' and d.daemon_type not in KILL_SUPPORTED_SERVICE_TYPES:
+            raise OrchestratorError(
+                f'kill action is not supported for {d.daemon_type} daemons'
+            )
+
         if (action == 'redeploy' or action == 'restart') and self.daemon_is_self(d.daemon_type, d.daemon_id) \
                 and not self.mgr_service.mgr_map_has_standby():
             raise OrchestratorError(
                 f'Unable to schedule redeploy for {daemon_name}: No standby MGRs')
 
-        if action in ['restart', 'stop'] and not force:
+        if action in ['restart', 'stop', 'kill'] and not force:
             r = service_registry.get_service(daemon_type_to_service(
                 d.daemon_type)).ok_to_stop([d.daemon_id], force=False)
             if r.retval:
@@ -3326,7 +3341,7 @@ Then run the following:
             raise OrchestratorError(f'key rotation by orchestrator not supported in this release (for {d.name()})')
 
         # Track user-initiated stop/start actions
-        if action == 'stop':
+        if action in ['stop', 'kill']:
             d.update_user_stopped_status(True)
             self.cache.save_host(d.hostname)
         elif action in ['start', 'restart']:

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1033,6 +1033,8 @@ class CephadmService(metaclass=ABCMeta):
         current and previous dependency lists return the next action that
         this service would prefer cephadm take.
         """
+        if scheduled_action == utils.Action.KILL:
+            return utils.NextDaemonStep(scheduled_action)
         if curr_deps == last_deps:
             return utils.NextDaemonStep(scheduled_action)
         sym_diff = set(curr_deps).symmetric_difference(last_deps)

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -106,6 +106,7 @@ class Action(str, Enum):
     ROTATE_KEY = 'rotate-key'
     START = 'start'
     STOP = 'stop'
+    KILL = 'kill'
 
     @classmethod
     def create(cls, action: Union[str, 'Action', None]) -> 'Action':

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -210,6 +210,7 @@ class ServiceAction(enum.Enum):
     restart = 'restart'
     redeploy = 'redeploy'
     reconfig = 'reconfig'
+    kill = 'kill'
 
 
 class DaemonAction(enum.Enum):
@@ -217,6 +218,7 @@ class DaemonAction(enum.Enum):
     stop = 'stop'
     restart = 'restart'
     reconfig = 'reconfig'
+    kill = 'kill'
 
 
 class IngressType(enum.Enum):

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1430,6 +1430,7 @@ class NFSServiceSpec(ServiceSpec):
                  enable_client_object_cache: bool = False,
                  client_object_cache_size: Optional[Union[str, int]] = None,
                  client_object_cache_max_dirty: Optional[Union[str, int]] = None,
+                 termination_grace_period_seconds: Optional[int] = None,
                  ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
@@ -1438,7 +1439,8 @@ class NFSServiceSpec(ServiceSpec):
             config=config, networks=networks, extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args, custom_configs=custom_configs,
             ip_addrs=ip_addrs, ssl=ssl, ssl_cert=ssl_cert, ssl_key=ssl_key, ssl_ca_cert=ssl_ca_cert,
-            certificate_source=certificate_source, custom_sans=custom_sans)
+            certificate_source=certificate_source, custom_sans=custom_sans,
+            termination_grace_period_seconds=termination_grace_period_seconds)
 
         self.port = port
 
@@ -1704,6 +1706,7 @@ class RGWSpec(ServiceSpec):
                  rgw_user_counters_cache_size: Optional[int] = None,
                  rgw_bucket_counters_cache: Optional[bool] = False,
                  rgw_bucket_counters_cache_size: Optional[int] = None,
+                 termination_grace_period_seconds: Optional[int] = None,
                  generate_cert: bool = False,
                  disable_multisite_sync_traffic: Optional[bool] = None,
                  wildcard_enabled: Optional[bool] = False,
@@ -1727,7 +1730,8 @@ class RGWSpec(ServiceSpec):
             placement=placement, unmanaged=unmanaged,
             preview_only=preview_only, config=config, networks=networks,
             extra_container_args=extra_container_args, extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs)
+            custom_configs=custom_configs,
+            termination_grace_period_seconds=termination_grace_period_seconds)
 
         #: The RGW realm associated with this service. Needs to be manually created
         #: if the spec is being applied directly to cephdam. In case of rgw module
@@ -2011,6 +2015,7 @@ class NvmeofServiceSpec(ServiceSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 termination_grace_period_seconds: Optional[int] = None,
                  ):
         assert service_type == 'nvmeof'
         super(NvmeofServiceSpec, self).__init__('nvmeof', service_id=service_id,
@@ -2024,7 +2029,10 @@ class NvmeofServiceSpec(ServiceSpec):
                                                 config=config, networks=networks,
                                                 extra_container_args=extra_container_args,
                                                 extra_entrypoint_args=extra_entrypoint_args,
-                                                custom_configs=custom_configs)
+                                                custom_configs=custom_configs,
+                                                termination_grace_period_seconds=(
+                                                    termination_grace_period_seconds
+                                                ))
 
         #: RADOS pool where ceph-nvmeof config data is stored (use '.nvmeof' as default).
         self.pool = pool or '.nvmeof'
@@ -2541,6 +2549,7 @@ class IngressSpec(ServiceSpec):
                  monitor_ip_addrs: Optional[Dict[str, str]] = None,
                  use_tcp_mode_over_rgw: bool = False,
                  haproxy_peer_communication_port: Optional[int] = None,
+                 termination_grace_period_seconds: Optional[int] = None,
                  ):
         assert service_type == 'ingress'
 
@@ -2555,7 +2564,8 @@ class IngressSpec(ServiceSpec):
             custom_sans=custom_sans,
             extra_container_args=extra_container_args,
             extra_entrypoint_args=extra_entrypoint_args,
-            custom_configs=custom_configs
+            custom_configs=custom_configs,
+            termination_grace_period_seconds=termination_grace_period_seconds
         )
         self.backend_service = backend_service
         self.frontend_port = frontend_port


### PR DESCRIPTION
mgr/cephadm: improve daemon termination controls

Testing logs:
1. Extend support of adding termination_grace_period on services including - RGW, NFS, NVMeOf, Ingress:

```
root@ceph-node-0 ~]# ceph orch ls --export
service_type: crash
service_name: crash
placement:
  host_pattern: '*'
---
service_type: ingress
service_id: test
service_name: ingress.test
placement:
  count: 1
spec:
  backend_service: nfs.test
  first_virtual_router_id: 50
  frontend_port: 2049
  monitor_cert_source: reuse_service_cert
  monitor_port: 9000
  termination_grace_period_seconds: 5
  virtual_ip: 192.168.100.200/24
---
service_type: mgr
service_name: mgr
placement:
  count: 2
---
service_type: mon
service_name: mon
placement:
  count: 5
---
service_type: nfs
service_id: test
service_name: nfs.test
placement:
  count: 1
spec:
  termination_grace_period_seconds: 5
---
service_type: osd
service_id: all-available-devices
service_name: osd.all-available-devices
placement:
  host_pattern: '*'
spec:
  data_devices:
    all: true
  filter_logic: AND
  objectstore: bluestore
  osd_type: classic
  termination_grace_period_seconds: 30

```


2. Add support to instantly kill a daemon

```
[ceph: root@ceph-node-0 ~]# ceph orch ps
NAME                           HOST         PORTS        STATUS         REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID  
crash.ceph-node-0              ceph-node-0               running (4h)     97s ago   4h    7927k        -  21.3.0-1871-ga26a694f  335c40a56a5d  da11dea16353  
crash.ceph-node-1              ceph-node-1               running (4h)     88s ago   4h    7952k        -  21.3.0-1871-ga26a694f  335c40a56a5d  4bd932af311b  
crash.ceph-node-2              ceph-node-2               running (35m)    97s ago  35m    7988k        -  21.3.0-1871-ga26a694f  335c40a56a5d  d239ab7834dd  
mgr.ceph-node-0.vxnzrz         ceph-node-0  *:8443,8765  running (4h)     97s ago   4h     220M        -  21.3.0-1871-ga26a694f  335c40a56a5d  ec94e15c5230  
mgr.ceph-node-1.tcdspb         ceph-node-1  *:8443,8765  running (4h)     88s ago   4h     157M        -  21.3.0-1871-ga26a694f  335c40a56a5d  9739f4fb54e8  
mon.ceph-node-0                ceph-node-0               running (4h)     97s ago   4h    51.6M    2048M  21.3.0-1871-ga26a694f  335c40a56a5d  1d0a3af14dbc  
mon.ceph-node-1                ceph-node-1               running (4h)     88s ago   4h    45.1M    2048M  21.3.0-1871-ga26a694f  335c40a56a5d  dcc2ca34bd49  
mon.ceph-node-2                ceph-node-2               running (35m)    97s ago  35m    40.7M    2048M  21.3.0-1871-ga26a694f  335c40a56a5d  705660b61898  
osd.0                          ceph-node-1               running (34m)    88s ago   4h    58.1M    4096M  21.3.0-1871-ga26a694f  335c40a56a5d  89812773e49a  
osd.1                          ceph-node-0               running (34m)    97s ago   4h    58.0M    4096M  21.3.0-1871-ga26a694f  335c40a56a5d  0556d799d1e5  
osd.2                          ceph-node-2               running (34m)    97s ago  34m    58.9M    2987M  21.3.0-1871-ga26a694f  335c40a56a5d  431473a8b631  
rbd-mirror.ceph-node-1.ajixoc  ceph-node-1               running (91s)    88s ago  91s    12.9M        -  21.3.0-1871-ga26a694f  335c40a56a5d  1d2245400922  

[ceph: root@ceph-node-0 ~]# ceph orch daemon kill rbd-mirror.ceph-node-1.ajixoc --force
Scheduled to kill rbd-mirror.ceph-node-1.ajixoc on host 'ceph-node-1'

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT    
crash                                 3/3  117s ago   4h   *            
mgr                                   2/2  117s ago   4h   count:2      
mon                                   3/5  117s ago   4h   count:5      
osd.all-available-devices               3  117s ago   4h   *            
rbd-mirror                            0/1  1s ago     11m  ceph-node-1 


[ceph: root@ceph-node-0 ~]# ceph orch ps
NAME                           HOST         PORTS        STATUS         REFRESHED   AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID  
crash.ceph-node-0              ceph-node-0               running (4h)      2m ago    4h    7927k        -  21.3.0-1871-ga26a694f  335c40a56a5d  da11dea16353  
crash.ceph-node-1              ceph-node-1               running (4h)      6s ago    4h    8024k        -  21.3.0-1871-ga26a694f  335c40a56a5d  4bd932af311b  
crash.ceph-node-2              ceph-node-2               running (36m)     2m ago   36m    7988k        -  21.3.0-1871-ga26a694f  335c40a56a5d  d239ab7834dd  
mgr.ceph-node-0.vxnzrz         ceph-node-0  *:8443,8765  running (4h)      2m ago    4h     220M        -  21.3.0-1871-ga26a694f  335c40a56a5d  ec94e15c5230  
mgr.ceph-node-1.tcdspb         ceph-node-1  *:8443,8765  running (4h)      6s ago    4h     157M        -  21.3.0-1871-ga26a694f  335c40a56a5d  9739f4fb54e8  
mon.ceph-node-0                ceph-node-0               running (4h)      2m ago    4h    51.6M    2048M  21.3.0-1871-ga26a694f  335c40a56a5d  1d0a3af14dbc  
mon.ceph-node-1                ceph-node-1               running (4h)      6s ago    4h    45.1M    2048M  21.3.0-1871-ga26a694f  335c40a56a5d  dcc2ca34bd49  
mon.ceph-node-2                ceph-node-2               running (35m)     2m ago   35m    40.7M    2048M  21.3.0-1871-ga26a694f  335c40a56a5d  705660b61898  
osd.0                          ceph-node-1               running (34m)     6s ago    4h    58.4M    4096M  21.3.0-1871-ga26a694f  335c40a56a5d  89812773e49a  
osd.1                          ceph-node-0               running (35m)     2m ago    4h    58.0M    4096M  21.3.0-1871-ga26a694f  335c40a56a5d  0556d799d1e5  
osd.2                          ceph-node-2               running (35m)     2m ago   35m    58.9M    2987M  21.3.0-1871-ga26a694f  335c40a56a5d  431473a8b631  
rbd-mirror.ceph-node-1.ajixoc  ceph-node-1               error             6s ago  116s        -        -  21.3.0-1871-ga26a694f  335c40a56a5d  1d2245400922 


```
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
