### PR TITLE
umbrella: mgr/snap_schedule: do not assume wall clock does not tick

### DIFF
--- a/src/pybind/mgr/snap_schedule/tests/fs/test_schedule.py
+++ b/src/pybind/mgr/snap_schedule/tests/fs/test_schedule.py
@@ -62,11 +62,7 @@ class TestSchedule(object):
 
     def test_created_now(self, simple_schedule):
         now = datetime.datetime.now(datetime.timezone.utc)
-        assert simple_schedule.created.minute == now.minute
-        assert simple_schedule.created.hour == now.hour
-        assert simple_schedule.created.day == now.day
-        assert simple_schedule.created.month == now.month
-        assert simple_schedule.created.year == now.year
+        assert abs((now - simple_schedule.created).total_seconds()) < 5
         assert simple_schedule.created.tzinfo == now.tzinfo
 
     def test_repeat_valid(self, simple_schedule):

--- a/src/pybind/mgr/snap_schedule/tests/fs/test_schedule.py
+++ b/src/pybind/mgr/snap_schedule/tests/fs/test_schedule.py
@@ -55,9 +55,7 @@ class TestSchedule(object):
         assert simple_schedule.start.second == 0
         assert simple_schedule.start.minute == 0
         assert simple_schedule.start.hour == 0
-        assert simple_schedule.start.day == now.day
-        assert simple_schedule.start.month == now.month
-        assert simple_schedule.start.year == now.year
+        assert simple_schedule.start.date() == simple_schedule.created.date()
         assert simple_schedule.start.tzinfo == now.tzinfo
 
     def test_created_now(self, simple_schedule):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/79983

---

backport of https://github.com/ceph/ceph/pull/69918
parent tracker: https://tracker.ceph.com/issues/79957

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh