### PR TITLE
doc/cephfs: cephfs-mirror failover documentation

### DIFF
--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -1464,3 +1464,287 @@ synchronized to the remote site, providing visibility into disaster recovery rea
 
 For detailed information about checkpoint commands, lifecycle, and best practices, see
 :doc:`cephfs-mirroring-checkpoints`.
+
+.. _cephfs_mirroring_disaster_recovery:
+
+Disaster recovery and failover
+------------------------------
+
+CephFS snapshot mirroring replicates data asynchronously from a primary cluster to a
+remote (secondary) cluster. When the primary site fails or you need to switch production
+to the remote site, there is **no promote command** (unlike RBD mirroring). Failover is
+a **manual cutover**: stop replication from the primary, verify the recovery point on
+the remote site, redirect clients to the remote cluster, and optionally restore live
+data from a snapshot in ``.snap/``.
+
+Only directories configured with ``ceph fs snapshot mirror add`` are replicated. The
+remote live directory is updated incrementally as each snapshot synchronizes; after a
+successful sync it reflects that snapshot's contents. Remote snapshots are created under
+``<mirrored_dir>/.snap/<snap_name>`` with ``primary_snap_id`` metadata linking them to
+the primary snapshot.
+
+Overview
+~~~~~~~~
+
+CephFS mirroring is push-based: ``cephfs-mirror`` runs on the primary cluster and writes
+to the remote file system. Promoting the remote site therefore means:
+
+#. Quiescing or losing the primary site and stopping mirroring.
+#. Choosing a recovery point (the latest completed sync or a specific snapshot).
+#. Opening the remote file system to clients and redirecting applications.
+
+There is no automatic failover and no single CLI command to reverse primary/secondary
+roles. Treat the remote file system as read-only while mirroring is active (see the note
+in :ref:`Mirroring Status<cephfs_mirroring_mirroring_status>`).
+
+Prerequisites, limitations, and data-loss considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Prerequisites**
+
+Before attempting failover, ensure:
+
+- Mirroring is enabled, a peer is configured, and the directories you need are added
+  for mirroring (``ceph fs snapshot mirror ls <fs_name>``).
+- You have administrative access to both clusters (or to the remote cluster, for
+  unplanned failover).
+- Applications can be stopped or redirected on the primary site (planned failover) or
+  are already unavailable (unplanned failover).
+
+**Limitations and data-loss considerations**
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Consideration
+     - Detail
+   * - Recovery scope
+     - Only mirrored directory paths are recoverable. Data outside those paths is not
+       on the remote site unless separately replicated.
+   * - Recovery point objective (RPO)
+     - Mirroring is asynchronous. Writes after the last **fully synchronized** snapshot
+       are lost. Use :doc:`cephfs-mirroring-checkpoints` and
+       ``ceph fs snapshot mirror status`` to identify the last good recovery point.
+   * - In-progress synchronization
+     - If failover occurs while ``state`` is ``syncing``, the remote live directory may
+       be partially updated (the ``ceph.mirror.dirty_snap_id`` extended attribute marks
+       an incomplete sync). Prefer a completed snapshot in ``.snap/`` rather than the
+       live directory in that case.
+   * - Split-brain
+     - If both sites accept writes after cutover, data diverges with no automatic merge.
+       Only one site should be writable after promotion.
+   * - Hard links
+     - Hard-linked files are synchronized as separate files.
+   * - No automatic failover
+     - The entire procedure is manual. Plan and test failover before you need it.
+   * - Remote snapshots
+     - Manually created snapshots on remote mirrored directories can cause
+       synchronization failures. Do not run snap-schedule on remote mirrored paths.
+
+Planned failover
+~~~~~~~~~~~~~~~~
+
+Use planned failover when the primary site is healthy and you are switching production
+to the remote site in a controlled way.
+
+#. **Quiesce the primary.** Pause applications writing to mirrored paths. Disable
+   mirroring and stop mirror daemons on the primary cluster::
+
+     ceph fs snapshot mirror disable <primary_fs>
+     systemctl stop 'cephfs-mirror@*'
+
+   Optionally refuse new client sessions on the primary file system::
+
+     ceph fs set <primary_fs> refuse_client_sessions true
+
+#. **Confirm synchronization is complete.** On the primary cluster, check per-directory
+   status (see :ref:`Directory snapshot sync metrics
+   <cephfs_mirroring_mgr_snapshot_status>`)::
+
+     ceph fs snapshot mirror status <primary_fs> [<mirrored_dir_path>]
+
+   For each mirrored directory, verify:
+
+   - ``state`` is ``idle`` (not ``syncing``, ``failed``, or ``stale``).
+   - ``current_syncing_snap`` is absent.
+   - Note ``last_synced_snap.name`` and ``last_synced_snap.sync_time_stamp``.
+
+   Optionally confirm checkpoints show ``complete`` if set::
+
+     ceph fs snapshot mirror checkpoint ls <primary_fs> <mirrored_dir_path>
+
+#. **Promote the remote site.** On the remote cluster, allow clients::
+
+     ceph fs set <remote_fs> refuse_client_sessions false
+
+   Redirect applications, DNS, Kubernetes PVs, or NFS exports to the remote cluster's
+   monitors and file system.
+
+#. **Recover data.** If the last sync completed cleanly, the live mirrored directories
+   already reflect ``last_synced_snap`` (see the next section). Run the
+   :ref:`verification checklist <cephfs_mirroring_failover_verification>` before
+   resuming production traffic.
+
+Unplanned failover
+~~~~~~~~~~~~~~~~~~
+
+Use unplanned failover when the primary site is unavailable and you must cut over
+immediately.
+
+#. **Promote the remote site.** On the remote cluster if set to true::
+
+     ceph fs set <remote_fs> refuse_client_sessions false
+
+   Redirect clients to the remote cluster as soon as possible.
+
+#. **Choose a recovery point.**
+
+   - If the primary was reachable recently and ``ceph fs snapshot mirror status`` showed
+     ``state: idle`` for all mirrored directories, the live directory likely reflects
+     the latest synchronized snapshot.
+   - If a sync was in progress at failure time, or you are unsure, **do not trust the
+     live directory**. Restore from a known-good snapshot in ``.snap/`` (see
+     :ref:`Recover to a user-selected snapshot
+     <cephfs_mirroring_failover_selected_snap>`).
+
+#. **Verify before resuming production.** Follow the :ref:`verification checklist
+   <cephfs_mirroring_failover_verification>`.
+
+Recover to the latest synchronized snapshot
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the last snapshot synchronization completed successfully (``state: idle`` and no
+``current_syncing_snap``), the **live mirrored directory on the remote site already
+matches** ``last_synced_snap``. No additional restore step is required to recover to
+that point.
+
+Verify on the remote cluster from a client mount::
+
+  ls <mount_point>/<mirrored_dir>/.snap/
+
+The newest snapshot name should match ``last_synced_snap.name`` reported on the primary
+before failover. Spot-check file counts, sizes, or application-level consistency before
+allowing writes.
+
+.. note:: The live directory is only guaranteed to match the latest sync when that sync
+          finished cleanly. After an unplanned failover with a sync in progress, use
+          :ref:`Recover to a user-selected snapshot
+          <cephfs_mirroring_failover_selected_snap>` instead.
+
+.. _cephfs_mirroring_failover_selected_snap:
+
+Recover to a user-selected snapshot
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use this procedure when you need an older recovery point (for example a checkpointed
+end-of-day snapshot) or when the live directory may be inconsistent.
+
+#. **Identify the target snapshot** on a client mount of the remote file system::
+
+     ls <mount_point>/<mirrored_dir>/.snap/
+
+   Pick ``<target_snap_name>``. If the primary is still reachable, confirm the snapshot
+   was replicated using the below command if checkpoint is set::
+
+     ceph fs snapshot mirror checkpoint ls <primary_fs> <mirrored_dir_path>
+
+   Checkpoints with status ``complete`` identify snapshots known to have reached the
+   remote site. See :doc:`cephfs-mirroring-checkpoints`.
+
+#. **Quiesce writes** i.e., don't allow any writes on the affected mirrored paths on the remote site.
+
+#. **Restore live data from the snapshot.** CephFS does not provide an in-place
+   directory rollback for generic paths. Copy from the snapshot view into the live
+   directory.
+
+   Partial restore (specific files or directories)::
+
+     cp -a <mount_point>/<mirrored_dir>/.snap/<target_snap_name>/<path> \
+           <mount_point>/<mirrored_dir>/<path>
+
+   Full directory restore (**destructive** — replaces live content with snapshot
+   content)::
+
+     rsync -a --delete \
+       <mount_point>/<mirrored_dir>/.snap/<target_snap_name>/ \
+       <mount_point>/<mirrored_dir>/
+
+   Repeat for each mirrored directory that requires rollback.
+
+   Redirect clients to the cloned subvolume after the clone completes.
+
+.. warning:: ``rsync --delete`` removes files present in the live directory but absent
+             from the selected snapshot. Test restore procedures in a non-production
+             environment when possible.
+
+.. _cephfs_mirroring_failover_verification:
+
+Verification checklist
+~~~~~~~~~~~~~~~~~~~~~~
+
+After promotion, verify the following before resuming production traffic:
+
+**Mirroring and recovery point (if primary is reachable)**
+
+- ``ceph fs snapshot mirror status <primary_fs> [<mirrored_dir_path>]`` — note
+  ``last_synced_snap`` for each directory.
+- ``ceph fs snapshot mirror checkpoint ls <primary_fs> <mirrored_dir_path>`` — target
+  snapshots show ``complete`` when checkpoints were used.
+
+**Remote file system health**
+
+::
+
+  ceph fs status <remote_fs>
+  ceph health detail
+
+**Snapshot inventory**
+
+For each mirrored directory on a client mount::
+
+  ls <mount_point>/<mirrored_dir>/.snap/
+
+Confirm ``<target_snap_name>`` exists and content looks correct when restoring from a
+specific snapshot.
+
+**Data validation**
+
+- Compare file counts and sizes against known-good baselines.
+- Run application-level consistency checks (database integrity, checksums, and so on).
+- Confirm clients can mount, read, and write::
+
+    ceph fs get <remote_fs>
+
+  ``refuse_client_sessions`` should be ``false``.
+
+Failback
+~~~~~~~~
+
+CephFS mirroring does not provide automatic failback. After the original primary site
+recovers:
+
+#. Do **not** allow writes on both sites at the same time.
+#. Decide whether to re-establish mirroring from the new primary (former remote) back to
+   the old site, or to perform a one-time bulk copy.
+#. When re-adding a peer or reversing roles, stop all mirror daemons first and consider
+   purging synchronized directories on the re-added peer as described in
+   `Re-adding Peers`_.
+#. Cut clients back to the original primary only after synchronization is verified.
+
+RPO/RTO planning
+~~~~~~~~~~~~~~~~
+
+Use :doc:`snapshot mirroring checkpoints <cephfs-mirroring-checkpoints>` to mark
+critical snapshots (for example application-consistent or end-of-day snapshots) and
+monitor whether they reach the remote site before you rely on them for failover.
+
+- **RPO**: Determined by the last fully synchronized snapshot (``last_synced_snap`` in
+  ``ceph fs snapshot mirror status``). Mark important snapshots as checkpoints and
+  confirm they reach status ``complete`` before a disaster.
+- **RTO**: Depends on how quickly you can quiesce the primary (planned failover),
+  redirect clients, and optionally restore from ``.snap/``. Test the full procedure
+  periodically.
+
+For checkpoint commands, lifecycle, and best practices, see
+:doc:`cephfs-mirroring-checkpoints`.


### PR DESCRIPTION
Add documentation to fail over to remote cluster
with cephfs-mirroring. This PR documents the steps for both
planned and unplanned fail-over (disaster recovery).

Fixes: https://tracker.ceph.com/issues/80467





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
