### PR TITLE
mgr/nfs,smb: request aes256k for new client keys

### DIFF
--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -589,6 +589,7 @@ class ExportMgr:
             'entity': f'client.{entity}',
             'caps': nfs_caps,
             'format': 'json',
+            'key_type': 'aes256k',
         })
         if ret == -errno.EINVAL and 'does not match' in err:
             ret, out, err = self.mgr.mon_command({

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1924,6 +1924,22 @@ def test_normalize_path(path, expected):
     assert normalize_path(path) == expected
 
 
+def test_create_user_key_uses_aes256k():
+    mgr = MagicMock()
+    mgr.mon_command.return_value = (
+        0,
+        json.dumps([{'entity': 'client.nfs.foo.cephfs.hash', 'key': 'secret'}]),
+        '',
+    )
+    export_mgr = ExportMgr(mgr)
+
+    assert export_mgr._create_user_key('foo', 'nfs.foo.cephfs.hash', '/', 'cephfs') == 'secret'
+
+    command = mgr.mon_command.call_args.args[0]
+    assert command['prefix'] == 'auth get-or-create'
+    assert command['key_type'] == 'aes256k'
+
+
 def test_ganesha_validate_squash():
     """Check error handling of internal validation function for squash value."""
     from nfs.ganesha_conf import _validate_squash

--- a/src/pybind/mgr/smb/fs.py
+++ b/src/pybind/mgr/smb/fs.py
@@ -38,6 +38,7 @@ class FileSystemAuthorizer:
             'filesystem': volume,
             'entity': entity,
             'caps': caps,
+            'key_type': 'aes256k',
         }
         log.info('Requesting fs authorzation: %r', cmd)
         ret, _, status = self._mc.mon_command(cmd)

--- a/src/pybind/mgr/smb/rgw_auth.py
+++ b/src/pybind/mgr/smb/rgw_auth.py
@@ -42,6 +42,7 @@ class RGWAuthorizer:
             'prefix': 'auth get-or-create',
             'entity': entity,
             'caps': caps,
+            'key_type': 'aes256k',
         }
         log.info('Requesting RGW authorization: %r', cmd)
         ret, _, status = self._mc.mon_command(cmd)

--- a/src/pybind/mgr/smb/tests/test_fs.py
+++ b/src/pybind/mgr/smb/tests/test_fs.py
@@ -24,6 +24,19 @@ def test_mocked_fs_authorizer():
         fsauth.authorize_entity('cephfs', 'client.smb.kaboom')
 
 
+def test_file_system_authorizer_uses_aes256k():
+    m = mock.MagicMock()
+    m.mon_command.return_value = (0, '', '')
+
+    smb.fs.FileSystemAuthorizer(m).authorize_entity(
+        'cephfs', 'client.smb.foo'
+    )
+
+    command = m.mon_command.call_args.args[0]
+    assert command['prefix'] == 'fs authorize'
+    assert command['key_type'] == 'aes256k'
+
+
 def test_mocked_fs_path_resolver(monkeypatch):
     # we have to "re-patch" whatever cephfs module gets mocked with because
     # the ObjectNotFound attribute is not an exception in the test environment

--- a/src/pybind/mgr/smb/tests/test_rgw_auth.py
+++ b/src/pybind/mgr/smb/tests/test_rgw_auth.py
@@ -1,0 +1,14 @@
+from unittest import mock
+
+from smb.rgw_auth import RGWAuthorizer
+
+
+def test_rgw_authorizer_uses_aes256k():
+    mon_command_issuer = mock.MagicMock()
+    mon_command_issuer.mon_command.return_value = (0, '', '')
+
+    RGWAuthorizer(mon_command_issuer).authorize_entity('client.smb.rgw.foo')
+
+    command = mon_command_issuer.mon_command.call_args.args[0]
+    assert command['prefix'] == 'auth get-or-create'
+    assert command['key_type'] == 'aes256k'


### PR DESCRIPTION
## Summary
- Request `aes256k` when NFS creates export credentials.
- Request `aes256k` for SMB CephFS and RGW authorization credentials.
- Add regression coverage for all affected command payloads.

CVE-2025-30156

## Testing
- `tox -e test -- nfs/tests smb/tests`
- `tox -e flake8 -- nfs/export.py nfs/tests/test_nfs.py smb/fs.py smb/rgw_auth.py smb/tests/test_fs.py smb/tests/test_rgw_auth.py`
- `tox -e check-black`
- `tox -e check-isort`