### PR TITLE
common/options: clarify osd_max_backfills vs osd_recovery_max_active

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -51,12 +51,24 @@ options:
 - name: osd_max_backfills
   type: uint
   level: advanced
-  desc: Maximum number of concurrent backfills to or from a single OSD.
-  long_desc: The maximum number of backfills allowed to or from a single OSD. Note
-    that this is applied separately for read and write operations. This setting is
-    automatically reset when the mClock scheduler is used.
+  desc: Maximum number of PGs concurrently backfilling to or from a single OSD.
+  fmt_desc: The maximum number of PGs that may be backfilling into or out of a
+    single OSD at one time. This is a reservation limit, so it caps backfill
+    concurrency (how many PGs move at once), not the rate at which each one moves;
+    for that, see ``osd_recovery_max_active``. Backfill populates a PG on an OSD
+    by scanning its object set and sending the objects the target is missing (used
+    when the PG log cannot drive recovery, e.g. an OSD new to the PG), as opposed
+    to log-based recovery of individual objects.
+    The limit is counted separately for the source (read) and destination (write)
+    side of a backfill. Because an erasure-coded PG must hold a reservation on all
+    of its shards' OSDs at once, wide EC pools are frequently limited by this even
+    when the disks are near-idle.
+  note: This setting is automatically reset when the mClock scheduler is used.
   default: 1
   see_also:
+  - osd_recovery_max_active
+  - osd_recovery_max_active_hdd
+  - osd_recovery_max_active_ssd
   - osd_mclock_override_recovery_settings
   flags:
   - runtime
@@ -1559,9 +1571,14 @@ options:
   level: advanced
   desc: Number of simultaneous active recovery operations per OSD (overrides _ssd
     and _hdd if non-zero)
-  fmt_desc: The number of active recovery requests per OSD at one time. More
-    requests will accelerate recovery, but the requests places an
-    increased load on the cluster.
+  fmt_desc: The number of recovery operations (individual object pushes and pulls)
+    that may be in flight at once on a single OSD, summed across all of that OSD's
+    actively recovering and backfilling PGs. Despite the name, this also throttles
+    the data-movement rate of backfill, not just log-based recovery; it governs how
+    fast the active work proceeds, whereas ``osd_max_backfills`` governs how many
+    PGs may be backfilling at once. More operations accelerate recovery and
+    backfill at the cost of higher OSD load; when the disks are not saturated, this
+    is the effective throughput lever.
   note: This value is only used if it is non-zero. Normally it
     is ``0``, which means that the ``hdd`` or ``ssd`` values
     (below) are used, depending on the type of the primary
@@ -1569,6 +1586,7 @@ options:
     This setting is automatically reset when the mClock scheduler is used.
   default: 0
   see_also:
+  - osd_max_backfills
   - osd_recovery_max_active_hdd
   - osd_recovery_max_active_ssd
   - osd_mclock_override_recovery_settings
@@ -1580,11 +1598,14 @@ options:
   level: advanced
   desc: Number of simultaneous active recovery operations per OSD (for rotational
     devices)
-  fmt_desc: The number of active recovery requests per OSD at one time, if the
-    primary device is rotational.
+  fmt_desc: As ``osd_recovery_max_active`` (the number of in-flight
+    recovery/backfill object operations per OSD), applied when
+    ``osd_recovery_max_active`` is ``0`` and the OSD's primary device is
+    rotational (an HDD).
   note: This setting is automatically reset when the mClock scheduler is used.
   default: 3
   see_also:
+  - osd_max_backfills
   - osd_recovery_max_active
   - osd_recovery_max_active_ssd
   - osd_mclock_override_recovery_settings
@@ -1596,11 +1617,14 @@ options:
   level: advanced
   desc: Number of simultaneous active recovery operations per OSD (for non-rotational
     solid state devices)
-  fmt_desc: The number of active recovery requests per OSD at one time, if the
-    primary device is non-rotational (i.e., an SSD).
+  fmt_desc: As ``osd_recovery_max_active`` (the number of in-flight
+    recovery/backfill object operations per OSD), applied when
+    ``osd_recovery_max_active`` is ``0`` and the OSD's primary device is
+    non-rotational (an SSD).
   note: This setting is automatically reset when the mClock scheduler is used.
   default: 10
   see_also:
+  - osd_max_backfills
   - osd_recovery_max_active
   - osd_recovery_max_active_hdd
   - osd_mclock_override_recovery_settings


### PR DESCRIPTION
## Description

`osd_max_backfills` and `osd_recovery_max_active[_hdd|_ssd]` are routinely confused because the names imply they do the same thing. They operate at different granularities:

- **`osd_max_backfills`** is a per-OSD *reservation* limit on whole PGs: it caps how many PGs may be backfilling at once (concurrency), not the rate of each one. An erasure-coded PG must reserve a slot on every shard's OSD simultaneously, so wide EC pools stall on it even when the disks are idle.
- **`osd_recovery_max_active[_hdd|_ssd]`** is a per-OSD limit on individual object operations in flight. Despite the "recovery" name it throttles *backfill* data movement as well as log-based recovery, so it sets the *rate*, not the concurrency.

This rewrites the `fmt_desc` of all four options to state which controls concurrency and which controls rate, notes that `osd_recovery_max_active` governs backfill as well as recovery, and cross-links the pair via `see_also`.

It also harmonizes `osd_max_backfills` onto the same `desc`/`fmt_desc`/`note` shape as the recovery options — it previously had a `long_desc` and no `fmt_desc`, so its detail did not render in the config reference. The read/write detail moves into `fmt_desc`; the mClock caveat becomes a `note`.

Documentation-only; no behavior change.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>

Signed-off-by: Anthony D'Atri <anthonyeleven@users.noreply.github.com>
Assisted by Claude Opus-4.8
