### PR TITLE
doc: rewrite three pages that document removed tools and platforms

### DIFF
--- a/doc/install/install-vm-cloud.rst
+++ b/doc/install/install-vm-cloud.rst
@@ -3,10 +3,10 @@
 =========================================
 
 If you intend to use Ceph Block Devices and the Ceph Storage Cluster as a
-backend for Virtual Machines (VMs) or  :term:`Cloud Platforms` the QEMU/KVM and
-``libvirt`` packages are important for enabling VMs and cloud platforms.
-Examples of VMs include: QEMU/KVM, XEN, VMWare, LXC, VirtualBox, etc. Examples
-of Cloud Platforms include OpenStack, CloudStack, OpenNebula, etc.
+backend for Virtual Machines (VMs) or :term:`Cloud Platforms`, install QEMU/KVM
+and ``libvirt`` from your distribution's packages. Ceph does not ship these
+packages. QEMU accesses Ceph Block Devices through ``librbd``, and ``libvirt``
+configures QEMU.
 
 
 .. ditaa::
@@ -28,105 +28,38 @@ of Cloud Platforms include OpenStack, CloudStack, OpenNebula, etc.
             +------------------------+ +------------------------+
 
 
-Install QEMU
-============
+Install QEMU and libvirt
+========================
 
-QEMU KVM can interact with Ceph Block Devices via ``librbd``, which is an
-important feature for using Ceph with cloud platforms. Once you install QEMU,
-see `QEMU and Block Devices`_ for usage.
+On Debian and Ubuntu, RBD support for QEMU is in the ``qemu-block-extra``
+package. Run the following command (replace ``qemu-system-x86`` with the
+package for your host architecture):
 
+.. prompt:: bash $
 
-Debian Packages
----------------
+   sudo apt install qemu-system-x86 qemu-utils qemu-block-extra libvirt-daemon-system libvirt-clients
 
-QEMU packages are incorporated into Ubuntu 12.04 Precise Pangolin and later
-versions. To  install QEMU, execute the following::
+On RHEL, CentOS Stream, Rocky Linux and other RPM-based distributions, run the
+following command:
 
-	sudo apt-get install qemu
+.. prompt:: bash $
 
+   sudo dnf install qemu-kvm qemu-kvm-block-rbd qemu-img libvirt
 
-RPM Packages
-------------
+To confirm that the installed QEMU supports RBD, check that ``rbd`` appears in
+the list of supported formats:
 
-To install QEMU, execute the following:
+.. prompt:: bash $
 
-
-#. Update your repositories. ::
-
-	sudo yum update
-
-#. Install QEMU for Ceph. ::
-
-	sudo yum install qemu-kvm qemu-kvm-tools qemu-img
-
-#. Install additional QEMU packages (optional)::
-
-	sudo yum install qemu-guest-agent qemu-guest-agent-win32
+   qemu-img --help | grep -w rbd
 
 
-Building QEMU
--------------
+Next steps
+==========
 
-To build QEMU from source, use the following procedure::
+To use QEMU with Ceph Block Devices, see `QEMU and Block Devices`_. To use
+``libvirt`` with Ceph Block Devices, see `Using libvirt with Ceph Block
+Device`_.
 
-	cd {your-development-directory}
-	git clone git://git.qemu.org/qemu.git
-	cd qemu
-	./configure --enable-rbd
-	make; make install
-
-
-
-Install libvirt
-===============
-
-To use ``libvirt`` with Ceph, you must have a running Ceph Storage Cluster, and
-you must have installed and configured QEMU. See `Using libvirt with Ceph Block
-Device`_ for usage.
-
-
-Debian Packages
----------------
-
-``libvirt`` packages are incorporated into Ubuntu 12.04 Precise Pangolin and
-later versions of Ubuntu. To install ``libvirt`` on these distributions,
-execute the following::
-
-	sudo apt-get update && sudo apt-get install libvirt-bin
-
-
-RPM Packages
-------------
-
-To use ``libvirt`` with a Ceph Storage Cluster, you must  have a running Ceph
-Storage Cluster and you must also install a version of QEMU with ``rbd`` format
-support.  See `Install QEMU`_ for details.
-
-
-``libvirt`` packages are incorporated into the recent CentOS/RHEL distributions.
-To install ``libvirt``, execute the following::
-
-	sudo yum install libvirt
-
-
-Building ``libvirt``
---------------------
-
-To build ``libvirt`` from source, clone the ``libvirt`` repository and use
-`AutoGen`_ to generate the build. Then, execute ``make`` and ``make install`` to
-complete the installation. For example::
-
-	git clone git://libvirt.org/libvirt.git
-	cd libvirt
-	./autogen.sh
-	make
-	sudo make install
-
-See `libvirt Installation`_ for details.
-
-
-
-.. _libvirt Installation: https://www.libvirt.org/compiling.html
-.. _AutoGen: https://www.gnu.org/software/autogen/
 .. _QEMU and Block Devices: ../../rbd/qemu-rbd
 .. _Using libvirt with Ceph Block Device: ../../rbd/libvirt

--- a/doc/man/8/ceph-create-keys.rst
+++ b/doc/man/8/ceph-create-keys.rst
@@ -9,48 +9,25 @@ ceph-create-keys -- ceph keyring generate tool
 Synopsis
 ========
 
-| **ceph-create-keys** [-h] [-v] [-t seconds] [--cluster *name*] --id *id*
+| **ceph-create-keys**
 
 
 Description
 ===========
 
-:program:`ceph-create-keys` is a utility to generate bootstrap keyrings using
-the given Monitor when it is ready.
+:program:`ceph-create-keys` is obsolete. Since the Nautilus release the
+Monitors create the ``client.admin`` and ``client.bootstrap-*`` keys
+themselves when they form a quorum. This command does nothing except print a
+message that says so. It accepts no options, and it will be removed in a
+future release. Remove any call to it from scripts and tools.
 
-It creates the following auth entities (or users)
-
-``client.admin``
-
-    and its key for your client host.
-
-``client.bootstrap-{osd, rgw, mds}``
-
-    and their keys for bootstrapping corresponding services
-
-To list all users in the cluster::
+To list all users and their keys in the cluster, run::
 
     ceph auth ls
 
+To retrieve a bootstrap key, run a command of the following form::
 
-Options
-=======
-
-.. option:: --cluster
-
-   name of the cluster (default 'ceph').
-
-.. option:: -t
-
-   time out after **seconds** (default: 600) waiting for a response from the Monitor
-
-.. option:: -i, --id
-
-   ID of a ceph-mon that is coming up. **ceph-create-keys** will wait until it joins quorum.
-
-.. option:: -v, --verbose
-
-   be more verbose.
+    ceph auth get client.bootstrap-osd
 
 
 Availability

--- a/doc/rados/troubleshooting/cpu-profiling.rst
+++ b/doc/rados/troubleshooting/cpu-profiling.rst
@@ -2,79 +2,63 @@
  CPU Profiling
 ===============
 
-If you built Ceph from source and compiled Ceph for use with `oprofile`_
-you can profile Ceph's CPU usage. See `Installing Oprofile`_ for details.
+Use ``perf``, the Linux profiler, to see where a Ceph daemon spends its CPU
+time. ``perf`` works with the release packages: no special build of Ceph is
+needed. Install the debug symbols for the daemon that you want to profile so
+that ``perf`` can resolve function names. The symbols are in the ``-dbg``
+packages on Debian-based distributions (for example ``ceph-osd-dbg``) and in
+the ``-debuginfo`` packages on RPM-based distributions.
+
+Run ``perf`` on the host that runs the daemon. All of the commands below
+require root privileges.
 
 
-Initializing oprofile
-=====================
+Finding the process
+===================
 
-``oprofile`` must be initialized the first time it is used. Locate the
-``vmlinux`` image that corresponds to the kernel you are running:
+Find the process ID (PID) of the daemon. The following command lists every
+OSD process on the host together with its command line, which includes the
+OSD ID:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
-   ls /boot
-   sudo opcontrol --init
-   sudo opcontrol --setup --vmlinux={path-to-image} --separate=library --callgraph=6
-
-
-Starting oprofile
-=================
-
-Run the following command to start ``oprofile``: 
-
-.. prompt:: bash $
-
-   opcontrol --start
+   pgrep -a ceph-osd
 
 
-Stopping oprofile
-=================
+Watching a daemon live
+======================
 
-Run the following command to stop ``oprofile``: 
+Run the following command to see a continuously updated list of the functions
+in which the daemon spends the most time:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
-   opcontrol --stop
-    
-    
-Retrieving oprofile Results
-===========================
-
-Run the following command to retrieve the top ``cmon`` results: 
-
-.. prompt:: bash $
-
-   opreport -gal ./cmon | less    
-    
-
-Run the following command to retrieve the top ``cmon`` results, with call
-graphs attached: 
-
-.. prompt:: bash $
-
-   opreport -cal ./cmon | less    
-    
-.. important:: After you have reviewed the results, reset ``oprofile`` before
-   running it again. The act of resetting ``oprofile`` removes data from the
-   session directory.
+   perf top -p {pid}
 
 
-Resetting oprofile
-==================
+Recording a profile
+===================
 
-Run the following command to reset ``oprofile``:  
+Run the following command to record 60 seconds of samples, including call
+graphs:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
-   sudo opcontrol --reset   
-   
-.. important:: Reset ``oprofile`` after analyzing data. This ensures that 
-   results from prior tests do not get mixed in with the results of the current
-   test. 
+   perf record -p {pid} -F 99 --call-graph dwarf -- sleep 60
 
-.. _oprofile: https://oprofile.sourceforge.net/about/
-.. _Installing Oprofile: ../../../dev/cpu-profiler
+Run the following command to view the recording. The ``caller`` view shows
+what each top function calls; use ``--call-graph callee`` to see instead who
+calls each top function:
 
+.. prompt:: bash #
 
+   perf report --call-graph caller
+
+.. note:: A ``perf record`` with ``--call-graph dwarf`` copies part of the
+   stack on every sample and can produce large files. Keep the sampling
+   frequency low (``-F 99`` in the example above) and the duration short on a
+   busy daemon.
+
+See :doc:`/dev/perf` for building flame graphs from a recording and for
+compiling Ceph with frame pointers, which allows the cheaper ``--call-graph
+fp`` mode.


### PR DESCRIPTION
Three pages that describe things that no longer exist, each fixed in its own commit:

- **`doc/rados/troubleshooting/cpu-profiling.rst`** profiled a binary named `cmon` (the Monitor has been `ceph-mon` since Argonaut) with oprofile's `opcontrol`, which oprofile removed in 1.0; nothing in the build system supports oprofile. Rewritten around `perf`, using the same commands as `doc/dev/perf.rst`, with a note on where to get debug symbols.
- **`doc/man/8/ceph-create-keys.rst`** documented options for a tool that is a five-line shell script printing "This tool is obsolete" (`src/ceph-create-keys`). The page is kept because `ceph.spec.in` and `debian/ceph-base.install` ship the man page with the script; its body is now an obsolescence notice with the `ceph auth` commands to use instead.
- **`doc/install/install-vm-cloud.rst`** targeted Ubuntu 12.04, installed `libvirt-bin` and `qemu-kvm-tools`, and built QEMU and libvirt from `git://` clones with `autogen.sh`. Replaced with the distribution packages (including the separate RBD block-driver packages), a check that QEMU has RBD support, and pointers to the RBD QEMU and libvirt pages.

Assisted by: Fable 5.1

Notes for reviewers:

- `doc/dev/cpu-profiler.rst` ("Installing Oprofile") still describes oprofile and links to the troubleshooting page. It is developer documentation and is left for a follow-up.
- Built with Sphinx locally; no new warnings in the touched files.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
