### PR TITLE
tentacle: node-proxy: don't crash on empty Redfish logout

### DIFF
--- a/src/ceph-node-proxy/ceph_node_proxy/main.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/main.py
@@ -210,7 +210,10 @@ def handler(signum: Any, frame: Any, t_mgr: "NodeProxyManager") -> None:
         and t_mgr.system.client is not None
     ):
         t_mgr.log.info("Logging out from RedFish API")
-        t_mgr.system.client.logout()
+        try:
+            t_mgr.system.client.logout()
+        except Exception as e:
+            t_mgr.log.error("Can't log out from RedFish API: %s", e)
     raise SystemExit(0)
 
 

--- a/src/ceph-node-proxy/ceph_node_proxy/redfish_client.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/redfish_client.py
@@ -93,13 +93,14 @@ class RedFishClient(BaseClient):
         result: Dict[str, Any] = {}
         try:
             if self.is_logged_in():
-                _, _data, _status_code = self.query(
+                _, _data, _ = self.query(
                     method="DELETE",
                     headers={"X-Auth-Token": self.token},
                     endpoint=self.location,
                 )
-                result = json.loads(_data)
-        except URLError:
+                if _data:
+                    result = json.loads(_data)
+        except (URLError, json.JSONDecodeError):
             self.log.error(f"Can't log out from {self.url}")
 
         self.location = ""

--- a/src/ceph-node-proxy/tests/test_redfish_client.py
+++ b/src/ceph-node-proxy/tests/test_redfish_client.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock, patch
+
+from ceph_node_proxy.redfish_client import RedFishClient
+
+
+def _logged_in_client() -> RedFishClient:
+    client = RedFishClient(host="bmc", username="u", password="p")
+    client.token = "tok"
+    client.location = "/redfish/v1/SessionService/Sessions/1"
+    return client
+
+
+def test_logout_empty_body() -> None:
+    client = _logged_in_client()
+    with (
+        patch.object(client, "is_logged_in", return_value=True),
+        patch.object(client, "query", return_value=(MagicMock(), "", 204)),
+    ):
+        result = client.logout()
+    assert result == {}
+    assert client.token == ""
+    assert client.location == ""
+
+
+def test_logout_json_body() -> None:
+    client = _logged_in_client()
+    with (
+        patch.object(client, "is_logged_in", return_value=True),
+        patch.object(client, "query", return_value=(MagicMock(), '{"ok": true}', 200)),
+    ):
+        result = client.logout()
+    assert result == {"ok": True}
+    assert client.token == ""
+    assert client.location == ""
+
+
+def test_logout_invalid_json_body() -> None:
+    client = _logged_in_client()
+    with (
+        patch.object(client, "is_logged_in", return_value=True),
+        patch.object(client, "query", return_value=(MagicMock(), "not-json", 200)),
+    ):
+        result = client.logout()
+    assert result == {}
+    assert client.token == ""
+    assert client.location == ""


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80479

---

backport of https://github.com/ceph/ceph/pull/71619
parent tracker: https://tracker.ceph.com/issues/80361

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh