### PR TITLE
cephadm: prevent orch reconfig from restarting OSDs

### DIFF
--- a/qa/suites/orch/cephadm/with-work/tasks/rotate-keys.yaml
+++ b/qa/suites/orch/cephadm/with-work/tasks/rotate-keys.yaml
@@ -7,10 +7,15 @@ tasks:
       do
           echo "rotating key for $f"
           K=$(ceph auth get-key $f)
-          NK="$K"
-          ceph orch daemon rotate-key $f
-          while [ "$K" == "$NK" ]; do
-              sleep 5
-              NK=$(ceph auth get-key $f)
-          done
+          ceph auth rotate $f >/dev/null
+          NK=$(ceph auth get-key $f)
+          test "$K" != "$NK"
+          ceph orch daemon redeploy $f
+          sleep 60
       done
+
+      osd_started=$(ceph orch ps --daemon-type osd --refresh -f json | jq -cS 'sort_by(.daemon_name) | map({daemon_name, started})')
+      ceph orch daemon reconfig osd.0
+      sleep 120
+      new_osd_started=$(ceph orch ps --daemon-type osd --refresh -f json | jq -cS 'sort_by(.daemon_name) | map({daemon_name, started})')
+      test "$osd_started" = "$new_osd_started"

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -639,6 +639,26 @@ def lookup_unit_name_by_daemon_name(ctx: CephadmContext, fsid: str, name: str) -
         raise Error('Failed to get unit name for {}'.format(daemon))
 
 
+def _extract_keyring_secret(keyring: str) -> Optional[str]:
+    """Extract the effective secret from a cephx keyring."""
+    secrets: Dict[str, str] = {}
+    for line in keyring.splitlines():
+        name, separator, value = line.partition('=')
+        name = name.strip().replace('_', ' ')
+        if separator and name in ('key', 'pending key'):
+            secrets[name] = value.strip()
+    return secrets.get('pending key') or secrets.get('key')
+
+
+def _keyring_secrets_differ(old_keyring: str, new_keyring: str) -> bool:
+    old_secret = _extract_keyring_secret(old_keyring)
+    new_secret = _extract_keyring_secret(new_keyring)
+    if old_secret is None or new_secret is None:
+        # Retain the whole-file comparison for malformed keyrings.
+        return old_keyring != new_keyring
+    return old_secret != new_secret
+
+
 def create_daemon_dirs(
     ctx: CephadmContext,
     ident: 'DaemonIdentity',
@@ -670,13 +690,9 @@ def create_daemon_dirs(
         except Exception:
             pass
         update_bluestore_label_osd_keyring = False
-        if (
-            ident.daemon_type == 'osd'
-            and key_path_exists
-            and key_path_content != keyring
-        ):
-            # need to update keyring with ceph-bluestore-tool
-            update_bluestore_label_osd_keyring = True
+        if ident.daemon_type == 'osd' and key_path_exists:
+            update_bluestore_label_osd_keyring = _keyring_secrets_differ(
+                key_path_content, keyring)
         with write_new(keyring_path, owner=(uid, gid)) as f:
             f.write(keyring)
         if update_bluestore_label_osd_keyring:

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -56,6 +56,40 @@ def bootstrap_test_ctx(*args, **kwargs):
 
 class TestCephAdm(object):
 
+    def test_extract_keyring_secret_ignores_caps_and_formatting(self):
+        secret = 'AQBexample=='
+        full_keyring = dedent(f'''\
+            [osd.0]
+                    key = {secret}
+                    caps mgr = "allow profile osd"
+                    caps mon = "allow profile osd"
+                    caps osd = "allow *"
+        ''')
+        minimal_keyring = f'[osd.0]\nkey = {secret}\n'
+
+        pending_keyring = (
+            f'[osd.0]\nkey = old-secret\npending key = {secret}\n')
+
+        assert _cephadm._extract_keyring_secret(full_keyring) == secret
+        assert _cephadm._extract_keyring_secret(minimal_keyring) == secret
+        assert _cephadm._extract_keyring_secret(pending_keyring) == secret
+
+    def test_osd_keyring_comparison_uses_secret(self):
+        secret = 'AQBexample=='
+        minimal_keyring = f'[osd.0]\nkey = {secret}\n'
+        full_keyring = (
+            f'[osd.0]\n\tkey = {secret}\n'
+            '\tcaps mgr = "allow profile osd"\n'
+            '\tcaps mon = "allow profile osd"\n'
+            '\tcaps osd = "allow *"\n'
+        )
+        changed_keyring = '[osd.0]\nkey = AQBchanged==\n'
+
+        assert not _cephadm._keyring_secrets_differ(
+            minimal_keyring, full_keyring)
+        assert _cephadm._keyring_secrets_differ(
+            minimal_keyring, changed_keyring)
+
     @mock.patch('cephadm.logger')
     def test_attempt_bind(self, _logger):
         from cephadmlib.net_utils import PortOccupiedError, attempt_bind

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -18,7 +18,7 @@ from ceph.utils import datetime_now
 from orchestrator import OrchestratorError, DaemonDescription
 from mgr_module import MonCommandFailed
 
-from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService, simplified_keyring
 from .service_registry import register_cephadm_service
 
 if TYPE_CHECKING:
@@ -508,6 +508,10 @@ class OSDService(CephService):
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         config, parent_deps = super().generate_config(daemon_spec)
+        keyring = config.get('keyring')
+        if keyring:
+            config['keyring'] = simplified_keyring(
+                str(self.get_auth_entity(daemon_spec.daemon_id)), keyring)
         if daemon_spec.service_name in self.mgr.spec_store:
             svc_spec = cast(DriveGroupSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
 

--- a/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_cephadm.py
@@ -4,7 +4,9 @@ from typing import Dict, List
 from unittest.mock import MagicMock
 
 from cephadm.services.service_registry import service_registry
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.services.monitoring import GrafanaService
+from cephadm.services.osd import OSDService
 from orchestrator import OrchestratorError
 
 
@@ -50,6 +52,27 @@ class FakeMgr:
 
 
 class TestCephadmService:
+    def test_osd_generate_config_simplifies_keyring(self):
+        mgr = FakeMgr()
+        service = OSDService(mgr)
+        secret = 'AQBexample=='
+        daemon_spec = CephadmDaemonDeploySpec(
+            host='host1',
+            daemon_id='0',
+            service_name='osd.test',
+            keyring=(
+                f'[osd.0]\n\tkey = {secret}\n'
+                '\tcaps mgr = "allow profile osd"\n'
+                '\tcaps mon = "allow profile osd"\n'
+                '\tcaps osd = "allow *"\n'
+            ),
+        )
+
+        config, deps = service.generate_config(daemon_spec)
+
+        assert config['keyring'] == f'[osd.0]\nkey = {secret}\n'
+        assert deps == []
+
     def test_set_value_on_dashboard(self):
         # pylint: disable=protected-access
         mgr = FakeMgr()


### PR DESCRIPTION
After upgrading to v19.2.6/v20.2.4, a reconfig operation on an OSD would also include a restart. 

The mgr gets the full output of auth get (including caps) while ceph-volume generates a minimal keyring containing only the secret. This difference causes an OSD restart in an attempt to update the keyring.  This causes a `orch reconfig` operation on an OSD to also include a restart. 


reproduce this like

```
ceph auth rotate osd.0  # not necessary but treat this like post upgrade / post rotation to one of the cve fix versions
ceph orch redeploy osd.0

ceph orch reconfig osd.0  # restarts
ceph orch reconfig osd.0  # restarts
```

Logs on any reconfig looks like this 
```
err: Reconfig daemon osd.0 ...
Stopping osd.0 to update osd_key bluestore label
Rotating osd.0 key with ceph-bluestore-tool
Successfully rotated osd.0 keyring
```

any update to the monmap would trigger a reconfig on all the OSDs and restart them. 

Includes some changes to `qa/suites/orch/cephadm/with-work/tasks/rotate-keys.yaml `

Fixes: https://tracker.ceph.com/issues/80440


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
