### PR TITLE
tentacle: rgw/amqp: check the iterator before dereferencing it

### DIFF
--- a/src/rgw/rgw_amqp.cc
+++ b/src/rgw/rgw_amqp.cc
@@ -793,7 +793,7 @@ private:
             // n/ack all up to (and including) the tag
             ldout(cct, 20) << "AMQP run: multiple n/acks received with tag=" << tag << " and result=" << result << dendl;
             auto it = conn->callbacks.begin();
-            while (it->tag <= tag && it != conn->callbacks.end()) {
+            while (it != conn->callbacks.end() && it->tag <= tag) {
               ldout(cct, 20) << "AMQP run: invoking callback with tag=" << it->tag << dendl;
               it->cb(result);
               it = conn->callbacks.erase(it);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/80472

---

backport of https://github.com/ceph/ceph/pull/71666
parent tracker: https://tracker.ceph.com/issues/80464

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh