### PR TITLE
doc/cephfs: fix OSD cap in the quota client example

### DIFF
--- a/doc/cephfs/quota.rst
+++ b/doc/cephfs/quota.rst
@@ -130,7 +130,7 @@ Limitations
 
    An example command to create such a user::
 
-     $ ceph auth get-or-create client.guest mds 'allow r path=/home/volumes, allow rw path=/home/volumes/group' mgr 'allow rw' osd 'allow rw tag cephfs metadata=*' mon 'allow r'
+     $ ceph auth get-or-create client.guest mds 'allow r path=/home/volumes, allow rw path=/home/volumes/group' mgr 'allow rw' osd 'allow rw tag cephfs data=*' mon 'allow r'
 
    A related known issue: when the kernel client mounts a subdirectory
    below the directory on which the quota is set, tools such as ``df``


### PR DESCRIPTION
The quota page's path-restricted client example granted osd 'allow rw tag cephfs metadata=*'. CephFS clients never access the metadata pool directly (the MDS does), so the example both grants a pointless metadata-pool cap and denies the data-pool access that file I/O needs: a client created from this example fails all reads and writes. Changed to 'allow rw tag cephfs data=*', matching the caps ceph fs authorize generates and every example in client-auth.rst.

Fixes: https://tracker.ceph.com/issues/79780

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
