### PR TITLE
ceph-volume-zfs: update plugin dispatcher with new subcommands and flags

### DIFF
--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/zfs.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/zfs.py
@@ -21,6 +21,8 @@ from ceph_volume_zfs.devices import zfs
 from ceph_volume_zfs.devices.zfs import inventory
 from ceph_volume_zfs.devices.zfs import prepare
 from ceph_volume_zfs.devices.zfs import zap
+from ceph_volume_zfs.devices.zfs import list as list_
+from ceph_volume_zfs.devices.zfs import activate
 
 
 if __name__ == '__main__':
@@ -43,7 +45,9 @@ class ZFS(object):
 
     def __init__(self, argv=None, parse=True):
         self.zfs_mapper = {
+            'activate': activate.Activate,
             'inventory': inventory.Inventory,
+            'list': list_.List,
             'prepare': prepare.Prepare,
             'zap': zap.Zap,
         }
@@ -129,8 +133,67 @@ class ZFS(object):
             default='/var/log/ceph/',
             help='Change the log path (defaults to /var/log/ceph)',
         )
+        parser.add_argument(
+            '-v', '--verbose',
+            action='store_true',
+            default=False,
+            help='Enable verbose output (detailed per-disk/per-action info where applicable)',
+        )
+        parser.add_argument(
+            '-j', '--json',
+            action='store_true',
+            default=False,
+            help='Output machine-readable JSON where applicable (shorthand for --format json-pretty)',
+        )
+        parser.add_argument(
+            '--format',
+            choices=['plain', 'json', 'json-pretty'],
+            default=None,
+            help='Output format (overrides -v/-j if given)',
+        )
+        parser.add_argument(
+            '--debug',
+            action='store_true',
+            default=False,
+            help='Include raw command output (e.g. gpart show) in reports, where applicable',
+        )
         args = parser.parse_args(main_args)
         conf.log_path = args.log_path
+        # -v/-j/--format/--debug are accepted both before the
+        # subcommand (parsed above, via args.*) and after it --
+        # subcommand_args is scanned and stripped of these tokens here
+        # so that e.g. `ceph-volume zfs inventory -v` works the same
+        # as `ceph-volume zfs -v inventory`, without inventory/
+        # prepare/zap needing to know about these flags themselves.
+        extra_verbose = False
+        extra_json = False
+        extra_format = None
+        extra_debug = False
+        filtered_subcommand_args = []
+        skip_next = False
+        for i, token in enumerate(subcommand_args):
+            if skip_next:
+                skip_next = False
+                continue
+            if token in ('-v', '--verbose'):
+                extra_verbose = True
+            elif token in ('-j', '--json'):
+                extra_json = True
+            elif token == '--debug':
+                extra_debug = True
+            elif token == '--format':
+                if i + 1 < len(subcommand_args):
+                    extra_format = subcommand_args[i + 1]
+                    skip_next = True
+            elif token.startswith('--format='):
+                extra_format = token.split('=', 1)[1]
+            else:
+                filtered_subcommand_args.append(token)
+        subcommand_args = filtered_subcommand_args
+        conf.verbose = args.verbose or extra_verbose
+        conf.json = args.json or extra_json
+        conf.format = args.format or extra_format
+        conf.debug = args.debug or extra_debug
         if os.path.isdir(conf.log_path):
             conf.log_path = os.path.join(args.log_path, 'ceph-volume-zfs.log')
         log.setup()
@@ -150,3 +213,4 @@ class ZFS(object):
             terminal.red(error)
         # dispatch to sub-commands
         terminal.dispatch(self.zfs_mapper, subcommand_args)
+


### PR DESCRIPTION
- Register activate, list subcommands alongside inventory/prepare/zap
- Add -v/--verbose, -j/--json, --format, --debug global flags
- Flags accepted both before and after the subcommand
- FreeBSD-only; no effect on Linux builds





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
