### PR TITLE
cmake: add sysctl(hw.physmem)/core-count fallbacks and clang memory tuning for FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
   FIND_PACKAGE(Threads)
 endif(CMAKE_SYSTEM_NAME MATCHES "Linux")
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+   CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  set(CLANG ON)
+endif()
+
 if(WIN32)
   # The Windows headers (e.g. coming from mingw or the Windows SDK) check
   # the targeted Windows version. The availability of certain functions and
@@ -294,7 +299,7 @@ if(WITH_RBD AND LINUX)
 endif()
 
 # libnbd
-if(WITH_RBD AND NOT WIN32)
+if(WITH_RBD AND NOT WIN32 AND NOT FREEBSD)
   find_package(libnbd 1.0 REQUIRED)
   set(HAVE_LIBNBD ${LIBNBD_FOUND})
 endif()

--- a/src/test/fs/CMakeLists.txt
+++ b/src/test/fs/CMakeLists.txt
@@ -13,7 +13,7 @@ if(${WITH_CEPHFS})
       ceph-common
       cephfs
   )
-  if(NOT WIN32)
+  if(NOT WIN32 AND NOT CLANG)
     target_link_options(ceph_test_trim_caps PRIVATE -Wl,--copy-dt-needed-entries)
   endif()
   install(TARGETS ceph_test_trim_caps DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -25,7 +25,7 @@ if(${WITH_CEPHFS})
       ceph-common
       cephfs
   )
-  if(NOT WIN32)
+  if(NOT WIN32 AND NOT CLANG)
     target_link_options(ceph_test_ino_release_cb PRIVATE -Wl,--copy-dt-needed-entries)
   endif()
   install(TARGETS ceph_test_ino_release_cb DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -39,7 +39,7 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
-  if(NOT WIN32)
+  if(NOT WIN32 AND NOT CLANG)
     target_link_options(ceph_test_libcephfs PRIVATE -Wl,--copy-dt-needed-entries)
   endif()
   install(TARGETS ceph_test_libcephfs
@@ -56,7 +56,7 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
-  if(NOT WIN32)
+  if(NOT WIN32 AND NOT CLANG)
     target_link_options(ceph_test_libcephfs_snapdiff PRIVATE -Wl,--copy-dt-needed-entries)
   endif()
   install(TARGETS ceph_test_libcephfs_snapdiff
@@ -73,7 +73,7 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
-  if(NOT WIN32)
+  if(NOT WIN32 AND NOT CLANG)
     target_link_options(ceph_test_libcephfs_suidsgid PRIVATE -Wl,--copy-dt-needed-entries)
   endif()
   install(TARGETS ceph_test_libcephfs_suidsgid
@@ -90,7 +90,7 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
-  if(NOT WIN32)
+  if(NOT WIN32 AND NOT CLANG)
     target_link_options(ceph_test_libcephfs_vxattr PRIVATE -Wl,--copy-dt-needed-entries)
   endif()
   install(TARGETS ceph_test_libcephfs_vxattr
@@ -107,7 +107,7 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
-  if(NOT WIN32)
+  if(NOT WIN32 AND NOT CLANG)
     target_link_options(ceph_test_libcephfs_newops PRIVATE -Wl,--copy-dt-needed-entries)
   endif()
   install(TARGETS ceph_test_libcephfs_newops
@@ -125,7 +125,7 @@ if(WITH_LIBCEPHFS)
       ${EXTRALIBS}
       ${CMAKE_DL_LIBS}
     )
-    if(NOT WIN32)
+    if(NOT WIN32 AND NOT CLANG)
       target_link_options(ceph_test_libcephfs_reclaim PRIVATE -Wl,--copy-dt-needed-entries)
     endif()
     install(TARGETS ceph_test_libcephfs_reclaim
@@ -142,7 +142,7 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
   )
-  if(NOT WIN32)
+  if(NOT WIN32 AND NOT CLANG)
     target_link_options(ceph_test_libcephfs_lazyio PRIVATE -Wl,--copy-dt-needed-entries)
   endif()
   install(TARGETS ceph_test_libcephfs_lazyio
@@ -159,7 +159,7 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
   )
-  if(NOT WIN32)
+  if(NOT WIN32 AND NOT CLANG)
     target_link_options(ceph_test_libcephfs_access PRIVATE -Wl,--copy-dt-needed-entries)
   endif()
   install(TARGETS ceph_test_libcephfs_access


### PR DESCRIPTION
cmake_host_system_information() can return 0 or an unusable value for
TOTAL_PHYSICAL_MEMORY and NUMBER_OF_LOGICAL_CORES on FreeBSD. Add
FreeBSD-specific fallbacks that query sysctl directly when the cmake
query fails, and reserve 15% headroom for OS/filesystem cache pressure
(ZFS ARC in particular doesn't reliably shrink fast enough under
sudden build-time memory pressure).

Also lower MAX_COMPILE_MEM/MAX_LINK_MEM when building with clang
(using the CLANG variable introduced in wip-clang-copy-dt-needed):
upstream's 3500/4500 MiB defaults are tuned against gcc, and were
observed causing real swap thrashing under clang at the default pool
depth. 1800/1000 MiB is an empirically-derived correction from one
machine's workload; revisit if jobs still end up swapping.

Depends on wip-clang-copy-dt-needed for the CLANG variable.
https://github.com/ceph/ceph/pull/71836


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
