### PR TITLE
squid: rgw: fix memory leak in RGWHTTPManager thread cleanup

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -1185,6 +1185,7 @@ void *RGWHTTPManager::reqs_thread_entry()
   std::unique_lock rl{reqs_lock};
   for (auto r : unregistered_reqs) {
     _unlink_request(r);
+    r->put();
   }
 
   unregistered_reqs.clear();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/74776

---

backport of https://github.com/ceph/ceph/pull/66874
parent tracker: https://tracker.ceph.com/issues/74762

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh