### PR TITLE
ceph-volume-zfs: implement list subcommand for FreeBSD

### DIFF
--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/list.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/list.py
@@ -1,0 +1,131 @@
+import argparse
+import json
+from textwrap import dedent
+
+from ceph_volume import conf, terminal
+from ceph_volume.util.disk import human_readable_size
+from ceph_volume_zfs.util.disk import list_ceph_zpools
+
+
+class List(object):
+
+    help = 'List Ceph OSDs backed by ZFS'
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def _matches(self, entry, wanted):
+        """
+        A filter argument can be an OSD id ('5'), a pool name
+        ('ceph-osd-5'), or a zvol device path
+        ('/dev/zvol/ceph-osd-5/osd-block-<fsid>'). Match against any
+        of them so the user doesn't have to remember which form the
+        tool wants.
+        """
+        if not wanted:
+            return True
+        if entry['pool'] == wanted:
+            return True
+        if entry['properties'].get('osd_id') == wanted:
+            return True
+        if entry['properties'].get('osd_fsid') == wanted:
+            return True
+        for zvol in entry['zvols']:
+            if wanted in (zvol['device'], zvol['dataset'], zvol['name']):
+                return True
+        for vdev in entry.get('vdevs', []):
+            # match /dev/ada0 or bare ada0
+            if wanted == vdev['path'] or wanted == vdev['path'].replace('/dev/', ''):
+                return True
+        return False
+
+    def plain_report(self, entries):
+        if not entries:
+            return 'No ZFS-backed Ceph OSDs found.\n'
+        lines = []
+        for entry in entries:
+            props = entry['properties']
+            lines.append('')
+            lines.append('osd.{}  (pool: {})'.format(
+                props.get('osd_id', 'unknown'), entry['pool']))
+            lines.append('  osd_fsid: {}'.format(props.get('osd_fsid', 'unknown')))
+            if props.get('cluster_name'):
+                lines.append('  cluster: {}'.format(props.get('cluster_name')))
+            if props.get('cluster_fsid'):
+                lines.append('  cluster_fsid: {}'.format(props.get('cluster_fsid')))
+            if entry.get('vdevs'):
+                for vdev in entry['vdevs']:
+                    state = vdev.get('state')
+                    lines.append('  backing device: {}{}'.format(
+                        vdev['path'],
+                        '  [{}]'.format(state) if state else '',
+                    ))
+            else:
+                lines.append('  backing device: unknown')
+            if not entry['zvols']:
+                lines.append('  zvols: none found (pool exists but has no volumes)')
+            for zvol in entry['zvols']:
+                zprops = zvol['properties']
+                lines.append('  device: {}'.format(zvol['device']))
+                try:
+                    human = human_readable_size(int(zvol['size']))
+                    lines.append('    size: {} bytes ({})'.format(zvol['size'], human))
+                except (TypeError, ValueError):
+                    lines.append('    size: {} bytes'.format(zvol['size']))
+                if zprops.get('type'):
+                    lines.append('    type: {}'.format(zprops.get('type')))
+                if zprops.get('objectstore'):
+                    lines.append('    objectstore: {}'.format(zprops.get('objectstore')))
+                if zprops.get('crush_device_class'):
+                    lines.append('    crush_device_class: {}'.format(
+                        zprops.get('crush_device_class')))
+                for link in ('db_device', 'wal_device', 'block_device'):
+                    if zprops.get(link):
+                        lines.append('    {}: {}'.format(link, zprops.get(link)))
+        lines.append('')
+        return '\n'.join(lines)
+
+    def format_report(self, entries):
+        fmt = getattr(conf, 'format', None)
+        if fmt == 'json':
+            print(json.dumps(entries))
+        elif fmt == 'json-pretty' or getattr(conf, 'json', False):
+            print(json.dumps(entries, indent=4, sort_keys=True))
+        else:
+            print(self.plain_report(entries))
+
+    def main(self):
+        sub_command_help = dedent("""
+        List the ZFS-backed Ceph OSDs on this host.
+
+        Only pools created by "ceph-volume zfs prepare" are shown --
+        they're identified by the ceph:managed_by property that
+        prepare sets. Unrelated zpools are never listed.
+
+        An optional filter narrows the output; it can be an OSD id, an
+        OSD fsid, a pool name, a zvol device path, or the backing
+        physical device (e.g. /dev/ada0).
+
+        Examples:
+          ceph-volume zfs list
+          ceph-volume zfs list 5
+          ceph-volume zfs list ceph-osd-5
+          ceph-volume zfs list /dev/ada0
+          ceph-volume zfs -j list
+        """)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume zfs list',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=sub_command_help,
+        )
+        parser.add_argument(
+            'filter',
+            nargs='?',
+            default=None,
+            help='Optional OSD id, OSD fsid, pool name, or zvol device path',
+        )
+        self.args = parser.parse_args(self.argv)
+
+        entries = [e for e in list_ceph_zpools() if self._matches(e, self.args.filter)]
+        self.format_report(entries)
+


### PR DESCRIPTION
Implements the list subcommand for the ZFS plugin backend:
- Discovers Ceph-managed zpools via ceph:managed_by=ceph-volume-zfs property
- Reports osd_id, osd_fsid, cluster, backing devices, zvol size
- Filter by OSD id, fsid, pool name, or backing device path
- Respects global -v/-j flags for verbose/JSON output
- FreeBSD-only; no effect on Linux builds





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
