### PR TITLE
umbrella: mgr/cephadm: show NO DATA when a host is missing a hardware category

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1785,10 +1785,8 @@ class NodeProxyCache:
         _result = {}
 
         for host in hosts:
-            try:
-                _result[host] = self.data[host]['status'][endpoint]
-            except KeyError:
-                raise KeyError(f'Invalid host {host} or component {endpoint}.')
+            status = self.data[host].get('status', {})
+            _result[host] = status.get(endpoint, {})
         return _result
 
     def firmware(self, **kw: Any) -> Dict[str, Any]:

--- a/src/pybind/mgr/cephadm/tests/test_node_proxy.py
+++ b/src/pybind/mgr/cephadm/tests/test_node_proxy.py
@@ -348,3 +348,32 @@ class TestNodeProxyEndpoint(helper.CPWebCase):
     def test_firmwares_legacy_endpoint(self):
         self.getPage("/host02/firmwares", method="GET")
         self.assertStatus('200 OK')
+
+
+class TestNodeProxyCacheCommon:
+    def _make_cache(self) -> NodeProxyCache:
+        mgr = MagicMock()
+        mgr.get_store = MagicMock(return_value='{}')
+        mgr.set_store = MagicMock()
+        mgr.inventory = {}
+        cache = NodeProxyCache(mgr)
+        cache.data = {
+            'at4n1': {'sn': '1', 'status': {'storage': {}, 'fcm': {'local': {'nvme0n1': {}}}}},
+            'at4n2': {'sn': '2', 'status': {'storage': {}, 'fans': {}}},
+        }
+        return cache
+
+    def test_common_includes_hosts_missing_component(self):
+        cache = self._make_cache()
+        result = cache.common('fcm')
+        assert result['at4n1'] == {'local': {'nvme0n1': {}}}
+        assert result['at4n2'] == {}
+
+    def test_common_hostname_without_component_returns_empty(self):
+        cache = self._make_cache()
+        assert cache.common('fcm', hostname='at4n2') == {'at4n2': {}}
+
+    def test_common_hostname_with_component(self):
+        cache = self._make_cache()
+        result = cache.common('fcm', hostname='at4n1')
+        assert result == {'at4n1': {'local': {'nvme0n1': {}}}}

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -634,7 +634,12 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
 
         fields = mapping.get(category, ())
         for host in data.keys():
-            for sys_id, details in data[host].items():
+            host_data = data[host] or {}
+            if not any(host_data.values()):
+                # HOST + 'NO DATA' already fill the first two columns...
+                table.add_row([host, 'NO DATA'] + [''] * (len(table.field_names) - 2))
+                continue
+            for sys_id, details in host_data.items():
                 for k, v in details.items():
                     row = []
                     for field in fields:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80475

---

backport of https://github.com/ceph/ceph/pull/71692
parent tracker: https://tracker.ceph.com/issues/80453

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh