### PR TITLE
mgr/cephadm: don't let key rotation silently complete

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -1739,7 +1739,7 @@ class CephadmUpgrade:
             return False
         else:
             logger.info('OSD/mds daemons not all upgraded, delaying key rotation')
-            return True
+            return False
 
     def _rotate_mgr_mon_auth_keys(self, target_image: str, target_digests: Optional[List[str]] = None) -> None:
         if self.upgrade_state:


### PR DESCRIPTION
During upgrade, handle_osd_mds_key_rotation() rotates a daemon's cephx key on the mon (auth rotate) and then redeploys the daemon. Redeploy call was not wrapped in exception handling, so a transient network failure (e.g. SSH connection drop to the host) during the redeploy would cause an upgrade without keys being rotated.

Add a _redeploy_daemon() helper, mirroring the existing _rotate_key() helper, so a failed redeploy is caught locally, raises a specific UPGRADE_KEY_ROTATION warning naming the affected daemon, and pauses the upgrade for resume once the network issue is resolved.

Fixes: https://tracker.ceph.com/issues/80459

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [X] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests