### PR TITLE
 mgr/nfs: add CephFS client pool support for NFS exports

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -196,6 +196,43 @@ orchestration, these commands check service status:
    ceph orch ls --service_name=ingress.nfs.<cluster_id>
 
 
+Rotate NFS Cluster Keys
+-----------------------
+
+.. prompt:: bash #
+
+   ceph nfs cluster rotate-key <cluster_id> [--all-daemon-and-export-keys] [--auth-entities <entity>...] [--key-type <type>]
+
+Rotate auth keys belonging to an NFS cluster. ``<cluster_id>`` is required.
+
+Which keys get rotated must be requested explicitly: exactly one of
+``--all-daemon-and-export-keys`` or ``--auth-entities`` has to be given. If
+neither (or both) is given, the command fails without rotating anything.
+
+``--all-daemon-and-export-keys`` rotates every auth entity of the cluster,
+including daemon keyrings (for example ``client.nfs.<cluster_id>`` and
+``client.nfs.<daemon_id>-rgw``) and CephFS export keyrings
+(``client.nfs.<cluster_id>.<fs_name>.<hash>``).
+
+``--auth-entities <entity> [<entity>...]`` rotates only the listed entities.
+The names must match the entity names reported by ``ceph auth ls`` (the
+``client.`` prefix may be omitted) and each entity must belong to the cluster.
+Rotating a subset leaves the cluster with a mix of old and new keys: entities
+that are not listed keep their current key until they are rotated separately.
+
+``--key-type <type>`` is optional and is passed through to ``ceph auth rotate``
+(for example ``aes256k``).
+
+After export keys are rotated, matching CephFS exports are updated with the new
+keyrings. After any daemon keys are rotated, the NFS service is redeployed
+(``ceph orch redeploy nfs.<cluster_id>``).
+
+For example::
+
+   ceph nfs cluster rotate-key cephfs-nfs1 --all-daemon-and-export-keys --key-type aes256k
+   ceph nfs cluster rotate-key cephfs-nfs1 --auth-entities client.nfs.cephfs-nfs1.cephfs.c44692f7 --key-type aes256k
+
+
 Updating an NFS Cluster
 -----------------------
 

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -99,6 +99,18 @@ changed on an already-running nfs cluster (including after an upgrade). To chang
 the pool size, delete the cluster and create a new one. RGW exports are not
 supported by client-pool mode.
 
+Pool CephX keys are rotated with the existing ``nfs cluster rotate-key``
+command. Pool users are treated as export keys: ``CEPH_USERS`` is rewritten
+with the new secrets and Ganesha is notified. Slot 0 of a pool is also the
+FSAL user of that pool's exports, so rotating it refreshes both ``CEPH_USERS``
+and the FSAL block of every export using that pool. The NFS service is not
+redeployed unless daemon keys are also rotated.
+
+.. prompt:: bash #
+
+   ceph nfs cluster rotate-key mynfs --all-daemon-and-export-keys
+   ceph nfs cluster rotate-key mynfs --auth-entities client.nfs.mynfs.cephfs.pool.0
+
 To deploy NFS with a high-availability front-end (virtual IP and load balancer), add the
 ``--ingress`` flag and specify a virtual IP address. This will deploy a combination
 of Keepalived and HAProxy to provide an high-availability NFS frontend for the NFS
@@ -242,7 +254,8 @@ neither (or both) is given, the command fails without rotating anything.
 ``--all-daemon-and-export-keys`` rotates every auth entity of the cluster,
 including daemon keyrings (for example ``client.nfs.<cluster_id>`` and
 ``client.nfs.<daemon_id>-rgw``) and CephFS export keyrings
-(``client.nfs.<cluster_id>.<fs_name>.<hash>``).
+(``client.nfs.<cluster_id>.<fs_name>.<hash>`` or, with client-pool mode,
+``client.nfs.<cluster_id>.<fs_name>.pool.<N>``).
 
 ``--auth-entities <entity> [<entity>...]`` rotates only the listed entities.
 The names must match the entity names reported by ``ceph auth ls`` (the
@@ -254,13 +267,16 @@ that are not listed keep their current key until they are rotated separately.
 (for example ``aes256k``).
 
 After export keys are rotated, matching CephFS exports are updated with the new
-keyrings. After any daemon keys are rotated, the NFS service is redeployed
-(``ceph orch redeploy nfs.<cluster_id>``).
+keyrings. In client-pool mode the ``CEPH_USERS`` RADOS object is updated as
+well, and rotating pool slot 0 updates both it and the FSAL credentials of the
+exports that carry it. After any daemon keys are rotated, the NFS service is
+redeployed (``ceph orch redeploy nfs.<cluster_id>``).
 
 For example::
 
    ceph nfs cluster rotate-key cephfs-nfs1 --all-daemon-and-export-keys --key-type aes256k
    ceph nfs cluster rotate-key cephfs-nfs1 --auth-entities client.nfs.cephfs-nfs1.cephfs.c44692f7 --key-type aes256k
+   ceph nfs cluster rotate-key cephfs-nfs1 --auth-entities client.nfs.cephfs-nfs1.cephfs.pool.0
 
 
 Updating an NFS Cluster

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -34,7 +34,8 @@ Create NFS-Ganesha Cluster
    ceph nfs cluster create <cluster_id> [<placement>] [--ingress] [--virtual_ip <value>] \
           [--ingress-mode {default|keepalive-only|haproxy-standard|haproxy-protocol}] \
           [--ingress-placement <placement>] [--port <int>] \
-          [--enable-rdma] [--rdma_port <int>] [--enable-nfsv3] [-i <spec_file>]
+          [--enable-rdma] [--rdma_port <int>] [--enable-nfsv3] \
+          [--clients-per-pool <int>] [-i <spec_file>]
 
 This creates a common recovery pool for all NFS-Ganesha daemons, a new user based on
 ``cluster_id``, and a common NFS-Ganesha config RADOS object.
@@ -68,6 +69,35 @@ NFS can be deployed on a port other than 2049 (the default) with ``--port <port>
 
 By default, only NFSv4 protocol is enabled. To enable both NFSv3 and NFSv4 protocols,
 add the ``--enable-nfsv3`` flag.
+
+By default, NFS-Ganesha shares a single CephFS client handle among all exports
+of the same filesystem (the default ``cmount_path`` is ``/``).  To spread
+export load across a bounded number of independent CephFS client handles,
+create the NFS cluster with ``--clients-per-pool N`` where ``N`` is an
+integer greater than or equal to 2:
+
+.. prompt:: bash #
+
+   ceph nfs cluster create mynfs --clients-per-pool 3
+
+When the first CephFS export with ``cmount_path=/`` for a filesystem is
+created, cephadm provisions ``N`` distinct CephX users and stores them in a
+``CEPH_USERS`` RADOS object
+(``ceph-users-nfs.<cluster_id>``). NFS-Ganesha loads that object alongside
+the existing export configuration and cycles through the handles in
+round-robin. The export block itself carries the first identity of the pool,
+so the export stays usable on its own.
+
+Exports with a non-root ``cmount_path`` keep a dedicated CephX user, as they
+did before client-pool mode.
+
+Pool users are removed when the last ``cmount_path=/`` export for that
+filesystem is deleted.
+
+``clients_per_pool`` is immutable after cluster creation. It cannot be set or
+changed on an already-running nfs cluster (including after an upgrade). To change
+the pool size, delete the cluster and create a new one. RGW exports are not
+supported by client-pool mode.
 
 To deploy NFS with a high-availability front-end (virtual IP and load balancer), add the
 ``--ingress`` flag and specify a virtual IP address. This will deploy a combination

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -50,6 +50,7 @@ from ceph.deployment.service_spec import (
     TunedProfileSpec,
     MgmtGatewaySpec,
     NvmeofServiceSpec,
+    NFSServiceSpec,
     CertificateSource
 )
 from ceph.deployment.drive_group import DeviceSelection
@@ -4774,6 +4775,9 @@ Then run the following:
             raise OrchestratorError('cannot scale %s service below 1' % (
                 spec.service_type))
 
+        if spec.service_type == 'nfs':
+            self._check_nfs_clients_per_pool(cast(NFSServiceSpec, spec))
+
         host_count = len(self.inventory.keys())
         max_count = self.max_count_per_host
 
@@ -4896,6 +4900,24 @@ Then run the following:
     @handle_orch_error
     def apply_rbd_mirror(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
+
+    def _check_nfs_clients_per_pool(self, spec: NFSServiceSpec) -> None:
+        """clients_per_pool is immutable after NFS cluster creation."""
+        name = spec.service_name()
+        if name not in self.spec_store:
+            return
+        existing = self.spec_store[name].spec
+        old_n = getattr(existing, 'clients_per_pool', None)
+        new_n = getattr(spec, 'clients_per_pool', None)
+        if new_n is None:
+            spec.clients_per_pool = old_n
+            return
+        if old_n != new_n:
+            raise OrchestratorError(
+                "clients_per_pool can only be set when creating an NFS cluster "
+                "and cannot be changed. Delete the cluster and create a new one "
+                "to use a different value."
+            )
 
     @handle_orch_error
     def apply_nfs(self, spec: ServiceSpec) -> str:

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -340,6 +340,7 @@ class NFSService(CephService):
                     with_units_to_int(str(spec.client_object_cache_max_dirty))
                     if spec.client_object_cache_max_dirty is not None else None
                 ),
+                "clients_per_pool": getattr(spec, 'clients_per_pool', None),
             }
             if spec.enable_haproxy_protocol:
                 context["haproxy_hosts"] = self._haproxy_hosts()

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -62,10 +62,13 @@ RGW {
         name = "client.{{ rgw_user }}";
 }
 
-{% if use_old_nodeid or enable_client_object_cache %}
+{% if use_old_nodeid or enable_client_object_cache or clients_per_pool %}
 CEPH {
 {% if use_old_nodeid %}
 	Use_old_uuid = true;
+{% endif %}
+{% if clients_per_pool %}
+        clients_per_pool = {{ clients_per_pool }};
 {% endif %}
 {% if enable_client_object_cache or client_object_cache_size is not none or client_object_cache_max_dirty is not none %}
         client_oc = {{ enable_client_object_cache | lower }};

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch, ANY
 import pytest
 
 from ceph.utils import datetime_now
-from orchestrator import DaemonDescriptionStatus
+from orchestrator import DaemonDescriptionStatus, OrchestratorError
 
 from cephadm.serve import CephadmServe
 from cephadm.services.service_registry import service_registry
@@ -749,6 +749,67 @@ class TestNFS:
                 assert "client_oc = true;" in ganesha_conf
                 assert "client_oc_size = 1048576;" in ganesha_conf
                 assert "client_oc_max_dirty = 0;" in ganesha_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_clients_per_pool_in_ganesha_conf(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        """clients_per_pool is written into a CEPH block."""
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test'):
+            nfs_spec = NFSServiceSpec(
+                service_id="foo",
+                placement=PlacementSpec(hosts=['test']),
+                clients_per_pool=3,
+            )
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='foo.test.0.0',
+                                            service_name=nfs_spec.service_name(),
+                                            rank=0))
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+                assert ganesha_conf.count('CEPH {') == 1
+                assert "clients_per_pool = 3;" in ganesha_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_clients_per_pool_immutable(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        """clients_per_pool cannot be set or changed on an existing cluster."""
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test'):
+            nfs_spec = NFSServiceSpec(
+                service_id="foo",
+                placement=PlacementSpec(hosts=['test']),
+            )
+            with with_service(cephadm_module, nfs_spec):
+                changed = NFSServiceSpec(
+                    service_id="foo",
+                    placement=PlacementSpec(hosts=['test']),
+                    clients_per_pool=3,
+                )
+                with pytest.raises(OrchestratorError, match="clients_per_pool"):
+                    cephadm_module.apply_nfs(changed)
+
+            pool_spec = NFSServiceSpec(
+                service_id="bar",
+                placement=PlacementSpec(hosts=['test']),
+                clients_per_pool=3,
+            )
+            with with_service(cephadm_module, pool_spec):
+                resized = NFSServiceSpec(
+                    service_id="bar",
+                    placement=PlacementSpec(hosts=['test']),
+                    clients_per_pool=4,
+                )
+                with pytest.raises(OrchestratorError, match="clients_per_pool"):
+                    cephadm_module.apply_nfs(resized)
 
 
 def test_nfs_placement_count_per_host_rejected():

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -213,6 +213,7 @@ class NFSCluster:
             enable_rdma: bool = False,
             rdma_port: Optional[int] = None,
             ingress_placement: Optional[str] = None,
+            clients_per_pool: Optional[int] = None,
     ) -> None:
         if not port:
             port = 2049   # default nfs port
