### PR TITLE
umbrella: mgr/cephadm: allow removing OSDs stuck in error state

### DIFF
--- a/doc/cephadm/services/osd.rst
+++ b/doc/cephadm/services/osd.rst
@@ -319,7 +319,10 @@ Expected output:
 
   Scheduled OSD(s) for removal
 
-OSDs that are not safe to destroy will be rejected.  Adding the ``--zap`` flag
+OSDs that are not safe to destroy will be rejected. Use ``--force`` to
+remove an OSD without waiting for PGs to drain or for ``osd safe-to-destroy``
+to succeed. This is required when the OSD daemon is already in an error
+state (for example when its backing devices are gone). Adding the ``--zap`` flag
 directs the orchestrator to remove all LVM and partition information from the
 OSD's drives, leaving it a blank slate for redeployment or other reuse.
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2120,7 +2120,10 @@ Then run the following:
             except MonCommandFailed as e:
                 self.log.error(f'Couldn\'t remove host {host} from CRUSH map: {str(e)}')
                 return (f'Cephadm failed removing host {host}\n'
-                        f'Failed to remove host {host} from the CRUSH map: {str(e)}')
+                        f'Failed to remove host {host} from the CRUSH map: {str(e)}\n'
+                        f'OSDs may still be present in the CRUSH bucket. '
+                        f"Remove them with 'ceph orch osd rm' or "
+                        f"'ceph orch host drain {host}' first.")
 
         self.inventory.rm_host(host)
         self.cache.rm_host(host)
@@ -4732,8 +4735,15 @@ Then run the following:
 
         daemons: List[orchestrator.DaemonDescription] = self.cache.get_daemons_by_host(hostname)
 
-        osds_to_remove = [d.daemon_id for d in daemons if d.daemon_type == 'osd']
-        self.remove_osds(osds_to_remove, zap=zap_osd_devices)
+        osd_daemons = [d for d in daemons if d.daemon_type == 'osd']
+        error_osds = [d.daemon_id for d in osd_daemons
+                      if d.status == DaemonDescriptionStatus.error]
+        other_osds = [d.daemon_id for d in osd_daemons
+                      if d.status != DaemonDescriptionStatus.error]
+        if error_osds:
+            self.remove_osds(error_osds, zap=zap_osd_devices, force=True)
+        if other_osds or not error_osds:
+            self.remove_osds(other_osds, zap=zap_osd_devices)
 
         daemons_table = ""
         daemons_table += "{:<20} {:<15}\n".format("type", "id")

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -15,7 +15,7 @@ import orchestrator
 from cephadm.serve import CephadmServe
 from cephadm.utils import SpecialHostLabels
 from ceph.utils import datetime_now
-from orchestrator import OrchestratorError, DaemonDescription
+from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus
 from mgr_module import MonCommandFailed
 
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService
@@ -788,6 +788,22 @@ class OSD:
     def safe_to_destroy(self) -> bool:
         return self.rm_util.safe_to_destroy([self.osd_id])
 
+    def daemon_is_error(self) -> bool:
+        try:
+            dd = self.rm_util.mgr.cache.get_daemon(f'osd.{self.osd_id}', self.hostname)
+        except OrchestratorError:
+            return False
+        return dd.status == DaemonDescriptionStatus.error
+
+    def update_from(self, other: "OSD") -> None:
+        self.force = other.force
+        self.zap = other.zap
+        self.replace = other.replace
+        self.replace_block = other.replace_block
+        self.replace_db = other.replace_db
+        self.replace_wal = other.replace_wal
+        self.no_destroy = other.no_destroy
+
     def down(self) -> bool:
         return self.rm_util.set_osd_flag([self], 'down')
 
@@ -931,63 +947,63 @@ class OSDRemovalQueue(object):
         # Check all osds for their state and take action (remove, purge etc)
         new_queue: Set[OSD] = set()
         for osd in all_osds:  # type: OSD
-            if not osd.force:
-                # skip criteria
+            # --force, or an already-failed empty daemon, must not wait on
+            # osd safe-to-destroy (it stays false while the cluster is degraded).
+            skip_safety = osd.force or (osd.daemon_is_error() and osd.get_pg_count() <= 0)
+            if not skip_safety:
                 if not osd.is_empty:
                     logger.debug(f"{osd} is not empty yet. Waiting a bit more")
                     new_queue.add(osd)
                     continue
 
-            if not osd.safe_to_destroy():
-                logger.debug(
-                    f"{osd} is not safe-to-destroy yet. Waiting a bit more")
-                new_queue.add(osd)
-                continue
+                if not osd.safe_to_destroy():
+                    logger.debug(
+                        f"{osd} is not safe-to-destroy yet. Waiting a bit more")
+                    new_queue.add(osd)
+                    continue
 
-            # abort criteria
-            if not osd.down():
-                # also remove it from the remove_osd list and set a health_check warning?
-                raise orchestrator.OrchestratorError(
-                    f"Could not mark {osd} down")
-
-            # stop and remove daemon
-            assert osd.hostname is not None
-
-            if self.mgr.cache.has_daemon(f'osd.{osd.osd_id}'):
-                CephadmServe(self.mgr)._remove_daemon(f'osd.{osd.osd_id}', osd.hostname)
-                logger.info(f"Successfully removed {osd} on {osd.hostname}")
-                result = True
-            else:
-                logger.info(f"Daemon {osd} on {osd.hostname} was already removed")
-
-            any_replace_params: bool = any([osd.replace,
-                                            osd.replace_block,
-                                            osd.replace_db,
-                                            osd.replace_wal])
-            if any_replace_params:
-                # mark destroyed in osdmap
-                if not osd.destroy():
+            try:
+                if not osd.down():
                     raise orchestrator.OrchestratorError(
-                        f"Could not destroy {osd}")
-                logger.info(
-                    f"Successfully destroyed old {osd} on {osd.hostname}; ready for replacement")
-                if any_replace_params:
-                    osd.zap = True
-            else:
-                # purge from osdmap
-                if not osd.purge():
-                    raise orchestrator.OrchestratorError(f"Could not purge {osd}")
-                logger.info(f"Successfully purged {osd} on {osd.hostname}")
+                        f"Could not mark {osd} down")
 
-            if osd.zap:
-                try:
-                    logger.info(f"Zapping devices for {osd} on {osd.hostname}")
-                    osd.do_zap()
-                    logger.info(f"Successfully zapped devices for {osd} on {osd.hostname}")
-                except Exception:
-                    logger.exception(f"Failed to zap devices for {osd} on {osd.hostname}")
-            self.mgr.cache.invalidate_host_devices(osd.hostname)
-            logger.debug(f"Removing {osd} from the queue.")
+                assert osd.hostname is not None
+
+                if self.mgr.cache.has_daemon(f'osd.{osd.osd_id}'):
+                    CephadmServe(self.mgr)._remove_daemon(f'osd.{osd.osd_id}', osd.hostname)
+                    logger.info(f"Successfully removed {osd} on {osd.hostname}")
+                    result = True
+                else:
+                    logger.info(f"Daemon {osd} on {osd.hostname} was already removed")
+
+                any_replace_params: bool = any([osd.replace,
+                                                osd.replace_block,
+                                                osd.replace_db,
+                                                osd.replace_wal])
+                if any_replace_params:
+                    if not osd.destroy():
+                        raise orchestrator.OrchestratorError(
+                            f"Could not destroy {osd}")
+                    logger.info(
+                        f"Successfully destroyed old {osd} on {osd.hostname}; ready for replacement")
+                    osd.zap = True
+                else:
+                    if not osd.purge():
+                        raise orchestrator.OrchestratorError(f"Could not purge {osd}")
+                    logger.info(f"Successfully purged {osd} on {osd.hostname}")
+
+                if osd.zap:
+                    try:
+                        logger.info(f"Zapping devices for {osd} on {osd.hostname}")
+                        osd.do_zap()
+                        logger.info(f"Successfully zapped devices for {osd} on {osd.hostname}")
+                    except Exception:
+                        logger.exception(f"Failed to zap devices for {osd} on {osd.hostname}")
+                self.mgr.cache.invalidate_host_devices(osd.hostname)
+                logger.debug(f"Removing {osd} from the queue.")
+            except Exception as e:
+                logger.exception(f"Failed to complete removal of {osd}: {e}")
+                new_queue.add(osd)
 
         # self could change while this is processing (osds get added from the CLI)
         # The new set is: 'an intersection of all osds that are still not empty/removed (new_queue) and
@@ -1063,9 +1079,17 @@ class OSDRemovalQueue(object):
     def enqueue(self, osd: "OSD") -> None:
         if not osd.exists:
             raise NotFoundError()
+        start_new = False
         with self.lock:
-            self.osds.add(osd)
-        osd.start()
+            for queued in self.osds:
+                if queued.osd_id == osd.osd_id:
+                    queued.update_from(osd)
+                    break
+            else:
+                self.osds.add(osd)
+                start_new = True
+        if start_new:
+            osd.start()
 
     def rm_by_osd_id(self, osd_id: int) -> None:
         osd: Optional["OSD"] = None

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -38,6 +38,7 @@ from ceph.deployment.inventory import Devices, Device
 from ceph.utils import datetime_to_str, datetime_now, str_to_datetime
 from orchestrator import DaemonDescription, InventoryHost, \
     HostSpec, OrchestratorError, DaemonDescriptionStatus, OrchestratorEvent
+from mgr_module import MonCommandFailed
 from tests import mock
 from .fixtures import wait, _run_cephadm, match_glob, with_host, \
     with_cephadm_module, with_service, make_daemons_running, async_side_effect
@@ -2721,6 +2722,18 @@ Traceback (most recent call last):
             with with_host(cephadm_module, 'test2', refresh_hosts=False, rm_with_force=False):
                 cephadm_module.inventory.add_label('test2', SpecialHostLabels.ADMIN)
 
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    def test_remove_host_crush_leftover_osds(self, cephadm_module: CephadmOrchestrator):
+        with with_host(cephadm_module, 'test', refresh_hosts=False, rm_with_force=True):
+            with mock.patch.object(
+                    cephadm_module, 'check_mon_command',
+                    side_effect=MonCommandFailed(
+                        'osd crush remove failed: (39) Directory not empty retval: -39')):
+                out = wait(cephadm_module, cephadm_module.remove_host(
+                    'test', force=True, rm_crush_entry=True))
+            assert 'OSDs may still be present' in out
+            assert 'ceph orch host drain test' in out
+
     @pytest.mark.parametrize("facts, settings, expected_value",
                              [
                                  # All options are available on all hosts
@@ -2938,6 +2951,23 @@ Traceback (most recent call last):
         with pytest.raises(OrchestratorError, match=r"Cannot find host 'host1' in the inventory."):
             cephadm_module.drain_host('host1', force=True, zap_osd_devices=True)
             _rm_osds.assert_called_with([], zap=True)
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
+    @mock.patch("cephadm.CephadmOrchestrator.remove_osds")
+    @mock.patch("cephadm.CephadmOrchestrator.add_host_label", lambda *a, **kw: None)
+    def test_host_drain_error_osds(self, _rm_osds, cephadm_module):
+        error_dd = DaemonDescription(
+            daemon_type='osd', daemon_id='0', hostname='test',
+            status=DaemonDescriptionStatus.error)
+        running_dd = DaemonDescription(
+            daemon_type='osd', daemon_id='1', hostname='test',
+            status=DaemonDescriptionStatus.running)
+        with with_host(cephadm_module, 'test', refresh_hosts=False, rm_with_force=True):
+            with mock.patch.object(cephadm_module.cache, 'get_daemons_by_host',
+                                   return_value=[error_dd, running_dd]):
+                cephadm_module.drain_host('test', force=True, zap_osd_devices=True)
+            _rm_osds.assert_any_call(['0'], zap=True, force=True)
+            _rm_osds.assert_any_call(['1'], zap=True)
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
     @mock.patch("cephadm.CephadmOrchestrator.stop_remove_osds")

--- a/src/pybind/mgr/cephadm/tests/test_osd_removal.py
+++ b/src/pybind/mgr/cephadm/tests/test_osd_removal.py
@@ -5,6 +5,7 @@ import pytest
 from tests import mock
 from .fixtures import with_cephadm_module
 from datetime import datetime
+from orchestrator import DaemonDescription, DaemonDescriptionStatus, OrchestratorError
 
 
 class MockOSD:
@@ -49,11 +50,6 @@ class TestOSDRemoval:
     def test_find_stop_threshold(self, rm_util, osds, ok_to_stop, expected):
         with mock.patch("cephadm.services.osd.RemoveUtil.ok_to_stop", side_effect=ok_to_stop):
             assert rm_util.find_osd_stop_threshold(osds) == expected
-
-    def test_process_removal_queue(self, rm_util):
-        # TODO: !
-        # rm_util.process_removal_queue()
-        pass
 
     @pytest.mark.parametrize(
         "max_osd_draining_count, draining_osds, idling_osds, ok_to_stop, expected",
@@ -227,6 +223,27 @@ class TestOSD:
         osd_obj.safe_to_destroy()
         osd_obj.rm_util.safe_to_destroy.assert_called_once()
 
+    def test_daemon_is_error(self, osd_obj):
+        dd = DaemonDescription(daemon_type='osd', daemon_id='0', hostname='h',
+                               status=DaemonDescriptionStatus.error)
+        osd_obj.hostname = 'h'
+        osd_obj.rm_util.mgr.cache.get_daemon.return_value = dd
+        assert osd_obj.daemon_is_error() is True
+
+        dd.status = DaemonDescriptionStatus.running
+        assert osd_obj.daemon_is_error() is False
+
+        osd_obj.rm_util.mgr.cache.get_daemon.side_effect = OrchestratorError('missing')
+        assert osd_obj.daemon_is_error() is False
+
+    def test_update_from(self, osd_obj):
+        osd_obj.force = True
+        osd_obj.zap = True
+        other = OSD(osd_id=0, remove_util=mock.MagicMock(), force=False, zap=False)
+        osd_obj.update_from(other)
+        assert osd_obj.force is False
+        assert osd_obj.zap is False
+
     @mock.patch("cephadm.services.osd.RemoveUtil.set_osd_flag")
     def test_down(self, _, osd_obj):
         osd_obj.down()
@@ -280,6 +297,82 @@ class TestOSDRemovalQueue:
         q = OSDRemovalQueue(mock.Mock())
         q.enqueue(osd_obj)
         osd_obj.start.assert_called_once()
+
+    @mock.patch("cephadm.services.osd.OSD.start")
+    @mock.patch("cephadm.services.osd.OSD.exists")
+    def test_enqueue_updates_existing(self, exist, start, osd_obj):
+        q = OSDRemovalQueue(mock.Mock())
+        osd_obj.force = True
+        osd_obj.zap = True
+        q.enqueue(osd_obj)
+        newer = OSD(osd_id=osd_obj.osd_id, remove_util=mock.MagicMock(),
+                    force=False, zap=False)
+        q.enqueue(newer)
+        queued = next(iter(q.osds))
+        assert queued is osd_obj
+        assert queued.force is False
+        assert queued.zap is False
+        start.assert_called_once()
+
+    def _removal_queue_with_osd(self, force=False):
+        mgr = mock.Mock()
+        mgr.max_osd_draining_count = 1
+        mgr.cache.has_daemon.return_value = False
+        osd = OSD(osd_id=1, remove_util=mock.MagicMock(), force=force, hostname='host1')
+        q = OSDRemovalQueue(mgr)
+        q.osds.add(osd)
+        return q, osd
+
+    @mock.patch("cephadm.services.osd.OSD.exists", True)
+    @mock.patch("cephadm.services.osd.OSD.daemon_is_error", return_value=False)
+    @mock.patch("cephadm.services.osd.OSD.get_pg_count", return_value=0)
+    @mock.patch("cephadm.services.osd.OSD.safe_to_destroy", return_value=False)
+    @mock.patch("cephadm.services.osd.OSD.purge")
+    def test_process_removal_queue_waits_when_not_safe(self, _purge, _std, _pgs, _err):
+        q, osd = self._removal_queue_with_osd(force=False)
+        q.process_removal_queue()
+        assert osd in q.osds
+        _purge.assert_not_called()
+
+    @mock.patch("cephadm.services.osd.OSD.exists", True)
+    @mock.patch("cephadm.services.osd.OSD.daemon_is_error", return_value=False)
+    @mock.patch("cephadm.services.osd.OSD.get_pg_count", return_value=0)
+    @mock.patch("cephadm.services.osd.OSD.safe_to_destroy", return_value=False)
+    @mock.patch("cephadm.services.osd.OSD.down", return_value=True)
+    @mock.patch("cephadm.services.osd.OSD.purge", return_value=True)
+    def test_process_removal_queue_force_skips_safe_to_destroy(
+            self, _purge, _down, _std, _pgs, _err):
+        q, osd = self._removal_queue_with_osd(force=True)
+        q.process_removal_queue()
+        _purge.assert_called_once()
+        _std.assert_not_called()
+        assert osd not in q.osds
+
+    @mock.patch("cephadm.services.osd.OSD.exists", True)
+    @mock.patch("cephadm.services.osd.OSD.daemon_is_error", return_value=True)
+    @mock.patch("cephadm.services.osd.OSD.get_pg_count", return_value=0)
+    @mock.patch("cephadm.services.osd.OSD.safe_to_destroy", return_value=False)
+    @mock.patch("cephadm.services.osd.OSD.down", return_value=True)
+    @mock.patch("cephadm.services.osd.OSD.purge", return_value=True)
+    def test_process_removal_queue_error_empty_skips_safe_to_destroy(
+            self, _purge, _down, _std, _pgs, _err):
+        q, osd = self._removal_queue_with_osd(force=False)
+        q.process_removal_queue()
+        _purge.assert_called_once()
+        _std.assert_not_called()
+        assert osd not in q.osds
+
+    @mock.patch("cephadm.services.osd.OSD.exists", True)
+    @mock.patch("cephadm.services.osd.OSD.daemon_is_error", return_value=False)
+    @mock.patch("cephadm.services.osd.OSD.get_pg_count", return_value=0)
+    @mock.patch("cephadm.services.osd.OSD.safe_to_destroy", return_value=True)
+    @mock.patch("cephadm.services.osd.OSD.down", return_value=True)
+    @mock.patch("cephadm.services.osd.OSD.purge", side_effect=Exception('purge failed'))
+    def test_process_removal_queue_keeps_osd_on_purge_failure(
+            self, _purge, _down, _std, _pgs, _err):
+        q, osd = self._removal_queue_with_osd(force=False)
+        q.process_removal_queue()
+        assert osd in q.osds
 
     @mock.patch("cephadm.services.osd.OSD.stop")
     @mock.patch("cephadm.services.osd.OSD.exists")

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -757,7 +757,7 @@ class Orchestrator(object):
         :param replace_block: marks the corresponding block device as being replaced.
         :param replace_db: marks the corresponding db device as being replaced.
         :param replace_wal: marks the corresponding wal device as being replaced.
-        :param force: Forces the OSD removal process without waiting for the data to be drained first.
+        :param force: Forces OSD removal without waiting for PG drain or osd safe-to-destroy.
         :param zap: Zap/Erase all devices associated with the OSDs (DESTROYS DATA)
         :param no_destroy: Do not destroy associated VGs/LVs with the OSD.
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80480

---

backport of https://github.com/ceph/ceph/pull/71586
parent tracker: https://tracker.ceph.com/issues/80328

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh