### PR TITLE
ceph-volume-zfs: implement activate subcommand for FreeBSD

### DIFF
--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/activate.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/activate.py
@@ -1,0 +1,87 @@
+import argparse
+from textwrap import dedent
+
+from ceph_volume_zfs.objectstore import Zfs
+
+
+class Activate(object):
+
+    help = 'Activate a prepared ZFS-backed OSD'
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def main(self):
+        sub_command_help = dedent("""
+        Rebuild a prepared OSD's runtime directory so ceph-osd can run
+        against it.
+
+        The OSD directory (/var/lib/ceph/osd/<cluster>-<id>) is tmpfs
+        and does not survive a reboot. That is by design: the durable
+        state lives on the block zvol, and
+        "ceph-bluestore-tool prime-osd-dir" reads it back out. So this
+        has to run once per boot for every OSD -- that is what
+        --all is for.
+
+        Discovery is entirely local: OSDs are found by scanning zpools
+        for the ceph:* properties that "ceph-volume zfs prepare" set.
+        No monitor contact is needed.
+
+        NOTE: this does not start the daemon by default. There is no
+        systemd on FreeBSD and no rc.d integration yet, so --start
+        just execs ceph-osd unsupervised.
+
+        Examples:
+          ceph-volume zfs activate --osd-id 5
+          ceph-volume zfs activate --osd-id 5 --osd-fsid <uuid>
+          ceph-volume zfs activate --all
+          ceph-volume zfs activate --all --start
+        """)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume zfs activate',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=sub_command_help,
+        )
+        parser.add_argument(
+            '--osd-id',
+            default=None,
+            help='OSD id to activate',
+        )
+        parser.add_argument(
+            '--osd-fsid',
+            default=None,
+            help='OSD fsid to activate',
+        )
+        parser.add_argument(
+            '--all',
+            action='store_true',
+            default=False,
+            help='Activate every ZFS-backed OSD found on this host',
+        )
+        parser.add_argument(
+            '--start',
+            action='store_true',
+            default=False,
+            help=(
+                'Also start ceph-osd. Unsupervised -- it will not restart '
+                'on its own if it dies (no rc.d integration yet).'
+            ),
+        )
+        parser.add_argument(
+            '--no-tmpfs',
+            action='store_true',
+            default=False,
+            help='Do not use tmpfs for the OSD data directory',
+        )
+        self.args = parser.parse_args(self.argv)
+
+        if not self.args.all and not self.args.osd_id and not self.args.osd_fsid:
+            parser.print_help()
+            return
+
+        objectstore = Zfs(args=self.args)
+        if self.args.all:
+            objectstore.activate_all()
+        else:
+            objectstore.activate()
+


### PR DESCRIPTION
- Discovers prepared OSDs via ceph:* ZFS properties (no monitor needed)
- Rebuilds tmpfs OSD directory after reboot via ceph-bluestore-tool prime-osd-dir
- --all activates every ZFS-backed OSD on the host
- --start optionally starts ceph-osd (unsupervised, no rc.d yet)
- -n/--dry-run prints the plan without executing anything
- FreeBSD-only; no effect on Linux builds





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