@@ -264,7 +265,8 @@ class NFSCluster:
                                   monitoring_ip_addrs=monitoring_ip_addrs,
                                   monitoring_port=monitoring_port,
                                   enable_rdma=enable_rdma,
-                                  rdma_port=rdma_port)
+                                  rdma_port=rdma_port,
+                                  clients_per_pool=clients_per_pool)
             completion = self.mgr.apply_nfs(spec)
             orchestrator.raise_if_exception(completion)
             ispec = IngressSpec(service_type='ingress',
@@ -297,7 +299,8 @@ class NFSCluster:
                                   monitoring_ip_addrs=monitoring_ip_addrs,
                                   monitoring_port=monitoring_port,
                                   enable_rdma=enable_rdma,
-                                  rdma_port=rdma_port)
+                                  rdma_port=rdma_port,
+                                  clients_per_pool=clients_per_pool)
             completion = self.mgr.apply_nfs(spec)
             orchestrator.raise_if_exception(completion)
         log.debug("Successfully deployed nfs daemons with cluster id %s and placement %s",
@@ -337,6 +340,7 @@ class NFSCluster:
             enable_rdma: bool = False,
             rdma_port: Optional[int] = None,
             ingress_placement: Optional[str] = None,
+            clients_per_pool: Optional[int] = None,
     ) -> None:
         try:
             if virtual_ip:
@@ -381,7 +385,8 @@ class NFSCluster:
                     monitoring_port=monitoring_port,
                     enable_rdma=enable_rdma,
                     rdma_port=rdma_port,
-                    ingress_placement=ingress_placement
+                    ingress_placement=ingress_placement,
+                    clients_per_pool=clients_per_pool
                 )
                 return
             raise NonFatalError(f"{cluster_id} cluster already exists")
@@ -655,6 +660,7 @@ class NFSCluster:
 
         deployment_type = "standalone"
         placement = None
