### PR TITLE
tentacle: rgw/multisite: fix segfault during multisite startup

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -635,7 +635,8 @@ public:
       while (collect(&ret, NULL)) {
         if (ret < 0) {
           tn->log(0, SSTR("ERROR: failed to read remote data log shards"));
-          return set_state(RGWCoroutine_Error);
+          drain_all();
+          return set_cr_error(ret);
         }
         yield;
       }
@@ -657,7 +658,8 @@ public:
       while (collect(&ret, NULL)) {
         if (ret < 0) {
           tn->log(0, SSTR("ERROR: failed to write data sync status markers"));
-          return set_state(RGWCoroutine_Error);
+          drain_all();
+          return set_cr_error(ret);
         }
         yield;
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80457

---

backport of https://github.com/ceph/ceph/pull/66466
parent tracker: https://tracker.ceph.com/issues/74040

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh