### PR TITLE
mds: use explicit snapshot versions for hardlink blockdiff

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -26,6 +26,7 @@
 #include <string_view>
 #include <map>
 #include <memory>
+#include <optional>
 #include <queue>
 
 #include "MDSRank.h"
@@ -14608,18 +14609,74 @@ void MDCache::upkeep_main(void)
   }
 }
 
+// Own the metadata used by blockdiff so that asynchronous object scans do not
+// depend on the lifetime or subsequent changes of a cached CInode.
+struct MDCache::FileBlockDiffSnapshot {
+  struct VersionKey {
+    inodeno_t ino;
+    snapid_t first;
+    snapid_t last;
+
+    bool operator==(const VersionKey& other) const {
+      return ino == other.ino && first == other.first && last == other.last;
+    }
+  } version;
+  snapid_t snapid;
+  CInode::mempool_inode inode;
+
+  inodeno_t ino() const { return version.ino; }
+  const CInode::mempool_inode* get_inode() const { return &inode; }
+};
+
+namespace {
+
+std::optional<MDCache::FileBlockDiffSnapshot>
+inode_snapshot_view(CInode *in, snapid_t snapid)
+{
+  if (in->first <= snapid && snapid <= in->last) {
+    return MDCache::FileBlockDiffSnapshot{
+      {in->ino(), in->first, in->last}, snapid, *in->get_inode()};
+  }
+
+  // Multiversion hardlinks keep historical metadata in the head inode.
+  if (!in->is_head() || !in->is_auth()) {
+    return std::nullopt;
+  }
+
+  snapid_t old_last = in->pick_old_inode(snapid);
+  if (!old_last) {
+    return std::nullopt;
+  }
+
+  const auto& old_inodes = in->get_old_inodes();
+  if (!old_inodes) {
+    return std::nullopt;
+  }
+  auto it = old_inodes->find(old_last);
+  if (it == old_inodes->end()) {
+    return std::nullopt;
+  }
+
+  return MDCache::FileBlockDiffSnapshot{
+    {in->ino(), it->second.first, it->first}, snapid, it->second.inode};
+}
+
+} // anonymous namespace
+
 struct C_ListSnapsAggregator : public MDSIOContext {
-  C_ListSnapsAggregator(MDSRank *mds, CInode *in1, CInode *in2, BlockDiff *block_diff,
-			Context *on_finish)
+  C_ListSnapsAggregator(MDSRank *mds,
+                        const MDCache::FileBlockDiffSnapshot *in1,
+                        const MDCache::FileBlockDiffSnapshot *in2,
+                        BlockDiff *block_diff, Context *on_finish)
     : MDSIOContext(mds),
-      in1(in1),
-      in2(in2),
+      in1(*in1),
+      in2(*in2),
       block_diff(block_diff),
       on_finish(on_finish) {
   }
 
   void finish(int r) override {
-    mds->mdcache->aggregate_snap_sets(snap_set_context, in1, in2,
+    mds->mdcache->aggregate_snap_sets(snap_set_context, &in1, &in2,
                                       block_diff, on_finish);
   }
 
@@ -14631,16 +14688,49 @@ struct C_ListSnapsAggregator : public MDSIOContext {
     snap_set_context.push_back(std::move(ssc));
   }
 
-  CInode *in1;
-  CInode *in2;
+  const MDCache::FileBlockDiffSnapshot in1;
+  const MDCache::FileBlockDiffSnapshot in2;
   BlockDiff *block_diff;
   Context *on_finish;
   std::vector<std::unique_ptr<MDCache::SnapSetContext>> snap_set_context;
 };
 
-void MDCache::file_blockdiff(CInode *in1, CInode *in2, BlockDiff *block_diff, uint64_t max_objects,
-			     MDSContext *ctx) {
-  ceph_assert(in1->last <= in2->last);
+void MDCache::file_blockdiff(CInode *in1, snapid_t snapid1,
+                            CInode *in2, snapid_t snapid2,
+                            BlockDiff *block_diff, uint64_t max_objects,
+                            MDSContext *ctx) {
+  ceph_assert(snapid1 <= snapid2);
+
+  auto view1 = inode_snapshot_view(in1, snapid1);
+  auto view2 = inode_snapshot_view(in2, snapid2);
+  if (!view1 || !view2) {
+    dout(1) << __func__ << ": failed to select inode versions: snapid1="
+            << snapid1 << " inode1=" << *in1 << " snapid2=" << snapid2
+            << " inode2=" << *in2 << dendl;
+    ctx->complete(-ESTALE);
+    return;
+  }
+
+  dout(20) << __func__ << ": snapid1=" << snapid1 << " version1=["
+           << view1->version.first << "," << view1->version.last
+           << "] snapid2=" << snapid2 << " version2=["
+           << view2->version.first << "," << view2->version.last << "]"
+           << dendl;
+
+  if (view1->version == view2->version) {
+    dout(20) << __func__ << ": snaps have same inode version" << dendl;
+    ctx->complete(0);
+    return;
+  }
+
+  file_blockdiff(&*view1, &*view2, block_diff, max_objects, ctx);
+}
+
+void MDCache::file_blockdiff(const FileBlockDiffSnapshot *in1,
+                            const FileBlockDiffSnapshot *in2,
+                            BlockDiff *block_diff, uint64_t max_objects,
+                            MDSContext *ctx) {
+  ceph_assert(in1->snapid <= in2->snapid);
 
   // I think this is not required since the MDS disallows setting
   // layout when truncate_seq > 1.
@@ -14712,14 +14802,16 @@ void MDCache::file_blockdiff(CInode *in1, CInode *in2, BlockDiff *block_diff, ui
 }
 
 void MDCache::aggregate_snap_sets(const std::vector<std::unique_ptr<SnapSetContext>> &snap_set_ctx,
-                                  CInode *in1, CInode *in2, BlockDiff *block_diff, Context *on_finish) {
+                                  const FileBlockDiffSnapshot *in1,
+                                  const FileBlockDiffSnapshot *in2,
+                                  BlockDiff *block_diff, Context *on_finish) {
   dout(20) << __func__ << dendl;
 
   // always signal to the client to request again since request
   // completion is signalled in file_blockdiff().
   int r = 1;
-  snapid_t snapid1 = in1->last;
-  snapid_t snapid2 = in2->last;
+  snapid_t snapid1 = in1->snapid;
+  snapid_t snapid2 = in2->snapid;
   uint64_t scans = snap_set_ctx.size();
 
   interval_set<uint64_t> extents;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1221,10 +1221,20 @@ private:
     librados::snap_set_t snaps;
   };
 
-  void file_blockdiff(CInode *in1, CInode *in2, BlockDiff *block_diff, uint64_t max_objects,
+  struct FileBlockDiffSnapshot;
+
+  void file_blockdiff(CInode *in1, snapid_t snapid1,
+                      CInode *in2, snapid_t snapid2,
+                      BlockDiff *block_diff, uint64_t max_objects,
+                      MDSContext *ctx);
+  void file_blockdiff(const FileBlockDiffSnapshot *in1,
+                      const FileBlockDiffSnapshot *in2,
+                      BlockDiff *block_diff, uint64_t max_objects,
                       MDSContext *ctx);
   void aggregate_snap_sets(const std::vector<std::unique_ptr<SnapSetContext>> &snap_set_ctx,
-                           CInode *in1, CInode *in2, BlockDiff *block_diff, Context *on_finish);
+                           const FileBlockDiffSnapshot *in1,
+                           const FileBlockDiffSnapshot *in2,
+                           BlockDiff *block_diff, Context *on_finish);
 
  protected:
   // track leader requests whose peers haven't acknowledged commit

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -12075,18 +12075,24 @@ void Server::handle_client_file_blockdiff(const MDRequestRef& mdr)
 
   dout(10) << __func__ << dendl;
 
-  // no real need to rdlock_path_pin_ref() since the caller holds an
-  // open ref, but we need the snapped inode.
   const filepath& refpath1 = mdr->get_filepath();
-  CInode* in1 = rdlock_path_pin_ref(mdr, refpath1, false, true);
+  const filepath& refpath2 = mdr->get_filepath2();
+  if (!refpath1.is_last_snap() || !refpath2.is_last_snap()) {
+    dout(10) << __func__ << ": not a snapshot path: " << refpath1
+	     << " vs " << refpath2 << " req=" << req << dendl;
+    respond_to_request(mdr, -EINVAL);
+    return;
+  }
+  CInode* in1 = rdlock_path_pin_ref(mdr, refpath1, true, false);
   if (!in1) {
     return;
   }
-  const filepath& refpath2 = mdr->get_filepath2();
-  CInode* in2 = rdlock_path_pin_ref(mdr, refpath2, false, true);
+  snapid_t snapid1 = mdr->snapid;
+  CInode* in2 = rdlock_path_pin_ref(mdr, refpath2, true, false);
   if (!in2) {
     return;
   }
+  snapid_t snapid2 = mdr->snapid;
 
   if (!in1->is_file() || !in2->is_file()) {
     dout(10) << __func__ << ": not a regular file req=" << req << dendl;
@@ -12094,24 +12100,35 @@ void Server::handle_client_file_blockdiff(const MDRequestRef& mdr)
     return;
   }
 
-  dout(20) << __func__ << ": in1=" << *in1 << dendl;
-  dout(20) << __func__ << ": in2=" << *in2 << dendl;
+  // Snapshots must be supplied oldest first. The paths come from the
+  // client, so reject the request rather than trip the assertion in
+  // MDCache::file_blockdiff().
+  if (snapid1 > snapid2) {
+    dout(10) << __func__ << ": snapshots out of order: snapid1=" << snapid1
+	     << " snapid2=" << snapid2 << " req=" << req << dendl;
+    respond_to_request(mdr, -EINVAL);
+    return;
+  }
+
+  dout(20) << __func__ << ": snapid1=" << snapid1
+           << " in1=" << *in1 << dendl;
+  dout(20) << __func__ << ": snapid2=" << snapid2
+           << " in2=" << *in2 << dendl;
 
   auto scan_idx = (uint64_t)req->head.args.blockdiff.scan_idx;
   auto max_objects = (uint32_t)req->head.args.blockdiff.max_objects;
 
   C_MDS_file_blockdiff_finish *ctx = new C_MDS_file_blockdiff_finish(this, mdr, in2, scan_idx);
 
-  if (in1 == in2) {
-    // does not matter if the inodes are snapped or refer to the head
-    // version -- both snaps are same.
+  if (in1 == in2 && snapid1 == snapid2) {
     dout(10) << __func__ << ": no diffs between snaps" << dendl;
     handle_file_blockdiff_finish(mdr, in2, ctx->block_diff, 0);
     delete ctx;
     return;
   }
 
-  mdcache->file_blockdiff(in1, in2, &(ctx->block_diff), max_objects, ctx);
+  mdcache->file_blockdiff(in1, snapid1, in2, snapid2,
+                          &(ctx->block_diff), max_objects, ctx);
 }
 
 void Server::handle_file_blockdiff_finish(const MDRequestRef& mdr, CInode *in, const BlockDiff &block_diff,

--- a/src/test/libcephfs/snapdiff.cc
+++ b/src/test/libcephfs/snapdiff.cc
@@ -239,6 +239,12 @@ public:
     auto file_path = make_file_path(relpath);
     return ceph_unlink(cmount, file_path.c_str());
   }
+  int link(const char* existing, const char* newname)
+  {
+    auto existing_path = make_file_path(existing);
+    auto new_path = make_file_path(newname);
+    return ceph_link(cmount, existing_path.c_str(), new_path.c_str());
+  }
   int symlink(const char* relpath, const char* target)
   {
     auto src_path = make_file_path(relpath);
@@ -417,8 +423,14 @@ public:
   int for_each_file_blockdiff(const char* relpath,
 			      const char* snap1,
 			      const char* snap2,
-			      interval_set<uint64_t> *expected=nullptr)
+			      interval_set<uint64_t> *expected=nullptr,
+                              interval_set<uint64_t> *actual=nullptr)
   {
+    // Preserve expected-set subtraction for existing callers; exact-result
+    // tests can collect the returned extents separately.
+    if (actual) {
+      actual->clear();
+    }
     auto s1 = make_snap_name(snap1);
     auto s2 = make_snap_name(snap2);
     ceph_file_blockdiff_info info;
@@ -439,6 +451,9 @@ public:
       r = ceph_file_blockdiff(&info, &blocks);
       if (r < 0) {
 	std::cerr << " Failed to get next changed block, ret:" << r << std::endl;
+	int finish_r = ceph_file_blockdiff_finish(&info);
+	EXPECT_EQ(0, finish_r)
+	  << "failed to finish blockdiff stream after error " << r;
 	return r;
       }
 
@@ -448,6 +463,9 @@ public:
 	std::cout << " == [" << b->offset << "~" << b->len << "] == " << std::endl;
 	if (expected) {
 	  expected->erase(b->offset, b->len);
+	}
+	if (actual) {
+	  actual->union_insert(b->offset, b->len);
 	}
 	++b;
 	--nr_blocks;
@@ -2099,6 +2117,77 @@ TEST(LibCephFS, SnapDiffNoChangeWithChangedHead)
 
   std::cout << "------------- closing -------------" << std::endl;
   ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, BlockDiffMultiversionHardlink)
+{
+  TestMount test_mount("BlockDiffMultiversionHardlink");
+
+  constexpr uint64_t block_size = 4 * 1024 * 1024;
+  constexpr uint64_t write_offset = 8 * 1024 * 1024;
+  constexpr uint64_t write_length = 1024 * 1024;
+
+  ASSERT_LE(0, test_mount.write_random("fileA", 4, block_size));
+  ASSERT_EQ(0, test_mount.link("fileA", "linkA"));
+  ASSERT_EQ(0, test_mount.sync());
+  ASSERT_EQ(0, test_mount.mksnap("snap1"));
+
+  ASSERT_LE(0, test_mount.write_random("fileA", 1, write_length,
+                                      write_offset, false));
+  ASSERT_EQ(0, test_mount.sync());
+  ASSERT_EQ(0, test_mount.mksnap("snap2"));
+
+  for (const char* path : {"fileA", "linkA"}) {
+    interval_set<uint64_t> expected;
+    interval_set<uint64_t> actual;
+    expected.union_insert(write_offset, write_length);
+    ASSERT_EQ(0, test_mount.for_each_file_blockdiff(
+                   path, "snap1", "snap2", nullptr, &actual));
+    ASSERT_EQ(expected, actual) << "unexpected changed extents for " << path;
+  }
+
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, BlockDiffReversedSnapshots)
+{
+  TestMount test_mount("BlockDiffReversedSnapshots");
+
+  constexpr uint64_t block_size = 4 * 1024 * 1024;
+  constexpr uint64_t write_offset = 8 * 1024 * 1024;
+  constexpr uint64_t write_length = 1024 * 1024;
+
+  // fileA is COWed between the snapshots, fileB is not -- the latter makes
+  // both paths resolve to the same CInode.
+  ASSERT_LE(0, test_mount.write_random("fileA", 4, block_size));
+  ASSERT_LE(0, test_mount.write_random("fileB", 4, block_size));
+  ASSERT_EQ(0, test_mount.sync());
+  ASSERT_EQ(0, test_mount.mksnap("snap1"));
+
+  ASSERT_LE(0, test_mount.write_random("fileA", 1, write_length,
+                                      write_offset, false));
+  ASSERT_EQ(0, test_mount.sync());
+  ASSERT_EQ(0, test_mount.mksnap("snap2"));
+
+  // Snapshots must be supplied oldest first; the MDS must reject the
+  // request rather than assert.
+  for (const char* path : {"fileA", "fileB"}) {
+    ASSERT_EQ(-EINVAL, test_mount.for_each_file_blockdiff(
+                         path, "snap2", "snap1"))
+      << "expected EINVAL for reversed snapshots on " << path;
+  }
+
+  // ...and still works in the correct order.
+  interval_set<uint64_t> expected;
+  interval_set<uint64_t> actual;
+  expected.union_insert(write_offset, write_length);
+  ASSERT_EQ(0, test_mount.for_each_file_blockdiff(
+                 "fileA", "snap1", "snap2", nullptr, &actual));
+  ASSERT_EQ(expected, actual);
+
   ASSERT_EQ(0, test_mount.rmsnap("snap1"));
   ASSERT_EQ(0, test_mount.rmsnap("snap2"));
 }


### PR DESCRIPTION
handle_client_file_blockdiff() returned an empty diff when both snapshot paths resolved to the same CInode. A multiversion hardlink can keep multiple snapshot versions in one head CInode, so this skipped real changes. MDCache::aggregate_snap_sets() also used in1->last / in2->last as the snapshot IDs for clone comparison instead of the requested IDs.

Capture mdr->snapid after each path traversal and select the inode version visible at that snapid. Require the authoritative inode when traversing snapshot paths because old_inodes is only valid there. Use the matching old_inodes entry when the snapshot predates the head version.

Build owned snapshot views carrying the explicit snapids and selected inode metadata. Both the object scan and its asynchronous aggregator use these views, so layout and size come from the selected versions and the aggregator no longer dereferences cached CInodes. Keep the existing object read and clone-diff logic operating on the views. Return an empty diff when both snapshots select the same inode version, identified by (ino, first, last), without scanning objects.

Reject non-snapshot paths and reversed snapshot order with -EINVAL at the request boundary, before reaching the internal ordering assertions. Equal snapshot IDs remain valid. Return -ESTALE if either snapshot's inode version cannot be selected.

Add hardlink and reversed-snapshot regression coverage, checking exact changed extents for valid comparisons. Extend the blockdiff test helper with optional actual-extent collection while keeping its existing expected-set subtraction semantics for other callers.

Fixes: https://tracker.ceph.com/issues/79274





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
