### PR TITLE
mon/MgrMap: fix standbys JSON shape in print_summary()

### DIFF
--- a/src/mon/MgrMap.cc
+++ b/src/mon/MgrMap.cc
@@ -523,7 +523,9 @@ void MgrMap::print_summary(ceph::Formatter *f, std::ostream *ss) const
     f->dump_int("num_standbys", standbys.size());
     f->open_array_section("standbys");
     for (const auto &i : standbys) {
-     f->dump_string("name", i.second.name);
+      f->open_object_section("standby");
+      f->dump_string("name", i.second.name);
+      f->close_section();
     }
     f->close_section();
     f->open_array_section("modules");


### PR DESCRIPTION
`MgrMap::print_summary()` emits each entry of the JSON `standbys` arrayas a bare string instead of an object, breaking strict JSON consumers.

Fixes: https://tracker.ceph.com/issues/80495

rook operator errors

```sh
$ kubectl -n rook-ceph logs deploy/rook-ceph-operator --since=1m | grep HEALTH_ERR | tail -1
2026-09-12 01:05:42.722646 I | ceph-spec: [rook-ceph/bd2a49acce13] "ceph-object-store-user-controller": CephCluster "rook-ceph" found but skipping reconcile since ceph health is &{Health:HEALTH_ERR Details:map[error:{Severity:Urgent Message:failed to unmarshal status response: json: cannot unmarshal string into Go struct field MgrMap.mgrmap.standbys of type client.MgrStandby}] LastChecked:2026-09-12T01:05:26Z LastChanged:2026-09-10T17:26:00Z PreviousHealth:HEALTH_WARN Capacity:{TotalBytes:6097215430656 UsedBytes:1021955608576 AvailableBytes:5075259822080 LastUpdated:2026-09-10T17:24:41Z} Versions:0x1bc10176ef00 FSID:}
```

because

```sh
$ ceph status --format json-pretty | jq '.mgrmap.standbys'
[
  "a"
]
```

which should be

```sh
[
  {"name": "a"}
]
```

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects Dashboard, opened tracker ticket
  - [ ] Affects Orchestrator, opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes bug reproduction test and/or coverage for new feature
  - [x] No tests needed. Very recent bug and/or code cleanup with no functional change