+        clients_per_pool = None
 
         nfs_sc = self.mgr.describe_service(
             service_type='nfs',
@@ -664,6 +670,7 @@ class NFSCluster:
         for svc in nfs_services:
             if svc.spec.service_id == cluster_id:
                 placement = svc.spec.placement
+                clients_per_pool = getattr(svc.spec, 'clients_per_pool', None)
                 break
 
         if ingress_mode:
@@ -687,6 +694,8 @@ class NFSCluster:
             r['port'] = ingress_port
         if monitor_port is not None:
             r['monitor_port'] = monitor_port
+        if clients_per_pool is not None:
+            r['clients_per_pool'] = clients_per_pool
 
         log.debug("Successfully fetched %s info: %s", cluster_id, r)
         return r

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -1,4 +1,5 @@
 import ipaddress
+import json
 import logging
 import re
 import socket
@@ -11,16 +12,19 @@ from object_format import ErrorResponse
 import orchestrator
 from orchestrator.module import IngressType
 
-from .exception import NFSInvalidOperation, ClusterNotFound
+from .exception import NFSInvalidOperation, ClusterNotFound, NFSObjectNotFound
 from .utils import (
     ManualRestartRequired,
     NonFatalError,
     available_clusters,
     conf_obj_name,
     restart_nfs_service,
+    redeploy_nfs_service,
     user_conf_obj_name,
     USER_CONF_PREFIX,
-    qos_conf_obj_name)
+    qos_conf_obj_name,
+    normalize_auth_entity,
+    entity_belongs_to_nfs_cluster)
 from .rados_utils import NFSRados
 from .ganesha_conf import format_block, GaneshaConfParser
 from .qos_conf import (
@@ -37,6 +41,19 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+ROTATE_KEY_SELECTION_REQUIRED = (
+    "no keys selected for rotation. Rotating cephx keys must be requested "
+    "explicitly, so pass exactly one of:\n"
+    "  --all-daemon-and-export-keys: rotate every auth entity belonging to NFS "
+    "cluster {cluster_id}, that is the daemon keyrings and the CephFS "
+    "export keyrings\n"
+    "  --auth-entities <entity> [<entity>...]: rotate only the listed entities. "
+    "The names must match the entity names reported by `ceph auth ls` and must "
+    "belong to NFS cluster {cluster_id}\n"
+    "Note that rotating a subset leaves the cluster with a mix of old and new "
+    "keys"
+)
 
 
 def _is_log_only_config(nfs_config: str) -> bool:
@@ -386,6 +403,167 @@ class NFSCluster:
             raise NonFatalError("Cluster does not exist")
         except Exception as e:
             log.exception(f"Failed to delete NFS Cluster {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def _resolve_entities(
+            self,
+            cluster_id: str,
+            auth_entities: List[str]
+    ) -> List[str]:
+        entities: List[str] = []
+        for raw in auth_entities:
+            normalized = normalize_auth_entity(raw)
+            if not entity_belongs_to_nfs_cluster(normalized, cluster_id):
+                raise NFSInvalidOperation(
+                    f"{normalized} does not belong to NFS cluster {cluster_id}"
+                )
+            entities.append(normalized)
+        # remove duplicates if any
+        return list(dict.fromkeys(entities))
+
+    def _list_cluster_auth_entities(self, cluster_id: str) -> List[str]:
+        """Return all auth entities belonging to this NFS cluster."""
+        result = self.mgr.check_mon_command({
+            'prefix': 'auth ls',
+            'format': 'json',
+        })
+        try:
+            auth_data = json.loads(result.stdout)
+        except ValueError as e:
+            raise NFSInvalidOperation(f"Failed to parse auth ls output: {e}")
+
+        auth_dump = auth_data.get('auth_dump', []) if isinstance(auth_data, dict) else auth_data
+        return [
+            entry['entity']
+            for entry in auth_dump
+            if isinstance(entry, dict)
+            and entry.get('entity')
+            and entity_belongs_to_nfs_cluster(entry['entity'], cluster_id)
+        ]
+
+    def _auth_rotate(self, entity: str, cluster_id: str, key_type: Optional[str]) -> None:
+        log.info(
+            "Rotating NFS key %s for cluster %s%s",
+            entity, cluster_id,
+            f" with key_type {key_type}" if key_type else ""
+        )
+        rotate_cmd: Dict[str, str] = {
+            'prefix': 'auth rotate',
+            'entity': entity,
+        }
+        if key_type:
+            rotate_cmd['key_type'] = key_type
+        self.mgr.check_mon_command(rotate_cmd)
+
+    def rotate_keys(
+            self,
+            cluster_id: str,
+            all_daemon_and_export_keys: bool = False,
+            auth_entities: Optional[List[str]] = None,
+            key_type: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Rotate NFS auth keys for a cluster.
+
+        Exactly one of `all_daemon_and_export_keys` (rotate every auth entity
+        of the cluster) or `auth_entities` (rotate only the listed entities)
+        must be given. Export configs are refreshed after export-key rotation.
+        The NFS service is redeployed when any daemon key is rotated.
+        """
+        try:
+            if all_daemon_and_export_keys and auth_entities:
+                raise NFSInvalidOperation(
+                    "--all-daemon-and-export-keys and --auth-entities are mutually "
+                    "exclusive. Pass --all-daemon-and-export-keys to rotate every key "
+                    "of the cluster, or --auth-entities to rotate only specific ones."
+                )
+            if not all_daemon_and_export_keys and not auth_entities:
+                raise NFSInvalidOperation(ROTATE_KEY_SELECTION_REQUIRED.format(
+                    cluster_id=cluster_id))
+
+            if cluster_id not in available_clusters(self.mgr):
+                raise ClusterNotFound()
+
+            if all_daemon_and_export_keys:
+                all_entities = self._list_cluster_auth_entities(cluster_id)
+            else:
+                all_entities = self._resolve_entities(cluster_id, auth_entities or [])
+            if not all_entities:
+                raise NFSObjectNotFound(
+                    f"No auth entities found for NFS cluster {cluster_id}"
+                )
+
+            # A stale cache would make an export look like a daemon key, so it
+            # would be rotated but never refreshed.
+            self.mgr.export_mgr.reload_exports()
+            export_user_ids = self.mgr.export_mgr.get_cephfs_export_user_ids(cluster_id)
+
+            problems: List[str] = []
+            rotated: List[str] = []
+            for ent in all_entities:
+                try:
+                    self._auth_rotate(ent, cluster_id, key_type)
+                except Exception as e:
+                    log.exception("Failed to rotate NFS key %s for cluster %s", ent, cluster_id)
+                    problems.append(f"failed to rotate {ent}: {e}")
+                    break
+                rotated.append(ent)
+
+            export_entities = [
+                ent for ent in rotated if ent[len('client.'):] in export_user_ids
+            ]
+            daemon_entities = [
+                ent for ent in rotated if ent[len('client.'):] not in export_user_ids
+            ]
+
+            updated_exports: List[str] = []
+            if export_entities:
+                try:
+                    updated_exports, stale = self.mgr.export_mgr.refresh_export_keys(
+                        cluster_id, export_entities
+                    )
+                    if stale:
+                        problems.append(
+                            f"exports left with a pre-rotation keyring: {', '.join(stale)}")
+                except Exception as e:
+                    log.exception("Failed to refresh exports of cluster %s", cluster_id)
+                    problems.append(f"failed to refresh export keyrings: {e}")
+
+            service_redeployed = False
+            if daemon_entities:
+                log.info(
+                    "Redeploying NFS service nfs.%s after rotating daemon keys: %s",
+                    cluster_id, daemon_entities
+                )
+                try:
+                    redeploy_nfs_service(self.mgr, cluster_id)
+                    service_redeployed = True
+                except Exception as e:
+                    log.exception("Failed to redeploy NFS service nfs.%s", cluster_id)
+                    problems.append(
+                        f"failed to redeploy nfs.{cluster_id} ({e}); its daemons still "
+                        "run with pre-rotation keyrings and must be redeployed manually"
+                    )
+
+            result: Dict[str, Any] = {
+                "cluster_id": cluster_id,
+                "rotated": rotated,
+                "export_keys": export_entities,
+                "daemon_keys": daemon_entities,
+                "updated_exports": updated_exports,
+                "service_redeployed": service_redeployed,
+            }
+            if key_type:
+                result["key_type"] = key_type
+
+            if problems:
+                raise ErrorResponse(
+                    f"NFS key rotation for cluster {cluster_id} did not complete: "
+                    f"{'; '.join(problems)}."
+                )
+            return result
+        except Exception as e:
+            log.exception("Failed to rotate NFS keys for cluster %s", cluster_id)
             raise ErrorResponse.wrap(e)
 
     def list_nfs_cluster(self) -> List[str]:

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -11,6 +11,7 @@ from typing import (
     TypeVar,
     Callable,
     Set,
+    Tuple,
     cast)
 from os.path import normpath
 from ceph.fs.earmarking import EarmarkTopScope
@@ -44,7 +45,8 @@ from .utils import (
     check_fs,
     get_nfs_spec_for_cluster,
     restart_nfs_service,
-    cephfs_path_is_dir)
+    cephfs_path_is_dir,
+    normalize_auth_entity)
 from .rados_utils import NFSRados
 
 if TYPE_CHECKING:
@@ -490,6 +492,64 @@ class ExportMgr:
     ) -> Optional[Dict[str, Any]]:
         export = self._fetch_export(cluster_id, pseudo_path)
         return export.to_dict() if export else None
+
+    def reload_exports(self) -> None:
+        """Drop the cached exports so that they are re-read from RADOS."""
+        self._exports = None
+
+    def get_cephfs_export_user_ids(self, cluster_id: str) -> Set[str]:
+        """Return CephFS export user_ids for the cluster."""
+        return {
+            export.fsal.user_id
+            for export in self.exports.get(cluster_id, [])
+            if isinstance(export.fsal, CephFSFSAL) and export.fsal.user_id
+        }
+
+    def refresh_export_keys(
+            self,
+            cluster_id: str,
+            entities: List[str]
+    ) -> Tuple[List[str], List[str]]:
+        """
+        Re-fetch CephX keys for the given export entities and update matching
+        CephFS exports so Ganesha receives the new keyrings.
+
+        Returns the pseudo paths that were updated and the ones that could not
+        be. One failure must not stop the others: their keys are already
+        rotated, so an export left behind is one Ganesha cannot authenticate.
+        """
+        entity_set = {normalize_auth_entity(e) for e in entities}
+        updated_pseudos: List[str] = []
+        stale_pseudos: List[str] = []
+
+        for export in list(self.exports.get(cluster_id, [])):
+            if not isinstance(export.fsal, CephFSFSAL) or not export.fsal.user_id:
+                continue
+            entity = f'client.{export.fsal.user_id}'
+            if entity not in entity_set:
+                continue
+
+            old_key = export.fsal.cephx_key
+            try:
+                self._ensure_cephfs_export_user(export)
+                if export.fsal.cephx_key == old_key:
+                    log.warning(
+                        "Export %s key for user %s did not change after rotate",
+                        export.pseudo, export.fsal.user_id
+                    )
+                self.exports[cluster_id].remove(export)
+                self._update_export(cluster_id, export, need_nfs_service_restart=False)
+            except Exception:
+                stale_pseudos.append(export.pseudo)
+                log.exception("Failed to update export %s after key rotation", export.pseudo)
+                continue
+
+            updated_pseudos.append(export.pseudo)
+            log.info(
+                "Updated export %s with rotated key for user %s",
+                export.pseudo, export.fsal.user_id
+            )
+        return updated_pseudos, stale_pseudos
 
     # This method is used by the dashboard module (../dashboard/controllers/nfs.py)
     # Do not change interface without updating the Dashboard code

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -314,14 +314,17 @@ class ExportMgr:
             return None
         return CephUsers.from_raw(raw)
 
-    def _write_ceph_users(self, cluster_id: str, ceph_users: CephUsers) -> None:
-        # Never notifies: this object is only ever written as part of an export
-        # change, and the export object write that follows it does the notify.
+    def _write_ceph_users(
+            self,
+            cluster_id: str,
+            ceph_users: CephUsers,
+            should_notify: bool = False
+    ) -> None:
         self._rados(cluster_id).write_obj(
             format_block(ceph_users.to_block()),
             ceph_users_obj_name(cluster_id),
             conf_obj_name(cluster_id),
-            should_notify=False,
+            should_notify=should_notify,
         )
 
     def _pool_user_ids(self, cluster_id: str, fs_name: str) -> List[str]:
@@ -632,11 +635,70 @@ class ExportMgr:
 
     def get_cephfs_export_user_ids(self, cluster_id: str) -> Set[str]:
         """Return CephFS export user_ids for the cluster."""
-        return {
+        user_ids = {
             export.fsal.user_id
             for export in self.exports.get(cluster_id, [])
-            if isinstance(export.fsal, CephFSFSAL) and export.fsal.user_id
+            if isinstance(export.fsal, CephFSFSAL)
+            and export.fsal.user_id
         }
+        ceph_users = self._read_ceph_users(cluster_id)
+        if ceph_users:
+            user_ids.update(u.user_id for u in ceph_users.users if u.user_id)
+        return user_ids
+
+    def _refresh_pool_user_keys(
+            self,
+            cluster_id: str,
+            entity_set: Set[str],
+            should_notify: bool
+    ) -> Tuple[List[str], List[str]]:
+        """
+        Re-fetch rotated CephX keys into CEPH_USERS.
+        """
+        ceph_users = self._read_ceph_users(cluster_id)
+        if not ceph_users or not ceph_users.users:
+            return [], []
+
+        updated: List[str] = []
+        stale: List[str] = []
+
+        for user in ceph_users.users:
+            entity = f'client.{user.user_id}'
+            if entity not in entity_set:
+                continue
+            old_key = user.secret_access_key
+            try:
+                key = self._create_user_key(
+                    cluster_id, user.user_id, "/", user.filesystem)
+                if key == old_key:
+                    log.warning(
+                        "Pool user %s key did not change after rotate",
+                        user.user_id
+                    )
+                user.secret_access_key = key
+                updated.append(user.user_id)
+            except Exception:
+                stale.append(user.user_id)
+                log.exception(
+                    "Failed to update pool user %s after key rotation",
+                    user.user_id
+                )
+
+        if updated:
+            try:
+                self._write_ceph_users(cluster_id, ceph_users, should_notify)
+            except Exception:
+                log.exception(
+                    "Failed to write CEPH_USERS for cluster %s after key rotation",
+                    cluster_id
+                )
+                # Nothing was persisted, so none of them made it.
+                return [], stale + updated
+            log.info(
+                "Updated CEPH_USERS for cluster %s after rotating pool users %s",
+                cluster_id, updated
+            )
+        return updated, stale
 
     def refresh_export_keys(
             self,
@@ -646,29 +708,28 @@ class ExportMgr:
         """
         Re-fetch CephX keys for the given export entities and update matching
         CephFS exports so Ganesha receives the new keyrings.
-
-        Returns the pseudo paths that were updated and the ones that could not
-        be. One failure must not stop the others: their keys are already
-        rotated, so an export left behind is one Ganesha cannot authenticate.
         """
         entity_set = {normalize_auth_entity(e) for e in entities}
+        matching = [
+            export for export in self.exports.get(cluster_id, [])
+            if isinstance(export.fsal, CephFSFSAL) and export.fsal.user_id
+            and f'client.{export.fsal.user_id}' in entity_set
+        ]
+        updated, stale = self._refresh_pool_user_keys(
+            cluster_id, entity_set, should_notify=not matching)
+
         updated_pseudos: List[str] = []
         stale_pseudos: List[str] = []
 
-        for export in list(self.exports.get(cluster_id, [])):
-            if not isinstance(export.fsal, CephFSFSAL) or not export.fsal.user_id:
-                continue
-            entity = f'client.{export.fsal.user_id}'
-            if entity not in entity_set:
-                continue
-
-            old_key = export.fsal.cephx_key
+        for export in matching:
+            fsal = cast(CephFSFSAL, export.fsal)
+            old_key = fsal.cephx_key
             try:
                 self._ensure_cephfs_export_user(export)
-                if export.fsal.cephx_key == old_key:
+                if fsal.cephx_key == old_key:
                     log.warning(
                         "Export %s key for user %s did not change after rotate",
-                        export.pseudo, export.fsal.user_id
+                        export.pseudo, fsal.user_id
                     )
                 self.exports[cluster_id].remove(export)
                 self._update_export(cluster_id, export, need_nfs_service_restart=False)
@@ -680,9 +741,9 @@ class ExportMgr:
             updated_pseudos.append(export.pseudo)
             log.info(
                 "Updated export %s with rotated key for user %s",
-                export.pseudo, export.fsal.user_id
+                export.pseudo, fsal.user_id
             )
-        return updated_pseudos, stale_pseudos
+        return updated + updated_pseudos, stale + stale_pseudos
 
     # This method is used by the dashboard module (../dashboard/controllers/nfs.py)
     # Do not change interface without updating the Dashboard code

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -25,6 +25,8 @@ from mgr_module import NFS_POOL_NAME as POOL_NAME, NFS_GANESHA_SUPPORTED_FSALS
 
 from .ganesha_conf import (
     CephFSFSAL,
+    CephUsers,
+    CephUser,
     Export,
     GaneshaConfParser,
     RGWFSAL,
@@ -41,6 +43,7 @@ from .utils import (
     NonFatalError,
     export_obj_name,
     conf_obj_name,
+    ceph_users_obj_name,
     available_clusters,
     check_fs,
     get_nfs_spec_for_cluster,
@@ -273,6 +276,126 @@ class ExportMgr:
         )
         log.debug(f"Established user {fsal.user_id} for cephfs {fsal.fs_name}")
 
+    def _get_cephfs_clients_per_pool(self, cluster_id: str) -> Optional[int]:
+        spec = get_nfs_spec_for_cluster(self.mgr, cluster_id)
+        if spec is None:
+            return None
+        n = getattr(spec, 'clients_per_pool', None)
+        if n is None or n < 2:
+            return None
+        return int(n)
+
+    def _uses_cephfs_client_pool(self, cluster_id: str, cmount_path: Optional[str]) -> bool:
+        """Pool users are only used for the default cmount_path=/."""
+        if cmount_path and cmount_path != "/":
+            return False
+        return self._get_cephfs_clients_per_pool(cluster_id) is not None
+
+    def _setup_cephfs_export_credentials(self, export: Export) -> None:
+        fsal = cast(CephFSFSAL, export.fsal)
+        if self._uses_cephfs_client_pool(export.cluster_id, fsal.cmount_path):
+            assert fsal.fs_name
+            pool_users = self._ensure_pool_users_for_fs(export.cluster_id, fsal.fs_name)
+            if pool_users:
+                # The FSAL block carries the first identity of the pool, so the
+                # export stays usable on its own, Ganesha picks a handle out of
+                # the CEPH_USERS block for the actual client pool.
+                primary = pool_users[0]
+                fsal.user_id = primary.user_id
+                fsal.cephx_key = primary.secret_access_key
+                log.debug("Pool mode: export for cephfs %s uses pool user %s",
+                          fsal.fs_name, fsal.user_id)
+                return
+        self._ensure_cephfs_export_user(export)
+
+    def _read_ceph_users(self, cluster_id: str) -> Optional[CephUsers]:
+        raw = self._rados(cluster_id).read_obj(ceph_users_obj_name(cluster_id))
+        if raw is None:
+            return None
+        return CephUsers.from_raw(raw)
+
+    def _write_ceph_users(self, cluster_id: str, ceph_users: CephUsers) -> None:
+        # Never notifies: this object is only ever written as part of an export
+        # change, and the export object write that follows it does the notify.
+        self._rados(cluster_id).write_obj(
+            format_block(ceph_users.to_block()),
+            ceph_users_obj_name(cluster_id),
+            conf_obj_name(cluster_id),
+            should_notify=False,
+        )
+
+    def _pool_user_ids(self, cluster_id: str, fs_name: str) -> List[str]:
+        """CephX ids that may appear in the FSAL of a pool-mode export.
+
+        The pool is whatever CEPH_USERS records, so ids are only derived from
+        the naming scheme when the pool has not been created yet. A pool that
+        adopts identities not following that scheme (e.g. the dedicated user of
+        an export that predates client-pool mode) keeps working unchanged.
+        """
+        ceph_users = self._read_ceph_users(cluster_id)
+        users = ceph_users.users_for_fs(fs_name) if ceph_users else []
+        if users:
+            return [u.user_id for u in users]
+        n = self._get_cephfs_clients_per_pool(cluster_id) or 0
+        return [get_pool_user_id(cluster_id, fs_name, i) for i in range(n)]
+
+    def _ensure_pool_users_for_fs(self, cluster_id: str, fs_name: str) -> List[CephUser]:
+        n = self._get_cephfs_clients_per_pool(cluster_id)
+        if not n:
+            return []
+        ceph_users = self._read_ceph_users(cluster_id) or CephUsers()
+        existing = ceph_users.users_for_fs(fs_name)
+        if existing:
+            log.debug("Pool users already exist for fs %s on cluster %s", fs_name, cluster_id)
+            return existing
+        new_users = []
+        for i in range(n):
+            user_id = get_pool_user_id(cluster_id, fs_name, i)
+            key = self._create_user_key(cluster_id, user_id, "/", fs_name)
+            new_users.append(CephUser(
+                user_id=user_id,
+                secret_access_key=key,
+                filesystem=fs_name,
+            ))
+        ceph_users.users.extend(new_users)
+        self._write_ceph_users(cluster_id, ceph_users)
+        log.info("Created %s pool users for fs %s on cluster %s", n, fs_name, cluster_id)
+        return new_users
+
+    def _cleanup_pool_users_for_fs(self, cluster_id: str, fs_name: str) -> None:
+        ceph_users = self._read_ceph_users(cluster_id)
+        users_to_rm: List[CephUser] = []
+        if ceph_users:
+            users_to_rm = ceph_users.users_for_fs(fs_name)
+            ceph_users.remove_fs(fs_name)
+        else:
+            n = self._get_cephfs_clients_per_pool(cluster_id)
+            if n:
+                users_to_rm = [
+                    CephUser(get_pool_user_id(cluster_id, fs_name, i), '', fs_name)
+                    for i in range(n)
+                ]
+        for user in users_to_rm:
+            self.mgr.check_mon_command({
+                'prefix': 'auth rm',
+                'entity': f'client.{user.user_id}',
+            })
+            log.info("Deleted pool user %s", user.user_id)
+        rados_obj = self._rados(cluster_id)
+        obj = ceph_users_obj_name(cluster_id)
+        conf = conf_obj_name(cluster_id)
+        if ceph_users is None:
+            return
+        if ceph_users.users:
+            rados_obj.update_obj(
+                format_block(ceph_users.to_block()),
+                obj,
+                conf,
+                should_notify=False,
+            )
+        else:
+            rados_obj.remove_obj(obj, conf, should_notify=False)
+
     def _gen_export_id(self, cluster_id: str) -> int:
         exports = sorted([ex.export_id for ex in self.exports[cluster_id]])
         nid = 1
@@ -320,8 +443,13 @@ class ExportMgr:
                 export = self._fetch_export(cluster_id, pseudo_path)
 
             if export:
-                exports_count = 0
-                if export.fsal.name == NFS_GANESHA_SUPPORTED_FSALS[0]:
+                fs_name = None
+                uses_pool = False
+                if isinstance(export.fsal, CephFSFSAL):
+                    fs_name = export.fsal.fs_name
+                    uses_pool = self._uses_cephfs_client_pool(cluster_id,
+                                                              export.fsal.cmount_path)
+                if export.fsal.name == NFS_GANESHA_SUPPORTED_FSALS[0] and not uses_pool:
                     exports_count = self.get_export_count_with_same_fsal(export.fsal.cmount_path,  # type: ignore
                                                                          cluster_id, export.fsal.fs_name)  # type: ignore
                     if exports_count == 1:
@@ -330,9 +458,14 @@ class ExportMgr:
                     self._rados(cluster_id).remove_obj(
                         export_obj_name(export.export_id), conf_obj_name(cluster_id),
                         (not self.skip_notify_nfs_server))
+
                 self.exports[cluster_id].remove(export)
                 if export.fsal.name == NFS_GANESHA_SUPPORTED_FSALS[1]:
                     self._delete_export_user(export)
+                if uses_pool and fs_name:
+                    remaining = self.get_export_count_with_same_fsal("/", cluster_id, fs_name)
+                    if remaining == 0:
+                        self._cleanup_pool_users_for_fs(cluster_id, fs_name)
                 if not self.exports[cluster_id]:
                     del self.exports[cluster_id]
                     log.debug("Deleted all exports for cluster %s", cluster_id)
@@ -729,8 +862,19 @@ class ExportMgr:
             if fsal["cmount_path"] != "/":
                 _validate_cmount_path(fsal["cmount_path"], path)  # type: ignore
 
-            user_id = f"nfs.{get_user_id(cluster_id, fs_name, fsal['cmount_path'])}"
-            if "user_id" in fsal and fsal["user_id"] != user_id:
+            cmount_path = fsal.get("cmount_path", "/")
+            user_id = f"nfs.{get_user_id(cluster_id, fs_name, cmount_path)}"
+            if self._uses_cephfs_client_pool(cluster_id, cmount_path):
+                # Any identity of the filesystem's client pool is valid here.
+                # Slot 0 is the dedicated user id, so an export created before
+                # client-pool mode was enabled keeps validating unchanged.
+                allowed = self._pool_user_ids(cluster_id, fs_name)
+                if "user_id" in fsal and fsal["user_id"] not in allowed:
+                    raise NFSInvalidOperation(
+                        f"export FSAL user_id must be one of {allowed} when "
+                        "clients_per_pool is enabled and cmount_path is '/'"
+                    )
+            elif "user_id" in fsal and fsal["user_id"] != user_id:
                 raise NFSInvalidOperation(f"export FSAL user_id must be '{user_id}'")
         else:
             raise NFSInvalidOperation(f"NFS Ganesha supported FSALs are {NFS_GANESHA_SUPPORTED_FSALS}."
@@ -748,7 +892,7 @@ class ExportMgr:
 
         export = Export.from_dict(ex_id, ex_dict)
         if export.fsal.name == NFS_GANESHA_SUPPORTED_FSALS[0]:
-            self._ensure_cephfs_export_user(export)
+            self._setup_cephfs_export_credentials(export)
         export.validate(self.mgr)
         log.debug("Successfully created %s export-%s from dict for cluster %s",
                   fsal_type, ex_id, cluster_id)
@@ -803,7 +947,6 @@ class ExportMgr:
                 earmark_resolver
             )
             log.debug("creating cephfs export %s", export)
-            self._ensure_cephfs_export_user(export)
             self._save_export(cluster_id, export)
             result = {
                 "bind": export.pseudo,
@@ -938,7 +1081,6 @@ class ExportMgr:
         if old_export.fsal.name == NFS_GANESHA_SUPPORTED_FSALS[0]:
             old_fsal = cast(CephFSFSAL, old_export.fsal)
             new_fsal = cast(CephFSFSAL, new_export.fsal)
-            self._ensure_cephfs_export_user(new_export)
             need_nfs_service_restart = not (old_fsal.user_id == new_fsal.user_id
                                             and old_fsal.fs_name == new_fsal.fs_name
                                             and old_export.path == new_export.path
@@ -965,6 +1107,22 @@ class ExportMgr:
 
         self.exports[cluster_id].remove(old_export)
 
+        if (old_export.fsal.name == NFS_GANESHA_SUPPORTED_FSALS[0]
+                and new_export.fsal.name == NFS_GANESHA_SUPPORTED_FSALS[0]):
+            old_fsal = cast(CephFSFSAL, old_export.fsal)
+            new_fsal = cast(CephFSFSAL, new_export.fsal)
+            old_fs = old_fsal.fs_name
+            new_uses_same_pool = (
+                old_fs
+                and new_fsal.fs_name == old_fs
+                and self._uses_cephfs_client_pool(cluster_id, new_fsal.cmount_path)
+            )
+            if (old_fs
+                    and self._uses_cephfs_client_pool(cluster_id, old_fsal.cmount_path)
+                    and not new_uses_same_pool
+                    and self.get_export_count_with_same_fsal("/", cluster_id, old_fs) == 0):
+                self._cleanup_pool_users_for_fs(cluster_id, old_fs)
+
         self._update_export(cluster_id, new_export, need_nfs_service_restart)
 
         return {"pseudo": new_export.pseudo, "state": "updated"}
@@ -977,7 +1135,9 @@ class ExportMgr:
         exports = self.list_exports(cluster_id, detailed=True)
         exports_count = 0
         for export in exports:
-            if export['fsal']['name'] == 'CEPH' and export['fsal']['cmount_path'] == cmount_path and export['fsal']['fs_name'] == fs_name:
+            if (export['fsal']['name'] == 'CEPH'
+                    and export['fsal'].get('cmount_path', '/') == cmount_path
+                    and export['fsal']['fs_name'] == fs_name):
                 exports_count += 1
         return exports_count
 
@@ -1108,3 +1268,16 @@ def get_user_id(cluster_id: str, fs_name: str, cmount_path: str) -> str:
     unique_id = f"{cluster_id}.{fs_name}.{hash_hex[:8]}"  # Use the first 8 characters of the hash
 
     return unique_id
+
+
+def get_pool_user_id(cluster_id: str, fs_name: str, index: int) -> str:
+    """Return the CephX user id (without client. prefix) for a pool slot.
+
+    Slot 0 keeps the id a cmount_path=/ export gets without client-pool mode,
+    the remaining slots use a pool suffix. A pool built for a filesystem that
+    already has exports therefore adopts the user those exports carry instead
+    of orphaning it: only the other clients_per_pool - 1 users are new.
+    """
+    if index == 0:
+        return f"nfs.{get_user_id(cluster_id, fs_name, '/')}"
+    return f"nfs.{cluster_id}.{fs_name}.pool.{index}"

--- a/src/pybind/mgr/nfs/ganesha_conf.py
+++ b/src/pybind/mgr/nfs/ganesha_conf.py
@@ -310,6 +310,59 @@ class RGWFSAL(FSAL):
         return r
 
 
+class CephUser:
+    """One CephX identity in a CEPH_USERS client-pool mapping."""
+    def __init__(self, user_id: str, secret_access_key: str, filesystem: str) -> None:
+        self.user_id = user_id
+        self.secret_access_key = secret_access_key
+        self.filesystem = filesystem
+
+    def to_user_block(self) -> RawBlock:
+        return RawBlock('USER', values={
+            'user_id': self.user_id,
+            'secret_access_key': self.secret_access_key,
+            'filesystem': self.filesystem,
+        })
+
+    @classmethod
+    def from_user_block(cls, block: RawBlock) -> 'CephUser':
+        return cls(
+            block.values.get('user_id', ''),
+            block.values.get('secret_access_key', ''),
+            block.values.get('filesystem', ''),
+        )
+
+
+class CephUsers:
+    """Ganesha CEPH_USERS block storing pool-mode CephX credentials."""
+    def __init__(self, users: Optional[List[CephUser]] = None) -> None:
+        self.users = users or []
+
+    @classmethod
+    def from_block(cls, block: RawBlock) -> 'CephUsers':
+        users = [CephUser.from_user_block(b) for b in block.blocks if b.block_name == 'USER']
+        return cls(users)
+
+    @classmethod
+    def from_raw(cls, raw: str) -> 'CephUsers':
+        if not raw:
+            return cls()
+        blocks = GaneshaConfParser(raw).parse()
+        for block in blocks:
+            if block.block_name == 'CEPH_USERS':
+                return cls.from_block(block)
+        return cls()
+
+    def to_block(self) -> RawBlock:
+        return RawBlock('CEPH_USERS', blocks=[u.to_user_block() for u in self.users])
+
+    def users_for_fs(self, fs_name: str) -> List[CephUser]:
+        return [u for u in self.users if u.filesystem == fs_name]
+
+    def remove_fs(self, fs_name: str) -> None:
+        self.users = [u for u in self.users if u.filesystem != fs_name]
+
+
 class Client:
     def __init__(self,
                  addresses: List[str],

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -186,6 +186,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                 rdma_port: Optional[int] = None,
                                 enable_nfsv3: bool = False,
                                 ingress_placement: Optional[str] = None,
+                                clients_per_pool: Optional[int] = None,
                                 inbuf: Optional[str] = None) -> None:
         """Create an NFS Cluster"""
         cluster_qos_config = None
@@ -238,7 +239,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                            tls_ciphers=tls_ciphers,
                                            enable_rdma=enable_rdma,
                                            rdma_port=rdma_port,
-                                           ingress_placement=ingress_placement)
+                                           ingress_placement=ingress_placement,
+                                           clients_per_pool=clients_per_pool)
 
     @NFSCLICommand('nfs cluster rm', perm='rw')
     @object_format.EmptyResponder()

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -155,6 +155,21 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.export_mgr.apply_export(cluster_id, export_config=inbuf,
                                             earmark_resolver=earmark_resolver)
 
+    @NFSCLICommand('nfs cluster rotate-key', perm='rw')
+    @object_format.Responder()
+    def _cmd_nfs_cluster_rotate_key(self,
+                                    cluster_id: str,
+                                    all_daemon_and_export_keys: bool = False,
+                                    auth_entities: Optional[List[str]] = None,
+                                    key_type: Optional[str] = None) -> Dict[str, Any]:
+        """Rotate NFS cluster/daemon and export auth keys; redeploy service if daemon keys change"""
+        return self.nfs.rotate_keys(
+            cluster_id=cluster_id,
+            all_daemon_and_export_keys=all_daemon_and_export_keys,
+            auth_entities=auth_entities,
+            key_type=key_type
+        )
+
     @NFSCLICommand('nfs cluster create', perm='rw')
     @object_format.EmptyResponder()
     def _cmd_nfs_cluster_create(self,

--- a/src/pybind/mgr/nfs/rados_utils.py
+++ b/src/pybind/mgr/nfs/rados_utils.py
@@ -43,12 +43,18 @@ class NFSRados:
             log.debug("write configuration into rados object %s/%s/%s",
                       self.pool, self.namespace, obj)
 
-            # Add created obj url to common config obj
-            ioctx.append(config_obj, format_block(
-                         self._create_url_block(obj)).encode('utf-8'))
+            # Add created obj url to common config obj if not already present
+            try:
+                size, _ = ioctx.stat(config_obj)
+                existing = ioctx.read(config_obj, size).decode('utf-8')
+            except ObjectNotFound:
+                existing = ''
+            url_block = format_block(self._create_url_block(obj))
+            if url_block not in existing:
+                ioctx.append(config_obj, url_block.encode('utf-8'))
+                log.debug("Added %s url to %s", obj, config_obj)
             if should_notify:
                 _check_rados_notify(ioctx, config_obj)
-            log.debug("Added %s url to %s", obj, config_obj)
 
     def read_obj(self, obj: str) -> Optional[str]:
         with self.rados.open_ioctx(self.pool) as ioctx:

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1270,6 +1270,181 @@ NFS_CORE_PARAM {
         assert export.clients[0].addresses == ["192.168.1.0/8"]
         assert export.cluster_id == self.cluster_id
 
+    def test_rotate_keys(self):
+        self._do_mock_test(self._do_test_rotate_keys)
+
+    def test_rotate_keys_all_entities(self):
+        self._do_mock_test(self._do_test_rotate_keys_all_entities)
+
+    def test_rotate_keys_rejects_foreign_entity(self):
+        self._do_mock_test(self._do_test_rotate_keys_rejects_foreign_entity)
+
+    def test_rotate_keys_requires_explicit_selection(self):
+        self._do_mock_test(self._do_test_rotate_keys_requires_explicit_selection)
+
+    def test_rotate_keys_rejects_both_selections(self):
+        self._do_mock_test(self._do_test_rotate_keys_rejects_both_selections)
+
+    def _do_test_rotate_keys(self):
+        nfs_mod = Module('nfs', '', '')
+        conf = nfs_mod.export_mgr
+        cluster = nfs_mod.nfs
+
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/cephfs_rotate',
+            read_only=False,
+            squash='none',
+        )
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/cephfs_rotate2',
+            read_only=False,
+            squash='none',
+        )
+
+        entity = 'client.nfs.foo.myfs.86ca58ef'
+        rotated_key = 'rotated-export-key'
+
+        def mock_create_user_key(self, cluster_id, entity_name, path, fs_name):
+            return rotated_key
+
+        with mock.patch.object(nfs_mod, 'check_mon_command') as check_mon, \
+                mock.patch.object(ExportMgr, '_create_user_key', mock_create_user_key), \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            result = cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                auth_entities=[entity, 'nfs.foo.myfs.86ca58ef'],
+                key_type='aes256k',
+            )
+
+        check_mon.assert_called_once_with({
+            'prefix': 'auth rotate',
+            'entity': entity,
+            'key_type': 'aes256k',
+        })
+        redeploy.assert_not_called()
+        assert result['cluster_id'] == self.cluster_id
+        assert result['rotated'] == [entity]
+        assert result['export_keys'] == [entity]
+        assert result['daemon_keys'] == []
+        assert result['key_type'] == 'aes256k'
+        assert result['service_redeployed'] is False
+        assert sorted(result['updated_exports']) == ['/cephfs_rotate', '/cephfs_rotate2']
+
+        for pseudo in ('/cephfs_rotate', '/cephfs_rotate2'):
+            export = conf._fetch_export(self.cluster_id, pseudo)
+            assert export is not None
+            assert export.fsal.cephx_key == rotated_key
+
+    def _do_test_rotate_keys_all_entities(self):
+        nfs_mod = Module('nfs', '', '')
+        conf = nfs_mod.export_mgr
+        cluster = nfs_mod.nfs
+
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/cephfs_rotate_all',
+            read_only=False,
+            squash='none',
+        )
+
+        export_entity = 'client.nfs.foo.myfs.86ca58ef'
+        daemon_entity = 'client.nfs.foo.0.0.host.hash-rgw'
+        cluster_entity = 'client.nfs.foo'
+        rotated_key = 'rotated-export-key'
+
+        def mock_create_user_key(self, cluster_id, entity_name, path, fs_name):
+            return rotated_key
+
+        auth_ls = {
+            'auth_dump': [
+                {'entity': cluster_entity},
+                {'entity': daemon_entity},
+                {'entity': export_entity},
+                {'entity': 'client.nfs.other.fs.deadbeef'},
+            ]
+        }
+
+        def mock_check_mon(cmd):
+            if cmd.get('prefix') == 'auth ls':
+                return mock.Mock(stdout=json.dumps(auth_ls), retval=0, stderr='')
+            return mock.Mock(stdout='', retval=0, stderr='')
+
+        with mock.patch.object(nfs_mod, 'check_mon_command', side_effect=mock_check_mon) as check_mon, \
+                mock.patch.object(ExportMgr, '_create_user_key', mock_create_user_key), \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            result = cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                all_daemon_and_export_keys=True,
+                key_type='aes256k',
+            )
+
+        rotate_calls = [
+            c.args[0] for c in check_mon.call_args_list
+            if c.args[0].get('prefix') == 'auth rotate'
+        ]
+        rotated = [c['entity'] for c in rotate_calls]
+        assert sorted(rotated) == sorted([cluster_entity, daemon_entity, export_entity])
+        assert all(c.get('key_type') == 'aes256k' for c in rotate_calls)
+        redeploy.assert_called_once_with(nfs_mod, self.cluster_id)
+        assert result['service_redeployed'] is True
+        assert sorted(result['daemon_keys']) == sorted([cluster_entity, daemon_entity])
+        assert result['export_keys'] == [export_entity]
+        assert result['updated_exports'] == ['/cephfs_rotate_all']
+
+    def _do_test_rotate_keys_rejects_foreign_entity(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = nfs_mod.nfs
+
+        with pytest.raises(Exception) as e:
+            cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                auth_entities=['client.nfs.other.fs.deadbeef'],
+            )
+        assert 'does not belong to NFS cluster' in str(e.value)
+
+    def _do_test_rotate_keys_requires_explicit_selection(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = nfs_mod.nfs
+
+        with mock.patch.object(nfs_mod, 'check_mon_command') as check_mon, \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            with pytest.raises(Exception) as e:
+                cluster.rotate_keys(cluster_id=self.cluster_id)
+
+        assert '--all-daemon-and-export-keys' in str(e.value)
+        assert '--auth-entities' in str(e.value)
+        assert 'ceph auth ls' in str(e.value)
+        check_mon.assert_not_called()
+        redeploy.assert_not_called()
+
+    def _do_test_rotate_keys_rejects_both_selections(self):
+        nfs_mod = Module('nfs', '', '')
+        cluster = nfs_mod.nfs
+
+        with mock.patch.object(nfs_mod, 'check_mon_command') as check_mon, \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            with pytest.raises(Exception) as e:
+                cluster.rotate_keys(
+                    cluster_id=self.cluster_id,
+                    all_daemon_and_export_keys=True,
+                    auth_entities=['client.nfs.foo.myfs.86ca58ef'],
+                )
+
+        assert 'mutually exclusive' in str(e.value)
+        check_mon.assert_not_called()
+        redeploy.assert_not_called()
+
     def test_create_export_default_transports_rdma_cluster(self):
         """When cluster has enable_rdma=True, new exports get default Transports = tcp, RDMA."""
         self._do_mock_test(self._do_test_create_export_default_transports_rdma_cluster)

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -239,6 +239,13 @@ QOS_BLOCK {
         else:
             self.temp_store[self.temp_store_namespace][key].raw = content.decode('utf-8')
 
+    def _ioctx_append_mock(self, key: str, content: bytes) -> None:
+        if key not in self.temp_store[self.temp_store_namespace]:
+            self.temp_store[self.temp_store_namespace][key] = \
+                TestNFS.RObject(key, content.decode('utf-8'))
+        else:
+            self.temp_store[self.temp_store_namespace][key].raw += content.decode('utf-8')
+
     def _ioctx_remove_mock(self, key: str) -> None:
         del self.temp_store[self.temp_store_namespace][key]
 
@@ -247,6 +254,8 @@ QOS_BLOCK {
         return r
 
     def _ioctl_stat_mock(self, key):
+        if key not in self.temp_store[self.temp_store_namespace]:
+            raise ObjectNotFound
         return self.temp_store[self.temp_store_namespace][key].stat()
 
     def _ioctl_read_mock(self, key: str, size: Optional[Any] = None) -> bytes:
@@ -269,7 +278,7 @@ QOS_BLOCK {
         }
 
     @contextmanager
-    def _mock_orchestrator(self, enable: bool) -> Iterator:
+    def _mock_orchestrator(self, enable: bool, clients_per_pool: Optional[int] = None) -> Iterator:
         self.io_mock = MagicMock()
         self.io_mock.set_namespace.side_effect = self._ioctx_set_namespace_mock
         self.io_mock.read = self._ioctl_read_mock
@@ -277,10 +286,14 @@ QOS_BLOCK {
         self.io_mock.list_objects.side_effect = self._ioctx_list_objects_mock
         self.io_mock.write_full.side_effect = self._ioctx_write_full_mock
         self.io_mock.remove_object.side_effect = self._ioctx_remove_mock
+        self.io_mock.append.side_effect = self._ioctx_append_mock
 
         # mock nfs services
         orch_nfs_services = [
-            ServiceDescription(spec=NFSServiceSpec(service_id=self.cluster_id))
+            ServiceDescription(spec=NFSServiceSpec(
+                service_id=self.cluster_id,
+                clients_per_pool=clients_per_pool,
+            ))
         ] if enable else []
 
         orch_nfs_daemons = [
@@ -519,8 +532,8 @@ NFS_CORE_PARAM {
         assert blocks[1].block_name == "%url"
         assert blocks[1].values['value'] == f"rados://{NFS_POOL_NAME}/{self.cluster_id}/export-2"
 
-    def _do_mock_test(self, func, *args) -> None:
-        with self._mock_orchestrator(True):
+    def _do_mock_test(self, func, *args, clients_per_pool: Optional[int] = None) -> None:
+        with self._mock_orchestrator(True, clients_per_pool=clients_per_pool):
             func(*args)
             self._reset_temp_store()
 
@@ -2058,6 +2071,289 @@ EXPORT {
     def test_export_qos_bw_ops(self, qos_type, clust_bw_params, clust_ops_params, export_bw_params, export_ops_params):
         self._do_mock_test(self._do_test_export_qos_bw_ops, qos_type, clust_bw_params, clust_ops_params, export_bw_params, export_ops_params)
 
+    def test_cephfs_client_pool_create_and_delete(self):
+        self._do_mock_test(self._do_test_cephfs_client_pool_create_and_delete, clients_per_pool=3)
+
+    def _do_test_cephfs_client_pool_create_and_delete(self):
+        from nfs.export import get_pool_user_id, get_user_id
+        from nfs.utils import ceph_users_obj_name
+        from nfs.ganesha_conf import CephUsers
+
+        nfs_mod = Module('nfs', '', '')
+        conf = ExportMgr(nfs_mod)
+        created = []
+
+        def mock_create_key(cluster_id, entity, path, fs_name):
+            created.append((entity, path, fs_name))
+            return f'key-{entity}'
+
+        with mock.patch.object(conf, '_create_user_key', side_effect=mock_create_key):
+            r = conf.create_export(
+                fsal_type='cephfs',
+                cluster_id=self.cluster_id,
+                fs_name='myfs',
+                path='/',
+                pseudo_path='/cephfs_pool',
+                read_only=False,
+                squash='root',
+            )
+        assert r["bind"] == "/cephfs_pool"
+        export = conf._fetch_export(self.cluster_id, '/cephfs_pool')
+        first_pool_user = get_pool_user_id(self.cluster_id, 'myfs', 0)
+        # Slot 0 is the id an export gets when client-pool mode is off.
+        assert first_pool_user == f'nfs.{get_user_id(self.cluster_id, "myfs", "/")}'
+        assert export.fsal.user_id == first_pool_user
+        assert export.fsal.cephx_key == f'key-{first_pool_user}'
+        assert [c[0] for c in created] == [
+            get_pool_user_id(self.cluster_id, 'myfs', 0),
+            get_pool_user_id(self.cluster_id, 'myfs', 1),
+            get_pool_user_id(self.cluster_id, 'myfs', 2),
+        ]
+        assert all(c[1] == '/' for c in created)
+
+        raw = conf._rados(self.cluster_id).read_obj(ceph_users_obj_name(self.cluster_id))
+        assert raw is not None
+        ceph_users = CephUsers.from_raw(raw)
+        assert len(ceph_users.users_for_fs('myfs')) == 3
+        conf_raw = conf._rados(self.cluster_id).read_obj(f'conf-nfs.{self.cluster_id}')
+        assert f'ceph-users-nfs.{self.cluster_id}' in conf_raw
+
+        # Second export of the same filesystem reuses the pool users.
+        created.clear()
+        with mock.patch.object(conf, '_create_user_key', side_effect=mock_create_key):
+            conf.create_export(
+                fsal_type='cephfs',
+                cluster_id=self.cluster_id,
+                fs_name='myfs',
+                path='/',
+                pseudo_path='/cephfs_pool2',
+                read_only=False,
+                squash='root',
+            )
+        assert created == []
+        # ... and share the first pool identity in their FSAL block.
+        export2 = conf._fetch_export(self.cluster_id, '/cephfs_pool2')
+        assert export2.fsal.user_id == first_pool_user
+        assert export2.fsal.cephx_key == f'key-{first_pool_user}'
+
+        rm_entities = []
+
+        def mock_check_mon_command(cmd):
+            if cmd.get('prefix') == 'auth rm':
+                rm_entities.append(cmd['entity'])
+            return 0, '', ''
+
+        with mock.patch.object(nfs_mod, 'check_mon_command', side_effect=mock_check_mon_command):
+            conf.delete_export(cluster_id=self.cluster_id, pseudo_path='/cephfs_pool')
+        assert rm_entities == []
+        assert conf._rados(self.cluster_id).read_obj(ceph_users_obj_name(self.cluster_id)) is not None
+
+        with mock.patch.object(nfs_mod, 'check_mon_command', side_effect=mock_check_mon_command):
+            conf.delete_export(cluster_id=self.cluster_id, pseudo_path='/cephfs_pool2')
+        assert set(rm_entities) == {
+            f'client.{get_pool_user_id(self.cluster_id, "myfs", 0)}',
+            f'client.{get_pool_user_id(self.cluster_id, "myfs", 1)}',
+            f'client.{get_pool_user_id(self.cluster_id, "myfs", 2)}',
+        }
+        assert conf._rados(self.cluster_id).read_obj(ceph_users_obj_name(self.cluster_id)) is None
+        conf_raw = conf._rados(self.cluster_id).read_obj(f'conf-nfs.{self.cluster_id}')
+        assert f'ceph-users-nfs.{self.cluster_id}' not in conf_raw
+
+    def test_cephfs_client_pool_two_filesystems(self):
+        self._do_mock_test(self._do_test_cephfs_client_pool_two_filesystems, clients_per_pool=2)
+
+    def _do_test_cephfs_client_pool_two_filesystems(self):
+        from nfs.export import get_pool_user_id
+        from nfs.utils import ceph_users_obj_name
+        from nfs.ganesha_conf import CephUsers
+
+        nfs_mod = Module('nfs', '', '')
+        conf = ExportMgr(nfs_mod)
+
+        def mock_create_key(cluster_id, entity, path, fs_name):
+            return f'key-{entity}'
+
+        with mock.patch.object(conf, '_create_user_key', side_effect=mock_create_key):
+            conf.create_export(
+                fsal_type='cephfs',
+                cluster_id=self.cluster_id,
+                fs_name='fs_a',
+                path='/',
+                pseudo_path='/a',
+                read_only=False,
+                squash='none',
+            )
+            conf.create_export(
+                fsal_type='cephfs',
+                cluster_id=self.cluster_id,
+                fs_name='fs_b',
+                path='/',
+                pseudo_path='/b',
+                read_only=False,
+                squash='none',
+            )
+
+        ceph_users = CephUsers.from_raw(
+            conf._rados(self.cluster_id).read_obj(ceph_users_obj_name(self.cluster_id)))
+        assert len(ceph_users.users_for_fs('fs_a')) == 2
+        assert len(ceph_users.users_for_fs('fs_b')) == 2
+
+        rm_entities = []
+
+        def mock_check_mon_command(cmd):
+            if cmd.get('prefix') == 'auth rm':
+                rm_entities.append(cmd['entity'])
+            return 0, '', ''
+
+        with mock.patch.object(nfs_mod, 'check_mon_command', side_effect=mock_check_mon_command):
+            conf.delete_export(cluster_id=self.cluster_id, pseudo_path='/a')
+        assert set(rm_entities) == {
+            f'client.{get_pool_user_id(self.cluster_id, "fs_a", 0)}',
+            f'client.{get_pool_user_id(self.cluster_id, "fs_a", 1)}',
+        }
+        ceph_users = CephUsers.from_raw(
+            conf._rados(self.cluster_id).read_obj(ceph_users_obj_name(self.cluster_id)))
+        assert not ceph_users.users_for_fs('fs_a')
+        assert len(ceph_users.users_for_fs('fs_b')) == 2
+
+        rm_entities.clear()
+        with mock.patch.object(nfs_mod, 'check_mon_command', side_effect=mock_check_mon_command):
+            conf.delete_export(cluster_id=self.cluster_id, pseudo_path='/b')
+        assert conf._rados(self.cluster_id).read_obj(ceph_users_obj_name(self.cluster_id)) is None
+
+    def test_cephfs_client_pool_ignores_non_root_cmount(self):
+        self._do_mock_test(self._do_test_cephfs_client_pool_ignores_non_root_cmount,
+                           clients_per_pool=2)
+
+    def _do_test_cephfs_client_pool_ignores_non_root_cmount(self):
+        from nfs.export import get_pool_user_id, get_user_id
+        from nfs.utils import ceph_users_obj_name
+
+        nfs_mod = Module('nfs', '', '')
+        conf = ExportMgr(nfs_mod)
+        created = []
+
+        def mock_create_key(cluster_id, entity, path, fs_name):
+            created.append((entity, path, fs_name))
+            return f'key-{entity}'
+
+        with mock.patch.object(conf, '_create_user_key', side_effect=mock_create_key):
+            conf.create_export(
+                fsal_type='cephfs',
+                cluster_id=self.cluster_id,
+                fs_name='myfs',
+                path='/volumes',
+                pseudo_path='/sub',
+                read_only=False,
+                squash='none',
+                cmount_path='/volumes',
+            )
+
+        hashed_user = f'nfs.{get_user_id(self.cluster_id, "myfs", "/volumes")}'
+        export = conf._fetch_export(self.cluster_id, '/sub')
+        assert export.fsal.user_id == hashed_user
+        assert export.fsal.cephx_key == f'key-{hashed_user}'
+        assert created == [(hashed_user, '/volumes', 'myfs')]
+        assert conf._rados(self.cluster_id).read_obj(
+            ceph_users_obj_name(self.cluster_id)) is None
+
+        created.clear()
+        with mock.patch.object(conf, '_create_user_key', side_effect=mock_create_key):
+            conf.create_export(
+                fsal_type='cephfs',
+                cluster_id=self.cluster_id,
+                fs_name='myfs',
+                path='/',
+                pseudo_path='/root',
+                read_only=False,
+                squash='none',
+            )
+
+        root_export = conf._fetch_export(self.cluster_id, '/root')
+        assert root_export.fsal.user_id == get_pool_user_id(self.cluster_id, 'myfs', 0)
+        assert [c[0] for c in created] == [
+            get_pool_user_id(self.cluster_id, 'myfs', 0),
+            get_pool_user_id(self.cluster_id, 'myfs', 1),
+        ]
+        export = conf._fetch_export(self.cluster_id, '/sub')
+        assert export.fsal.user_id == hashed_user
+
+        rm_entities = []
+
+        def mock_check_mon_command(cmd):
+            if cmd.get('prefix') == 'auth rm':
+                rm_entities.append(cmd['entity'])
+            return 0, '', ''
+
+        with mock.patch.object(nfs_mod, 'check_mon_command', side_effect=mock_check_mon_command):
+            conf.delete_export(cluster_id=self.cluster_id, pseudo_path='/root')
+        assert set(rm_entities) == {
+            f'client.{get_pool_user_id(self.cluster_id, "myfs", 0)}',
+            f'client.{get_pool_user_id(self.cluster_id, "myfs", 1)}',
+        }
+        assert conf._fetch_export(self.cluster_id, '/sub').fsal.user_id == hashed_user
+
+        rm_entities.clear()
+        with mock.patch.object(nfs_mod, 'check_mon_command', side_effect=mock_check_mon_command):
+            conf.delete_export(cluster_id=self.cluster_id, pseudo_path='/sub')
+        assert rm_entities == [f'client.{hashed_user}']
+
+    def test_cephfs_client_pool_single_notify_per_change(self):
+        self._do_mock_test(self._do_test_cephfs_client_pool_single_notify_per_change,
+                           clients_per_pool=2)
+
+    def _do_test_cephfs_client_pool_single_notify_per_change(self):
+        """Ganesha is notified once per export change, not once per object.
+
+        A change in client-pool mode writes both the export object and the
+        CEPH_USERS object. Only the export object write notifies, and it is
+        always the last one, so ganesha rereads both at once.
+        """
+        from nfs.utils import ceph_users_obj_name
+
+        nfs_mod = Module('nfs', '', '')
+        conf = ExportMgr(nfs_mod)
+
+        self.io_mock.notify.reset_mock()
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/pool',
+            read_only=False,
+            squash='none',
+        )
+        # Both objects were written ...
+        assert conf._rados(self.cluster_id).read_obj(
+            ceph_users_obj_name(self.cluster_id)) is not None
+        # ... and ganesha was told about it exactly once.
+        assert self.io_mock.notify.call_count == 1
+
+        self.io_mock.notify.reset_mock()
+        r = conf.apply_export(self.cluster_id, json.dumps({
+            'path': '/',
+            'pseudo': '/pool',
+            'cluster_id': self.cluster_id,
+            'access_type': 'RO',
+            'squash': 'none',
+            'fsal': {'name': 'CEPH', 'fs_name': 'myfs'},
+        }))
+        assert len(r.changes) == 1
+        assert self.io_mock.notify.call_count == 1
+
+        def mock_check_mon_command(cmd):
+            return 0, '', ''
+
+        self.io_mock.notify.reset_mock()
+        with mock.patch.object(nfs_mod, 'check_mon_command',
+                               side_effect=mock_check_mon_command):
+            conf.delete_export(cluster_id=self.cluster_id, pseudo_path='/pool')
+        # Export object removed and the pool torn down: still a single notify.
+        assert conf._rados(self.cluster_id).read_obj(
+            ceph_users_obj_name(self.cluster_id)) is None
+        assert self.io_mock.notify.call_count == 1
+
 
 class TestNFSClusterIngressPlacement:
     cluster_id = 'mynfs'
@@ -2118,6 +2414,28 @@ def test_ganesha_validate_access_type():
         _validate_access_type(ok)
     with pytest.raises(NFSInvalidOperation):
         _validate_access_type("any")
+
+
+def test_ceph_users_block_roundtrip():
+    from nfs.ganesha_conf import CephUsers, CephUser, GaneshaConfParser, format_block
+
+    users = CephUsers([
+        CephUser('nfs.myc.fs_a.pool.0', 'key0', 'fs_a'),
+        CephUser('nfs.myc.fs_a.pool.1', 'key1', 'fs_a'),
+        CephUser('nfs.myc.fs_b.pool.0', 'key2', 'fs_b'),
+    ])
+    raw = format_block(users.to_block())
+    parsed = CephUsers.from_raw(raw)
+    assert len(parsed.users_for_fs('fs_a')) == 2
+    assert len(parsed.users_for_fs('fs_b')) == 1
+    assert parsed.users_for_fs('fs_a')[0].user_id == 'nfs.myc.fs_a.pool.0'
+    assert parsed.users_for_fs('fs_a')[0].secret_access_key == 'key0'
+    parsed.remove_fs('fs_a')
+    assert not parsed.users_for_fs('fs_a')
+    assert len(parsed.users_for_fs('fs_b')) == 1
+    blocks = GaneshaConfParser(raw).parse()
+    assert blocks[0].block_name == 'CEPH_USERS'
+    assert blocks[0].blocks[0].block_name == 'USER'
 
 
 class TestCephfsClientForMgr:

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -2355,6 +2355,211 @@ EXPORT {
         assert self.io_mock.notify.call_count == 1
 
 
+    def test_cephfs_client_pool_rotate_key(self):
+        self._do_mock_test(self._do_test_cephfs_client_pool_rotate_key, clients_per_pool=2)
+
+    def _do_test_cephfs_client_pool_rotate_key(self):
+        from nfs.export import get_pool_user_id, get_user_id
+        from nfs.utils import ceph_users_obj_name
+        from nfs.ganesha_conf import CephUsers
+
+        nfs_mod = Module('nfs', '', '')
+        conf = nfs_mod.export_mgr
+        cluster = nfs_mod.nfs
+
+        pool0 = get_pool_user_id(self.cluster_id, 'myfs', 0)
+        pool1 = get_pool_user_id(self.cluster_id, 'myfs', 1)
+        entity0 = f'client.{pool0}'
+        entity1 = f'client.{pool1}'
+        hashed_user = f'nfs.{get_user_id(self.cluster_id, "myfs", "/volumes")}'
+        hashed_entity = f'client.{hashed_user}'
+
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/poolrot',
+            read_only=False,
+            squash='none',
+        )
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/volumes',
+            pseudo_path='/sub',
+            read_only=False,
+            squash='none',
+            cmount_path='/volumes',
+        )
+
+        def mock_create_user_key(self, cluster_id, entity_name, path, fs_name):
+            return f'rotated-{entity_name}'
+
+        with mock.patch.object(nfs_mod, 'check_mon_command') as check_mon, \
+                mock.patch.object(ExportMgr, '_create_user_key', mock_create_user_key), \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            result = cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                auth_entities=[entity0],
+                key_type='aes256k',
+            )
+
+        check_mon.assert_called_once_with({
+            'prefix': 'auth rotate',
+            'entity': entity0,
+            'key_type': 'aes256k',
+        })
+        redeploy.assert_not_called()
+        assert result['rotated'] == [entity0]
+        assert result['export_keys'] == [entity0]
+        assert result['daemon_keys'] == []
+        assert result['service_redeployed'] is False
+        # Slot 0 is refreshed both in CEPH_USERS and in the FSAL that carries it.
+        assert result['updated_exports'] == [pool0, '/poolrot']
+
+        export = conf._fetch_export(self.cluster_id, '/poolrot')
+        assert export.fsal.user_id == pool0
+        assert export.fsal.cephx_key == f'rotated-{pool0}'
+        hashed = conf._fetch_export(self.cluster_id, '/sub')
+        assert hashed.fsal.user_id == hashed_user
+        assert hashed.fsal.cephx_key == 'thekeyforclientabc'
+
+        ceph_users = CephUsers.from_raw(
+            conf._rados(self.cluster_id).read_obj(ceph_users_obj_name(self.cluster_id)))
+        keys = {u.user_id: u.secret_access_key for u in ceph_users.users}
+        assert keys[pool0] == f'rotated-{pool0}'
+        assert keys[pool1] == 'thekeyforclientabc'
+
+        with mock.patch.object(nfs_mod, 'check_mon_command') as check_mon, \
+                mock.patch.object(ExportMgr, '_create_user_key', mock_create_user_key), \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            result = cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                auth_entities=[hashed_entity],
+            )
+
+        check_mon.assert_called_once_with({
+            'prefix': 'auth rotate',
+            'entity': hashed_entity,
+        })
+        redeploy.assert_not_called()
+        assert result['export_keys'] == [hashed_entity]
+        assert result['updated_exports'] == ['/sub']
+        hashed = conf._fetch_export(self.cluster_id, '/sub')
+        assert hashed.fsal.cephx_key == f'rotated-{hashed_user}'
+        ceph_users = CephUsers.from_raw(
+            conf._rados(self.cluster_id).read_obj(ceph_users_obj_name(self.cluster_id)))
+        keys = {u.user_id: u.secret_access_key for u in ceph_users.users}
+        assert keys[pool0] == f'rotated-{pool0}'
+        assert keys[pool1] == 'thekeyforclientabc'
+
+        daemon_entity = 'client.nfs.foo.0.0.host.hash-rgw'
+        cluster_entity = 'client.nfs.foo'
+        auth_ls = {
+            'auth_dump': [
+                {'entity': cluster_entity},
+                {'entity': daemon_entity},
+                {'entity': entity0},
+                {'entity': entity1},
+                {'entity': hashed_entity},
+                {'entity': 'client.nfs.other.fs.deadbeef'},
+            ]
+        }
+
+        def mock_check_mon(cmd):
+            if cmd.get('prefix') == 'auth ls':
+                return mock.Mock(stdout=json.dumps(auth_ls), retval=0, stderr='')
+            return mock.Mock(stdout='', retval=0, stderr='')
+
+        with mock.patch.object(nfs_mod, 'check_mon_command', side_effect=mock_check_mon) as check_mon, \
+                mock.patch.object(ExportMgr, '_create_user_key', mock_create_user_key), \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            result = cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                all_daemon_and_export_keys=True,
+                key_type='aes256k',
+            )
+
+        rotate_calls = [
+            c.args[0] for c in check_mon.call_args_list
+            if c.args[0].get('prefix') == 'auth rotate'
+        ]
+        rotated = [c['entity'] for c in rotate_calls]
+        assert sorted(rotated) == sorted(
+            [cluster_entity, daemon_entity, entity0, entity1, hashed_entity])
+        redeploy.assert_called_once_with(nfs_mod, self.cluster_id)
+        assert result['service_redeployed'] is True
+        assert sorted(result['daemon_keys']) == sorted([cluster_entity, daemon_entity])
+        assert sorted(result['export_keys']) == sorted([entity0, entity1, hashed_entity])
+        export = conf._fetch_export(self.cluster_id, '/poolrot')
+        assert export.fsal.user_id == pool0
+        assert export.fsal.cephx_key == f'rotated-{pool0}'
+        ceph_users = CephUsers.from_raw(
+            conf._rados(self.cluster_id).read_obj(ceph_users_obj_name(self.cluster_id)))
+        keys = {u.user_id: u.secret_access_key for u in ceph_users.users}
+        assert keys[pool0] == f'rotated-{pool0}'
+        assert keys[pool1] == f'rotated-{pool1}'
+
+    def test_cephfs_client_pool_rotate_key_notifies_without_export(self):
+        self._do_mock_test(self._do_test_cephfs_client_pool_rotate_key_notifies_without_export,
+                           clients_per_pool=2)
+
+    def _do_test_cephfs_client_pool_rotate_key_notifies_without_export(self):
+        """A pool slot other than 0 lives in CEPH_USERS alone.
+
+        No export FSAL carries it, so no export write follows to notify
+        ganesha: the CEPH_USERS rewrite has to do it itself, or the pool keeps
+        serving a key that auth rotate has already invalidated.
+        """
+        from nfs.export import get_pool_user_id
+        from nfs.utils import ceph_users_obj_name
+        from nfs.ganesha_conf import CephUsers
+
+        nfs_mod = Module('nfs', '', '')
+        conf = nfs_mod.export_mgr
+        cluster = nfs_mod.nfs
+
+        conf.create_export(
+            fsal_type='cephfs',
+            cluster_id=self.cluster_id,
+            fs_name='myfs',
+            path='/',
+            pseudo_path='/poolrot',
+            read_only=False,
+            squash='none',
+        )
+        pool0 = get_pool_user_id(self.cluster_id, 'myfs', 0)
+        pool1 = get_pool_user_id(self.cluster_id, 'myfs', 1)
+
+        def mock_create_user_key(self, cluster_id, entity_name, path, fs_name):
+            return f'rotated-{entity_name}'
+
+        self.io_mock.notify.reset_mock()
+        with mock.patch.object(nfs_mod, 'check_mon_command'), \
+                mock.patch.object(ExportMgr, '_create_user_key', mock_create_user_key), \
+                mock.patch('nfs.cluster.redeploy_nfs_service') as redeploy:
+            result = cluster.rotate_keys(
+                cluster_id=self.cluster_id,
+                auth_entities=[f'client.{pool1}'],
+            )
+
+        # Neither an export write nor a redeploy would have notified here.
+        redeploy.assert_not_called()
+        assert result['updated_exports'] == [pool1]
+        assert self.io_mock.notify.call_count == 1
+
+        ceph_users = CephUsers.from_raw(
+            conf._rados(self.cluster_id).read_obj(ceph_users_obj_name(self.cluster_id)))
+        keys = {u.user_id: u.secret_access_key for u in ceph_users.users}
+        assert keys[pool1] == f'rotated-{pool1}'
+        # Slot 0 was not rotated, so it keeps the key its export still carries.
+        assert keys[pool0] == 'thekeyforclientabc'
+        assert conf._fetch_export(self.cluster_id, '/poolrot').fsal.cephx_key == \
+            'thekeyforclientabc'
+
+
 class TestNFSClusterIngressPlacement:
     cluster_id = 'mynfs'
     virtual_ip = '192.168.1.100/24'

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -12,6 +12,8 @@ from mgr_module import NFS_POOL_NAME as POOL_NAME
 
 from rados import Rados, LIBRADOS_ALL_NSPACES, ObjectNotFound
 
+from .exception import NFSInvalidOperation
+
 if TYPE_CHECKING:
     from nfs.module import Module
 
@@ -45,6 +47,22 @@ class ManualRestartRequired(NonFatalError):
 
     def __init__(self, msg: str) -> None:
         super().__init__(" ".join((msg, "(Manual Restart of NFS Pods required)")))
+
+
+def normalize_auth_entity(entity: str) -> str:
+    """Return a full auth entity name (client.<user_id>)."""
+    entity = entity.strip()
+    if not entity:
+        raise NFSInvalidOperation("empty auth entity")
+    if entity.startswith('client.'):
+        return entity
+    return f'client.{entity}'
+
+
+def entity_belongs_to_nfs_cluster(entity: str, cluster_id: str) -> bool:
+    """True if entity is the cluster key or any key under that NFS cluster."""
+    prefix = f'client.nfs.{cluster_id}'
+    return entity == prefix or entity.startswith(prefix + '.')
 
 
 def export_obj_name(export_id: int) -> str:
@@ -126,6 +144,15 @@ def restart_nfs_service(mgr: 'Module', cluster_id: str) -> None:
     This methods restarts the nfs daemons
     '''
     completion = mgr.service_action(action='restart',
+                                    service_name='nfs.' + cluster_id)
+    orchestrator.raise_if_exception(completion)
+
+
+def redeploy_nfs_service(mgr: 'Module', cluster_id: str) -> None:
+    '''
+    Redeploy NFS daemons so they pick up rotated daemon keyrings.
+    '''
+    completion = mgr.service_action(action='redeploy',
                                     service_name='nfs.' + cluster_id)
     orchestrator.raise_if_exception(completion)
 

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -21,6 +21,7 @@ EXPORT_PREFIX: str = "export-"
 CONF_PREFIX: str = "conf-nfs."
 USER_CONF_PREFIX: str = "userconf-nfs."
 QOS_CONF_PREFIX: str = "qosconf-nfs."
+CEPH_USERS_CONF_PREFIX: str = "ceph-users-nfs."
 
 log = logging.getLogger(__name__)
 
@@ -83,6 +84,11 @@ def user_conf_obj_name(cluster_id: str) -> str:
 def qos_conf_obj_name(cluster_id: str) -> str:
     """Return a rados object name for the qos config."""
     return f"{QOS_CONF_PREFIX}{cluster_id}"
+
+
+def ceph_users_obj_name(cluster_id: str) -> str:
+    """Return a rados object name for the CEPH_USERS (client pool) config."""
+    return f"{CEPH_USERS_CONF_PREFIX}{cluster_id}"
 
 
 def available_clusters(mgr: 'Module') -> List[str]:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1430,6 +1430,7 @@ class NFSServiceSpec(ServiceSpec):
                  enable_client_object_cache: bool = False,
                  client_object_cache_size: Optional[Union[str, int]] = None,
                  client_object_cache_max_dirty: Optional[Union[str, int]] = None,
+                 clients_per_pool: Optional[int] = None,
                  ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
@@ -1466,6 +1467,10 @@ class NFSServiceSpec(ServiceSpec):
         self.enable_client_object_cache = enable_client_object_cache
         self.client_object_cache_size = client_object_cache_size
         self.client_object_cache_max_dirty = client_object_cache_max_dirty
+
+        # Max independent CephFS client handles Ganesha may use per filesystem.
+        # Immutable after cluster creation. None disables pool mode (default).
+        self.clients_per_pool = clients_per_pool
 
         # colocation_ports is a list of port dicts for ADDITIONAL colocated daemons
         # The first daemon always uses port and monitoring_port from the spec
@@ -1558,6 +1563,13 @@ class NFSServiceSpec(ServiceSpec):
                                       f"{'ip_addrs' if self.ip_addrs else 'networks'} fields")
 
         verify_boolean(self.enable_client_object_cache, "enable_client_object_cache")
+        if self.clients_per_pool is not None:
+            verify_int(self.clients_per_pool, "clients_per_pool")
+            if self.clients_per_pool < 2:
+                raise SpecValidationError(
+                    "Invalid NFS spec: clients_per_pool must be an integer >= 2. "
+                    "This field can only be set at NFS cluster creation time."
+                )
         cache_size = verify_size_with_units(
             self.client_object_cache_size, "client_object_cache_size"
         )


### PR DESCRIPTION

NFS shares a single CephFS client handle across all exports of 
filesystem that use the default cmount_path of "/". Under load, that single
handle becomes a bottleneck for all exports of that filesystem.
Added an optional clients_per_pool setting to the nfs cluster so nfs can
spread exports across a bounded number of independent CephFS client.
    
When the first CephFS export with cmount_path="/" is created for a
filesystem, the nfs module provisions N CephX users named
client.nfs.<cluster_id>.<fs_name>.pool.<num>  and stores them in a new
CEPH_USERS RADOS object (ceph-users-nfs.<cluster_id>), which is linked
from the cluster's common config object. New CephUser/CephUsers classes
handle serialising that block.
    
Fixes: https://tracker.ceph.com/issues/80403
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

Testing logs:
```
[ceph: root@ceph-node-0 /]# ceph nfs export create cephfs test /export1 myfs
{
  "bind": "/export1",
  "cluster": "test",
  "fs": "myfs",
  "mode": "RW",
  "path": "/"
}
[ceph: root@ceph-node-0 /]# rados -N test -p '.nfs' get conf-nfs.test -
%url "rados://.nfs/test/ceph-users-nfs.test"

%url "rados://.nfs/test/export-1"

[ceph: root@ceph-node-0 /]# rados -N test -p '.nfs' get ceph-users-nfs.test -
CEPH_USERS {
    USER {
        user_id = "nfs.test.myfs.23f0f81e";
        secret_access_key = "AgAv4qhqSjx8ICAAbkb5BXA3l0zAtZZnSSBBX2NF5INoar/5vcvLIk4JEUc=";
        filesystem = "myfs";
    }
    USER {
        user_id = "nfs.test.myfs.pool.1";
        secret_access_key = "AgAv4qhqc+V7IiAAxPok1Z9V7ewivV1Hn3okpSy0AvqcKE/JAaD66A6JnnE=";
        filesystem = "myfs";
    }
    USER {
        user_id = "nfs.test.myfs.pool.2";
        secret_access_key = "AgAv4qhqmbLqJiAAtCtbkg/nne1xjdgXGdqX+C8TpYLLJw7O2X75dw7+rWk=";
        filesystem = "myfs";
    }
}
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# rados -N test -p '.nfs' get export-1 -     
EXPORT {
    FSAL {
        name = "CEPH";
        user_id = "nfs.test.myfs.23f0f81e";
        filesystem = "myfs";
        secret_access_key = "AgAv4qhqSjx8ICAAbkb5BXA3l0zAtZZnSSBBX2NF5INoar/5vcvLIk4JEUc=";
        cmount_path = "/";
    }
    export_id = 1;
    path = "/";
    pseudo = "/export1";
    access_type = "RW";
    squash = "none";
    attr_expiration_time = 0;
    security_label = true;
    protocols = 4;
    transports = "TCP";
}
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# #ceph nfs export create cephfs test /export2 myfs
[ceph: root@ceph-node-0 /]# ceph nfs export create cephfs test /export2 myfs
{
  "bind": "/export2",
  "cluster": "test",
  "fs": "myfs",
  "mode": "RW",
  "path": "/"
}
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# rados -N test -p '.nfs' get export-2 -
EXPORT {
    FSAL {
        name = "CEPH";
        user_id = "nfs.test.myfs.23f0f81e";
        filesystem = "myfs";
        secret_access_key = "AgAv4qhqSjx8ICAAbkb5BXA3l0zAtZZnSSBBX2NF5INoar/5vcvLIk4JEUc=";
        cmount_path = "/";
    }
    export_id = 2;
    path = "/";
    pseudo = "/export2";
    access_type = "RW";
    squash = "none";
    attr_expiration_time = 0;
    security_label = true;
    protocols = 4;
    transports = "TCP";
}
[ceph: root@ceph-node-0 /]# rados -N test -p '.nfs' get ceph-users-nfs.test -
CEPH_USERS {
    USER {
        user_id = "nfs.test.myfs.23f0f81e";
        secret_access_key = "AgAv4qhqSjx8ICAAbkb5BXA3l0zAtZZnSSBBX2NF5INoar/5vcvLIk4JEUc=";
        filesystem = "myfs";
    }
    USER {
        user_id = "nfs.test.myfs.pool.1";
        secret_access_key = "AgAv4qhqc+V7IiAAxPok1Z9V7ewivV1Hn3okpSy0AvqcKE/JAaD66A6JnnE=";
        filesystem = "myfs";
    }
    USER {
        user_id = "nfs.test.myfs.pool.2";
        secret_access_key = "AgAv4qhqmbLqJiAAtCtbkg/nne1xjdgXGdqX+C8TpYLLJw7O2X75dw7+rWk=";
        filesystem = "myfs";
    }
}
[ceph: root@ceph-node-0 /]# 

```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
