### PR TITLE
mds: defer dirfrag snap purge progress until commit completes

### DIFF
--- a/qa/suites/fs/functional/tasks/snap-purge.yaml
+++ b/qa/suites/fs/functional/tasks/snap-purge.yaml
@@ -1,0 +1,4 @@
+tasks:
+- cephfs_test_runner:
+    modules:
+      - tasks.cephfs.test_snap_purge

--- a/qa/tasks/cephfs/test_snap_purge.py
+++ b/qa/tasks/cephfs/test_snap_purge.py
@@ -1,0 +1,126 @@
+import json
+import signal
+from io import BytesIO, StringIO
+
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
+
+
+class TestSnapPurge(CephFSTestCase):
+    CLIENTS_REQUIRED = 1
+    MDSS_REQUIRED = 1
+
+    def setUp(self):
+        super().setUp()
+        for key, value in {
+            'mds_bal_fragment_dirs': 'false',
+            'mds_dir_prefetch': 'false',
+            'mds_dir_prefetch_backend': 'false',
+            'mds_dir_keys_per_op': '4',
+            'mds_early_reply': 'false',
+            # Keep stale keys on disk until the crash.
+            'mds_log_max_segments': '100000',
+            'mds_log_max_events': '-1',
+        }.items():
+            self.addCleanup(self.config_rm, 'mds', key)
+            self.config_set('mds', key, value)
+        self.fs.set_allow_new_snaps(True)
+
+    def _keys(self, obj):
+        return set(self.fs.radosmo(
+            ['listomapkeys', obj], stdout=StringIO()).splitlines())
+
+    def _header(self, obj):
+        raw = self.fs.radosmo(['getomapheader', obj, '-'], stdout=BytesIO())
+        return json.loads(self.fs.dencoder('fnode_t', raw))
+
+    def _dump_dir(self):
+        dirs = self.fs.rank_asok(['dump', 'dir', '/tree/dir', 'true'])
+        self.assertEqual(len(dirs), 1)
+        return dirs[0]
+
+    def _prepare_stale_keys(self):
+        self.mount_a.run_shell(['mkdir', '-p', 'tree/dir'])
+        victims = ['victim_{:02d}'.format(i) for i in range(16)]
+        self.mount_a.run_shell(
+            ['touch', 'tree/dir/keep'] + ['tree/dir/' + v for v in victims])
+        obj = '{:x}.00000000'.format(self.mount_a.path_to_ino('tree/dir'))
+        self.mount_a.run_shell(['mkdir', 'tree/.snap/s1'])
+        self.mount_a.run_shell(['rm'] + ['tree/dir/' + v for v in victims])
+        self.fs.flush()
+        stale = {k for k in self._keys(obj)
+                 if not k.endswith('_head') and k.rsplit('_', 1)[0] in victims}
+        self.assertEqual(len(stale), len(victims))
+
+        self.mount_a.umount_wait()
+        self.fs.flush()
+        self.fs.mds_fail_restart(self.fs.get_rank()['name'])
+        self.fs.wait_for_daemons()
+        self.mount_a.mount_wait()
+
+        destroyed_before = int(self.fs.rank_asok(
+            ['dump', 'snaps', '--server'])['last_destroyed'])
+        self.mount_a.run_shell(['rmdir', 'tree/.snap/s1'])
+
+        def snap_destroyed():
+            snaps = self.fs.rank_asok(['dump', 'snaps', '--server'])
+            return (not snaps['pending_destroy'] and
+                    int(snaps['last_destroyed']) > destroyed_before)
+
+        self.wait_until_true(snap_destroyed, timeout=60)
+        target = int(self.fs.rank_asok(
+            ['dump', 'snaps', '--server'])['last_destroyed'])
+        header = self._header(obj)
+        self.assertLess(int(header['snap_purged_thru']), target)
+        self.assertTrue(stale <= self._keys(obj),
+                        'stale keys must survive until the target is fetched')
+
+        self.mount_a.run_shell(['stat', 'tree/dir'])
+        cold = self._dump_dir()
+        if cold.get('status') != 'dirfrag not in cache':
+            self.assertNotIn('complete', cold['states'])
+            self.assertEqual(cold['dentries'], [])
+        return obj, stale, header, target
+
+    def _list_dir(self):
+        return sorted(self.mount_a.run_shell(
+            ['ls', '-1', 'tree/dir']).stdout.getvalue().splitlines())
+
+    def test_purge_watermark_survives_journal_replay(self):
+        obj, stale, header, target = self._prepare_stale_keys()
+        self.assertEqual(self._list_dir(), ['keep'])
+        self.assertIn('complete', self._dump_dir()['states'])
+
+        # A journal flush would commit the removals before the crash.
+        self.mount_a.run_shell(['touch', 'tree/dir/journal_marker'])
+        self.mount_a.umount_wait()
+        before_crash = self._keys(obj)
+        self.assertTrue(stale <= before_crash)
+        self.assertNotIn('journal_marker_head', before_crash)
+        self.assertEqual(self._header(obj), header)
+
+        mds_id = self.fs.get_rank()['name']
+        self.fs.mds_signal(mds_id, signal.SIGKILL)
+        self.fs.rank_fail()
+        self.fs.mds_restart(mds_id)
+        self.fs.wait_for_daemons()
+        self.mount_a.mount_wait()
+
+        self.assertEqual(self._list_dir(), ['journal_marker', 'keep'])
+        self.fs.flush()
+        self.assertFalse(stale & self._keys(obj),
+                         'replay advanced the watermark past uncommitted deletes')
+        self.assertGreaterEqual(int(self._header(obj)['snap_purged_thru']), target)
+
+    def test_partial_fetch_does_not_certify_purge(self):
+        obj, stale, header, target = self._prepare_stale_keys()
+        self.mount_a.run_shell(['stat', 'tree/dir/keep'])
+        self.assertNotIn('complete', self._dump_dir()['states'])
+        self.fs.flush()
+        self.assertTrue(stale <= self._keys(obj))
+        self.assertEqual(self._header(obj)['snap_purged_thru'],
+                         header['snap_purged_thru'])
+
+        self.assertEqual(self._list_dir(), ['keep'])
+        self.fs.flush()
+        self.assertFalse(stale & self._keys(obj))
+        self.assertGreaterEqual(int(self._header(obj)['snap_purged_thru']), target)

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1528,8 +1528,10 @@ void CDir::mark_clean()
 // caller should hold auth pin of this
 void CDir::log_mark_dirty()
 {
-  if (is_dirty() || projected_version > get_version())
-    return; // noop if it is already dirty or will be dirty
+  // An in-flight commit must not mark newly discovered purge work clean.
+  if (projected_version > get_version() ||
+      (is_dirty() && get_version() > committing_version))
+    return;
 
   auto _fnode = allocate_fnode(*get_fnode());
   _fnode->version = pre_dirty();
@@ -2108,6 +2110,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
 
   // purge stale snaps?
   bool force_dirty = false;
+  snapid_t snap_purge_target = 0;
   const set<snapid_t> *snaps = NULL;
   SnapRealm *realm = inode->find_snaprealm();
   if (fnode->snap_purged_thru < realm->get_last_destroyed()) {
@@ -2115,10 +2118,8 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
     dout(10) << " snap_purged_thru " << fnode->snap_purged_thru
 	     << " < " << realm->get_last_destroyed()
 	     << ", snap purge based on " << *snaps << dendl;
-    if (get_num_snap_items() == 0) {
-      const_cast<snapid_t&>(fnode->snap_purged_thru) = realm->get_last_destroyed();
-      force_dirty = true;
-    }
+    if (complete && r == 0 && get_num_snap_items() == 0)
+      snap_purge_target = realm->get_last_destroyed();
   }
 
 
@@ -2215,6 +2216,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
       // dirfrag as a whole will continue to look okay (minus the
       // mysteriously-missing dentry)
       go_bad_dentry(key.snapid, key.name);
+      snap_purge_target = 0;
 
       // Anyone who was WAIT_DENTRY for this guy will get kicked
       // to RetryRequest, and hit the DamageTable-interrogating path.
@@ -2294,6 +2296,12 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
 
     if (!(++count % mdcache->mds->heartbeat_reset_grace()))
       mdcache->mds->heartbeat_reset();
+  }
+
+  if (snap_purge_target > fnode->snap_purged_thru && !mdcache->is_readonly()) {
+    pending_snap_purge_target = std::max(pending_snap_purge_target,
+                                       snap_purge_target);
+    force_dirty = true;
   }
 
   // dirty myself to remove stale snap dentries
