### PR TITLE
tentacle: mgr/cephadm: populate RGW port_ips for explicit placement IPs

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1152,7 +1152,11 @@ class RgwService(CephService):
             assert daemon_spec.host is not None
             ip_to_bind_to = self.mgr.get_first_matching_network_ip(daemon_spec.host, spec) or ''
             if ip_to_bind_to:
-                daemon_spec.port_ips = {str(port): ip_to_bind_to}
+                # Tell the host-side port-in-use precheck (fetch_endpoints /
+                # port_in_use) to probe this IP. Without port_ips it falls
+                # back to 0.0.0.0 and can false-conflict with listeners on
+                # other addresses.
+                daemon_spec.port_ips.update({str(port): ip_to_bind_to})
             else:
                 logger.warning(
                     f'Failed to find ip in {spec.networks} for host {daemon_spec.host}. '
@@ -1160,6 +1164,9 @@ class RgwService(CephService):
                 )
         elif daemon_spec.ip:
             ip_to_bind_to = daemon_spec.ip
+            # Same as only_bind_port_on_networks: keep precheck in sync with
+            # the narrow endpoint=<ip>:<port> / port=<ip>:<port> bind below.
+            daemon_spec.port_ips.update({str(port): ip_to_bind_to})
 
         if ftype == 'beast':
             if spec.ssl:

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -2336,6 +2336,40 @@ class TestRGWService:
                 })
                 assert f == expected
 
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_rgw_port_ips_with_explicit_ip(self, cephadm_module: CephadmOrchestrator):
+        """Explicit placement IP must populate port_ips for the host-side precheck.
+
+        Without this, fetch_endpoints() defaults to 0.0.0.0 and port_in_use()
+        falsely conflicts with unrelated listeners on other addresses.
+        """
+        ip = '1.2.3.4'
+        port = 7480
+        with with_host(cephadm_module, 'host1'):
+            s = RGWSpec(
+                service_id='foo',
+                placement=PlacementSpec(hosts=['host1']),
+                rgw_frontend_type='beast',
+                rgw_frontend_port=port,
+            )
+            with with_service(cephadm_module, s) as _:
+                daemon_spec = service_registry.get_service('rgw').prepare_create(
+                    CephadmDaemonDeploySpec(
+                        host='host1',
+                        daemon_type='rgw',
+                        daemon_id='foo.host1.0',
+                        service_name=s.service_name(),
+                        ports=[port],
+                        ip=ip,
+                    ))
+                assert daemon_spec.port_ips == {str(port): ip}
+                _, f, _ = cephadm_module.check_mon_command({
+                    'prefix': 'config get',
+                    'who': f'client.{daemon_spec.name()}',
+                    'key': 'rgw_frontends',
+                })
+                assert f == f'beast endpoint={ip}:{port}'
+
     @pytest.mark.parametrize(
         "disable_sync_traffic",
         [


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80451

---

backport of https://github.com/ceph/ceph/pull/71047
parent tracker: https://tracker.ceph.com/issues/78018

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh