### PR TITLE
doc/rbd: document the ceph nvme-gw monitor commands

### DIFF
--- a/doc/rbd/nvmeof-target-configure.rst
+++ b/doc/rbd/nvmeof-target-configure.rst
@@ -126,3 +126,114 @@ Use the ``ceph nvmeof`` command to configure NVMe-oF gateways.
 
       ceph nvmeof namespace list --nqn SUBSYSTEM_NQN
 
+
+.. _nvmeof-monitor-commands:
+
+Monitor Commands for Gateway Groups
+===================================
+
+Besides the ``ceph nvmeof`` gateway CLI described above, Ceph provides
+a separate ``ceph nvme-gw`` command family that is served by the
+Monitors. The two operate at different layers: ``ceph nvmeof``
+configures subsystems, listeners, hosts, and namespaces on the gateway
+daemons, while ``ceph nvme-gw`` manages the gateway group state that
+the Monitors track for high availability: group membership, ANA group
+assignments, administrative state, and failover behavior.
+
+Inspecting gateway groups
+-------------------------
+
+To display the state of the gateways in a group, run a command of the
+following form:
+
+.. prompt:: bash #
+
+   ceph nvme-gw show POOL_NAME GROUP_NAME
+
+The JSON output includes the number of gateways in the group, the ANA
+group list, the total namespace count, and one entry per gateway
+showing its ANA group, location, administrative state (``ENABLED`` or
+``DISABLED``), availability (for example ``AVAILABLE``, ``CREATED``,
+or ``DELETING``), listener count, and per-ANA-group state.
+
+To dump every gateway group in the cluster, run:
+
+.. prompt:: bash #
+
+   ceph nvme-gw show-all
+
+To list all listeners in a group, including the listeners that
+gateways create automatically rather than only the ones defined
+through the ``ceph nvmeof`` CLI, run a command of the following form:
+
+.. prompt:: bash #
+
+   ceph nvme-gw listeners POOL_NAME GROUP_NAME
+
+The output groups listeners by subsystem NQN and shows the address
+family, address, service ID, and owning gateway of each listener.
+Only gateways that are currently available contribute listeners to
+the output. The ``listeners`` command was added in the Tentacle
+release.
+
+Commands managed by the orchestrator
+------------------------------------
+
+The following commands change gateway group state and are normally
+issued by cephadm, not by operators:
+
+* ``ceph nvme-gw create`` and ``ceph nvme-gw delete`` register and
+  remove a gateway in a group. cephadm runs them when NVMe-oF gateway
+  daemons are deployed and removed. Do not run them manually against
+  a cephadm-managed cluster: deleting a gateway triggers an immediate
+  failover of its ANA groups.
+* ``ceph nvme-gw enable`` and ``ceph nvme-gw disable`` set a single
+  gateway's administrative state. cephadm uses them to quiesce
+  gateways when a host enters maintenance and to bring them back
+  afterwards. Disabling an available gateway takes it out of service
+  and temporarily suppresses failovers while its ANA groups move, so
+  disabling all the gateways in a group removes NVMe-oF access to its
+  namespaces.
+
+Locations and disaster recovery
+-------------------------------
+
+Gateways can be assigned a *location*, an availability domain label
+such as a site or rack, which the Monitors use for disaster-recovery
+handling. These commands require the ``beacon-diff`` Monitor feature
+and fail cleanly when it is not available:
+
+.. prompt:: bash #
+
+   ceph nvme-gw set-location GATEWAY_ID POOL_NAME GROUP_NAME LOCATION
+
+When all the gateways in a location have become unavailable, for
+example after the loss of a site, the location can be declared to be
+in a disaster state so that the surviving locations take over its ANA
+groups without waiting for a failback:
+
+.. prompt:: bash #
+
+   ceph nvme-gw disaster-set POOL_NAME GROUP_NAME LOCATION
+
+The command is rejected while any gateway in the location is still
+available, which prevents declaring a disaster during a transient
+outage. Once the location has recovered, clear the disaster state to
+permit failback:
+
+.. prompt:: bash #
+
+   ceph nvme-gw disaster-clear POOL_NAME GROUP_NAME LOCATION
+
+.. warning:: ``disaster-set`` and ``disaster-clear`` move live I/O
+   paths between locations. Use them only as part of a planned
+   disaster-recovery procedure.
+
+The ``beacon-diff`` feature itself can be toggled cluster-wide:
+
+.. prompt:: bash #
+
+   ceph nvme-gw set beacon-diff enable
+
+This affects gateway beacon reporting and failover timing for all
+gateway groups; leave it at the default unless directed otherwise.


### PR DESCRIPTION
The ceph nvme-gw monitor command family (show, show-all, listeners, create/delete, enable/disable, set-location, disaster-set/clear, set beacon-diff) had no operator documentation; only the Tentacle release notes mentioned the listeners command. This adds a reference section to the NVMe-oF target configuration page that:

- explains how the monitor-side nvme-gw family differs from the ceph nvmeof gateway CLI documented on the same page
- documents the read-only diagnostics (show, show-all, listeners) with the output fields verified against the NVMeofGwMon source and the qa workunit jq extractions
- marks create/delete and enable/disable as orchestrator-managed (cephadm issues them on deploy/removal and host maintenance) with the availability implications of running them by hand
- documents the location and disaster-recovery commands, including the built-in guard that disaster-set is rejected while any gateway in the location is still available

All behavior statements were verified against src/mon/NVMeofGwMon.cc, src/mon/NVMeofGwMap.cc, and the cephadm module; nothing is asserted that the code does not show. One term worth an SME glance: the release notes use auto-listeners for gateway-created listeners, and the section describes them as listeners that gateways create automatically, which matches the code but could use confirmation from the NVMe-oF team.

Fixes: https://tracker.ceph.com/issues/79798

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
