### PR TITLE
qa/nvme_loop: connect with a complete host identity

### DIFF
--- a/qa/tasks/nvme_loop.py
+++ b/qa/tasks/nvme_loop.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import json
+import uuid
 
 from io import StringIO
 from teuthology import misc as teuthology
@@ -15,7 +16,6 @@ log = logging.getLogger(__name__)
 @contextlib.contextmanager
 def task(ctx, config):
     log.info('Setting up nvme_loop on scratch devices...')
-    host = 'hostnqn'
     port = '1'
     devs_by_remote = {}
     old_scratch_by_remote = {}
@@ -30,15 +30,14 @@ def task(ctx, config):
                 'grep', '^nvme_loop', '/proc/modules', run.Raw('||'),
                 'sudo', 'modprobe', 'nvme_loop',
                 run.Raw('&&'),
-                'sudo', 'mkdir', '-p', f'{base}/hosts/{host}',
-                run.Raw('&&'),
                 'sudo', 'mkdir', '-p', f'{base}/ports/{port}',
                 run.Raw('&&'),
                 'echo', 'loop', run.Raw('|'),
                 'sudo', 'tee', f'{base}/ports/{port}/addr_trtype',
             ]
         )
-        provide_hostname = True
+        host_id = str(uuid.uuid4())
+        host_nqn = f'nqn.2014-08.org.nvmexpress:uuid:{host_id}'
         for dev in devs:
             short = dev.split('/')[-1]
             log.info(f'Connecting nvme_loop {remote.shortname}:{dev}...')
@@ -59,18 +58,10 @@ def task(ctx, config):
                 'sudo', 'ln', '-s', f'{base}/subsystems/{short}',
                 f'{base}/ports/{port}/subsystems/{short}',
                 run.Raw('&&'),
-                'sudo', 'nvme', 'connect', '-t', 'loop', '-n', short
+                'sudo', 'nvme', 'connect', '-t', 'loop', '-n', short,
+                '-q', host_nqn, '-I', host_id,
             ]
-            if provide_hostname:
-                nvme_connect_args.extend(['-q', host])
-            try:
-                remote.run(args=nvme_connect_args)
-            except Exception:
-                if provide_hostname:
-                    provide_hostname = False
-                    remote.run(args=['sudo', 'nvme', 'connect', '-t', 'loop', '-n', short])
-                else:
-                    raise
+            remote.run(args=nvme_connect_args)
 
         # identify nvme_loops devices
         old_scratch_by_remote[remote] = remote.read_file('/scratch_devs')


### PR DESCRIPTION
the nvme-fabrics kernel module, which modprobing nvme_loop pulls in, registers a default (hostnqn, hostid) pair when it is loaded, and fills in whichever half a connect leaves out. it then refuses a pair that shares one half with an entry it already has, so a connect that passes a host nqn and no hostid collides with that default entry:
```
  nvme_fabrics: found same hostid d887744e-5975-4cca-96ee-22ae7036d4e7 but different hostnqn hostnqn
```
"nvme connect" prints that as "Failed to write to /dev/nvme-fabrics: Invalid argument".

we passed "-q hostnqn", a placeholder that is not an nqn, and no hostid, so the connect fails unless nvme-cli sends a hostid of its own. whether it does depends on the image and the nvme-cli version rather than on the distro: centos 9 hit this in 2024 (#67684) and rocky 10 in 2025 (#73823), and both were papered over by reinstalling nvme-cli from qa/distros. 17cc03da91c added the retry without "-q" for ubuntu noble, which only helps when nvme-cli then sends both halves or neither. on the current ubuntu images it sends one, so both attempts fail.

generate a uuid per host and pass both halves instead. the first device creates the entry and the rest take a reference to it, so nothing depends on what an image left in /etc/nvme. the retry goes too, and so does the configfs hosts directory: the subsystem sets attr_allow_any_host, so the host acl is never read.

Fixes: https://tracker.ceph.com/issues/71816





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
