### PR TITLE
cmake: stop nasm feature probes from unlinking /dev/null

### DIFF
--- a/cmake/modules/CheckNasm.cmake
+++ b/cmake/modules/CheckNasm.cmake
@@ -18,10 +18,16 @@ macro(check_nasm_support _object_format _support_x64 _support_x64_and_avx2 _supp
       " ${_support_x64})
       set(CMAKE_REQUIRED_QUIET ${save_quiet})
       if(${_support_x64})
+        # nasm deletes its output file when assembly fails, which is
+        # what a feature probe does by design; pointing -o at /dev/null
+        # therefore unlinks the device node when the probe runs as root.
+        set(nasm_probe_dir "${CMAKE_BINARY_DIR}/CMakeFiles/CheckNasm")
+        file(MAKE_DIRECTORY "${nasm_probe_dir}")
+        set(nasm_probe_out "${nasm_probe_dir}/probe.o")
         execute_process(COMMAND nasm -f ${object_format} -i
           ${CMAKE_SOURCE_DIR}/src/isa-l/include/
           ${CMAKE_SOURCE_DIR}/src/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm
-          -o /dev/null
+          -o ${nasm_probe_out}
           RESULT_VARIABLE rc
           OUTPUT_QUIET
           ERROR_QUIET)
@@ -31,7 +37,7 @@ macro(check_nasm_support _object_format _support_x64 _support_x64_and_avx2 _supp
         execute_process(COMMAND nasm -D HAVE_AS_KNOWS_AVX512 -f ${object_format}
           -i ${CMAKE_SOURCE_DIR}/src/isa-l/include/
           ${CMAKE_SOURCE_DIR}/src/isa-l/erasure_code/gf_vect_dot_prod_avx512.asm
-          -o /dev/null
+          -o ${nasm_probe_out}
           RESULT_VARIABLE rt
           OUTPUT_QUIET
           ERROR_QUIET)
@@ -41,7 +47,7 @@ macro(check_nasm_support _object_format _support_x64 _support_x64_and_avx2 _supp
 	execute_process(COMMAND nasm -D AS_FEATURE_LEVEL=10 -f ${object_format}
           -i ${CMAKE_SOURCE_DIR}/src/isa-l/include/
           ${CMAKE_SOURCE_DIR}/src/isa-l/crc/crc32_iscsi_by16_10.asm
-          -o /dev/null
+          -o ${nasm_probe_out}
           RESULT_VARIABLE rt
           OUTPUT_QUIET
           ERROR_QUIET)


### PR DESCRIPTION
`cmake/modules/CheckNasm.cmake` probes the installed nasm for AVX2 /
AVX512 / VPCLMUL support by assembling three sample sources with
`-o /dev/null`. nasm removes its output file when assembly fails, and a
failing probe is the normal case on an assembler that lacks one of
those instruction sets: the probe fails, nasm calls `remove()` on its
output path, and when the configure step runs as root that unlinks
`/dev/null`. The next process to redirect to `/dev/null` recreates it
as a regular file, after which anything depending on the device node
misbehaves (in practice, sshd stops accepting new connections until the
node is recreated from a console).

Point the three probes at a scratch file under
`build/CMakeFiles/CheckNasm` instead of `/dev/null`, so a failed probe
deletes only that scratch file. No change to what the probes detect.

Found while configuring an unrelated branch as root on a build host.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