@@ -2382,10 +2390,12 @@ void CDir::commit(version_t want, MDSContext *c, bool ignore_authpinnability, in
 
 class C_IO_Dir_Committed : public CDirIOContext {
   version_t version;
+  snapid_t snap_purged_thru;
 public:
-  C_IO_Dir_Committed(CDir *d, version_t v) : CDirIOContext(d), version(v) { }
+  C_IO_Dir_Committed(CDir *d, version_t v, snapid_t purged) :
+    CDirIOContext(d), version(v), snap_purged_thru(purged) { }
   void finish(int r) override {
-    dir->_committed(r, version);
+    dir->_committed(r, version, snap_purged_thru);
   }
   void print(ostream& out) const override {
     out << "dirfrag_committed(" << dir->dirfrag() << ")";
@@ -2394,10 +2404,14 @@ public:
 
 class C_IO_Dir_Commit_Ops : public Context {
 public:
-  C_IO_Dir_Commit_Ops(CDir* d, int pr, auto&& s, auto&& bl, auto&& r, auto&& stales)
+  C_IO_Dir_Commit_Ops(CDir* d, int pr, bufferlist&& h, snapid_t purged,
+                    auto&& s, auto&& bl,
+                    auto&& r, auto&& stales)
   :
     dir(d),
     op_prio(pr),
+    header(std::move(h)),
+    snap_purged_thru(purged),
     to_set(std::forward<decltype(s)>(s)),
     dfts(std::forward<decltype(bl)>(bl)),
     to_remove(std::forward<decltype(r)>(r)),
@@ -2409,7 +2423,8 @@ public:
   }
 
   void finish(int r) override {
-    dir->_omap_commit_ops(r, op_prio, metapool, version, is_new, to_set, dfts,
+    dir->_omap_commit_ops(r, op_prio, metapool, version, is_new, header,
+                         snap_purged_thru, to_set, dfts,
 			  to_remove, stale_items);
   }
 
@@ -2419,6 +2434,8 @@ private:
   int64_t metapool;
   version_t version;
   bool is_new;
+  bufferlist header;
+  snapid_t snap_purged_thru;
   vector<CDir::dentry_commit_item> to_set;
   bufferlist dfts;
   vector<string> to_remove;
@@ -2463,6 +2480,7 @@ void CDir::_encode_primary_inode_base(dentry_commit_item &item, bufferlist &dfts
 
 // This is not locked by mds_lock
 void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t version, bool _new,
+			    bufferlist &header, snapid_t snap_purged_thru,
 			    vector<dentry_commit_item> &to_set, bufferlist &dfts,
                             vector<string>& to_remove,
 			    mempool::mds_co::compact_set<mempool::mds_co::string> &stales)
@@ -2475,7 +2493,8 @@ void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t vers
   }
 
   C_GatherBuilder gather(g_ceph_context,
-                         new C_OnFinisher(new C_IO_Dir_Committed(this, version),
+                         new C_OnFinisher(new C_IO_Dir_Committed(this, version,
+                                                                 snap_purged_thru),
 			 mdcache->mds->finisher));
 
   SnapContext snapc;
@@ -2488,14 +2507,14 @@ void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t vers
   unsigned max_write_size = mdcache->max_dir_commit_size;
   unsigned write_size = 0;
 
-  auto commit_one = [&](bool header=false) {
+  auto commit_one = [&](bool with_header=false) {
     ObjectOperation op;
 
     /*
      * Shouldn't submit empty op to Rados, which could cause
      * the cephfs to become readonly.
      */
-    ceph_assert(header || !_set.empty() || !_rm.empty());
+    ceph_assert(with_header || !_set.empty() || !_rm.empty());
 
 
     // don't create new dirfrag blindly
@@ -2511,9 +2530,7 @@ void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t vers
      * the message containing the header off last, we cannot get our header
      * into an incorrect state.
      */
-    if (header) {
-      bufferlist header;
-      encode(*fnode, header);
+    if (with_header) {
       op.omap_set_header(header);
     }
 
@@ -2697,8 +2714,15 @@ void CDir::_omap_commit(int op_prio)
     }
   }
 
-  auto c = new C_IO_Dir_Commit_Ops(this, op_prio, std::move(to_set), std::move(dfts),
-                                   std::move(to_remove), std::move(stale_items));
+  fnode_t committed_fnode = *fnode;
+  committed_fnode.snap_purged_thru = std::max(fnode->snap_purged_thru,
+                                           pending_snap_purge_target);
+  bufferlist header;
+  encode(committed_fnode, header);
+  auto c = new C_IO_Dir_Commit_Ops(this, op_prio, std::move(header),
+                                 committed_fnode.snap_purged_thru,
+                                 std::move(to_set), std::move(dfts),
+                                 std::move(to_remove), std::move(stale_items));
   stale_items.clear(); /* in CDir */
   mdcache->mds->finisher->queue(c);
 }
@@ -2805,7 +2829,7 @@ void CDir::_commit(version_t want, int op_prio)
  *
  * @param v version i just committed
  */
-void CDir::_committed(int r, version_t v)
+void CDir::_committed(int r, version_t v, snapid_t snap_purged_thru)
 {
   if (r < 0) {
     // the directory could be partly purged during MDS failover
@@ -2833,6 +2857,15 @@ void CDir::_committed(int r, version_t v)
   ceph_assert(v > committed_version);
   ceph_assert(v <= committing_version);
   committed_version = v;
+
+  if (fnode->snap_purged_thru < snap_purged_thru) {
+    auto next_fnode = allocate_fnode(*fnode);
+    next_fnode->snap_purged_thru = snap_purged_thru;
+    reset_fnode(std::move(next_fnode));
+  }
+  // Retain the target across projections that could roll the watermark back.
+  if (pending_snap_purge_target <= snap_purged_thru && !is_projected())
+    pending_snap_purge_target = 0;
 
   // _all_ commits done?
   if (committing_version == committed_version) 

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -690,6 +690,7 @@ protected:
   // -- commit --
   void _commit(version_t want, int op_prio);
   void _omap_commit_ops(int r, int op_prio, int64_t metapool, version_t version, bool _new,
+			bufferlist &header, snapid_t snap_purged_thru,
 			std::vector<dentry_commit_item> &to_set, bufferlist &dfts,
 			std::vector<std::string> &to_remove,
 			mempool::mds_co::compact_set<mempool::mds_co::string> &_stale);
@@ -698,7 +699,7 @@ protected:
   void _omap_commit(int op_prio);
   void _parse_dentry(CDentry *dn, dentry_commit_item &item,
                      const std::set<snapid_t> *snaps, bufferlist &bl);
-  void _committed(int r, version_t v);
+  void _committed(int r, version_t v, snapid_t snap_purged_thru);
 
   static fnode_const_ptr empty_fnode;
   // fnode is a pointer to constant fnode_t, the constant fnode_t can be shared
@@ -729,6 +730,8 @@ protected:
   version_t committed_version = 0;
 
   mempool::mds_co::compact_set<mempool::mds_co::string> stale_items;
+  // Keep purge progress out of journaled fnodes until the removals reach disk.
+  snapid_t pending_snap_purge_target = 0;
 
   // lock nesting, freeze
   static int num_frozen_trees;


### PR DESCRIPTION
A fetch currently advances the live fnode's snap_purged_thru while its stale_items removals are still only in memory. A later metadata operation can journal that fnode before the dirfrag is committed. After a crash, replay restores the advanced watermark without the removals, allowing a subsequent fetch to skip stale snapshot keys that remain in OMAP.

Keep the fetch's purge target separate from the live fnode. Capture the OMAP header and removal set together under mds_lock, write the header in the final batch, and publish the watermark only after commit success. Preserve the target across outstanding fnode projections, and give purge work discovered after commit capture a later dirty version.

Only a full fetch without cached snapshot dentries or decoding errors can certify purge progress. Named-key reads may remove keys they examine but must not advance the watermark for the whole dirfrag.

Add CephFS regression coverage for journal replay before the removals are committed and for partial fetches followed by a full fetch. The tests use the existing fetch path and configuration, without readdir pipelining.

Fixes: https://tracker.ceph.com/issues/80496



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
