### PR TITLE
tentacle: mgr/cephadm: update osdspec_affinity bdev label on set-spec-affinity

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -169,7 +169,7 @@ from cephadmlib.container_daemon_form import (
 from cephadmlib.sysctl import install_sysctl, migrate_sysctl_dir
 from cephadmlib.firewalld import Firewalld, update_firewalld
 from cephadmlib import templating
-from cephadmlib.daemons.ceph import get_ceph_mounts_for_type, ceph_daemons
+from cephadmlib.daemons.ceph import get_ceph_mounts_for_type, ceph_daemons, update_osd_bluestore_affinity
 from cephadmlib.daemons import (
     Ceph,
     CephExporter,
@@ -4337,13 +4337,21 @@ def update_service_for_daemon(ctx: CephadmContext,
     # check if all the daemon names are valid
     if not set(update_daemons).issubset(set(available_daemons)):
         raise Error(f'Error EINVAL: one or more daemons of {update_daemons} does not exist on this host')
+    # osdspec_affinity stores the bare service id (e.g. "foobar"), not the
+    # full service name (e.g. "osd.foobar"), consistent with how ceph-volume
+    # writes it at OSD creation time via CEPH_VOLUME_OSDSPEC_AFFINITY.
+    _, _, service_id = ctx.service_name.partition('.')
+    if not service_id:
+        service_id = ctx.service_name
     for name in update_daemons:
         path = os.path.join(ctx.data_dir, ctx.fsid, name, 'unit.meta')
         update_meta_file(path, data)
+        update_osd_bluestore_affinity(ctx, name, service_id)
         print(f'Successfully updated daemon {name} with service {ctx.service_name}')
 
 
 @infer_fsid
+@infer_image
 def command_update_osd_service(ctx: CephadmContext) -> int:
     """update service for provided daemon"""
     update_daemons = [f'osd.{osd_id}' for osd_id in ctx.osd_ids.split(',')]

--- a/src/cephadm/cephadmlib/daemons/ceph.py
+++ b/src/cephadm/cephadmlib/daemons/ceph.py
@@ -667,6 +667,77 @@ class CephExporter(ContainerDaemonForm):
         populate_files(ssl_dir, cert_files, uid, gid)
 
 
+def update_osd_bluestore_affinity(
+    ctx: CephadmContext, daemon_name: str, service_name: str
+) -> None:
+    """Update osdspec_affinity via ceph-bluestore-tool set-label-key.
+
+    ceph-bluestore-tool only exists inside the Ceph container image, so we
+    spin up an ephemeral privileged container to run it. The block device is
+    held exclusively by the running OSD (EBUSY), so the container is stopped
+    first and restarted afterwards. The host root is mounted at /rootfs inside
+    the container, so the block symlink is prefixed accordingly.
+    """
+    osd_data_dir = os.path.join(ctx.data_dir, ctx.fsid, daemon_name)
+    block_path = os.path.join(osd_data_dir, 'block')
+
+    if not os.path.exists(block_path):
+        raise Error(
+            f'Block device not found at {block_path} for {daemon_name}'
+        )
+
+    # daemon_name is "osd.3" (type="osd", id="3")
+    daemon_type, daemon_id = daemon_name.split('.', 1)
+    ident = DaemonIdentity(ctx.fsid, daemon_type, daemon_id)
+
+    logger.info(
+        f'Stopping {ident.container_name} to update osdspec_affinity bdev label'
+    )
+    call(
+        ctx,
+        [ctx.container_engine.path, 'stop', ident.container_name],
+        verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
+    )
+    try:
+        block_path_in_container = '/rootfs' + block_path
+        c = CephContainer(
+            ctx,
+            image=ctx.image,
+            privileged=True,
+            entrypoint='ceph-bluestore-tool',
+            args=[
+                '--dev',
+                block_path_in_container,
+                'set-label-key',
+                '-k',
+                'osdspec_affinity',
+                '-v',
+                service_name,
+            ],
+            volume_mounts=get_ceph_mounts_for_type(ctx, ctx.fsid, 'osd'),
+        )
+        _, err, ret = call(
+            ctx,
+            c.run_cmd(),
+            verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
+        )
+        if ret:
+            raise Error(
+                f'ceph-bluestore-tool set-label-key failed for {daemon_name} '
+                f'(osdspec_affinity={service_name}): {err}'
+            )
+        logger.debug(
+            f'Updated osdspec_affinity={service_name} for {daemon_name}'
+        )
+    finally:
+        logger.info(f'Restarting {ident.unit_name}')
+        call(
+            ctx,
+            ['systemctl', 'start', ident.unit_name],
+            verbosity=CallVerbosity.QUIET_UNLESS_ERROR,
+        )
+
+
 def get_ceph_mounts_for_type(
     ctx: CephadmContext, fsid: str, daemon_type: str
 ) -> Dict[str, str]:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4319,7 +4319,8 @@ Then run the following:
     @handle_orch_error
     def set_osd_spec(self, service_name: str, osd_ids: List[str]) -> str:
         """
-        Update unit.meta file for osd with service name
+        Update unit.meta, BlueStore bdev label and filesystem osdspec_affinity
+        for the given OSDs so that `ceph osd metadata` reflects the new spec.
         """
         if service_name not in self.spec_store:
             raise OrchestratorError(f"Cannot find service '{service_name}' in the inventory. "


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80485

---

backport of https://github.com/ceph/ceph/pull/71488
parent tracker: https://tracker.ceph.com/issues/80204

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh